### PR TITLE
feat: markdown affordances + mission-setup Stop + closeAll capture (7 gated fixes)

### DIFF
--- a/src/__tests__/vex-agent/engine/core/runner/process-mission-setup-turn.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/process-mission-setup-turn.test.ts
@@ -351,6 +351,42 @@ describe("runner", () => {
       expect(mockUpdateDraft).not.toHaveBeenCalled();
     });
 
+    it("honours a user Stop during setup — no patch applied, no not-ready notice, faithful stopReason, signal threaded to both turn-loop positions", async () => {
+      mockHydrate.mockResolvedValueOnce(makeHydratedSession({
+        sessionKind: "mission",
+        missionId: "mission-1",
+      }));
+      mockGetMission
+        .mockResolvedValueOnce(makeMission({ title: "SOL Flip" }))
+        .mockResolvedValueOnce(makeMission({ title: "SOL Flip" }));
+      // result.text is BOTH a parseable mission patch (```json block with a
+      // title) AND matches START_SUGGESTION_PATTERN ("start the mission") — so
+      // the test proves the Stop guard suppresses BOTH the patch-apply and the
+      // not-ready notice, not the parser/regex failing to match.
+      const stoppedText =
+        "You can start the mission now.\n```json\n{\"title\":\"SOL Flip\"}\n```";
+      mockRunTurnLoop.mockResolvedValueOnce({
+        text: stoppedText,
+        toolCallsMade: 2,
+        pendingApprovals: [],
+        stopReason: "user_stopped",
+      });
+
+      const signal = new AbortController().signal;
+      const result = await processMissionSetupTurn("session-1", "stop", signal);
+
+      // (1) No mission patch applied from the truncated/partial Stop text.
+      expect(mockUpdateDraft).not.toHaveBeenCalled();
+      // (2) No not-ready guidance notice appended on Stop.
+      expect(mockAddEngineMessage).not.toHaveBeenCalled();
+      // (3) Faithful stopReason — not masked to null.
+      expect(result.stopReason).toBe("user_stopped");
+      // Signal forwarded into runTurnLoop at BOTH pos 10 (abortSignal) and
+      // pos 11 (inferenceAbortSignal).
+      expect(mockRunTurnLoop.mock.calls[0][9]).toBe(signal);
+      expect(mockRunTurnLoop.mock.calls[0][10]).toBe(signal);
+    });
+
     it("carries LIVE plan-mode into the dispatch context during setup (Approach A: plan co-authored with the contract; mission_draft_update stays unblocked via the PLAN_GATE_SAFE_CONTROL safe-list)", async () => {
       // Approach A: when the session has plan-mode enabled, setup co-authors the
       // action plan (HOW) alongside the mission contract (WHAT), so the dispatch

--- a/src/__tests__/vex-agent/engine/ingress.test.ts
+++ b/src/__tests__/vex-agent/engine/ingress.test.ts
@@ -233,7 +233,9 @@ describe("ingress.routeUserMessage", () => {
     const result = await routeUserMessage("s1", "goal is x");
 
     expect(result).toBe(setupResult);
-    expect(mockProcessMissionSetupTurn).toHaveBeenCalledWith("s1", "goal is x");
+    // The chat-turn Stop signal (undefined here) is threaded into setup so a
+    // Stop pressed during mission SETUP is honoured, mirroring the agent path.
+    expect(mockProcessMissionSetupTurn).toHaveBeenCalledWith("s1", "goal is x", undefined);
   });
 
   it("routes to agent when no mission and no run exist", async () => {

--- a/src/__tests__/vex-agent/engine/prompts/prompt-stack.test.ts
+++ b/src/__tests__/vex-agent/engine/prompts/prompt-stack.test.ts
@@ -62,6 +62,12 @@ describe("prompt-stack", () => {
           // Global output-format directive (batch 3) — present in every mode.
           expect(joined).toContain("# Response formatting");
           expect(joined).toContain("GitHub-Flavored Markdown");
+          // Bounded markdown-affordances steering: token logos only from a
+          // tool-provided logoUrl/imageUrl (never invented), explorer/dexscreener
+          // links allowed. Replaces the old blanket "do not embed images" line.
+          expect(joined).toContain("token logo as a Markdown image");
+          expect(joined).toContain("never invent or guess an image URL");
+          expect(joined).not.toContain("do not embed images");
 
           // Tool usage markers
           expect(joined).toContain("discover_tools");

--- a/src/__tests__/vex-agent/sync/capture-contract.test.ts
+++ b/src/__tests__/vex-agent/sync/capture-contract.test.ts
@@ -137,6 +137,12 @@ describe("capture contract — contract invariants", () => {
     expect(c.exceptions).toBeDefined();
     expect(c.exceptions!.some(e => e.includes("instrumentKey"))).toBe(true);
   });
+
+  it("solana.predict.closeAll has exception for instrumentKey (claim items match via positionKey)", () => {
+    const c = MUTATION_MATRIX.get("solana.predict.closeAll")!;
+    expect(c.exceptions).toBeDefined();
+    expect(c.exceptions!.some(e => /no instrumentKey/i.test(e))).toBe(true);
+  });
 });
 
 // ── Capture validator tests ────────────────────────────────────
@@ -192,6 +198,22 @@ describe("capture contract — runtime validator", () => {
       outputValueUsd: "3.50", valuationSource: "prediction_exact",
     });
     expect(valid).toBe(true);
+  });
+
+  it("solana.predict.closeAll item passes without instrumentKey (exception) with valuation", () => {
+    const valid = validateCaptureContract("solana.predict.closeAll", {
+      type: "prediction", walletAddress: "0x", status: "claimed", positionKey: "PK1",
+      outputValueUsd: "3.50", valuationSource: "prediction_exact",
+    });
+    expect(valid).toBe(true);
+  });
+
+  it("solana.predict.closeAll item missing positionKey is REJECTED (exception is instrumentKey-only)", () => {
+    const valid = validateCaptureContract("solana.predict.closeAll", {
+      type: "prediction", walletAddress: "0x", status: "claimed",
+      outputValueUsd: "3.50", valuationSource: "prediction_exact",
+    });
+    expect(valid).toBe(false);
   });
 
   it("rejects unexpected type", () => {

--- a/src/__tests__/vex-agent/tools/protocols/solana-jupiter/solana-jupiter-projectors.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/solana-jupiter/solana-jupiter-projectors.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the Solana/Jupiter concise token projector — focused on the
+ * re-surfaced, bounded `logoUrl` field (Option A2 token logos) and the
+ * invariant that the social/url bag and raw sub-objects stay dropped.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  projectJupiterToken,
+  projectJupiterTokens,
+} from "@vex-agent/tools/protocols/solana-jupiter/projectors.js";
+import type { JupiterMintInformation } from "@tools/solana-ecosystem/jupiter/jupiter-tokens/types.js";
+
+/** Minimal valid token with the required fields; spread overrides per case. */
+function makeToken(
+  overrides: Partial<JupiterMintInformation> = {},
+): JupiterMintInformation {
+  return {
+    id: "So11111111111111111111111111111111111111112",
+    name: "Wrapped SOL",
+    symbol: "SOL",
+    decimals: 9,
+    ...overrides,
+  };
+}
+
+describe("projectJupiterToken — logoUrl", () => {
+  it("surfaces a bounded logoUrl for a valid https icon", () => {
+    const out = projectJupiterToken(
+      makeToken({ icon: "https://cdn.jup.ag/tokens/sol.png" }),
+    );
+    expect(out.logoUrl).toBe("https://cdn.jup.ag/tokens/sol.png");
+  });
+
+  it("returns null logoUrl for a non-https icon", () => {
+    expect(
+      projectJupiterToken(makeToken({ icon: "http://cdn.jup.ag/sol.png" }))
+        .logoUrl,
+    ).toBeNull();
+    expect(
+      projectJupiterToken(makeToken({ icon: "ftp://cdn.jup.ag/sol.png" }))
+        .logoUrl,
+    ).toBeNull();
+  });
+
+  it("returns null logoUrl for a malformed / control-char / oversized icon", () => {
+    expect(projectJupiterToken(makeToken({ icon: "not a url" })).logoUrl).toBeNull();
+    expect(
+      projectJupiterToken(makeToken({ icon: `https://a${String.fromCharCode(0)}.com/x.png` }))
+        .logoUrl,
+    ).toBeNull();
+    const tooLong = `https://cdn.jup.ag/${"a".repeat(600)}.png`;
+    expect(projectJupiterToken(makeToken({ icon: tooLong })).logoUrl).toBeNull();
+  });
+
+  it("returns null logoUrl when icon is absent or null", () => {
+    expect(projectJupiterToken(makeToken()).logoUrl).toBeNull();
+    expect(projectJupiterToken(makeToken({ icon: null })).logoUrl).toBeNull();
+  });
+});
+
+describe("projectJupiterToken — dropped-field invariants stay intact", () => {
+  it("drops social/url bag and raw sub-objects, keeps no `icon` key", () => {
+    const out = projectJupiterToken(
+      makeToken({
+        icon: "https://cdn.jup.ag/sol.png",
+        twitter: "https://x.com/sol",
+        telegram: "https://t.me/sol",
+        website: "https://solana.com",
+        dev: "DevPubkey",
+        mintAuthority: "MintPubkey",
+        freezeAuthority: "FreezePubkey",
+        firstPool: { id: "pool1", createdAt: "2024-01-01" },
+        updatedAt: "2024-01-02",
+      }),
+    );
+    // The concise row exposes logoUrl but NOT the raw icon nor the social bag.
+    expect("icon" in out).toBe(false);
+    expect("twitter" in out).toBe(false);
+    expect("telegram" in out).toBe(false);
+    expect("website" in out).toBe(false);
+    expect("dev" in out).toBe(false);
+    expect("mintAuthority" in out).toBe(false);
+    expect("freezeAuthority" in out).toBe(false);
+    expect("firstPool" in out).toBe(false);
+    expect("updatedAt" in out).toBe(false);
+    expect(out.logoUrl).toBe("https://cdn.jup.ag/sol.png");
+  });
+});
+
+describe("projectJupiterTokens", () => {
+  it("maps each token and tolerates a non-array input", () => {
+    const rows = projectJupiterTokens([
+      makeToken({ icon: "https://cdn.jup.ag/a.png" }),
+      makeToken({ id: "Mint2", icon: "javascript:alert(1)" }),
+    ]);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.logoUrl).toBe("https://cdn.jup.ag/a.png");
+    expect(rows[1]?.logoUrl).toBeNull();
+    expect(projectJupiterTokens(null)).toEqual([]);
+    expect(projectJupiterTokens(undefined)).toEqual([]);
+  });
+});

--- a/src/vex-agent/engine/core/runner/setup-turn.ts
+++ b/src/vex-agent/engine/core/runner/setup-turn.ts
@@ -34,6 +34,7 @@ import { toToolDefinitions, DEFAULT_LOOP_CONFIG, ITERATION_LIMIT_REPLY } from ".
 export async function processMissionSetupTurn(
   sessionId: string,
   userInput: string,
+  signal?: AbortSignal,
 ): Promise<TurnResult> {
   logger.info("engine.mission.setup_turn", { sessionId });
 
@@ -142,6 +143,7 @@ export async function processMissionSetupTurn(
     } : undefined,
   };
 
+  const startedAt = Date.now();
   const result = await runTurnLoop(
     setupContext,
     hydrated.messages,
@@ -152,6 +154,13 @@ export async function processMissionSetupTurn(
     tools,
     loopConfig,
     promptOptions,
+    // Setup threads the Stop signal into BOTH the tool-call iteration
+    // boundary (pos 10 `abortSignal`) AND the in-flight inference stream
+    // (pos 11 `inferenceAbortSignal`): pos 11 cancels a long setup
+    // inference, pos 10 stops the next tool-call iteration. This is
+    // intentionally broader than agent.ts (which threads only pos 11).
+    signal, // abortSignal
+    signal, // inferenceAbortSignal
   );
 
   // Graceful cap-hit reply (setup): when the loop exhausted maxIterations
@@ -161,6 +170,13 @@ export async function processMissionSetupTurn(
   // not-ready notice below. The turn-loop persists real model text itself;
   // nothing was saved on this path, so we persist the synthesised reply here.
   const capHit = result.stopReason === "iteration_limit" && !result.text;
+  logger.info("engine.mission.setup_turn.timing", {
+    sessionId,
+    elapsedMs: Date.now() - startedAt,
+    toolCallsMade: result.toolCallsMade,
+    stopReason: result.stopReason,
+    capHit,
+  });
   if (capHit) {
     await appendMessage(
       sessionId,
@@ -169,8 +185,10 @@ export async function processMissionSetupTurn(
     );
   }
 
-  // Apply mission patch from model response to draft (never from synthesised text)
-  if (!capHit && result.text && missionId) {
+  // Apply mission patch from model response to draft (never from synthesised
+  // text, never from text truncated by a user Stop — a partial patch could
+  // corrupt the draft).
+  if (!capHit && result.stopReason !== "user_stopped" && result.text && missionId) {
     const parsed = parseModelMissionOutput(result.text);
     if (parsed) {
       await applyMissionPatch(missionId, parsed);
@@ -185,6 +203,7 @@ export async function processMissionSetupTurn(
   let text = capHit ? ITERATION_LIMIT_REPLY : result.text;
   if (
     !capHit
+    && result.stopReason !== "user_stopped"
     && latestSetupState
     && latestSetupState.status !== "ready"
     && textSuggestsMissionStart(text)
@@ -212,7 +231,7 @@ export async function processMissionSetupTurn(
       text,
       toolCallsMade: result.toolCallsMade,
       pendingApprovals: [],
-      stopReason: null,
+      stopReason: result.stopReason,
       missionStatus,
     };
   } finally {

--- a/src/vex-agent/engine/ingress.ts
+++ b/src/vex-agent/engine/ingress.ts
@@ -105,7 +105,7 @@ export async function routeUserMessage(
   // No active run — distinguish agent / mission-setup by mission presence.
   const mission = await missionsRepo.getActiveMission(sessionId);
   if (mission && mission.status !== "running") {
-    return processMissionSetupTurn(sessionId, userInput);
+    return processMissionSetupTurn(sessionId, userInput, signal);
   }
 
   // Chat/agent turn — the only path that honours the chat-turn "stop

--- a/src/vex-agent/engine/prompts/base.ts
+++ b/src/vex-agent/engine/prompts/base.ts
@@ -69,7 +69,8 @@ export function buildBasePrompt(context: EngineContext): string {
   lines.push("- Use headings, bullet/numbered lists, **bold**, *italic*, and `inline code`.");
   lines.push("- Put code, addresses, hashes, and JSON in fenced code blocks.");
   lines.push("- Use Markdown tables for structured/tabular data (balances, comparisons).");
-  lines.push("- Use plain `https://` links; do not embed images or raw HTML.");
+  lines.push("- Use plain `https://` links — never raw HTML. You may link to explorer.solana.com and dexscreener.com.");
+  lines.push("- You may embed a token logo as a Markdown image, but ONLY using a `logoUrl`/`imageUrl` returned by a tool — never invent or guess an image URL.");
   lines.push("Lead with the answer, then detail. Keep it concise.");
   lines.push("");
 

--- a/src/vex-agent/tools/protocols/mutation-matrix.ts
+++ b/src/vex-agent/tools/protocols/mutation-matrix.ts
@@ -74,7 +74,7 @@ const entries: [string, MutationContract][] = [
   ["solana.predict.buy",     { role: "pnl_prediction", capture: "full", expectedType: "prediction", previewSupport: false, fanOut: "single", requiredFields: PNL_PREDICTION_FIELDS, valuationExpected: "exact", requiredMetaFields: ["contracts"] }],
   ["solana.predict.sell",    { role: "pnl_prediction", capture: "full", expectedType: "prediction", previewSupport: false, fanOut: "single", requiredFields: PNL_PREDICTION_FIELDS, valuationExpected: "exact" }],
   ["solana.predict.claim",   { role: "pnl_prediction", capture: "full", expectedType: "prediction", previewSupport: false, fanOut: "single", requiredFields: ["walletAddress", "status", "positionKey"], exceptions: ["claim: no instrumentKey — matches via positionKey"], valuationExpected: "exact" }],
-  ["solana.predict.closeAll",{ role: "pnl_prediction", capture: "full", expectedType: "prediction", previewSupport: false, fanOut: "items",  requiredFields: PNL_PREDICTION_FIELDS, valuationExpected: "exact" }],
+  ["solana.predict.closeAll",{ role: "pnl_prediction", capture: "full", expectedType: "prediction", previewSupport: false, fanOut: "items",  requiredFields: PNL_PREDICTION_FIELDS, exceptions: ["closeAll claim item: no instrumentKey — matches via positionKey"], valuationExpected: "exact" }],
 
   // Polymarket CLOB — dual-type: matched→prediction (position, exact valuation), live→order (pending, no valuation)
   ["polymarket.clob.buy",    { role: "pnl_prediction", capture: "full", expectedType: ["prediction", "order"], previewSupport: true,  fanOut: "single", requiredFields: ["walletAddress", "status", "positionKey", "instrumentKey"], valuationExpected: "conditional" }],

--- a/src/vex-agent/tools/protocols/solana-jupiter/projectors.ts
+++ b/src/vex-agent/tools/protocols/solana-jupiter/projectors.ts
@@ -13,7 +13,8 @@
  * uses, tags/launchpad, age, and a concise per-interval stats subset.
  *
  * Default-concise with NO verbosity knob: there is no agent use case for the
- * dropped icon/social URLs or raw provider sub-objects. (Both wiring tools are
+ * dropped social URLs or raw provider sub-objects (the icon is re-surfaced as a
+ * single bounded `logoUrl` the renderer can display). (Both wiring tools are
  * `mutating:false` / `actionKind:"read"` with no `_tradeCapture`, so projecting
  * the `ok()` arg — which trims both the output string and the unused `data` — is
  * safe; see CC-3 / P0-3 in the tool-output eval.)
@@ -57,9 +58,10 @@ export interface ConciseJupiterTokenAudit {
 
 /**
  * Concise Jupiter token row. Keeps identity, market signals, organic/trending
- * signals, the safety audit, tags/launchpad and age; drops icon/social URLs,
- * raw authority pubkeys, the open passthrough bag, APY, and raw provider
- * sub-objects (`firstPool`, full stat blocks).
+ * signals, the safety audit, tags/launchpad, age, and a single bounded
+ * `logoUrl` (from `icon`); drops social URLs, raw authority pubkeys, the open
+ * passthrough bag, APY, and raw provider sub-objects (`firstPool`, full stat
+ * blocks).
  */
 export interface ConciseJupiterToken {
   /** Mint address (Jupiter `id`). */
@@ -77,6 +79,8 @@ export interface ConciseJupiterToken {
   organicScore: number | null;
   organicScoreLabel: string | null;
   isVerified: boolean | null;
+  /** Bounded, https-only token logo URL (from `icon`); `null` when unsafe/absent. */
+  logoUrl: string | null;
   tags: string[] | null;
   launchpad: string | null;
   createdAt: string | null;
@@ -97,6 +101,35 @@ function numOrNull(value: number | null | undefined): number | null {
 /** Normalise an optional/nullable boolean off an external shape to `boolean | null`. */
 function boolOrNull(value: boolean | null | undefined): boolean | null {
   return typeof value === "boolean" ? value : null;
+}
+
+/** Max length of a surfaced logo URL — bounds the field against an oversized icon. */
+const MAX_LOGO_URL_LEN = 512;
+
+/**
+ * Normalise Jupiter's `icon` to a bounded, https-only logo URL the renderer can
+ * safely display. Returns `null` when the value is absent, non-https, carries a
+ * control char, or exceeds the length cap.
+ *
+ * The logic is duplicated (not imported from the renderer's `safeImgSrc`) on
+ * purpose: the engine and the untrusted renderer must not share a helper across
+ * the process boundary. The renderer re-validates every src independently, so
+ * this is a bounding/normalisation step, not the trust gate.
+ */
+function normalizeLogoUrl(icon: string | null | undefined): string | null {
+  if (typeof icon !== "string") return null;
+  const trimmed = icon.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_LOGO_URL_LEN) return null;
+  for (let i = 0; i < trimmed.length; i += 1) {
+    const code = trimmed.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) return null; // control chars
+  }
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "https:" ? url.href : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -144,11 +177,11 @@ function projectAudit(
  * Project a raw `JupiterMintInformation` to a concise, decision-relevant row.
  *
  * KEEP: mint/symbol/name/decimals, usdPrice, marketCap (`mcap`)/fdv, liquidity,
- * circ/total supply, holderCount, organicScore (+ label), isVerified, the audit
- * safety flags, tags, launchpad, createdAt, and a concise per-interval stats
- * subset.
+ * circ/total supply, holderCount, organicScore (+ label), isVerified, a bounded
+ * https-only `logoUrl` (from `icon`), the audit safety flags, tags, launchpad,
+ * createdAt, and a concise per-interval stats subset.
  *
- * DROP: icon, twitter/telegram/website/discord/instagram/tiktok/otherUrl, dev,
+ * DROP: twitter/telegram/website/discord/instagram/tiktok/otherUrl, dev,
  * raw mintAuthority/freezeAuthority pubkeys (the disabled-booleans carry the
  * signal), tokenProgram, partnerConfig, graduatedPool/graduatedAt, priceBlockId,
  * apy, the raw `firstPool` sub-object, the full stat blocks, updatedAt, and the
@@ -170,6 +203,7 @@ export function projectJupiterToken(token: JupiterMintInformation): ConciseJupit
     organicScore: numOrNull(token.organicScore),
     organicScoreLabel: typeof token.organicScoreLabel === "string" ? token.organicScoreLabel : null,
     isVerified: boolOrNull(token.isVerified),
+    logoUrl: normalizeLogoUrl(token.icon),
     tags: Array.isArray(token.tags) ? token.tags : null,
     launchpad: typeof token.launchpad === "string" ? token.launchpad : null,
     createdAt: typeof token.createdAt === "string" ? token.createdAt : null,

--- a/vex-app/scripts/check-build-artifacts.mjs
+++ b/vex-app/scripts/check-build-artifacts.mjs
@@ -5,7 +5,9 @@
  * Run after `pnpm build` (or in CI release workflow). Asserts:
  *   1. dist/main/index.js exists and matches package.json `main` field.
  *   2. dist/preload/index.cjs exists, is CJS, exposes contextBridge, NEVER raw ipcRenderer.
- *   3. dist/renderer/index.html has strict CSP — no `'unsafe-inline'`, no `'unsafe-eval'`.
+ *   3. dist/renderer/index.html has strict CSP — no `'unsafe-inline'`, no `'unsafe-eval'`,
+ *      and `script-src`/`connect-src` parse to EXACTLY `'self'` (img-src may widen
+ *      to `https:` for token logos — Option A2).
  *   4. dist/renderer/assets/*.js bundle has no `localStorage`/`sessionStorage`/`dangerouslySetInnerHTML`.
  *   5. Built CSP includes mandatory directives: default-src 'self', object-src 'none',
  *      base-uri 'none', frame-ancestors 'none', form-action 'none'.
@@ -137,6 +139,29 @@ check("renderer index.html CSP — no unsafe-inline / unsafe-eval", () => {
   for (const directive of required) {
     if (!csp.includes(directive)) {
       throw new Error(`CSP missing required directive: ${directive}`);
+    }
+  }
+
+  // Parse directives so the script/connect strictness check is exact — a
+  // substring scan would let `connect-src 'self' https://evil` slip past.
+  // Split on `;`, then split each directive into name + source tokens.
+  const directives = new Map();
+  for (const part of csp.split(";")) {
+    const tokens = part.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) continue;
+    directives.set(tokens[0], tokens.slice(1));
+  }
+  // script-src and connect-src must remain EXACTLY ['self']. img-src is
+  // allowed to widen (token logos: `'self' data: https:`) — not asserted here.
+  for (const name of ["script-src", "connect-src"]) {
+    const sources = directives.get(name);
+    if (!sources) {
+      throw new Error(`CSP missing required directive: ${name} 'self'`);
+    }
+    if (sources.length !== 1 || sources[0] !== "'self'") {
+      throw new Error(
+        `CSP ${name} must be exactly 'self' (found: ${name} ${sources.join(" ")})`
+      );
     }
   }
 });

--- a/vex-app/src/main/security/__tests__/url.test.ts
+++ b/vex-app/src/main/security/__tests__/url.test.ts
@@ -67,6 +67,8 @@ describe("isAllowedExternalUrl", () => {
     "releases.electronjs.org",
     "desktop.docker.com",
     "docs.docker.com",
+    "explorer.solana.com",
+    "dexscreener.com",
     { host: "github.com", pathPrefix: "/Vex-Foundation/" },
     { host: "github.com", pathPrefix: "/electron/electron/releases" },
     {
@@ -95,6 +97,8 @@ describe("isAllowedExternalUrl", () => {
     "https://github.com/Vex-Foundation/Vex/releases",
     "https://github.com/electron/electron/releases",
     "https://github.com/electron/electron/releases/tag/v42.0.0",
+    "https://dexscreener.com/solana/8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj",
+    "https://explorer.solana.com/tx/3xY2",
     "https://chromewebstore.google.com/detail/x-auth-helper/igpkhkjmpdecacocghpgkghdcmcmpfhp",
     "https://chromewebstore.google.com/detail/x-auth-helper/igpkhkjmpdecacocghpgkghdcmcmpfhp/reviews",
     "https://addons.mozilla.org/en-US/firefox/addon/rettiwt-auth-helper",
@@ -129,6 +133,11 @@ describe("isAllowedExternalUrl", () => {
     "https://docs.tavily.com/",
     "https://api.tavily.com/",
     "https://app.tavily.com.evil.com/",
+    // Solana explorer / DexScreener — exact-host pollution / near-miss deny
+    "https://dexscreener.com.evil.com/",
+    "https://notdexscreener.com/",
+    "https://explorer.solana.com.evil.com/",
+    "http://dexscreener.com/", // wrong scheme
     // Chrome Web Store — exact-extension path-boundary regression
     "https://chromewebstore.google.com/detail/x-auth-helper/igpkhkjmpdecacocghpgkghdcmcmpfhp-malicious",
     "https://chromewebstore.google.com/detail/x-auth-helper-clone/igpkhkjmpdecacocghpgkghdcmcmpfhp",

--- a/vex-app/src/main/windows/main-window.ts
+++ b/vex-app/src/main/windows/main-window.ts
@@ -56,6 +56,11 @@ const ALLOWED_EXTERNAL: ReadonlyArray<ExternalAllowEntry> = [
   "releases.electronjs.org",
   "desktop.docker.com",
   "docs.docker.com",
+  // Solana explorer + DexScreener: agent-surfaced token/tx links. Exact-host
+  // entries are safe — `isAllowedExternalUrl` matches `url.hostname === entry`,
+  // so `dexscreener.com.evil.com` / `notdexscreener.com` do not match.
+  "explorer.solana.com",
+  "dexscreener.com",
   // GitHub: restrict to Vex Foundation org + Electron releases (specific repos only)
   { host: "github.com", pathPrefix: "/Vex-Foundation/" },
   { host: "github.com", pathPrefix: "/electron/electron/releases" },
@@ -75,6 +80,27 @@ const ALLOWED_EXTERNAL: ReadonlyArray<ExternalAllowEntry> = [
 
 function checkExternalUrl(raw: string): boolean {
   return isAllowedExternalUrl(raw, ALLOWED_EXTERNAL);
+}
+
+/** Max length of a sanitized URL emitted to the log. */
+const SANITIZED_URL_MAX_LEN = 200;
+
+/**
+ * Reduce a URL to `scheme//host/pathname` for logging, dropping `search` and
+ * `hash`. Denied URLs may carry secrets in the query string (e.g.
+ * `?token=…`), so the raw URL must NEVER reach the log. A non-parseable input
+ * returns the literal `"[unparseable-url]"` rather than echoing the raw value.
+ */
+function sanitizeUrlForLog(raw: string): string {
+  try {
+    const url = new URL(raw);
+    const sanitized = `${url.protocol}//${url.host}${url.pathname}`;
+    return sanitized.length > SANITIZED_URL_MAX_LEN
+      ? `${sanitized.slice(0, SANITIZED_URL_MAX_LEN)}…`
+      : sanitized;
+  } catch {
+    return "[unparseable-url]";
+  }
 }
 
 function isAllowedAppUrl(raw: string): boolean {
@@ -179,6 +205,8 @@ export async function createMainWindow(): Promise<BrowserWindow> {
   win.webContents.setWindowOpenHandler(({ url }) => {
     if (checkExternalUrl(url)) {
       void shell.openExternal(url);
+    } else {
+      log.warn(`[window] blocked window.open to ${sanitizeUrlForLog(url)}`);
     }
     return { action: "deny" };
   });
@@ -189,6 +217,8 @@ export async function createMainWindow(): Promise<BrowserWindow> {
       event.preventDefault();
       if (checkExternalUrl(url)) {
         void shell.openExternal(url);
+      } else {
+        log.warn(`[window] blocked navigation to ${sanitizeUrlForLog(url)}`);
       }
     }
   });

--- a/vex-app/src/main/windows/main-window.ts
+++ b/vex-app/src/main/windows/main-window.ts
@@ -64,9 +64,13 @@ const ALLOWED_EXTERNAL: ReadonlyArray<ExternalAllowEntry> = [
   // GitHub: restrict to Vex Foundation org + Electron releases (specific repos only)
   { host: "github.com", pathPrefix: "/Vex-Foundation/" },
   { host: "github.com", pathPrefix: "/electron/electron/releases" },
-  // Rettiwt extension stores — exact extension URLs only. Path-boundary
-  // in `pathStartsWithBoundary` keeps `-malicious`/`-clone` suffixes out.
-  // Chrome ext ID from Rettiwt-API-dev/README.md (X Auth Helper).
+  // Rettiwt = the privacy-respecting Twitter/X API client the agent uses for
+  // authenticated timeline/tweet reads (src/tools/twitter-account). Its
+  // "X Auth Helper" browser extensions let a user mint a Rettiwt API key from
+  // their own logged-in X session — no cookie/password is handed to Vex — so
+  // these two store URLs are allow-listed to open externally. Exact extension
+  // URLs only: path-boundary matching in `pathStartsWithBoundary` blocks
+  // `-malicious`/`-clone` lookalike suffixes on the same store host.
   {
     host: "chromewebstore.google.com",
     pathPrefix:

--- a/vex-app/src/renderer/index.html
+++ b/vex-app/src/renderer/index.html
@@ -3,9 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      img-src is intentionally widened to `https:` so agent-surfaced token
+      logos render (Option A2). script-src / connect-src stay strict 'self' —
+      images cannot execute or exfiltrate via these directives, and the build
+      gate (scripts/check-build-artifacts.mjs) asserts that invariant.
+    -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
     />
     <title>Vex</title>
   </head>

--- a/vex-app/src/renderer/lib/markdown/MarkdownContent.tsx
+++ b/vex-app/src/renderer/lib/markdown/MarkdownContent.tsx
@@ -10,7 +10,11 @@
  *   - links: absolute `https:` only (`safeHref`); anything else renders as
  *     plain text. Allowed links get `target="_blank" rel="noopener noreferrer"`
  *     and main's `shell.openExternal` allowlist stays the final gate;
- *   - images render as ALT TEXT only — never an `<img>` (no remote fetch);
+ *   - images: a `safeImgSrc`-validated https source renders as a hardened
+ *     raw-remote `<img>` (no-referrer, lazy, CSS-bounded, alt-text fallback on
+ *     error) — the deliberate Option-A2 token-logo decision; anything else
+ *     (non-https, credentialed, localhost/private host, control chars) falls
+ *     back to ALT TEXT only;
  *   - GFM tables + task lists render as semantic elements (cells/items go
  *     through the same escaped-React-text path — no HTML sink);
  *   - raw-HTML and any still-unsupported tokens render as escaped text;
@@ -43,6 +47,70 @@ export function safeHref(href: string): string | null {
   try {
     const url = new URL(trimmed); // throws on relative (no base)
     return url.protocol === "https:" ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when a hostname targets the local machine or a private/link-local
+ * network — an SSRF-style surface even for a bare <img> fetch. Blocks
+ * `localhost`, any `*.local`, IPv4 loopback/private/link-local ranges, and the
+ * IPv6 loopback / unique-local (fc00::/7) / link-local (fe80::/10) ranges.
+ *
+ * URL normalizes IPv6 hosts to bracketed lowercase (`[::1]`), so we strip the
+ * brackets before range-testing.
+ */
+function isLocalOrPrivateHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (host === "localhost" || host.endsWith(".local")) return true;
+
+  // IPv4 dotted-quad ranges: 127/8, 10/8, 172.16/12, 192.168/16, 169.254/16.
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (ipv4 !== null) {
+    const a = Number(ipv4[1]);
+    const b = Number(ipv4[2]);
+    if (a === 127) return true; // loopback 127.0.0.0/8
+    if (a === 10) return true; // private 10.0.0.0/8
+    if (a === 172 && b >= 16 && b <= 31) return true; // private 172.16.0.0/12
+    if (a === 192 && b === 168) return true; // private 192.168.0.0/16
+    if (a === 169 && b === 254) return true; // link-local 169.254.0.0/16
+    return false;
+  }
+
+  // IPv6 (URL keeps brackets: `[::1]`). Strip them, then range-test.
+  if (host.startsWith("[") && host.endsWith("]")) {
+    const v6 = host.slice(1, -1);
+    if (v6 === "::1") return true; // loopback ::1
+    // IPv4-mapped IPv6 (`::ffff:7f00:1` = 127.0.0.1). URL normalizes mapped
+    // forms to this compressed prefix, so a single startsWith closes the
+    // mapped-loopback/private bypass without re-parsing the embedded IPv4.
+    if (v6.startsWith("::ffff:")) return true;
+    if (/^f[cd][0-9a-f]{0,2}:/.test(v6)) return true; // unique-local fc00::/7
+    if (/^fe[89ab][0-9a-f]?:/.test(v6)) return true; // link-local fe80::/10
+    return false;
+  }
+
+  return false;
+}
+
+/**
+ * Allow only an absolute `https:` image URL with NO embedded credentials and a
+ * host that is not localhost/loopback/private/link-local. Otherwise null (the
+ * caller falls back to alt text). This is the Option-A2 gate: token logos are
+ * fetched raw from arbitrary https hosts.
+ */
+export function safeImgSrc(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (hasControlChars(trimmed)) return null;
+  if (trimmed.startsWith("//")) return null; // protocol-relative
+  try {
+    const url = new URL(trimmed); // throws on relative (no base)
+    if (url.protocol !== "https:") return null;
+    if (url.username !== "" || url.password !== "") return null; // no creds
+    if (isLocalOrPrivateHost(url.hostname)) return null;
+    return url.href;
   } catch {
     return null;
   }
@@ -107,9 +175,23 @@ function renderInline(tokens: readonly Token[] | undefined): ReactNode[] {
           <span key={i}>{children}</span>
         );
       }
-      case "image":
-        // Alt text only — never an <img> (no remote fetch / tracking pixel).
-        return <span key={i}>{token.text}</span>;
+      case "image": {
+        // Option A2: render a hardened raw-remote <img> when the source passes
+        // `safeImgSrc` (https-only, no creds, no localhost/private host).
+        // Residual risk: an arbitrary https host serving the image learns the
+        // client IP and a load timestamp (tracking-pixel surface); mitigated
+        // by `referrerPolicy="no-referrer"` (no URL/path leakage) but not
+        // eliminated. DNS-rebinding is an accepted residual under Option A.
+        // This is the deliberate product decision — see the C2 plan.
+        const safe = safeImgSrc(token.href);
+        const alt = token.text ?? "";
+        return safe !== null ? (
+          <MarkdownImage key={i} src={safe} alt={alt} />
+        ) : (
+          // Source rejected → keep the original alt-text-only behavior.
+          <span key={i}>{token.text}</span>
+        );
+      }
       default:
         // Raw HTML + anything unsupported → escaped text node.
         return <span key={i}>{tokenText(token)}</span>;
@@ -260,6 +342,35 @@ function renderBlocks(tokens: readonly Token[]): ReactNode[] {
 function codeLang(raw: string | undefined): string {
   const first = raw?.trim().split(/\s+/)[0];
   return first !== undefined && first.length > 0 ? first : "code";
+}
+
+/**
+ * Hardened token-logo image (Option A2). The src is pre-validated by
+ * `safeImgSrc`. `referrerPolicy="no-referrer"` keeps the URL/path off the
+ * wire; size is CSS-bounded so a hostile dimension can't blow out the layout.
+ * On a load error we drop back to the alt text rather than showing a broken
+ * image glyph.
+ */
+function MarkdownImage({
+  src,
+  alt,
+}: {
+  readonly src: string;
+  readonly alt: string;
+}): JSX.Element {
+  const [failed, setFailed] = useState(false);
+  if (failed) return <span>{alt}</span>;
+  return (
+    <img
+      src={src}
+      alt={alt}
+      referrerPolicy="no-referrer"
+      loading="lazy"
+      decoding="async"
+      onError={() => setFailed(true)}
+      className="inline-block max-h-[5rem] max-w-[5rem] rounded-[4px] align-text-bottom"
+    />
+  );
 }
 
 const COPY_RESET_MS = 1_500;

--- a/vex-app/src/renderer/lib/markdown/__tests__/MarkdownContent.test.tsx
+++ b/vex-app/src/renderer/lib/markdown/__tests__/MarkdownContent.test.tsx
@@ -7,7 +7,7 @@
 import { describe, expect, it } from "vitest";
 import { render } from "@testing-library/react";
 import { createElement } from "react";
-import { MarkdownContent, safeHref } from "../MarkdownContent.js";
+import { MarkdownContent, safeHref, safeImgSrc } from "../MarkdownContent.js";
 
 function renderMd(text: string) {
   return render(createElement(MarkdownContent, { text }));
@@ -31,6 +31,40 @@ describe("safeHref", () => {
     expect(safeHref("//protocol-relative.example")).toBeNull();
     expect(safeHref("   ")).toBeNull();
     expect(safeHref(`https://e${NUL}.com`)).toBeNull();
+  });
+});
+
+describe("safeImgSrc", () => {
+  it("allows an absolute https URL", () => {
+    expect(safeImgSrc("https://cdn.example/logo.png")).toBe(
+      "https://cdn.example/logo.png",
+    );
+  });
+
+  it("rejects every non-https / unsafe form", () => {
+    expect(safeImgSrc("http://cdn.example/a.png")).toBeNull();
+    expect(safeImgSrc("javascript:alert(1)")).toBeNull();
+    expect(safeImgSrc("data:image/png;base64,AAAA")).toBeNull();
+    expect(safeImgSrc("//cdn.example/a.png")).toBeNull(); // protocol-relative
+    expect(safeImgSrc("https://user:pass@cdn.example/a.png")).toBeNull(); // creds
+    expect(safeImgSrc("   ")).toBeNull();
+    expect(safeImgSrc(`https://e${NUL}.com/a.png`)).toBeNull(); // control char
+  });
+
+  it("rejects localhost / loopback / private / link-local hosts", () => {
+    expect(safeImgSrc("https://localhost/a.png")).toBeNull();
+    expect(safeImgSrc("https://printer.local/a.png")).toBeNull();
+    expect(safeImgSrc("https://127.0.0.1/a.png")).toBeNull();
+    expect(safeImgSrc("https://10.1.2.3/a.png")).toBeNull();
+    expect(safeImgSrc("https://172.16.0.1/a.png")).toBeNull();
+    expect(safeImgSrc("https://192.168.1.1/a.png")).toBeNull();
+    expect(safeImgSrc("https://169.254.1.1/a.png")).toBeNull();
+    expect(safeImgSrc("https://[::1]/a.png")).toBeNull();
+    expect(safeImgSrc("https://[fc00::1]/a.png")).toBeNull();
+    expect(safeImgSrc("https://[fe80::1]/a.png")).toBeNull();
+    expect(safeImgSrc("https://[::ffff:127.0.0.1]/a.png")).toBeNull(); // IPv4-mapped IPv6
+    // A public IP / host is still allowed.
+    expect(safeImgSrc("https://8.8.8.8/a.png")).toBe("https://8.8.8.8/a.png");
   });
 });
 
@@ -74,10 +108,33 @@ describe("MarkdownContent", () => {
     expect(container.textContent).toContain('onerror="alert(1)"');
   });
 
-  it("renders image markdown as alt text only (no img element)", () => {
+  it("renders an https image as a hardened no-referrer <img>", () => {
     const { container } = renderMd("![the alt](https://a.b/c.png)");
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("https://a.b/c.png");
+    expect(img?.getAttribute("referrerpolicy")).toBe("no-referrer");
+    expect(img?.getAttribute("loading")).toBe("lazy");
+    expect(img?.getAttribute("decoding")).toBe("async");
+    expect(img?.getAttribute("alt")).toBe("the alt");
+  });
+
+  it("falls back to alt text (no <img>) for every unsafe image source", () => {
+    const cases = [
+      "![a](http://a.b/c.png)", // wrong scheme
+      "![b](javascript:alert(1))",
+      "![c](//a.b/c.png)", // protocol-relative
+      "![d](https://u:p@a.b/c.png)", // embedded credentials
+      "![e](https://localhost/c.png)", // localhost
+    ];
+    for (const md of cases) {
+      const { container } = renderMd(md);
+      expect(container.querySelector("img")).toBeNull();
+    }
+    // A control-char source: build the markdown with an embedded NUL.
+    const { container } = renderMd(`![f](https://a${NUL}.b/c.png)`);
     expect(container.querySelector("img")).toBeNull();
-    expect(container.textContent).toContain("the alt");
+    expect(container.textContent).toContain("f");
   });
 
   it("renders a GFM table as a semantic <table> with header + body cells", () => {

--- a/vex-app/vite.renderer.config.ts
+++ b/vex-app/vite.renderer.config.ts
@@ -33,7 +33,10 @@ function devCspRelaxer(isDev: boolean): Plugin {
     "default-src 'self'",
     "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
     "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' data:",
+    // img-src intentionally widened to https: for agent-surfaced token logos
+    // (Option A2). script-src/connect-src stay strict — kept in sync with the
+    // prod CSP in src/renderer/index.html.
+    "img-src 'self' data: https:",
     "font-src 'self'",
     "connect-src 'self' ws://127.0.0.1:5173 http://127.0.0.1:5173",
     "object-src 'none'",


### PR DESCRIPTION
## Summary
Seven independently Codex-gated, locally-verified commits (UX + safety + agent output). Each went through a plan-review gate → implementation (opus) → final-review gate; `tsc` + focused vitest are green on both the root engine and `vex-app`, plus an at-risk sweep (286 tests) over the projector / discovery / tool-output-overflow surface.

### Renderer markdown affordances (token logos + clickable links)
- `7bd6b2e` allow `explorer.solana.com` + `dexscreener.com` external links; sanitized deny-logging (`scheme//host/path` only — never the raw URL/query).
- `44d9253` render a hardened raw-remote `<img>` for token logos. **Security: CSP `img-src` widened to `https:` (Option A2)** — `script-src`/`connect-src` stay strict `'self'` (a build gate asserts this by parsing directives). Images are https-only, no embedded creds, and reject localhost/loopback/private/link-local + IPv4-mapped-IPv6 hosts, with `referrerPolicy="no-referrer"` and `onError`→alt-text fallback.
- `66dead0` re-surface a single bounded `logoUrl` (https-only, length-capped) in the concise Jupiter token projection.
- `9ef6159` prompt: the agent may embed a token logo image **only** from a tool-returned `logoUrl`/`imageUrl` (never invented), plus clickable explorer/dexscreener links.

### Engine fixes
- `962da42` honor **Stop during mission setup**: thread the abort signal into the setup turn-loop (iteration boundary + in-flight inference), gate patch-apply + the not-ready notice on `user_stopped`, and return the real `stopReason`. Adds a setup timing log to localize the prior 15–100s delay.
- `1e19a60` exempt `solana.predict.closeAll` items from the `instrumentKey` requirement (claim-within-closeAll items match via `positionKey`) so valid fills reach `proj_activity` (the Moves feed).
- `ea75c77` self-contained Rettiwt extension-allowlist provenance comment (docs only).

## Verification
- root `tsc --noEmit` ✅ · `vex-app` lint (tsc shared+e2e + process-boundary check) ✅
- focused vitest per change ✅ · at-risk sweep (jupiter projector/manifest/handlers, discovery-golden, protocol-discovery, tool-output-overflow, tool-output-read, prompts): **286 passed** ✅
- CI runs the full suite + build.

## Risk notes
- The A2 CSP relaxation is a deliberate product decision (raw remote token-logo images). Residual = tracking-pixel (client IP + load timing), mitigated by `no-referrer`; no script/fetch channel is widened and the build gate locks `script-src`/`connect-src` to `'self'`.
- The `closeAll` instrumentKey exception is tool-level; a negative test confirms it does not relax `positionKey`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
