### PR TITLE
fix(wizard): navigate after Finalize + optional connections with alerts

### DIFF
--- a/vex-app/src/main/onboarding/__tests__/finalize.test.ts
+++ b/vex-app/src/main/onboarding/__tests__/finalize.test.ts
@@ -121,7 +121,9 @@ describe("completeSetup", () => {
     expect(mockInitSentry).not.toHaveBeenCalled();
   });
 
-  it("validation.invalid_input when prior steps incomplete", async () => {
+  it("validation.invalid_input when the master password is missing", async () => {
+    // Master password is the ONLY hard finalize requirement (optional-
+    // connections model). Absent it, finalize must reject.
     mockGatherEnvState.mockResolvedValue({
       ...(fullEnvState() as Record<string, unknown>),
       hasKeystorePassword: false,
@@ -131,6 +133,41 @@ describe("completeSetup", () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected err");
     expect(result.error.code).toBe("validation.invalid_input");
+  });
+
+  it("SUCCEEDS with master password present but all four connections unconfigured", async () => {
+    // Optional-connections model: wallets, API keys, embeddings, and the
+    // inference provider may all be deferred to in-app Settings. As long
+    // as the master password exists, finalize must complete.
+    mockGatherEnvState.mockResolvedValue({
+      ...(fullEnvState() as Record<string, unknown>),
+      hasKeystorePassword: true,
+      hasJupiterApiKey: false,
+      apiKeys: {
+        jupiterConfigured: false,
+        tavilyConfigured: false,
+        rettiwtConfigured: false,
+        polymarketStatus: "missing",
+      },
+      embeddings: {
+        configured: false,
+        reachable: false,
+        baseUrlRedacted: null,
+        allFieldsConfigured: false,
+        dbReachable: null,
+      },
+      walletStatus: { evm: "missing", solana: "missing" },
+      walletAddresses: { evm: null, solana: null },
+      provider: { configured: false, name: null, modelLabel: null },
+    });
+    mockAutoBackup.mockResolvedValue(null);
+    mockWizardUpdate.mockResolvedValue({ ok: true });
+
+    const result = await completeSetup({ telemetryConsent: false });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.backupPath).toBeNull();
+    expect(mockWizardUpdate).toHaveBeenCalledTimes(1);
   });
 
   it("autoBackup throws: returns onboarding.step_failed step=auto_backup", async () => {

--- a/vex-app/src/main/onboarding/finalize.ts
+++ b/vex-app/src/main/onboarding/finalize.ts
@@ -3,9 +3,13 @@
  *
  * Sequenced execution with explicit failure contract (codex v3 D10):
  *
- *   1. Validate envState — defensive; renderer is supposed to gate
- *      Review behind every prior step but a hand-crafted wizard-state
- *      file could land here without provider/wallets/etc.
+ *   1. Validate envState — the four infrastructure connections (wallets,
+ *      API keys, embeddings, provider) are OPTIONAL (configure later in
+ *      Settings); the ONLY hard requirement is the master password. This
+ *      check is defensive: the renderer lets the operator advance past
+ *      unconfigured connections with a consequence alert, but a master
+ *      password must exist before we can encrypt keystores / unlock the
+ *      vault, so a hand-crafted wizard-state file is still rejected here.
  *   2. autoBackup() (engine bridge `@vex-lib/wallet-backup`). Throws
  *      VexError(AUTO_BACKUP_FAILED) on fs failure → mapped to
  *      onboarding.step_failed step:auto_backup. backupPath is
@@ -77,25 +81,18 @@ interface IncompleteItem {
   readonly reason: string;
 }
 
+// Optional-connections model: the four infrastructure connections
+// (wallets, API keys, embeddings, inference provider) are OPTIONAL — the
+// operator can configure them later from in-app Settings. The wizard
+// steps let the user advance past them with a consequence alert. The
+// ONLY hard requirement at finalize is the master password, because it
+// is what encrypts every wallet keystore and gates the local vault.
+// Keeping the server as the hard authority means a hand-crafted
+// wizard-state.json still cannot finalize without a master password.
 function listMissingItems(envState: EnvState): IncompleteItem[] {
   const missing: IncompleteItem[] = [];
   if (!envState.hasKeystorePassword) {
     missing.push({ section: "keystore", reason: "Master password not set." });
-  }
-  if (envState.walletStatus.evm !== "present") {
-    missing.push({ section: "wallets", reason: "EVM wallet not configured." });
-  }
-  if (envState.walletStatus.solana !== "present") {
-    missing.push({ section: "wallets", reason: "Solana wallet not configured." });
-  }
-  if (!envState.apiKeys.jupiterConfigured) {
-    missing.push({ section: "apiKeys", reason: "Jupiter API key required." });
-  }
-  if (!envState.embeddings.allFieldsConfigured) {
-    missing.push({ section: "embedding", reason: "Embedding configuration incomplete." });
-  }
-  if (!envState.provider.configured) {
-    missing.push({ section: "provider", reason: "Inference provider not configured." });
   }
   return missing;
 }
@@ -104,7 +101,8 @@ function buildValidationError(missing: IncompleteItem[]): VexError {
   return {
     code: "validation.invalid_input",
     domain: "onboarding",
-    message: "Setup is incomplete — finish every prior step before finalizing.",
+    message:
+      "Setup cannot be finalized without a master password — it encrypts your wallet keystores and unlocks the local vault.",
     retryable: false,
     userActionable: true,
     redacted: true,

--- a/vex-app/src/renderer/features/wizard/WizardShell.tsx
+++ b/vex-app/src/renderer/features/wizard/WizardShell.tsx
@@ -29,7 +29,11 @@
  *
  * If `completed === true` (Review finalised on a previous launch) we
  * flip the view to `appShell` immediately unless the app shell opened
- * the wizard in reconfiguration mode.
+ * the wizard in reconfiguration mode. Two effects own this routing: the
+ * one-time init effect handles first-mount (relaunch into a completed
+ * setup), and a dedicated COMPLETION WATCHER handles the in-session flip
+ * after Finalize succeeds on Review (where `currentStepId` is already
+ * non-null, so the init effect's guard skips it).
  */
 
 import { useCallback, useEffect, useState, type JSX } from "react";
@@ -184,6 +188,45 @@ export function WizardShell(): JSX.Element {
         return;
       }
       setCurrentStepId(persisted.currentStepId);
+    };
+    void route();
+    return () => {
+      cancelled = true;
+    };
+  }, [persisted, currentStepId, setCurrentView, wizardEntryMode, openUnlock]);
+
+  // Completion watcher. The init effect above owns first-mount routing
+  // and early-returns once `currentStepId !== null`, so it never re-runs
+  // the completed-routing after the wizard is mounted. When Finalize
+  // succeeds the wizardState query refetches with `completed: true` while
+  // the user is still parked on Review (`currentStepId === "review"`);
+  // this effect performs the SAME completed-routing as the init effect so
+  // the shell actually flips to the app shell. It guards on
+  // `currentStepId !== null` (the init effect owns first-mount; this
+  // avoids a relaunch double-fire) and on `persisted.completed` (only
+  // fires after a real completion). Reconfigure mode is skipped so a
+  // settings-editor reviewing infrastructure is not bounced out of Review.
+  useEffect(() => {
+    if (persisted === null || currentStepId === null || !persisted.completed) {
+      return;
+    }
+    if (wizardEntryMode === "reconfigure") return;
+    let cancelled = false;
+    const route = async (): Promise<void> => {
+      const status = await window.vex.secrets.status();
+      if (cancelled) return;
+      const vaultConfigured = status.ok ? status.data.vaultConfigured : false;
+      const unlocked = status.ok ? status.data.unlocked : false;
+
+      if (vaultConfigured && !unlocked) {
+        openUnlock("appShell");
+        return;
+      }
+      if (!vaultConfigured) {
+        setCurrentStepId("keystore");
+        return;
+      }
+      setCurrentView("appShell");
     };
     void route();
     return () => {

--- a/vex-app/src/renderer/features/wizard/__tests__/WizardShell.test.tsx
+++ b/vex-app/src/renderer/features/wizard/__tests__/WizardShell.test.tsx
@@ -365,6 +365,109 @@ describe("WizardShell", () => {
     );
   });
 
+  // ── Completion watcher (Finalize-on-Review in-session flip) ────────
+  //
+  // Reproduces the stuck-on-Review bug: the wizard mounts on Review with
+  // `completed: false`, then the wizardState query refetches `completed:
+  // true` (Finalize succeeded). The init effect early-returns because
+  // `currentStepId === "review"` is non-null, so the dedicated COMPLETION
+  // WATCHER effect must perform the completed-routing.
+  function reviewState(completed: boolean): Result<WizardState> {
+    return {
+      ok: true,
+      data: {
+        schemaVersion: 2,
+        currentStepId: "review",
+        completedSteps: [
+          "keystore",
+          "wallets",
+          "apiKeys",
+          "embedding",
+          "agentCore",
+          "provider",
+        ],
+        completed,
+      },
+    };
+  }
+
+  interface SecretsStatusData {
+    readonly vaultConfigured: boolean;
+    readonly unlocked: boolean;
+  }
+
+  /**
+   * Mount on Review (incomplete) with an UNLOCKED vault so the init
+   * effect cleanly sets `currentStepId === "review"` (a locked vault on
+   * an incomplete non-keystore step would divert to openUnlock("wizard")
+   * and never render Review). Wait for ReviewStep, then optionally swap
+   * the secrets status to `completeStatus` and flip the query result to
+   * `completed: true` + re-render — exactly what `useCompleteSetup`'s
+   * wizardState invalidation produces. The watcher effect re-fires with
+   * the post-finalize status. Returns the render handle.
+   */
+  async function renderReviewThenCompleteReturning(
+    completeStatus?: SecretsStatusData,
+  ): Promise<ReturnType<typeof renderWithQuery>> {
+    mockUseWizardState.mockReturnValue(makeQueryResult(reviewState(false)));
+    const handle = renderWithQuery(<WizardShell />);
+    await handle.findByTestId("review-step");
+    if (completeStatus) {
+      mockSecretsStatus.mockResolvedValue({ ok: true, data: completeStatus });
+    }
+    // Only the mocked query result flips; `rerender` re-runs the tree so
+    // the watcher effect re-fires now that `completed === true`.
+    mockUseWizardState.mockReturnValue(makeQueryResult(reviewState(true)));
+    handle.rerender(<WizardShell />);
+    return handle;
+  }
+
+  it("(a) completion watcher: flips to appShell when completed flips true while on Review (vault unlocked)", async () => {
+    // Default mockSecretsStatus = vaultConfigured:true, unlocked:true.
+    await renderReviewThenCompleteReturning();
+    await waitFor(() => {
+      expect(mockSetCurrentView).toHaveBeenCalledWith("appShell");
+    });
+  });
+
+  it("(b) completion watcher: does NOT flip to appShell in reconfigure mode", async () => {
+    mockWizardEntryMode = "reconfigure";
+    // In reconfigure mode the init effect parks on Review and the watcher
+    // must skip. Mount directly completed — the watcher must not fire.
+    mockUseWizardState.mockReturnValue(makeQueryResult(reviewState(true)));
+    const { findByTestId } = renderWithQuery(<WizardShell />);
+    await findByTestId("review-step");
+    // Give any pending async route() a tick to settle.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockSetCurrentView).not.toHaveBeenCalledWith("appShell");
+  });
+
+  it("(c) SECURITY: completion watcher opens unlock (not appShell) when vault is locked", async () => {
+    // Vault was unlocked while editing; it relocks by the time Finalize
+    // lands (e.g. an idle lock). The watcher must route to unlock, not
+    // straight into the app shell.
+    await renderReviewThenCompleteReturning({
+      vaultConfigured: true,
+      unlocked: false,
+    });
+    await waitFor(() => {
+      expect(mockOpenUnlock).toHaveBeenCalledWith("appShell");
+    });
+    expect(mockSetCurrentView).not.toHaveBeenCalledWith("appShell");
+  });
+
+  it("(d) SECURITY: completion watcher routes to keystore (not appShell) when vault is not configured", async () => {
+    const { findByTestId } = await renderReviewThenCompleteReturning({
+      vaultConfigured: false,
+      unlocked: false,
+    });
+    // Vault not configured → watcher re-routes to keystore via local step
+    // state; the keystore step renders and the app shell is never opened.
+    await findByTestId("keystore-step");
+    expect(mockOpenUnlock).not.toHaveBeenCalledWith("appShell");
+    expect(mockSetCurrentView).not.toHaveBeenCalledWith("appShell");
+  });
+
   it("renders the error shell when the query returns ok:false", async () => {
     mockUseWizardState.mockReturnValue(
       makeQueryResult(

--- a/vex-app/src/renderer/features/wizard/steps/ApiKeysStep.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/ApiKeysStep.tsx
@@ -14,10 +14,18 @@
  * still accepts `polymarket` for potential programmatic callers — that
  * surface lives at the boundary, not in the UI.
  *
+ * Optional-connections model: API keys are OPTIONAL. Jupiter is needed
+ * to swap tokens on Solana, but the operator may defer it (and the rest)
+ * to in-app Settings. Nothing on this step BLOCKS advancement anymore —
+ * we warn and let the user continue.
+ *
  * Skip-card semantics (codex turn 1 D3 + feature #7 Q5):
- *   - Step 3 is "configured" iff JUPITER_API_KEY is set AND the
- *     Polymarket status is NOT "partial". Partial blocks the skip and
- *     surfaces a warning callout above the Polymarket card.
+ *   - The skip-card ("API keys already configured") is only the right
+ *     copy when JUPITER_API_KEY is already set; otherwise the form shows
+ *     with a non-blocking warning alert and the user advances via "Skip
+ *     optional" / "Save and continue". A partial Polymarket no longer
+ *     blocks the skip — it surfaces a warning callout above the
+ *     Polymarket card but the user can continue.
  *   - Skip-card is ONLY shown in `first-pass` flow mode. In `back-edit`
  *     mode (user clicked Edit from Review) we always render the full
  *     form so they can change anything.
@@ -69,8 +77,8 @@ export interface ApiKeysStepProps {
   readonly flowMode: WizardFlowMode;
 }
 
-const POLYMARKET_PARTIAL_MESSAGE =
-  "Polymarket has only some credentials saved. Use auto-configure to repair before continuing.";
+const JUPITER_MISSING_WARNING =
+  "Jupiter is required to swap tokens on Solana — without it Solana swaps are unavailable; you can add it later in Settings.";
 
 export function ApiKeysStep({
   completedSteps,
@@ -110,7 +118,12 @@ export function ApiKeysStep({
   const vaultUnlocked = envState?.secrets.unlocked ?? false;
   // Feature #7 Q5: back-edit ALWAYS renders the full form. In setup
   // mode the skip-card stays available unless the operator clicked the
-  // "Configure Polymarket now" CTA (skipExpanded === true).
+  // "Configure Polymarket now" CTA (skipExpanded === true). The skip-card
+  // copy assumes Jupiter is already configured, so it only shows when
+  // `jupiterConfigured`. A partial Polymarket keeps the user on the FORM
+  // so the partial warning callout stays visible — but, per the
+  // optional-connections model, it no longer BLOCKS advancing (the
+  // submit/skip handlers warn-but-advance regardless).
   const canSkip =
     flowMode === "first-pass"
     && jupiterConfigured
@@ -134,18 +147,13 @@ export function ApiKeysStep({
       e.preventDefault();
       setFormError(null);
       const payload = buildPayload(refs);
-      // Same required-state guards as the Skip button (codex DRIFT
-      // turn 9): empty Save when Jupiter is not yet configured must
-      // not advance; partial Polymarket in env requires auto-setup
-      // repair before continuing (manual repair path is gone).
-      if (!jupiterConfigured && payload.jupiterApiKey === undefined) {
-        setFormError(
-          "Jupiter API key is required for Solana trading. Enter it before continuing.",
-        );
-        return;
-      }
-      if (polymarketPartial) {
-        setFormError(POLYMARKET_PARTIAL_MESSAGE);
+      // Optional-connections model: API keys never block advancement.
+      // An empty Save with Jupiter unconfigured still advances (the
+      // missing-Jupiter warning alert is always visible). A partial
+      // Polymarket likewise warns (callout above its card) but does not
+      // block — if nothing was entered, skip the IPC and just advance.
+      if (Object.keys(payload).length === 0) {
+        await advanceToEmbedding();
         return;
       }
       // Snapshot the payload, clear the inputs SYNCHRONOUSLY before
@@ -165,29 +173,15 @@ export function ApiKeysStep({
         setSubmitting(false);
       }
     },
-    [
-      advanceToEmbedding,
-      invalidateEnvState,
-      refs,
-      jupiterConfigured,
-      polymarketPartial,
-    ],
+    [advanceToEmbedding, invalidateEnvState, refs],
   );
 
   const onSkipContinue = useCallback(async () => {
+    // Optional-connections model: skipping never blocks — Jupiter and
+    // Polymarket warnings are surfaced visually but the user advances.
     setFormError(null);
-    if (!jupiterConfigured && !submittedOnce) {
-      setFormError(
-        "Jupiter API key is required for Solana trading. Enter it before skipping the optional ones.",
-      );
-      return;
-    }
-    if (polymarketPartial) {
-      setFormError(POLYMARKET_PARTIAL_MESSAGE);
-      return;
-    }
     await advanceToEmbedding();
-  }, [advanceToEmbedding, jupiterConfigured, polymarketPartial, submittedOnce]);
+  }, [advanceToEmbedding]);
 
   const meta = WIZARD_STEP_META.apiKeys;
 
@@ -214,7 +208,7 @@ export function ApiKeysStep({
       panelDataAttr={{ kind: "apikeys", value: "form" }}
       icon={meta.icon}
       title="Connect your API keys"
-      description="Jupiter is required for Solana trading. The optional keys (Tavily, Rettiwt, Polymarket) unlock specific tools later. Keys are stored on this machine in your local config and sent only to the matching provider when you invoke a tool that needs them."
+      description="All API keys are optional — you can add them later in Settings. Jupiter powers Solana swaps; the others (Tavily, Rettiwt, Polymarket) unlock specific tools later. Keys are stored on this machine in your local config and sent only to the matching provider when you invoke a tool that needs them."
       formProps={{
         onSubmit: (e) => {
           void onSubmit(e);
@@ -233,6 +227,15 @@ export function ApiKeysStep({
       }
     >
       <div className="flex flex-col gap-4">
+        {!jupiterConfigured ? (
+          <p
+            role="status"
+            data-vex-apikeys-warning="jupiter-missing"
+            className="rounded-md border border-[color-mix(in_oklab,var(--color-warning)_40%,transparent)] bg-[color-mix(in_oklab,var(--color-warning)_10%,transparent)] px-3 py-2 text-sm text-[var(--color-warning)]"
+          >
+            {JUPITER_MISSING_WARNING}
+          </p>
+        ) : null}
         <JupiterCard
           status={statusFor(jupiterConfigured)}
           configured={jupiterConfigured}

--- a/vex-app/src/renderer/features/wizard/steps/EmbeddingStep.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/EmbeddingStep.tsx
@@ -154,6 +154,11 @@ export function EmbeddingStep({
 
   const isDimLocked = serverError?.code === "embedding.dim_locked";
   const isDbDown = serverError?.code === "embedding.db_unavailable";
+  // Embeddings are OPTIONAL (configure later in Settings). In the forward
+  // setup flow we let the operator advance without configuring an
+  // endpoint, surfacing a consequence alert (no memory / semantic search
+  // until it's set up). back-edit keeps the save-only footer.
+  const showConfigureLater = flowMode === "first-pass";
 
   return (
     <WizardStepPanel
@@ -162,9 +167,10 @@ export function EmbeddingStep({
       title="Embedding configuration"
       description={
         <>
-          Vex needs an OpenAI-compatible embedding endpoint to power
-          long-term memory recall. The bundled stack runs llama.cpp:server with
-          EmbeddingGemma 300M on{" "}
+          Embeddings are optional — you can configure them later in
+          Settings. They power long-term memory recall via an
+          OpenAI-compatible endpoint. The bundled stack runs
+          llama.cpp:server with EmbeddingGemma 300M on{" "}
           <code>127.0.0.1:{DEFAULT_EMBED_PORT}</code> — point this at
           your own OpenAI / Ollama / remote endpoint if you prefer.
         </>
@@ -176,21 +182,47 @@ export function EmbeddingStep({
         noValidate: true,
       }}
       footer={
-        <Button
-          type="submit"
-          disabled={configure.isPending || stepAdvance.isPending}
-        >
-          {configure.isPending
-            ? "Saving…"
-            : stepAdvance.isPending
-              ? "Continuing…"
-              : flowMode === "back-edit"
-                ? "Save and return to review"
-                : "Save and continue"}
-        </Button>
+        <>
+          {showConfigureLater ? (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                void advanceToAgentCore();
+              }}
+              disabled={configure.isPending || stepAdvance.isPending}
+              data-vex-embedding-configure-later
+            >
+              {stepAdvance.isPending ? "Continuing…" : "Configure later"}
+            </Button>
+          ) : null}
+          <Button
+            type="submit"
+            disabled={configure.isPending || stepAdvance.isPending}
+          >
+            {configure.isPending
+              ? "Saving…"
+              : stepAdvance.isPending
+                ? "Continuing…"
+                : flowMode === "back-edit"
+                  ? "Save and return to review"
+                  : "Save and continue"}
+          </Button>
+        </>
       }
     >
       <div className="flex flex-col gap-5">
+        {showConfigureLater ? (
+          <p
+            role="status"
+            data-vex-embedding-configure-later-alert
+            className="rounded-md border border-[color-mix(in_oklab,var(--color-warning)_40%,transparent)] bg-[color-mix(in_oklab,var(--color-warning)_10%,transparent)] px-3 py-2 text-sm text-[var(--color-warning)]"
+          >
+            Without an embedding endpoint, long-term memory and semantic
+            search stay unavailable until you configure one. You can set this
+            up later from Settings.
+          </p>
+        ) : null}
         <EmbeddingWarningPanels
           isDimLocked={isDimLocked}
           isDbDown={isDbDown}

--- a/vex-app/src/renderer/features/wizard/steps/ProviderStep.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/ProviderStep.tsx
@@ -237,12 +237,17 @@ export function ProviderStep({
   }
 
   // ── Form ─────────────────────────────────────────────────────────
+  // The inference provider is OPTIONAL at setup (configure later in
+  // Settings), but it carries the strongest consequence: without a
+  // provider the agent cannot run inference at all. In the forward setup
+  // flow we let the operator advance, surfacing that warning prominently.
+  const showConfigureLater = flowMode === "first-pass";
   return (
     <WizardStepPanel
       panelDataAttr={{ kind: "provider", value: "form" }}
       icon={meta.icon}
       title="Inference provider"
-      description="Vex needs an OpenRouter key and model id before starting the agent."
+      description="The inference provider is optional here — you can add it later in Settings — but the agent cannot run until one is configured. Provide an OpenRouter key and model id to set it up now."
       formProps={{
         onSubmit: (e) => {
           void onSubmit(e);
@@ -251,18 +256,46 @@ export function ProviderStep({
         providerFormAttr: "openrouter",
       }}
       footer={
-        <Button type="submit" disabled={submitting || stepAdvance.isPending}>
-          {submitting
-            ? "Verifying..."
-            : stepAdvance.isPending
-              ? "Continuing..."
-              : flowMode === "back-edit"
-                ? "Verify and return to review"
-                : "Verify and save"}
-        </Button>
+        <>
+          {showConfigureLater ? (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                void advanceToReview();
+              }}
+              disabled={submitting || stepAdvance.isPending}
+              data-vex-provider-configure-later
+            >
+              {stepAdvance.isPending
+                ? "Continuing..."
+                : "Continue without a provider"}
+            </Button>
+          ) : null}
+          <Button type="submit" disabled={submitting || stepAdvance.isPending}>
+            {submitting
+              ? "Verifying..."
+              : stepAdvance.isPending
+                ? "Continuing..."
+                : flowMode === "back-edit"
+                  ? "Verify and return to review"
+                  : "Verify and save"}
+          </Button>
+        </>
       }
     >
       <div className="flex flex-col gap-5">
+        {showConfigureLater ? (
+          <p
+            role="status"
+            data-vex-provider-configure-later-alert
+            className="rounded-md border border-[color-mix(in_oklab,var(--color-warning)_40%,transparent)] bg-[color-mix(in_oklab,var(--color-warning)_10%,transparent)] px-3 py-2 text-sm text-[var(--color-warning)]"
+          >
+            The agent cannot run any inference without a provider — it will
+            stay idle until you add an OpenRouter key and model. You can do
+            this later from Settings, but nothing will run until then.
+          </p>
+        ) : null}
         <div className="flex flex-col gap-2">
           <Label htmlFor="vex-provider-key">OpenRouter API key</Label>
           <PasswordField

--- a/vex-app/src/renderer/features/wizard/steps/WalletsStep.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/WalletsStep.tsx
@@ -255,12 +255,23 @@ export function WalletsStep({
     );
   }
 
+  // First-pass with at least one wallet still missing: wallets are
+  // OPTIONAL (configure later in Settings), so the operator may continue.
+  // We surface a consequence alert (no wallet → no trading / on-chain
+  // activity; Polymarket auto-setup needs an EVM wallet) and a
+  // "Continue without …" action alongside the management UI. Copy adapts
+  // to whether one chain is already present or neither is.
+  const showConfigureLater = flowMode === "first-pass" && !bothReady;
+  const continueLaterLabel = anyWallet
+    ? "Continue without the other wallet"
+    : "Continue without a wallet";
+
   return (
     <WizardStepPanel
       panelDataAttr={{ kind: "wallets", value: "setup" }}
       icon={meta.icon}
       title={flowMode === "back-edit" ? "Manage wallets" : "Set up wallets"}
-      description="Vex needs both an EVM wallet (Ethereum + L2s) and a Solana wallet. Generate fresh keys, import existing ones, or restore from a backup keystore file. Each chain is encrypted with the master password from Step 1."
+      description="Wallets are optional — you can add them later in Settings. Vex supports an EVM wallet (Ethereum + L2s) and a Solana wallet. Generate fresh keys, import existing ones, or restore from a backup keystore file. Each chain is encrypted with the master password from Step 1."
       footer={
         flowMode === "back-edit" ? (
           <Button
@@ -271,9 +282,33 @@ export function WalletsStep({
           >
             {stepAdvance.isPending ? "Returning…" : "Return to review"}
           </Button>
+        ) : showConfigureLater ? (
+          <Button
+            variant="ghost"
+            onClick={() => {
+              void advanceToApiKeys();
+            }}
+            disabled={stepAdvance.isPending}
+            data-vex-wallets-configure-later
+          >
+            {stepAdvance.isPending ? "Continuing…" : continueLaterLabel}
+          </Button>
         ) : null
       }
     >
+      {showConfigureLater ? (
+        <p
+          role="status"
+          data-vex-wallets-configure-later-alert
+          className="mb-4 rounded-md border border-[color-mix(in_oklab,var(--color-warning)_40%,transparent)] bg-[color-mix(in_oklab,var(--color-warning)_10%,transparent)] px-3 py-2 text-sm text-[var(--color-warning)]"
+        >
+          {anyWallet
+            ? "With only one chain, Vex can only trade or act on that chain. "
+            : "Without a wallet, Vex can't trade or take any on-chain action. "}
+          Polymarket auto-setup needs an EVM key in particular. You can add or
+          import wallets later from Settings.
+        </p>
+      ) : null}
       <Tabs defaultValue="evm">
         <TabsList>
           <TabsTrigger value="evm" className="flex items-center gap-2">

--- a/vex-app/src/renderer/features/wizard/steps/__tests__/ApiKeysStep.test.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/__tests__/ApiKeysStep.test.tsx
@@ -7,7 +7,10 @@
  *  - Skip-card surfaces "Configure Polymarket now" CTA in setup mode
  *    when polymarketStatus !== "configured" (feature #7).
  *  - back-edit flow ALWAYS renders the form (feature #7 Codex Q5).
- *  - "Repair Polymarket" warning rendered when polymarketStatus === "partial".
+ *  - "Repair Polymarket" warning rendered when polymarketStatus === "partial"
+ *    (warn-but-advance — no longer blocks; optional-connections model).
+ *  - Non-blocking "Jupiter missing" warning when Jupiter is unconfigured;
+ *    "Skip optional" / "Save and continue" ADVANCE regardless.
  *  - Successful submit clears all input refs synchronously and advances.
  *  - "Skip optional" advances without calling setApiKeys.
  *  - Legacy API-key fields are not rendered.
@@ -206,27 +209,66 @@ describe("ApiKeysStep", () => {
     });
   });
 
-  it("'Skip optional' blocks when Jupiter is not configured", async () => {
+  // Optional-connections model: API keys never block advancement. The
+  // form shows a non-blocking "Jupiter missing" warning and the user can
+  // proceed via "Skip optional" / "Save and continue".
+
+  it("first-pass: surfaces a non-blocking Jupiter-missing warning when Jupiter is unconfigured", () => {
     mockUseEnvState.mockReturnValue(makeQueryResult(envState()));
-    const { getByText, findByText } = renderWithQuery(
+    const { container } = renderWithQuery(
+      <ApiKeysStep completedSteps={["keystore", "wallets"]} onAdvance={mockOnAdvance} flowMode="first-pass" />,
+    );
+    expect(
+      container.querySelector('[data-vex-apikeys-warning="jupiter-missing"]'),
+    ).not.toBeNull();
+  });
+
+  it("'Skip optional' ADVANCES even when Jupiter is not configured (optional model)", async () => {
+    mockUseEnvState.mockReturnValue(makeQueryResult(envState()));
+    mockSetWizardMutate.mockResolvedValue({
+      ok: true,
+      data: {
+        schemaVersion: 1,
+        currentStepId: "embedding",
+        completedSteps: ["keystore", "wallets", "apiKeys"],
+        completed: false,
+      },
+    } as Result<WizardState>);
+    const { getByText } = renderWithQuery(
       <ApiKeysStep completedSteps={["keystore", "wallets"]} onAdvance={mockOnAdvance} flowMode="first-pass" />,
     );
     fireEvent.click(getByText("Skip optional"));
-    await findByText(/Jupiter API key is required/i);
-    expect(mockOnAdvance).not.toHaveBeenCalled();
-    expect(mockSetWizardMutate).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockOnAdvance).toHaveBeenCalledWith("embedding");
+    });
+    expect(mockSetApiKeys).not.toHaveBeenCalled();
   });
 
-  it("'Skip optional' blocks when Polymarket configuration is partial", async () => {
+  it("'Skip optional' ADVANCES even when Polymarket configuration is partial (warn-but-advance)", async () => {
     mockUseEnvState.mockReturnValue(
       makeQueryResult(envState({ jupiterConfigured: true, polymarketStatus: "partial" })),
     );
-    const { getByText, findByText } = renderWithQuery(
+    mockSetWizardMutate.mockResolvedValue({
+      ok: true,
+      data: {
+        schemaVersion: 1,
+        currentStepId: "embedding",
+        completedSteps: ["keystore", "wallets", "apiKeys"],
+        completed: false,
+      },
+    } as Result<WizardState>);
+    const { getByText, container } = renderWithQuery(
       <ApiKeysStep completedSteps={["keystore", "wallets"]} onAdvance={mockOnAdvance} flowMode="first-pass" />,
     );
+    // Partial Polymarket still shows the form (jupiter set) with the
+    // partial warning callout, but no longer blocks the skip.
+    expect(
+      container.querySelector('[data-vex-apikeys-warning="polymarket-partial"]'),
+    ).not.toBeNull();
     fireEvent.click(getByText("Skip optional"));
-    await findByText(/Polymarket has only some credentials saved/i);
-    expect(mockOnAdvance).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockOnAdvance).toHaveBeenCalledWith("embedding");
+    });
   });
 
   it("'Skip optional' advances when Jupiter configured + polymarket not partial", async () => {
@@ -254,28 +296,50 @@ describe("ApiKeysStep", () => {
     expect(mockSetApiKeys).not.toHaveBeenCalled();
   });
 
-  it("'Save and continue' empty submit blocks when Jupiter is not configured", async () => {
+  it("'Save and continue' empty submit ADVANCES without calling setApiKeys (optional model)", async () => {
     mockUseEnvState.mockReturnValue(makeQueryResult(envState()));
-    const { container, findByText } = renderWithQuery(
+    mockSetWizardMutate.mockResolvedValue({
+      ok: true,
+      data: {
+        schemaVersion: 1,
+        currentStepId: "embedding",
+        completedSteps: ["keystore", "wallets", "apiKeys"],
+        completed: false,
+      },
+    } as Result<WizardState>);
+    const { container } = renderWithQuery(
       <ApiKeysStep completedSteps={["keystore", "wallets"]} onAdvance={mockOnAdvance} flowMode="first-pass" />,
     );
     const form = container.querySelector('[data-vex-wizard-apikeys="form"] form')!;
     fireEvent.submit(form);
-    await findByText(/Jupiter API key is required/i);
+    // Empty payload → no IPC write, but the user advances.
+    await waitFor(() => {
+      expect(mockOnAdvance).toHaveBeenCalledWith("embedding");
+    });
     expect(mockSetApiKeys).not.toHaveBeenCalled();
-    expect(mockOnAdvance).not.toHaveBeenCalled();
   });
 
-  it("'Save and continue' BLOCKS when Polymarket partial + trio not supplied", async () => {
+  it("'Save and continue' ADVANCES when Polymarket partial + nothing entered (warn-but-advance)", async () => {
     mockUseEnvState.mockReturnValue(
       makeQueryResult(envState({ jupiterConfigured: true, polymarketStatus: "partial" })),
     );
-    const { container, findByText } = renderWithQuery(
+    mockSetWizardMutate.mockResolvedValue({
+      ok: true,
+      data: {
+        schemaVersion: 1,
+        currentStepId: "embedding",
+        completedSteps: ["keystore", "wallets", "apiKeys"],
+        completed: false,
+      },
+    } as Result<WizardState>);
+    const { container } = renderWithQuery(
       <ApiKeysStep completedSteps={["keystore", "wallets"]} onAdvance={mockOnAdvance} flowMode="first-pass" />,
     );
     const form = container.querySelector('[data-vex-wizard-apikeys="form"] form')!;
     fireEvent.submit(form);
-    await findByText(/Polymarket has only some credentials saved/i);
+    await waitFor(() => {
+      expect(mockOnAdvance).toHaveBeenCalledWith("embedding");
+    });
     expect(mockSetApiKeys).not.toHaveBeenCalled();
   });
 
@@ -399,18 +463,6 @@ describe("ApiKeysStep", () => {
     expect(
       container.querySelector("[data-vex-polymarket-auto-helper]")?.textContent,
     ).toMatch(/Unlock Vex first/);
-  });
-
-  it("'Save and continue' empty submit does not auto-advance when Jupiter is missing", async () => {
-    mockUseEnvState.mockReturnValue(makeQueryResult(envState()));
-    const { container, findByText } = renderWithQuery(
-      <ApiKeysStep completedSteps={["keystore", "wallets"]} onAdvance={mockOnAdvance} flowMode="first-pass" />,
-    );
-    const form = container.querySelector('[data-vex-wizard-apikeys="form"] form')!;
-    fireEvent.submit(form);
-    await findByText(/Jupiter API key is required/i);
-    expect(mockOnAdvance).not.toHaveBeenCalled();
-    expect(mockSetWizardMutate).not.toHaveBeenCalled();
   });
 
   // ── PR8 redesign — per-provider cards ────────────────────────────────

--- a/vex-app/src/renderer/features/wizard/steps/__tests__/EmbeddingStep.test.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/__tests__/EmbeddingStep.test.tsx
@@ -143,6 +143,32 @@ describe("EmbeddingStep", () => {
     expect(container.querySelector('[data-vex-wizard-embedding="form"]')).not.toBeNull();
   });
 
+  it("first-pass: 'Configure later' advances without configuring an endpoint + shows the alert (optional model)", async () => {
+    mockUseEnvState.mockReturnValue(makeQueryResult(envState(false)));
+    mockSetWizardMutate.mockResolvedValue({
+      ok: true,
+      data: {
+        schemaVersion: 1,
+        currentStepId: "agentCore",
+        completedSteps: ["keystore", "wallets", "apiKeys", "embedding"],
+        completed: false,
+      },
+    } as Result<WizardState>);
+    const { container, getByText } = renderWithQuery(
+      <EmbeddingStep completedSteps={["keystore", "wallets", "apiKeys"]} onAdvance={mockOnAdvance} flowMode="first-pass" />,
+    );
+    // Consequence alert is shown above the form.
+    expect(
+      container.querySelector("[data-vex-embedding-configure-later-alert]"),
+    ).not.toBeNull();
+    fireEvent.click(getByText("Configure later"));
+    await waitFor(() => {
+      expect(mockOnAdvance).toHaveBeenCalledWith("agentCore");
+    });
+    // No embedding configure mutation when deferring.
+    expect(mockConfigureMutate).not.toHaveBeenCalled();
+  });
+
   it("client-side rejects malformed URL before calling configure", async () => {
     mockUseEnvState.mockReturnValue(makeQueryResult(envState(false)));
     const { container, getByLabelText, getByText } = renderWithQuery(

--- a/vex-app/src/renderer/features/wizard/steps/__tests__/ProviderStep.test.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/__tests__/ProviderStep.test.tsx
@@ -176,6 +176,43 @@ describe("ProviderStep", () => {
     ).toBeNull();
   });
 
+  it("first-pass: 'Continue without a provider' advances without persisting + shows the strong alert (optional model)", async () => {
+    mockUseEnvState.mockReturnValue(makeQueryResult(envState()));
+    mockSetWizardMutate.mockResolvedValue({
+      ok: true,
+      data: {
+        schemaVersion: 2,
+        currentStepId: "review",
+        completedSteps: [
+          "keystore",
+          "wallets",
+          "apiKeys",
+          "embedding",
+          "agentCore",
+          "provider",
+        ],
+        completed: false,
+      },
+    } as Result<WizardState>);
+    const { container, getByText } = renderWithQuery(
+      <ProviderStep
+        completedSteps={["keystore", "wallets", "apiKeys", "embedding", "agentCore"]}
+        onAdvance={mockOnAdvance}
+        flowMode="first-pass"
+      />,
+    );
+    // Strongest consequence alert is shown.
+    expect(
+      container.querySelector("[data-vex-provider-configure-later-alert]"),
+    ).not.toBeNull();
+    fireEvent.click(getByText("Continue without a provider"));
+    await waitFor(() => {
+      expect(mockOnAdvance).toHaveBeenCalledWith("review");
+    });
+    // Deferring never verifies/persists a provider.
+    expect(mockPersistProvider).not.toHaveBeenCalled();
+  });
+
   it("BLOCKS submit when apiKey is empty (no IPC call)", async () => {
     mockUseEnvState.mockReturnValue(makeQueryResult(envState()));
     const { container, findByText } = renderWithQuery(

--- a/vex-app/src/renderer/features/wizard/steps/__tests__/WalletsStep.test.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/__tests__/WalletsStep.test.tsx
@@ -255,6 +255,33 @@ describe("WalletsStep", () => {
     expect(getByRole("tab", { name: /Solana/i })).toBeTruthy();
   });
 
+  it("first-pass with no wallet: surfaces the configure-later alert + 'Continue without a wallet' and advances (optional model)", async () => {
+    mockUseEnvState.mockReturnValue(
+      envQueryFor({ evm: "missing", solana: "missing" })
+    );
+    mockSetWizardMutate.mockResolvedValue({
+      ok: true,
+      data: {
+        schemaVersion: 1,
+        currentStepId: "apiKeys",
+        completedSteps: ["keystore", "wallets"],
+        completed: false,
+      },
+    });
+    const view = renderStep(["keystore"]);
+    // Consequence alert is shown.
+    expect(
+      view.container.querySelector("[data-vex-wallets-configure-later-alert]")
+    ).not.toBeNull();
+    // Advance is allowed even with no wallet configured.
+    fireEvent.click(
+      view.getByRole("button", { name: /Continue without a wallet/i })
+    );
+    await waitFor(() => {
+      expect(mockOnAdvance).toHaveBeenCalledWith("apiKeys");
+    });
+  });
+
   it("renders skip card when both chains have wallets, with both addresses + Continue", async () => {
     mockUseEnvState.mockReturnValue(
       envQueryFor({

--- a/vex-app/src/renderer/features/wizard/steps/api-keys/ProviderCards.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/api-keys/ProviderCards.tsx
@@ -48,12 +48,12 @@ export function JupiterCard({
         />
       }
       name="Jupiter"
-      required
       status={status}
       description={
         <>
-          Required for Solana swap + portfolio tools. Free API key — open
-          the portal, then{" "}
+          Needed for Solana token swaps + portfolio tools — optional, add it
+          later in Settings (Solana swaps stay unavailable until you do). Free
+          API key — open the portal, then{" "}
           <span className="font-medium text-[var(--color-text-primary)]">
             Settings → API Keys → + Create new API key
           </span>
@@ -77,7 +77,7 @@ export function JupiterCard({
       <p className="text-xs text-[var(--color-text-muted)]">
         {configured
           ? "Leave blank to keep, or paste a new key to overwrite."
-          : "Required to continue."}
+          : "Optional — leave blank to add later; Solana swaps stay unavailable until you set it."}
       </p>
     </ProviderCard>
   );

--- a/vex-app/src/renderer/features/wizard/steps/review/ReviewStep.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/review/ReviewStep.tsx
@@ -137,8 +137,9 @@ export function ReviewStep({
     if (result.data.telemetryWarning) {
       setWarning(result.data.telemetryWarning);
     }
-    // wizardState invalidation in useCompleteSetup triggers WizardShell
-    // to flip to the appShell view; no explicit nav needed here.
+    // wizardState invalidation in useCompleteSetup refetches `completed:
+    // true`, which fires WizardShell's COMPLETION WATCHER effect to flip
+    // to the appShell view (or unlock/keystore); no explicit nav here.
   }, [completeSetup, telemetryAvailable, telemetryConsent]);
 
   // ── back-edit branch: render the chosen sub-step directly, with a
@@ -301,9 +302,10 @@ export function ReviewStep({
 
       {/*
         Onward navigation note: after a successful finalize, useCompleteSetup
-        invalidates wizardState; WizardShell then reads `completed: true`
-        and switches the view to the Phase 2 appShell. We don't call
-        `onAdvance` here because there is no next step — the wizard ends.
+        invalidates wizardState; the refetched `completed: true` fires
+        WizardShell's COMPLETION WATCHER effect, which switches the view to
+        the Phase 2 appShell. We don't call `onAdvance` here because there
+        is no next step — the wizard ends.
       */}
       <span className="sr-only" data-vex-onadvance-stub>
         {typeof onAdvance === "function" ? "" : ""}

--- a/vex-app/src/renderer/features/wizard/steps/review/cards/ApiKeysCard.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/review/cards/ApiKeysCard.tsx
@@ -14,9 +14,13 @@ export function ApiKeysCard({
   editDisabled,
 }: ApiKeysCardProps): JSX.Element {
   const k = envState.apiKeys;
-  const status = k.jupiterConfigured ? "ok" : "missing";
+  // Optional-connections model: API keys never block finalize. Jupiter
+  // unconfigured is a warning (Solana swaps unavailable), not a hard miss.
+  const status = k.jupiterConfigured ? "ok" : "warning";
   const items: string[] = [];
-  items.push(`Jupiter: ${k.jupiterConfigured ? "set" : "missing (required)"}`);
+  items.push(
+    `Jupiter: ${k.jupiterConfigured ? "set" : "not set — Solana swaps unavailable"}`,
+  );
   items.push(`Tavily: ${k.tavilyConfigured ? "set" : "—"}`);
   items.push(`Rettiwt: ${k.rettiwtConfigured ? "set" : "—"}`);
   const poly =
@@ -30,7 +34,7 @@ export function ApiKeysCard({
     <SummaryCard
       title="API keys"
       status={status}
-      statusLabel={status === "ok" ? "Required keys set" : "Jupiter missing"}
+      statusLabel={status === "ok" ? "Configured" : "Jupiter optional"}
       onEdit={onEdit}
       editDisabled={editDisabled}
       testId="apiKeys"

--- a/vex-app/src/renderer/features/wizard/steps/review/cards/EmbeddingCard.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/review/cards/EmbeddingCard.tsx
@@ -14,7 +14,9 @@ export function EmbeddingCard({
   editDisabled,
 }: EmbeddingCardProps): JSX.Element {
   const e = envState.embeddings;
-  const status = e.allFieldsConfigured ? "ok" : "missing";
+  // Optional-connections model: embeddings never block finalize. Not
+  // configured is a warning (no memory / semantic search), not a hard miss.
+  const status = e.allFieldsConfigured ? "ok" : "warning";
   return (
     <SummaryCard
       title="Embedding"
@@ -24,13 +26,17 @@ export function EmbeddingCard({
           ? e.reachable
             ? "Configured · reachable"
             : "Configured · not reachable"
-          : "Not configured"
+          : "Optional — not configured"
       }
       onEdit={onEdit}
       editDisabled={editDisabled}
       testId="embedding"
     >
-      <span>Endpoint: {e.baseUrlRedacted ?? "—"}</span>
+      {e.allFieldsConfigured ? (
+        <span>Endpoint: {e.baseUrlRedacted ?? "—"}</span>
+      ) : (
+        <span>Memory and semantic search stay off until configured.</span>
+      )}
     </SummaryCard>
   );
 }

--- a/vex-app/src/renderer/features/wizard/steps/review/cards/ProviderCard.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/review/cards/ProviderCard.tsx
@@ -14,16 +14,25 @@ export function ProviderCard({
   editDisabled,
 }: ProviderCardProps): JSX.Element {
   const p = envState.provider;
+  // Optional-connections model: the provider never blocks finalize, but
+  // it carries the strongest consequence — without it the agent cannot
+  // run inference. Surface that as a warning, not a hard miss.
   return (
     <SummaryCard
       title="Inference provider"
-      status={p.configured ? "ok" : "missing"}
-      statusLabel={p.configured ? p.name ?? "configured" : "Not configured"}
+      status={p.configured ? "ok" : "warning"}
+      statusLabel={
+        p.configured ? p.name ?? "configured" : "Optional — agent can't run"
+      }
       onEdit={onEdit}
       editDisabled={editDisabled}
       testId="provider"
     >
-      {p.configured && p.modelLabel ? <span>Model: {p.modelLabel}</span> : null}
+      {p.configured && p.modelLabel ? (
+        <span>Model: {p.modelLabel}</span>
+      ) : p.configured ? null : (
+        <span>The agent stays idle until a provider is configured.</span>
+      )}
     </SummaryCard>
   );
 }

--- a/vex-app/src/renderer/features/wizard/steps/review/cards/WalletsCard.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/review/cards/WalletsCard.tsx
@@ -39,7 +39,9 @@ export function WalletsCard({
 }: WalletsCardProps): JSX.Element {
   const evmOk = envState.walletStatus.evm === "present";
   const solOk = envState.walletStatus.solana === "present";
-  const status = evmOk && solOk ? "ok" : evmOk || solOk ? "partial" : "missing";
+  // Optional-connections model: wallets never block finalize. No wallet at
+  // all is a warning (no trading / on-chain activity), not a hard miss.
+  const status = evmOk && solOk ? "ok" : evmOk || solOk ? "partial" : "warning";
   const evmAddr = envState.walletAddresses?.evm ?? null;
   const solAddr = envState.walletAddresses?.solana ?? null;
 
@@ -52,7 +54,11 @@ export function WalletsCard({
       title="Wallets"
       status={status}
       statusLabel={
-        status === "ok" ? "Both chains" : status === "partial" ? "Partial" : "Missing"
+        status === "ok"
+          ? "Both chains"
+          : status === "partial"
+            ? "Partial"
+            : "None — optional"
       }
       onEdit={onEdit}
       editDisabled={editDisabled}

--- a/vex-app/src/renderer/lib/api/finalize.ts
+++ b/vex-app/src/renderer/lib/api/finalize.ts
@@ -7,8 +7,10 @@
  * primary UX gate.
  *
  * On success we invalidate BOTH envState + wizardState — the latter
- * flips `completed: true` so WizardShell's effect-based "show
- * placeholder when completed" branch fires on the next render cycle.
+ * refetches with `completed: true`, which fires WizardShell's dedicated
+ * COMPLETION WATCHER effect (the one-time init effect skips it because
+ * `currentStepId` is already "review" by then), routing the user to the
+ * app shell / unlock / keystore as appropriate.
  */
 
 import {


### PR DESCRIPTION
## Summary
Two setup-wizard bug fixes (diagnosed via a 4-tracer + adversarial-verify workflow; root cause confirmed; reviewed through two Codex Lead-Dev gates).

### Fix 1 — wizard stuck on Review after Finalize
`completeSetup` succeeded and `persisted.completed` flipped true, but the wizard never navigated to the app shell. The completed-routing lived inside a one-time-init `useEffect` guarded on `currentStepId === null`, so once the user reached Review it never re-fired. **Added a dedicated completion-watcher effect** that performs the same vault-gated routing when `persisted.completed` flips true post-init — skips reconfigure mode, and flips to the app shell **only when the vault is configured AND unlocked** (otherwise opens unlock / routes to keystore).

### Fix 2 — optional connections with consequence alerts
Wallets, API keys, embeddings, and the inference provider are now **OPTIONAL** (configurable later in Settings). The four wizard steps gain a "configure later" advance path with a **consequence alert** (e.g. Jupiter → Solana swaps unavailable; no provider → the agent can't run inference). Review cards turn non-gating/warning. `finalize.listMissingItems` now blocks **only** on a missing master password.

**Security invariant preserved:** the master password stays the single hard requirement (the vault-encryption gate `finalize.ts:82-84` is unchanged), and the app-shell flip only happens when the vault is configured AND unlocked — pinned by the new watcher tests (locked → opens unlock only; missing vault → keystore only; neither opens the app shell).

Polymarket auto-setup was separately investigated (button → sudo modal → `polymarketAutoSetup` IPC → registered main handler is correct end-to-end — no bug) and left untouched; only its `partial` state was made non-gating.

The app already boots gracefully with no provider configured (workers log `no_provider_config` and skip rather than crash), so the optional-connections model is safe at runtime.

## Verification
- `pnpm --dir vex-app lint` (tsc shared+e2e + process-boundary check) → exit 0.
- focused vitest: WizardShell + finalize 25/25, ApiKeysStep 21/21, full focused set 88/88. CI runs the full suite + e2e.
- **Caveat:** `tsconfig.renderer.json` (NOT part of the gated lint) carries pre-existing, non-gated type errors. This PR introduces **0 new error categories** — it does NOT claim full renderer typecheck is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
