### PR TITLE
feat(updater): user-triggered in-app updater (M13)

### DIFF
--- a/vex-app/dev-app-update.yml
+++ b/vex-app/dev-app-update.yml
@@ -1,0 +1,20 @@
+# Dev-only updater feed (M13) — NOT a production release config.
+#
+# electron-updater reads this file ONLY in a non-packaged run when
+# `forceDevUpdateConfig` is enabled. Per `src/main/updates/configureUpdater.ts`,
+# that happens exclusively when BOTH:
+#   - the app is not packaged (dev), AND
+#   - the env flag VEX_UPDATER_DEV_FEED=1 is set.
+#
+# Purpose: exercise the full banner -> download -> progress -> restart flow
+# against a LOCAL static server (no signing) during development. Stand up a
+# server that serves `latest.yml` + a dummy newer artifact at the url below,
+# then launch with VEX_UPDATER_DEV_FEED=1 and trigger a manual check.
+#
+# Real signed releases use a separate publish config + hosting in the RELEASE
+# track (code signing, macOS notarization, CI matrix) — intentionally NOT here.
+# Linux AppImage installed-app update behavior is release-track QA, not covered
+# by this dev harness.
+provider: generic
+url: http://127.0.0.1:8910/updates
+channel: latest

--- a/vex-app/src/main/database/__tests__/mission-runs-db-agent-work.test.ts
+++ b/vex-app/src/main/database/__tests__/mission-runs-db-agent-work.test.ts
@@ -1,0 +1,109 @@
+/**
+ * hasActiveAgentWork tri-state gate (M13, Codex review #2).
+ *
+ *   - DB unconfigured (buildPoolConfig null)  -> fail-OPEN ({active:false}).
+ *   - configured but connect/query fails      -> fail-CLOSED ({active:true}).
+ *   - query succeeds                          -> running/lease/approval signal.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const connect = vi.fn();
+const query = vi.fn();
+const end = vi.fn();
+
+class FakeClient {
+  connect = connect;
+  query = query;
+  end = end;
+  constructor(_config: unknown) {}
+}
+
+vi.mock("pg", () => ({ Client: FakeClient }));
+
+const buildPoolConfig = vi.fn();
+vi.mock("../db-config.js", () => ({
+  buildPoolConfig: () => buildPoolConfig(),
+}));
+
+vi.mock("../../logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { hasActiveAgentWork } = await import("../mission-runs-db.js");
+
+const CONFIG = {
+  host: "127.0.0.1",
+  port: 5432,
+  database: "vex",
+  user: "vex",
+  password: "secret",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  connect.mockResolvedValue(undefined);
+  end.mockResolvedValue(undefined);
+});
+
+describe("hasActiveAgentWork", () => {
+  it("fail-OPEN when the DB is unconfigured (pre-onboarding)", async () => {
+    buildPoolConfig.mockResolvedValue(null);
+    await expect(hasActiveAgentWork()).resolves.toEqual({
+      active: false,
+      reason: "",
+    });
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("fail-CLOSED when a configured DB cannot connect", async () => {
+    buildPoolConfig.mockResolvedValue(CONFIG);
+    connect.mockRejectedValue(new Error("ECONNREFUSED"));
+    const result = await hasActiveAgentWork();
+    expect(result.active).toBe(true);
+    expect(result.reason).toMatch(/verify/i);
+  });
+
+  it("fail-CLOSED when the query throws (services half-up)", async () => {
+    buildPoolConfig.mockResolvedValue(CONFIG);
+    query.mockRejectedValue(new Error('relation "mission_runs" does not exist'));
+    const result = await hasActiveAgentWork();
+    expect(result.active).toBe(true);
+    expect(end).toHaveBeenCalled();
+  });
+
+  it("active when a mission is running", async () => {
+    buildPoolConfig.mockResolvedValue(CONFIG);
+    query.mockResolvedValue({
+      rows: [
+        { running_mission: true, active_lease: false, pending_approval: false },
+      ],
+    });
+    const result = await hasActiveAgentWork();
+    expect(result.active).toBe(true);
+    expect(end).toHaveBeenCalled();
+  });
+
+  it("active when an approval is pending", async () => {
+    buildPoolConfig.mockResolvedValue(CONFIG);
+    query.mockResolvedValue({
+      rows: [
+        { running_mission: false, active_lease: false, pending_approval: true },
+      ],
+    });
+    await expect(hasActiveAgentWork()).resolves.toMatchObject({ active: true });
+  });
+
+  it("idle when nothing is active", async () => {
+    buildPoolConfig.mockResolvedValue(CONFIG);
+    query.mockResolvedValue({
+      rows: [
+        { running_mission: false, active_lease: false, pending_approval: false },
+      ],
+    });
+    await expect(hasActiveAgentWork()).resolves.toEqual({
+      active: false,
+      reason: "",
+    });
+  });
+});

--- a/vex-app/src/main/database/mission-runs-db.ts
+++ b/vex-app/src/main/database/mission-runs-db.ts
@@ -287,3 +287,92 @@ export async function getActiveRunForSession(
     }
   });
 }
+
+const AGENT_WORK_UNVERIFIABLE =
+  "Couldn't verify it's safe to update right now. Make sure Vex's services are running, then try again.";
+
+/**
+ * Safe-restart signal for the updater (M13): is any agent work in flight that
+ * an app restart could corrupt? Does NOT reuse `withClient` because it must be
+ * TRI-STATE on DB availability:
+ *   - DB UNCONFIGURED (`buildPoolConfig() === null`, e.g. pre-onboarding) ->
+ *     not active (fail-OPEN): no agent can run without a DB.
+ *   - CONFIGURED but connect/query fails -> ACTIVE (fail-CLOSED): a broken
+ *     runtime signal must not be read as "idle" (no in-memory fallback gate
+ *     exists).
+ *   - query succeeds -> running mission OR live runner lease OR pending approval.
+ */
+export async function hasActiveAgentWork(): Promise<{
+  active: boolean;
+  reason: string;
+}> {
+  let cfg: Awaited<ReturnType<typeof buildPoolConfig>>;
+  try {
+    cfg = await buildPoolConfig();
+  } catch (cause) {
+    log.warn("[mission-runs-db] hasActiveAgentWork: buildPoolConfig threw", cause);
+    return { active: true, reason: AGENT_WORK_UNVERIFIABLE };
+  }
+  if (cfg === null) {
+    // DB not configured yet — no agent work is possible (fail-open).
+    return { active: false, reason: "" };
+  }
+
+  const clientConfig: ClientConfig = {
+    host: cfg.host,
+    port: cfg.port,
+    database: cfg.database,
+    user: cfg.user,
+    password: cfg.password,
+    connectionTimeoutMillis: CONNECT_TIMEOUT_MS,
+    statement_timeout: QUERY_TIMEOUT_MS,
+  };
+  const client = new Client(clientConfig);
+  try {
+    await client.connect();
+  } catch (cause) {
+    log.warn("[mission-runs-db] hasActiveAgentWork: connect failed", cause);
+    return { active: true, reason: AGENT_WORK_UNVERIFIABLE };
+  }
+  try {
+    const result = await client.query<{
+      running_mission: boolean;
+      active_lease: boolean;
+      pending_approval: boolean;
+    }>(
+      `SELECT
+         EXISTS(SELECT 1 FROM mission_runs WHERE status = 'running')      AS running_mission,
+         EXISTS(SELECT 1 FROM runner_leases WHERE expires_at >= NOW())    AS active_lease,
+         EXISTS(SELECT 1 FROM approval_queue WHERE status = 'pending')    AS pending_approval`,
+    );
+    const row = result.rows[0];
+    if (!row) return { active: false, reason: "" };
+    if (row.running_mission || row.active_lease) {
+      return {
+        active: true,
+        reason:
+          "An agent run is still in progress. Let it finish or pause it, then update.",
+      };
+    }
+    if (row.pending_approval) {
+      return {
+        active: true,
+        reason:
+          "An approval is waiting for your decision. Resolve it before updating.",
+      };
+    }
+    return { active: false, reason: "" };
+  } catch (cause) {
+    log.warn("[mission-runs-db] hasActiveAgentWork: query failed", cause);
+    return { active: true, reason: AGENT_WORK_UNVERIFIABLE };
+  } finally {
+    try {
+      await client.end();
+    } catch (cause) {
+      log.warn(
+        "[mission-runs-db] hasActiveAgentWork: client.end failed (non-fatal)",
+        cause,
+      );
+    }
+  }
+}

--- a/vex-app/src/main/index.ts
+++ b/vex-app/src/main/index.ts
@@ -28,6 +28,10 @@ import {
   registerAppProtocolPrivileges,
 } from "./protocol/app-protocol.js";
 import { registerAllIpcHandlers } from "./ipc/register-all.js";
+import {
+  configureUpdater,
+  removeUpdaterEventListeners,
+} from "./updates/configureUpdater.js";
 import { cleanupOnBoot, cleanupOnQuit } from "./lifecycle/secret-cleanup.js";
 import { globalCleanup } from "./lifecycle/cleanup-registry.js";
 import { makeOrderedQuitCleanup } from "./lifecycle/ordered-quit-cleanup.js";
@@ -145,6 +149,16 @@ app.whenReady().then(async () => {
 
   // 6. IPC surface
   registerAllIpcHandlers();
+
+  // 6-updater. User-triggered updater (M13): own the electron-updater event
+  // stream so the renderer's update card reflects live status. MANUAL check
+  // only — NO startup auto-check (preferences contract: "manual check only,
+  // no startup auto, no periodic poll"); download + restart are explicit user
+  // actions. Teardown removes our listeners on quit.
+  configureUpdater();
+  globalCleanup.add(() => {
+    removeUpdaterEventListeners();
+  });
 
   // 6a. Agent integration stage 7-1: own the Track-2 compaction worker so
   // enqueued compact_jobs process into session memory. Enabled by default,

--- a/vex-app/src/main/ipc/__tests__/ipc-channel-registration-reconciliation.test.ts
+++ b/vex-app/src/main/ipc/__tests__/ipc-channel-registration-reconciliation.test.ts
@@ -110,11 +110,6 @@ const RESERVED_UNREGISTERED: Readonly<Record<string, string>> = {
     "Reserved provider model-list responder — provider step verifies inside providerPersist; standalone list is not wired yet.",
   [CH.onboarding.providerTest]:
     "Reserved provider connection-test responder — verify is folded into providerPersist; standalone test is not wired yet.",
-
-  // Manual updater check (M13). No updater handler exists in main yet; the
-  // channel constant is reserved for the user-triggered update flow.
-  [CH.updater.check]:
-    "Reserved manual updater check (M13) — no updater handler is registered yet.",
 };
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/vex-app/src/main/ipc/database.ts
+++ b/vex-app/src/main/ipc/database.ts
@@ -25,6 +25,7 @@ import {
   type MigrateRunResult,
 } from "../database/migrate-runner.js";
 import { broadcastToAllWindows } from "../lifecycle/broadcast.js";
+import { CRITICAL_OP, trackCriticalOp } from "../updates/critical-ops.js";
 import { log } from "../logger/index.js";
 import { ensureEmbeddingDefaults } from "../onboarding/ensure-embedding-defaults.js";
 import { registerHandler } from "./register-handler.js";
@@ -89,7 +90,9 @@ export function registerDatabaseHandlers(): Array<() => void> {
       domain: "database",
       inputSchema: migrateInputSchema,
       outputSchema: migrateResultSchema,
-      handle: async (_input, ctx): Promise<Result<MigrateResult>> => {
+      handle: trackCriticalOp(
+        CRITICAL_OP.dbMigration,
+        async (_input, ctx): Promise<Result<MigrateResult>> => {
         let run: Promise<MigrateRunResult>;
         if (migrateInFlight !== null) {
           log.info(
@@ -146,6 +149,7 @@ export function registerDatabaseHandlers(): Array<() => void> {
           }
         }
       },
+      ),
     })
   );
 

--- a/vex-app/src/main/ipc/docker.ts
+++ b/vex-app/src/main/ipc/docker.ts
@@ -37,6 +37,7 @@ import { CONFIG_DIR } from "../paths/config-dir.js";
 import { DEFAULT_PG_PORT } from "@shared/local-service-ports.js";
 import { setDbConnection } from "../database/connection-state.js";
 import { broadcastToAllWindows } from "../lifecycle/broadcast.js";
+import { CRITICAL_OP, trackCriticalOp } from "../updates/critical-ops.js";
 import { registerHandler } from "./register-handler.js";
 import {
   cancelledError,
@@ -92,10 +93,13 @@ export function registerDockerHandlers(): Array<() => void> {
       domain: "docker",
       inputSchema: installInputSchema,
       outputSchema: installResultSchema,
-      handle: async (input): Promise<Result<InstallResult>> => {
-        const result = await performInstall(input.method);
-        return ok(result);
-      },
+      handle: trackCriticalOp(
+        CRITICAL_OP.dockerLifecycle,
+        async (input): Promise<Result<InstallResult>> => {
+          const result = await performInstall(input.method);
+          return ok(result);
+        },
+      ),
     })
   );
 
@@ -105,10 +109,13 @@ export function registerDockerHandlers(): Array<() => void> {
       domain: "docker",
       inputSchema: empty,
       outputSchema: startResultSchema,
-      handle: async (): Promise<Result<StartResult>> => {
-        const result = await performStart();
-        return ok(result);
-      },
+      handle: trackCriticalOp(
+        CRITICAL_OP.dockerLifecycle,
+        async (): Promise<Result<StartResult>> => {
+          const result = await performStart();
+          return ok(result);
+        },
+      ),
     })
   );
 
@@ -161,7 +168,9 @@ export function registerDockerHandlers(): Array<() => void> {
       domain: "docker",
       inputSchema: composeUpInputSchema,
       outputSchema: composeUpResultSchema,
-      handle: async (input, ctx): Promise<Result<ComposeUpResult>> => {
+      handle: trackCriticalOp(
+        CRITICAL_OP.dockerLifecycle,
+        async (input, ctx): Promise<Result<ComposeUpResult>> => {
         const key = `pgPort=${input.pgPort ?? "default"}`;
         if (composeUpInFlight !== null && composeUpInFlightKey === key) {
           log.info(
@@ -246,6 +255,7 @@ export function registerDockerHandlers(): Array<() => void> {
           }
         }
       },
+      ),
     })
   );
 
@@ -255,7 +265,9 @@ export function registerDockerHandlers(): Array<() => void> {
       domain: "docker",
       inputSchema: empty,
       outputSchema: composeDownResultSchema,
-      handle: async (): Promise<Result<ComposeDownResult>> => {
+      handle: trackCriticalOp(
+        CRITICAL_OP.dockerLifecycle,
+        async (): Promise<Result<ComposeDownResult>> => {
         if (!lastComposeOutPath || !lastInstallId) {
           return ok({
             kind: "not_running",
@@ -273,6 +285,7 @@ export function registerDockerHandlers(): Array<() => void> {
         }
         return ok(result);
       },
+      ),
     })
   );
 

--- a/vex-app/src/main/ipc/register-all.ts
+++ b/vex-app/src/main/ipc/register-all.ts
@@ -43,6 +43,7 @@ import { registerSettingsHandlers } from "./settings.js";
 import { registerSupportHandler } from "./support.js";
 import { registerSystemHandlers } from "./system.js";
 import { registerTelemetryHandler } from "./telemetry.js";
+import { registerUpdaterHandlers } from "./updates.js";
 import { registerUsageHandlers } from "./usage.js";
 import { registerWalletExportHandler } from "./wallet-export.js";
 import { registerWalletsSessionHandlers } from "./wallets-session.js";
@@ -109,6 +110,10 @@ export function registerAllIpcHandlers(): void {
   teardowns.push(...registerSettingsHandlers());
   teardowns.push(registerTelemetryHandler());
   teardowns.push(registerSupportHandler());
+  // Updater (M13): user-triggered in-app update check/download/restart.
+  // Handlers are thin; the autoUpdater event stream is owned by
+  // `configureUpdater()` in index.ts.
+  teardowns.push(...registerUpdaterHandlers());
 
   globalCleanup.add(() => {
     for (const t of teardowns) t();

--- a/vex-app/src/main/ipc/updates.ts
+++ b/vex-app/src/main/ipc/updates.ts
@@ -1,0 +1,106 @@
+/**
+ * vex.updater.* — user-triggered in-app update IPC surface (M13).
+ *
+ * All six handlers route through `registerHandler` (sender validation + strict
+ * empty input envelope + output Zod validation + redacted Result). The actual
+ * `electron-updater` work lives in `../updates/updateActions.ts`; this module
+ * is the thin boundary that maps channels -> actions with the request's
+ * correlation id.
+ */
+
+import { z } from "zod";
+import { CH } from "@shared/ipc/channels.js";
+import { type Result } from "@shared/ipc/result.js";
+import {
+  releaseNotesOpenedSchema,
+  updateCancelledSchema,
+  updateRestartingSchema,
+  updateStartedSchema,
+  updateStatusSchema,
+  type ReleaseNotesOpened,
+  type UpdateCancelled,
+  type UpdateRestarting,
+  type UpdateStarted,
+  type UpdateStatus,
+} from "@shared/schemas/updater.js";
+import {
+  cancelDownload,
+  checkNow,
+  getStatus,
+  openReleaseNotes,
+  restartAndInstallNow,
+  startUpdateNow,
+} from "../updates/updateActions.js";
+import { registerHandler } from "./register-handler.js";
+
+const empty = z.object({}).strict();
+
+export function registerUpdaterHandlers(): Array<() => void> {
+  const teardowns: Array<() => void> = [];
+
+  teardowns.push(
+    registerHandler({
+      channel: CH.updater.getStatus,
+      domain: "updater",
+      inputSchema: empty,
+      outputSchema: updateStatusSchema,
+      handle: (): Promise<Result<UpdateStatus>> => getStatus(),
+    }),
+  );
+
+  teardowns.push(
+    registerHandler({
+      channel: CH.updater.check,
+      domain: "updater",
+      inputSchema: empty,
+      outputSchema: updateStatusSchema,
+      handle: (_input, ctx): Promise<Result<UpdateStatus>> =>
+        checkNow(ctx.requestId),
+    }),
+  );
+
+  teardowns.push(
+    registerHandler({
+      channel: CH.updater.startUpdateNow,
+      domain: "updater",
+      inputSchema: empty,
+      outputSchema: updateStartedSchema,
+      handle: (_input, ctx): Promise<Result<UpdateStarted>> =>
+        startUpdateNow(ctx.requestId),
+    }),
+  );
+
+  teardowns.push(
+    registerHandler({
+      channel: CH.updater.cancelDownload,
+      domain: "updater",
+      inputSchema: empty,
+      outputSchema: updateCancelledSchema,
+      handle: (): Promise<Result<UpdateCancelled>> => cancelDownload(),
+    }),
+  );
+
+  teardowns.push(
+    registerHandler({
+      channel: CH.updater.restartAndInstallNow,
+      domain: "updater",
+      inputSchema: empty,
+      outputSchema: updateRestartingSchema,
+      handle: (_input, ctx): Promise<Result<UpdateRestarting>> =>
+        restartAndInstallNow(ctx.requestId),
+    }),
+  );
+
+  teardowns.push(
+    registerHandler({
+      channel: CH.updater.openReleaseNotes,
+      domain: "updater",
+      inputSchema: empty,
+      outputSchema: releaseNotesOpenedSchema,
+      handle: (_input, ctx): Promise<Result<ReleaseNotesOpened>> =>
+        openReleaseNotes(ctx.requestId),
+    }),
+  );
+
+  return teardowns;
+}

--- a/vex-app/src/main/ipc/wallet-export/handler.ts
+++ b/vex-app/src/main/ipc/wallet-export/handler.ts
@@ -32,6 +32,7 @@ import {
   recordExportSuccess,
 } from "../../wallet/export-throttle.js";
 import { log } from "../../logger/index.js";
+import { CRITICAL_OP, trackCriticalOp } from "../../updates/critical-ops.js";
 import { registerHandler } from "../register-handler.js";
 import { invalidWalletSelectionError } from "../_wallet-refs.js";
 import {
@@ -52,10 +53,12 @@ export function registerWalletExportHandler(): () => void {
     domain: "wallet",
     inputSchema: walletExportPrivateKeyInputSchema,
     outputSchema: walletExportPrivateKeyResultSchema,
-    handle: async (
-      input,
-      ctx,
-    ): Promise<Result<WalletExportPrivateKeyResult>> => {
+    handle: trackCriticalOp(
+      CRITICAL_OP.secretVaultOp,
+      async (
+        input,
+        ctx,
+      ): Promise<Result<WalletExportPrivateKeyResult>> => {
       // 1. Throttle gate ─────────────────────────────────────────────
       const gate = checkExportAllowed();
       if (!gate.allowed) {
@@ -245,6 +248,7 @@ export function registerWalletExportHandler(): () => void {
         copied: true,
         clearAfterMs: CLEAR_AFTER_MS,
       });
-    },
+      },
+    ),
   });
 }

--- a/vex-app/src/main/onboarding/__tests__/mutex-critical-op.test.ts
+++ b/vex-app/src/main/onboarding/__tests__/mutex-critical-op.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Safe-restart gating at the keystore/secret-vault seam (M13, Codex final
+ * review finding 1). Every wallet write routes through `withWalletLock` and
+ * every secret .env write through `withEnvWriteLock`; both must mark a
+ * `secretVaultOp` critical op for the locked section so the updater gate blocks
+ * a restart while a keystore/secret operation is in flight.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __resetWalletMutexForTests,
+  withWalletLock,
+} from "../wallet-mutex.js";
+import {
+  __resetEnvWriteMutexForTests,
+  withEnvWriteLock,
+} from "../env-write-mutex.js";
+import {
+  __resetCriticalOpsForTests,
+  criticalOpInFlight,
+} from "../../updates/critical-ops.js";
+
+afterEach(() => {
+  __resetWalletMutexForTests();
+  __resetEnvWriteMutexForTests();
+  __resetCriticalOpsForTests();
+});
+
+describe("mutex safe-restart gating", () => {
+  it("withWalletLock holds a critical op for the locked section", async () => {
+    expect(criticalOpInFlight()).toBe(false);
+    let insideFlag = false;
+    await withWalletLock(async () => {
+      insideFlag = criticalOpInFlight();
+    });
+    expect(insideFlag).toBe(true);
+    expect(criticalOpInFlight()).toBe(false);
+  });
+
+  it("withEnvWriteLock holds a critical op for the locked section", async () => {
+    let insideFlag = false;
+    await withEnvWriteLock(async () => {
+      insideFlag = criticalOpInFlight();
+    });
+    expect(insideFlag).toBe(true);
+    expect(criticalOpInFlight()).toBe(false);
+  });
+
+  it("releases the critical op even when the locked fn throws", async () => {
+    await expect(
+      withWalletLock(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(criticalOpInFlight()).toBe(false);
+  });
+});

--- a/vex-app/src/main/onboarding/env-write-mutex.ts
+++ b/vex-app/src/main/onboarding/env-write-mutex.ts
@@ -21,6 +21,8 @@
  * No handler path needs both locks (audited M9 plan turn 1 R1).
  */
 
+import { CRITICAL_OP, beginCriticalOp } from "../updates/critical-ops.js";
+
 let envChain: Promise<unknown> = Promise.resolve();
 
 export function withEnvWriteLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -30,22 +32,20 @@ export function withEnvWriteLock<T>(fn: () => Promise<T>): Promise<T> {
     resolved = res;
     rejected = rej;
   });
-  const next = envChain.then(
-    async () => {
-      try {
-        resolved(await fn());
-      } catch (e) {
-        rejected(e);
-      }
-    },
-    async () => {
-      try {
-        resolved(await fn());
-      } catch (e) {
-        rejected(e);
-      }
+  // Every env-write mutation persists a secret (api key / provider / embedding /
+  // agent-core) into the vault + .env. Mark it as a secret-vault op so the
+  // updater safe-restart gate (M13) blocks while it runs. `finally` releases.
+  const run = async (): Promise<void> => {
+    const endCriticalOp = beginCriticalOp(CRITICAL_OP.secretVaultOp);
+    try {
+      resolved(await fn());
+    } catch (e) {
+      rejected(e);
+    } finally {
+      endCriticalOp();
     }
-  );
+  };
+  const next = envChain.then(run, run);
   envChain = next.catch(() => undefined);
   return result;
 }

--- a/vex-app/src/main/onboarding/wallet-mutex.ts
+++ b/vex-app/src/main/onboarding/wallet-mutex.ts
@@ -19,6 +19,8 @@
  * failed wallet operation never blocks subsequent ones.
  */
 
+import { CRITICAL_OP, beginCriticalOp } from "../updates/critical-ops.js";
+
 let walletChain: Promise<unknown> = Promise.resolve();
 
 export function withWalletLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -28,22 +30,20 @@ export function withWalletLock<T>(fn: () => Promise<T>): Promise<T> {
     resolved = res;
     rejected = rej;
   });
-  const next = walletChain.then(
-    async () => {
-      try {
-        resolved(await fn());
-      } catch (e) {
-        rejected(e);
-      }
-    },
-    async () => {
-      try {
-        resolved(await fn());
-      } catch (e) {
-        rejected(e);
-      }
+  // Mark a keystore/secret-vault operation in flight for the whole locked
+  // section so the updater's safe-restart gate (M13) blocks while a wallet
+  // generate/import/restore is mutating keystores. `finally` always releases.
+  const run = async (): Promise<void> => {
+    const endCriticalOp = beginCriticalOp(CRITICAL_OP.secretVaultOp);
+    try {
+      resolved(await fn());
+    } catch (e) {
+      rejected(e);
+    } finally {
+      endCriticalOp();
     }
-  );
+  };
+  const next = walletChain.then(run, run);
   walletChain = next.catch(() => undefined);
   return result;
 }

--- a/vex-app/src/main/updates/__tests__/configureUpdater.test.ts
+++ b/vex-app/src/main/updates/__tests__/configureUpdater.test.ts
@@ -1,0 +1,91 @@
+/**
+ * configureUpdater event wiring (M13). Verifies the two-step contract at the
+ * event layer (`update-downloaded` sets `downloaded` only, never auto-restart)
+ * and the restart-flag recovery (Codex final review #3 follow-up): an updater
+ * `error` raised while a restart is in progress clears the flag so
+ * `restartAndInstallNow()` is not permanently idempotent after a failed install.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listeners: Record<string, (...args: unknown[]) => void> = {};
+const autoUpdater: Record<string, unknown> = {
+  on: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+    listeners[event] = fn;
+  }),
+  removeListener: vi.fn(),
+};
+
+vi.mock("electron-updater", () => ({ default: { autoUpdater } }));
+vi.mock("electron", () => ({ app: { isPackaged: true } }));
+
+const setStatus = vi.fn();
+vi.mock("../statusCache.js", () => ({
+  setStatus: (s: unknown) => setStatus(s),
+  currentVersion: () => "1.0.0",
+}));
+
+vi.mock("../sanitize.js", () => ({
+  availableStatus: () => ({ kind: "available" }),
+  downloadingStatus: () => ({ kind: "downloading" }),
+  errorStatus: () => ({
+    kind: "error",
+    currentVersion: "1.0.0",
+    message: "x",
+    retryable: true,
+  }),
+  filteredUpdaterLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+let restartInProgress = false;
+const clearUpdateRestartInProgress = vi.fn(() => {
+  restartInProgress = false;
+});
+vi.mock("../safeRestart.js", () => ({
+  isUpdateRestartInProgress: () => restartInProgress,
+  clearUpdateRestartInProgress: () => clearUpdateRestartInProgress(),
+}));
+
+const { configureUpdater, removeUpdaterEventListeners } = await import(
+  "../configureUpdater.js"
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  restartInProgress = false;
+  for (const key of Object.keys(listeners)) delete listeners[key];
+  // Reset the module-level `configured` guard so each test re-registers.
+  removeUpdaterEventListeners();
+});
+
+describe("configureUpdater event wiring", () => {
+  it("update-downloaded sets `downloaded` only (no auto-restart)", () => {
+    configureUpdater();
+    listeners["update-downloaded"]?.({ version: "1.1.0" });
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "downloaded", latestVersion: "1.1.0" }),
+    );
+  });
+
+  it("error during an in-progress restart clears the restart flag", () => {
+    configureUpdater();
+    restartInProgress = true;
+    listeners["error"]?.(new Error("install failed"));
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "error" }),
+    );
+    expect(clearUpdateRestartInProgress).toHaveBeenCalledTimes(1);
+  });
+
+  it("error with no restart in progress does not clear the flag", () => {
+    configureUpdater();
+    restartInProgress = false;
+    listeners["error"]?.(new Error("check failed"));
+    expect(clearUpdateRestartInProgress).not.toHaveBeenCalled();
+  });
+});

--- a/vex-app/src/main/updates/__tests__/critical-ops.test.ts
+++ b/vex-app/src/main/updates/__tests__/critical-ops.test.ts
@@ -1,0 +1,62 @@
+/**
+ * critical-ops registry (M13). The safe-restart gate consults
+ * `criticalOpInFlight()`, so ref-counting + guaranteed release (even on throw)
+ * are the invariants that keep the gate from sticking "blocked".
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CRITICAL_OP,
+  activeCriticalOps,
+  beginCriticalOp,
+  criticalOpInFlight,
+  trackCriticalOp,
+  __resetCriticalOpsForTests,
+} from "../critical-ops.js";
+
+afterEach(() => {
+  __resetCriticalOpsForTests();
+});
+
+describe("critical-ops registry", () => {
+  it("starts idle", () => {
+    expect(criticalOpInFlight()).toBe(false);
+    expect(activeCriticalOps()).toEqual([]);
+  });
+
+  it("ref-counts begin/end for the same label", () => {
+    const end1 = beginCriticalOp(CRITICAL_OP.dockerLifecycle);
+    const end2 = beginCriticalOp(CRITICAL_OP.dockerLifecycle);
+    expect(criticalOpInFlight()).toBe(true);
+    expect(activeCriticalOps()).toEqual([CRITICAL_OP.dockerLifecycle]);
+    end1();
+    expect(criticalOpInFlight()).toBe(true); // still one outstanding
+    end2();
+    expect(criticalOpInFlight()).toBe(false);
+  });
+
+  it("end() is idempotent (double-call does not underflow)", () => {
+    const end = beginCriticalOp(CRITICAL_OP.dbMigration);
+    end();
+    end();
+    expect(criticalOpInFlight()).toBe(false);
+    // A subsequent op still flips it back on.
+    const end2 = beginCriticalOp(CRITICAL_OP.dbMigration);
+    expect(criticalOpInFlight()).toBe(true);
+    end2();
+  });
+
+  it("trackCriticalOp releases on success", async () => {
+    const fn = trackCriticalOp(CRITICAL_OP.dbMigration, async () => "done");
+    await expect(fn()).resolves.toBe("done");
+    expect(criticalOpInFlight()).toBe(false);
+  });
+
+  it("trackCriticalOp releases on throw", async () => {
+    const fn = trackCriticalOp(CRITICAL_OP.dockerLifecycle, async () => {
+      throw new Error("boom");
+    });
+    await expect(fn()).rejects.toThrow("boom");
+    expect(criticalOpInFlight()).toBe(false);
+  });
+});

--- a/vex-app/src/main/updates/__tests__/safeRestart.test.ts
+++ b/vex-app/src/main/updates/__tests__/safeRestart.test.ts
@@ -1,0 +1,74 @@
+/**
+ * safeRestart gate (M13). Blocks on DB-backed agent work OR an in-memory
+ * critical op; `prepareForUpdateRestart` flags the restart + tears down the
+ * updater event stream (lightweight, per Codex review #2).
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hasActiveAgentWork = vi.fn();
+vi.mock("../../database/mission-runs-db.js", () => ({
+  hasActiveAgentWork: () => hasActiveAgentWork(),
+}));
+
+const {
+  canRestartForUpdate,
+  prepareForUpdateRestart,
+  isUpdateRestartInProgress,
+  __resetSafeRestartForTests,
+} = await import("../safeRestart.js");
+const { CRITICAL_OP, beginCriticalOp, __resetCriticalOpsForTests } =
+  await import("../critical-ops.js");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hasActiveAgentWork.mockResolvedValue({ active: false, reason: "" });
+  __resetSafeRestartForTests();
+  __resetCriticalOpsForTests();
+});
+
+describe("canRestartForUpdate", () => {
+  it("allows when idle (no agent work, no critical op)", async () => {
+    await expect(canRestartForUpdate()).resolves.toEqual({ ok: true });
+  });
+
+  it("blocks on active agent work, surfacing its reason", async () => {
+    hasActiveAgentWork.mockResolvedValue({
+      active: true,
+      reason: "An agent run is still in progress.",
+    });
+    await expect(canRestartForUpdate()).resolves.toEqual({
+      ok: false,
+      message: "An agent run is still in progress.",
+    });
+  });
+
+  it("blocks on an in-flight docker lifecycle op", async () => {
+    beginCriticalOp(CRITICAL_OP.dockerLifecycle);
+    const result = await canRestartForUpdate();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toMatch(/Docker/);
+  });
+
+  it("blocks on an in-flight db migration op", async () => {
+    beginCriticalOp(CRITICAL_OP.dbMigration);
+    const result = await canRestartForUpdate();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toMatch(/migration/i);
+  });
+
+  it("blocks on an in-flight secret-vault op (wallet/keystore)", async () => {
+    beginCriticalOp(CRITICAL_OP.secretVaultOp);
+    const result = await canRestartForUpdate();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toMatch(/wallet|secret/i);
+  });
+});
+
+describe("prepareForUpdateRestart", () => {
+  it("flags the restart in progress (listeners are torn down by quit cleanup, not here)", () => {
+    expect(isUpdateRestartInProgress()).toBe(false);
+    prepareForUpdateRestart();
+    expect(isUpdateRestartInProgress()).toBe(true);
+  });
+});

--- a/vex-app/src/main/updates/__tests__/sanitize.test.ts
+++ b/vex-app/src/main/updates/__tests__/sanitize.test.ts
@@ -1,0 +1,113 @@
+/**
+ * sanitize (M13) — the redaction boundary. Asserts the public status carries
+ * only versions/severity/summary/bounded progress, error messages are generic,
+ * and the updater logger scrubs URLs/paths (electron-updater logs them raw).
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProgressInfo, UpdateInfo } from "electron-updater";
+
+const logInfo = vi.fn();
+vi.mock("../../logger/index.js", () => ({
+  log: { info: logInfo, warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../statusCache.js", () => ({
+  getCurrentStatus: () => ({
+    kind: "available",
+    currentVersion: "1.0.0",
+    latestVersion: "2.0.0",
+    severity: "normal",
+  }),
+}));
+
+const {
+  availableStatus,
+  downloadingStatus,
+  errorStatus,
+  publicUpdateError,
+  filteredUpdaterLogger,
+} = await import("../sanitize.js");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("availableStatus", () => {
+  it("projects version/severity/summary and drops paths/files/urls", () => {
+    // Test fixture: a realistic UpdateInfo carries paths/files we must NOT leak.
+    const info = {
+      version: "2.0.0",
+      releaseDate: "2026-01-01",
+      releaseName: "What's new",
+      path: "/Users/x/Library/Caches/vex/Vex-2.0.0.dmg",
+      files: [{ url: "https://feed.example/Vex-2.0.0.dmg" }],
+    } as unknown as UpdateInfo;
+    const status = availableStatus(info, "1.0.0");
+    expect(status).toEqual({
+      kind: "available",
+      currentVersion: "1.0.0",
+      latestVersion: "2.0.0",
+      severity: "normal",
+      releaseDate: "2026-01-01",
+      summary: "What's new",
+    });
+    expect(JSON.stringify(status)).not.toContain("https://");
+    expect(JSON.stringify(status)).not.toContain("/Users/");
+  });
+});
+
+describe("downloadingStatus", () => {
+  it("clamps percent and recovers the latest version from cache", () => {
+    const progress = {
+      percent: 150,
+      transferred: 5,
+      total: 10,
+      bytesPerSecond: 2,
+    } as unknown as ProgressInfo;
+    expect(downloadingStatus(progress, "1.0.0")).toMatchObject({
+      kind: "downloading",
+      latestVersion: "2.0.0",
+      percent: 100,
+    });
+  });
+});
+
+describe("errorStatus + publicUpdateError", () => {
+  it("errorStatus is generic + redacted (no url/path leak)", () => {
+    const status = errorStatus(
+      new Error("ENOENT https://feed/latest.yml at /tmp/file"),
+      "1.0.0",
+    );
+    expect(status).toEqual({
+      kind: "error",
+      currentVersion: "1.0.0",
+      message: expect.any(String),
+      retryable: true,
+    });
+    expect(JSON.stringify(status)).not.toContain("https://");
+    expect(JSON.stringify(status)).not.toContain("/tmp/");
+  });
+
+  it("publicUpdateError builds a redacted updater VexError", () => {
+    expect(publicUpdateError("update.download_failed", "cid")).toMatchObject({
+      code: "update.download_failed",
+      domain: "updater",
+      redacted: true,
+      correlationId: "cid",
+    });
+  });
+});
+
+describe("filteredUpdaterLogger", () => {
+  it("scrubs URLs and paths before logging", () => {
+    filteredUpdaterLogger.info(
+      "downloading https://feed.example/Vex-2.0.0.dmg to /Users/x/Library/Caches/vex/pending",
+    );
+    expect(logInfo).toHaveBeenCalledTimes(1);
+    const logged = String(logInfo.mock.calls[0]?.[0]);
+    expect(logged).not.toContain("https://");
+    expect(logged).not.toContain("/Users/");
+    expect(logged).toContain("[url]");
+  });
+});

--- a/vex-app/src/main/updates/__tests__/updateActions.test.ts
+++ b/vex-app/src/main/updates/__tests__/updateActions.test.ts
@@ -1,0 +1,261 @@
+/**
+ * updateActions (M13) — the two-step contract (Codex review #1 blocker).
+ *
+ * Asserts: download requires an `available` status + a passing gate;
+ * `restartAndInstallNow` is the ONLY path to `quitAndInstall`, requires a
+ * `downloaded` status + gate, and is idempotent; cancel resets; checkNow
+ * persists `lastCheckedAt` and maps failures to a redacted error.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const autoUpdater = {
+  checkForUpdates: vi.fn(),
+  downloadUpdate: vi.fn(),
+  quitAndInstall: vi.fn(),
+};
+class FakeCancellationToken {
+  cancel = vi.fn();
+}
+
+vi.mock("electron-updater", () => ({
+  default: { autoUpdater, CancellationToken: FakeCancellationToken },
+}));
+
+const openExternal = vi.fn().mockResolvedValue(undefined);
+vi.mock("electron", () => ({
+  shell: { openExternal: (...args: unknown[]) => openExternal(...args) },
+}));
+
+let currentStatus: unknown = { kind: "idle", currentVersion: "1.0.0" };
+const setStatus = vi.fn((s: unknown) => {
+  currentStatus = s;
+});
+vi.mock("../statusCache.js", () => ({
+  getCurrentStatus: () => currentStatus,
+  setStatus: (s: unknown) => setStatus(s),
+  currentVersion: () => "1.0.0",
+}));
+
+const canRestartForUpdate = vi.fn();
+const prepareForUpdateRestart = vi.fn();
+let restartInProgress = false;
+vi.mock("../safeRestart.js", () => ({
+  canRestartForUpdate: () => canRestartForUpdate(),
+  prepareForUpdateRestart: () => prepareForUpdateRestart(),
+  isUpdateRestartInProgress: () => restartInProgress,
+}));
+
+vi.mock("../sanitize.js", () => ({
+  errorStatus: (_e: unknown, v: string) => ({
+    kind: "error",
+    currentVersion: v,
+    message: "Update failed.",
+    retryable: true,
+  }),
+  publicUpdateError: (
+    code: string,
+    correlationId: string,
+    message?: string,
+  ) => ({
+    code,
+    domain: "updater",
+    message: message ?? code,
+    retryable: true,
+    userActionable: true,
+    redacted: true,
+    correlationId,
+  }),
+}));
+
+const prefUpdate = vi.fn().mockResolvedValue({});
+vi.mock("../../preferences/store.js", () => ({
+  preferencesStore: { update: (p: unknown) => prefUpdate(p) },
+}));
+
+vi.mock("../../logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const actions = await import("../updateActions.js");
+
+const AVAILABLE = {
+  kind: "available",
+  currentVersion: "1.0.0",
+  latestVersion: "1.1.0",
+  severity: "normal",
+} as const;
+const DOWNLOADED = {
+  kind: "downloaded",
+  currentVersion: "1.0.0",
+  latestVersion: "1.1.0",
+} as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  currentStatus = { kind: "idle", currentVersion: "1.0.0" };
+  restartInProgress = false;
+  canRestartForUpdate.mockResolvedValue({ ok: true });
+  autoUpdater.checkForUpdates.mockResolvedValue(null);
+  autoUpdater.downloadUpdate.mockResolvedValue([]);
+  actions.__resetUpdateActionsForTests();
+});
+
+describe("getStatus", () => {
+  it("returns the cached status", async () => {
+    currentStatus = DOWNLOADED;
+    await expect(actions.getStatus()).resolves.toEqual({
+      ok: true,
+      data: DOWNLOADED,
+    });
+  });
+});
+
+describe("startUpdateNow (step 1: download only)", () => {
+  it("refuses when no update is available", async () => {
+    currentStatus = { kind: "idle", currentVersion: "1.0.0" };
+    const r = await actions.startUpdateNow("req");
+    expect(r.ok).toBe(false);
+    expect(autoUpdater.downloadUpdate).not.toHaveBeenCalled();
+  });
+
+  it("downloads when available and the gate passes", async () => {
+    currentStatus = AVAILABLE;
+    const r = await actions.startUpdateNow("req");
+    expect(r).toEqual({ ok: true, data: { started: true } });
+    expect(autoUpdater.downloadUpdate).toHaveBeenCalledTimes(1);
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "downloading", percent: 0 }),
+    );
+  });
+
+  it("blocks (no download) when the gate fails", async () => {
+    currentStatus = AVAILABLE;
+    canRestartForUpdate.mockResolvedValue({ ok: false, message: "busy" });
+    const r = await actions.startUpdateNow("req");
+    expect(r.ok).toBe(false);
+    expect(autoUpdater.downloadUpdate).not.toHaveBeenCalled();
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "blockedByOperation", reason: "busy" }),
+    );
+  });
+
+  it("is idempotent while a download is in flight", async () => {
+    currentStatus = AVAILABLE;
+    autoUpdater.downloadUpdate.mockReturnValue(new Promise(() => {}));
+    await actions.startUpdateNow("a");
+    const second = await actions.startUpdateNow("b");
+    expect(second).toEqual({ ok: true, data: { started: true } });
+    expect(autoUpdater.downloadUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the in-flight token after a successful download (a later download can start)", async () => {
+    currentStatus = AVAILABLE;
+    let resolveDownload!: (paths: string[]) => void;
+    autoUpdater.downloadUpdate.mockReturnValueOnce(
+      new Promise<string[]>((resolve) => {
+        resolveDownload = resolve;
+      }),
+    );
+    await actions.startUpdateNow("a");
+    expect(autoUpdater.downloadUpdate).toHaveBeenCalledTimes(1);
+
+    // Finish the download; the .then() must clear the in-flight token.
+    resolveDownload([]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // A fresh available status -> a brand new download must start.
+    currentStatus = AVAILABLE;
+    autoUpdater.downloadUpdate.mockResolvedValueOnce([]);
+    await actions.startUpdateNow("b");
+    expect(autoUpdater.downloadUpdate).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("restartAndInstallNow (step 2: explicit restart)", () => {
+  it("refuses when nothing is downloaded", async () => {
+    currentStatus = AVAILABLE;
+    const r = await actions.restartAndInstallNow("req");
+    expect(r.ok).toBe(false);
+    expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  it("installs when downloaded and the gate passes", async () => {
+    currentStatus = DOWNLOADED;
+    const r = await actions.restartAndInstallNow("req");
+    expect(r).toEqual({ ok: true, data: { restarting: true } });
+    expect(prepareForUpdateRestart).toHaveBeenCalledTimes(1);
+    expect(autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "installing" }),
+    );
+  });
+
+  it("blocks (no install) when the gate fails", async () => {
+    currentStatus = DOWNLOADED;
+    canRestartForUpdate.mockResolvedValue({
+      ok: false,
+      message: "migration running",
+    });
+    const r = await actions.restartAndInstallNow("req");
+    expect(r.ok).toBe(false);
+    expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "blockedByOperation",
+        reason: "migration running",
+      }),
+    );
+  });
+
+  it("is idempotent when a restart is already in progress", async () => {
+    currentStatus = DOWNLOADED;
+    restartInProgress = true;
+    const r = await actions.restartAndInstallNow("req");
+    expect(r).toEqual({ ok: true, data: { restarting: true } });
+    expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+  });
+});
+
+describe("cancelDownload / checkNow / openReleaseNotes", () => {
+  it("cancelDownload cancels the token and returns to available", async () => {
+    currentStatus = AVAILABLE;
+    autoUpdater.downloadUpdate.mockReturnValue(new Promise(() => {}));
+    await actions.startUpdateNow("req");
+    const r = await actions.cancelDownload();
+    expect(r).toEqual({ ok: true, data: { cancelled: true } });
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "available", latestVersion: "1.1.0" }),
+    );
+  });
+
+  it("checkNow runs a check and persists lastCheckedAt", async () => {
+    const r = await actions.checkNow("req");
+    expect(r.ok).toBe(true);
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+    expect(prefUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updater: expect.objectContaining({ lastCheckedAt: expect.any(String) }),
+      }),
+    );
+  });
+
+  it("checkNow maps a thrown check to update.check_failed (redacted)", async () => {
+    autoUpdater.checkForUpdates.mockRejectedValue(
+      new Error("https://feed.example/latest.yml unreachable"),
+    );
+    const r = await actions.checkNow("req");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe("update.check_failed");
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "error" }),
+    );
+  });
+
+  it("openReleaseNotes opens an external URL", async () => {
+    const r = await actions.openReleaseNotes("req");
+    expect(r).toEqual({ ok: true, data: { opened: true } });
+    expect(openExternal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vex-app/src/main/updates/configureUpdater.ts
+++ b/vex-app/src/main/updates/configureUpdater.ts
@@ -1,0 +1,115 @@
+/**
+ * Main-process `electron-updater` configuration (M13).
+ *
+ * Policy (skill vex-user-triggered-updates §"Non-negotiable rules"):
+ *   - check may be MANUAL only (no auto-download, no auto-install);
+ *   - download starts only via `updates.startUpdateNow()`;
+ *   - restart/install happens only via `updates.restartAndInstallNow()`.
+ *
+ * This module owns the autoUpdater event stream and funnels every transition
+ * through the sanitized status cache. `update-downloaded` ONLY sets
+ * `downloaded` — it NEVER auto-restarts (two-step UX). It deliberately does NOT
+ * import `updateActions` (keeps the dependency graph acyclic).
+ */
+
+import { app } from "electron";
+import electronUpdater from "electron-updater";
+import type { ProgressInfo, UpdateInfo } from "electron-updater";
+import {
+  availableStatus,
+  downloadingStatus,
+  errorStatus,
+  filteredUpdaterLogger,
+} from "./sanitize.js";
+import {
+  clearUpdateRestartInProgress,
+  isUpdateRestartInProgress,
+} from "./safeRestart.js";
+import { currentVersion, setStatus } from "./statusCache.js";
+
+const { autoUpdater } = electronUpdater;
+
+let configured = false;
+const removers: Array<() => void> = [];
+
+export function configureUpdater(): void {
+  if (configured) return;
+  configured = true;
+
+  autoUpdater.logger = filteredUpdaterLogger;
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = false;
+  autoUpdater.allowDowngrade = false;
+  autoUpdater.allowPrerelease = false;
+  autoUpdater.disableWebInstaller = true;
+  autoUpdater.autoRunAppAfterInstall = true;
+
+  // Dev feed is OPT-IN. In plain dev we never auto-resolve a feed (no error
+  // spam, no surprise downloads). To exercise the flow locally, drop a
+  // `dev-app-update.yml` and run with VEX_UPDATER_DEV_FEED=1.
+  if (!app.isPackaged && process.env.VEX_UPDATER_DEV_FEED === "1") {
+    autoUpdater.forceDevUpdateConfig = true;
+  }
+
+  const onChecking = (): void => {
+    setStatus({ kind: "checking", currentVersion: currentVersion() });
+  };
+  const onAvailable = (info: UpdateInfo): void => {
+    setStatus(availableStatus(info, currentVersion()));
+  };
+  const onNotAvailable = (): void => {
+    setStatus({
+      kind: "current",
+      currentVersion: currentVersion(),
+      checkedAt: new Date().toISOString(),
+    });
+  };
+  const onProgress = (info: ProgressInfo): void => {
+    setStatus(downloadingStatus(info, currentVersion()));
+  };
+  const onDownloaded = (info: UpdateInfo): void => {
+    // TWO-STEP: only mark downloaded. The restart is a SEPARATE explicit user
+    // action (`restartAndInstallNow`). Never auto-restart here.
+    const latestVersion =
+      typeof info.version === "string" && info.version.length > 0
+        ? info.version
+        : currentVersion();
+    setStatus({ kind: "downloaded", currentVersion: currentVersion(), latestVersion });
+  };
+  const onError = (error: Error): void => {
+    setStatus(errorStatus(error, currentVersion()));
+    // A failed quitAndInstall()/install() emits `error` while a restart is in
+    // progress (the app stays open). Release the restart flag so
+    // restartAndInstallNow() is not permanently idempotent and the user can
+    // retry, rather than getting a silent ok({restarting:true}) no-op.
+    if (isUpdateRestartInProgress()) clearUpdateRestartInProgress();
+  };
+
+  autoUpdater.on("checking-for-update", onChecking);
+  autoUpdater.on("update-available", onAvailable);
+  autoUpdater.on("update-not-available", onNotAvailable);
+  autoUpdater.on("download-progress", onProgress);
+  autoUpdater.on("update-downloaded", onDownloaded);
+  autoUpdater.on("error", onError);
+
+  removers.push(
+    () => autoUpdater.removeListener("checking-for-update", onChecking),
+    () => autoUpdater.removeListener("update-available", onAvailable),
+    () => autoUpdater.removeListener("update-not-available", onNotAvailable),
+    () => autoUpdater.removeListener("download-progress", onProgress),
+    () => autoUpdater.removeListener("update-downloaded", onDownloaded),
+    () => autoUpdater.removeListener("error", onError),
+  );
+}
+
+/**
+ * Idempotent teardown of the listeners this module added. Used ONLY by app
+ * quit cleanup (globalCleanup in index.ts) — NOT by the update restart path,
+ * which intentionally keeps listeners active through quitAndInstall() so a
+ * synchronous install() `error` is still delivered.
+ */
+export function removeUpdaterEventListeners(): void {
+  for (const remove of removers) remove();
+  removers.length = 0;
+  configured = false;
+}

--- a/vex-app/src/main/updates/critical-ops.ts
+++ b/vex-app/src/main/updates/critical-ops.ts
@@ -1,0 +1,73 @@
+/**
+ * Ref-counted registry of in-flight CRITICAL operations — local, handler-
+ * duration operations that must not be interrupted by an update restart
+ * (skill vex-user-triggered-updates §"Safe restart gate").
+ *
+ * Recon confirmed no queryable in-flight signal exists today (the docker/db
+ * single-flight vars are module-local), so the few destructive, handler-
+ * duration handlers register here via `beginCriticalOp`/end and the
+ * safe-restart gate consults `criticalOpInFlight()`.
+ *
+ * NOTE: agent/mission execution is NOT tracked here — it outlives the IPC
+ * handler that starts it, so wrapping those handlers would mark the op for
+ * only the brief enqueue. That dimension is gated by a DB query
+ * (`hasActiveAgentWork`) instead.
+ */
+
+export const CRITICAL_OP = {
+  dockerLifecycle: "docker_lifecycle",
+  dbMigration: "db_migration",
+  // Keystore / secret-vault writes + private-key decrypt (wallet generate /
+  // import / restore / export, provider+api-key+embedding+agent-core persist).
+  secretVaultOp: "secret_vault_op",
+} as const;
+
+export type CriticalOpLabel = (typeof CRITICAL_OP)[keyof typeof CRITICAL_OP];
+
+const counts = new Map<string, number>();
+
+/** Mark a critical op in flight. Returns an idempotent `end` callback. */
+export function beginCriticalOp(label: CriticalOpLabel): () => void {
+  counts.set(label, (counts.get(label) ?? 0) + 1);
+  let ended = false;
+  return () => {
+    if (ended) return;
+    ended = true;
+    const next = (counts.get(label) ?? 1) - 1;
+    if (next <= 0) counts.delete(label);
+    else counts.set(label, next);
+  };
+}
+
+/** True while any critical op is running. */
+export function criticalOpInFlight(): boolean {
+  return counts.size > 0;
+}
+
+/** Labels currently in flight (for a user-actionable block reason). */
+export function activeCriticalOps(): readonly string[] {
+  return [...counts.keys()];
+}
+
+/**
+ * Wrap an async handler so its whole duration counts as a critical op.
+ * `finally` guarantees the count is released on every return/throw path.
+ */
+export function trackCriticalOp<A extends unknown[], R>(
+  label: CriticalOpLabel,
+  fn: (...args: A) => Promise<R>,
+): (...args: A) => Promise<R> {
+  return async (...args: A): Promise<R> => {
+    const end = beginCriticalOp(label);
+    try {
+      return await fn(...args);
+    } finally {
+      end();
+    }
+  };
+}
+
+/** Test-only: clear all counts. */
+export function __resetCriticalOpsForTests(): void {
+  counts.clear();
+}

--- a/vex-app/src/main/updates/safeRestart.ts
+++ b/vex-app/src/main/updates/safeRestart.ts
@@ -1,0 +1,90 @@
+/**
+ * Safe-restart gate for the user-triggered updater (M13).
+ *
+ * `quitAndInstall` must never interrupt work that an abrupt restart could
+ * corrupt (skill §"Safe restart gate"). Two signals:
+ *   - agent/mission execution — a DB-backed query (`hasActiveAgentWork`), the
+ *     only correct signal since runs outlive the IPC handler that starts them;
+ *   - local destructive ops (docker lifecycle / db migration) — the in-memory
+ *     `critical-ops` registry.
+ *
+ * `prepareForUpdateRestart()` is intentionally lightweight: it only flags the
+ * restart, then the caller invokes `quitAndInstall`. It deliberately does NOT
+ * remove updater event listeners (electron-updater can emit `error`
+ * synchronously from install(), and Node throws on a listener-less 'error'
+ * event); they are torn down by the normal quit cleanup. The heavy teardown
+ * (drain workers -> `compose stop` WITHOUT
+ * `--volumes` -> lock secrets) is done by the existing `will-quit` ->
+ * `globalCleanup` path that `quitAndInstall`'s `app.quit()` triggers;
+ * electron-updater spawns the detached installer in `install()` BEFORE
+ * `app.quit()`, so it survives the subsequent hard exit. We deliberately do
+ * NOT pre-drain `globalCleanup` or reset Docker/volumes here.
+ */
+
+import { hasActiveAgentWork } from "../database/mission-runs-db.js";
+import {
+  CRITICAL_OP,
+  activeCriticalOps,
+  criticalOpInFlight,
+} from "./critical-ops.js";
+
+export type RestartGate = { ok: true } | { ok: false; message: string };
+
+let updateRestartInProgress = false;
+
+export function isUpdateRestartInProgress(): boolean {
+  return updateRestartInProgress;
+}
+
+/**
+ * Clear the in-progress flag. Called from the updater `error` listener when a
+ * restart was underway: if `quitAndInstall()`/`install()` fails (e.g. a missing
+ * installer path) the app stays open, so the flag must be released or
+ * `restartAndInstallNow()` would short-circuit forever and the user could never
+ * retry.
+ */
+export function clearUpdateRestartInProgress(): void {
+  updateRestartInProgress = false;
+}
+
+export async function canRestartForUpdate(): Promise<RestartGate> {
+  const agentWork = await hasActiveAgentWork();
+  if (agentWork.active) {
+    return { ok: false, message: agentWork.reason };
+  }
+  if (criticalOpInFlight()) {
+    return { ok: false, message: criticalOpReason(activeCriticalOps()) };
+  }
+  return { ok: true };
+}
+
+export function prepareForUpdateRestart(): void {
+  updateRestartInProgress = true;
+  // Do NOT remove updater event listeners here: electron-updater can emit
+  // `error` synchronously from install()/quitAndInstall() (e.g. a missing
+  // installer path), and Node throws on an EventEmitter 'error' with no
+  // listener. Listeners are torn down by the normal quit cleanup
+  // (globalCleanup -> removeUpdaterEventListeners) AFTER quitAndInstall.
+}
+
+const CRITICAL_OP_REASONS: Record<string, string> = {
+  [CRITICAL_OP.dockerLifecycle]:
+    "Docker setup is still running. Wait for it to finish, then update.",
+  [CRITICAL_OP.dbMigration]:
+    "A database migration is still running. Wait for it to finish, then update.",
+  [CRITICAL_OP.secretVaultOp]:
+    "A wallet or secret-vault operation is still in progress. Wait for it to finish, then update.",
+};
+
+function criticalOpReason(labels: readonly string[]): string {
+  for (const label of labels) {
+    const reason = CRITICAL_OP_REASONS[label];
+    if (reason) return reason;
+  }
+  return "An operation is still running. Finish it before updating.";
+}
+
+/** Test-only: reset the in-progress flag. */
+export function __resetSafeRestartForTests(): void {
+  updateRestartInProgress = false;
+}

--- a/vex-app/src/main/updates/sanitize.ts
+++ b/vex-app/src/main/updates/sanitize.ts
@@ -1,0 +1,164 @@
+/**
+ * Map raw `electron-updater` payloads to the public `UpdateStatus`/`VexError`
+ * contracts, and provide a redaction-filtered updater logger.
+ *
+ * Redaction contract (skill §"Non-negotiable rules" 8): NOTHING that crosses
+ * the IPC boundary or a log sink may carry installer paths, artifact URLs,
+ * tokens, raw metadata, or release-notes HTML. `UpdateInfo`/`ProgressInfo` are
+ * projected to versions + bounded progress + a short plain summary only; error
+ * messages are coarse and user-safe; the updater logger scrubs URLs/paths.
+ */
+
+import type { ProgressInfo, UpdateInfo } from "electron-updater";
+import type { VexError, VexErrorCode } from "@shared/ipc/result.js";
+import type { UpdateStatus } from "@shared/schemas/updater.js";
+import { getCurrentStatus } from "./statusCache.js";
+import { log } from "../logger/index.js";
+
+const SUMMARY_MAX = 200;
+
+/** Recover the latest version from the current status, else fall back. */
+function latestFromCacheOr(fallback: string): string {
+  const prev = getCurrentStatus();
+  return "latestVersion" in prev ? prev.latestVersion : fallback;
+}
+
+export function availableStatus(
+  info: UpdateInfo,
+  currentVersion: string,
+): UpdateStatus {
+  const latestVersion =
+    typeof info.version === "string" && info.version.length > 0
+      ? info.version
+      : currentVersion;
+  const releaseName =
+    typeof info.releaseName === "string" ? info.releaseName.trim() : "";
+  const releaseDate =
+    typeof info.releaseDate === "string" ? info.releaseDate.trim() : "";
+  return {
+    kind: "available",
+    currentVersion,
+    latestVersion,
+    severity: "normal",
+    ...(releaseDate.length > 0 ? { releaseDate } : {}),
+    ...(releaseName.length > 0
+      ? { summary: releaseName.slice(0, SUMMARY_MAX) }
+      : {}),
+  };
+}
+
+export function downloadingStatus(
+  progress: ProgressInfo,
+  currentVersion: string,
+): UpdateStatus {
+  return {
+    kind: "downloading",
+    currentVersion,
+    latestVersion: latestFromCacheOr(currentVersion),
+    percent: clampPercent(progress.percent),
+    ...(isFiniteNonNeg(progress.bytesPerSecond)
+      ? { bytesPerSecond: progress.bytesPerSecond }
+      : {}),
+    ...(isFiniteNonNeg(progress.transferred)
+      ? { transferred: progress.transferred }
+      : {}),
+    ...(isFiniteNonNeg(progress.total) ? { total: progress.total } : {}),
+  };
+}
+
+export function errorStatus(
+  error: unknown,
+  currentVersion: string,
+): UpdateStatus {
+  return {
+    kind: "error",
+    currentVersion,
+    message: safeUpdateErrorMessage(error),
+    retryable: true,
+  };
+}
+
+/**
+ * Redacted, user-safe error string. `electron-updater` error messages can embed
+ * feed URLs / file paths, so the raw message is never surfaced — only a coarse,
+ * actionable line. Structural diagnosis is logged separately in main.
+ */
+export function safeUpdateErrorMessage(_error: unknown): string {
+  return "Update failed. Check your connection and try again.";
+}
+
+type UpdateErrorCode = Extract<VexErrorCode, `update.${string}`>;
+
+const UPDATE_ERROR_MESSAGES: Record<UpdateErrorCode, string> = {
+  "update.check_failed":
+    "Couldn't check for updates. Check your connection and try again.",
+  "update.download_failed": "The update download failed. Try again.",
+  "update.apply_failed": "Couldn't apply the update right now. Try again.",
+};
+
+export function publicUpdateError(
+  code: UpdateErrorCode,
+  correlationId: string,
+  messageOverride?: string,
+): VexError {
+  return {
+    code,
+    domain: "updater",
+    message: messageOverride ?? UPDATE_ERROR_MESSAGES[code],
+    retryable: true,
+    userActionable: true,
+    redacted: true,
+    correlationId,
+  };
+}
+
+// ── filtered updater logger ─────────────────────────────────────────────────
+// electron-updater logs feed/artifact URLs and installer paths directly. Scrub
+// http(s) URLs and absolute file paths before delegating to the redacted app
+// logger (which separately scrubs key material / addresses).
+
+const URL_RE = /\bhttps?:\/\/\S+/gi;
+const WIN_PATH_RE = /\b[A-Za-z]:\\[^\s"']+/g;
+const NIX_PATH_RE = /(?<![\w[])\/(?:[^\s"'/]+\/)+[^\s"']*/g;
+
+function safeStringify(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === "object" && value !== null) {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "[object]";
+    }
+  }
+  return String(value);
+}
+
+function scrub(value: unknown): string {
+  return safeStringify(value)
+    .replace(URL_RE, "[url]")
+    .replace(WIN_PATH_RE, "[path]")
+    .replace(NIX_PATH_RE, "[path]");
+}
+
+export interface UpdaterLogger {
+  info(message: unknown): void;
+  warn(message: unknown): void;
+  error(message: unknown): void;
+  debug(message: unknown): void;
+}
+
+export const filteredUpdaterLogger: UpdaterLogger = {
+  info: (m) => log.info(`[updater] ${scrub(m)}`),
+  warn: (m) => log.warn(`[updater] ${scrub(m)}`),
+  error: (m) => log.error(`[updater] ${scrub(m)}`),
+  debug: (m) => log.debug(`[updater] ${scrub(m)}`),
+};
+
+function clampPercent(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.min(100, Math.max(0, value));
+}
+
+function isFiniteNonNeg(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}

--- a/vex-app/src/main/updates/statusCache.ts
+++ b/vex-app/src/main/updates/statusCache.ts
@@ -1,0 +1,56 @@
+/**
+ * Single source of truth for the renderer-visible update state (M13).
+ *
+ * Main owns `electron-updater`; the renderer only ever sees the sanitized
+ * `UpdateStatus` cached here and broadcast on `EV.updater.status`. `setStatus`
+ * re-validates with the shared schema (defense-in-depth) so a mapping bug can
+ * never push an off-contract / unredacted shape across the IPC boundary.
+ */
+
+import { app } from "electron";
+import { EV } from "@shared/ipc/channels.js";
+import {
+  updateStatusSchema,
+  type UpdateStatus,
+} from "@shared/schemas/updater.js";
+import { broadcastToAllWindows } from "../lifecycle/broadcast.js";
+import { log } from "../logger/index.js";
+
+function resolveVersion(): string {
+  try {
+    return app.getVersion();
+  } catch {
+    return "0.0.0";
+  }
+}
+
+let current: UpdateStatus = { kind: "idle", currentVersion: resolveVersion() };
+
+/** Current app version — the `currentVersion` field on every status. */
+export function currentVersion(): string {
+  return resolveVersion();
+}
+
+/** Last-known status (what `getStatus()` returns; no network call). */
+export function getCurrentStatus(): UpdateStatus {
+  return current;
+}
+
+/** Validate, cache, and broadcast a status transition to all windows. */
+export function setStatus(next: UpdateStatus): void {
+  const parsed = updateStatusSchema.safeParse(next);
+  if (!parsed.success) {
+    log.error(
+      "[updates] refused to set invalid UpdateStatus",
+      parsed.error.format(),
+    );
+    return;
+  }
+  current = parsed.data;
+  broadcastToAllWindows(EV.updater.status, parsed.data);
+}
+
+/** Test-only: reset the cache to idle. */
+export function __resetStatusCacheForTests(): void {
+  current = { kind: "idle", currentVersion: resolveVersion() };
+}

--- a/vex-app/src/main/updates/updateActions.ts
+++ b/vex-app/src/main/updates/updateActions.ts
@@ -1,0 +1,208 @@
+/**
+ * Business actions behind the `vex.updater.*` IPC surface (M13).
+ *
+ * Two-step UX: `startUpdateNow` consents to DOWNLOAD only; `restartAndInstallNow`
+ * is the SEPARATE explicit restart action. `update-downloaded` (in
+ * configureUpdater) never auto-restarts. Every action returns a redacted
+ * `Result`; the renderer never receives installer paths/URLs/tokens.
+ */
+
+import { shell } from "electron";
+import electronUpdater from "electron-updater";
+import { err, ok, type Result } from "@shared/ipc/result.js";
+import type {
+  ReleaseNotesOpened,
+  UpdateCancelled,
+  UpdateRestarting,
+  UpdateStarted,
+  UpdateStatus,
+} from "@shared/schemas/updater.js";
+import { log } from "../logger/index.js";
+import { preferencesStore } from "../preferences/store.js";
+import { errorStatus, publicUpdateError } from "./sanitize.js";
+import {
+  canRestartForUpdate,
+  isUpdateRestartInProgress,
+  prepareForUpdateRestart,
+} from "./safeRestart.js";
+import { currentVersion, getCurrentStatus, setStatus } from "./statusCache.js";
+
+const { autoUpdater, CancellationToken } = electronUpdater;
+
+let downloadInFlight: InstanceType<typeof CancellationToken> | null = null;
+
+// TODO(release-track): replace with the real release-notes URL once hosting
+// lands. Built in main; the renderer never constructs updater URLs.
+const RELEASE_NOTES_URL = "https://vex.example/releases";
+
+export async function getStatus(): Promise<Result<UpdateStatus>> {
+  return ok(getCurrentStatus());
+}
+
+export async function checkNow(
+  correlationId: string,
+): Promise<Result<UpdateStatus>> {
+  try {
+    // `checkForUpdates()` resolves null when no feed/update; the autoUpdater
+    // events fired during the check have already updated the status cache.
+    await autoUpdater.checkForUpdates();
+    void preferencesStore
+      .update({ updater: { lastCheckedAt: new Date().toISOString() } })
+      .catch((cause) =>
+        log.warn("[updates] failed to persist updater.lastCheckedAt", cause),
+      );
+    return ok(getCurrentStatus());
+  } catch (error) {
+    log.warn(`[updates] checkForUpdates failed correlationId=${correlationId}`);
+    setStatus(errorStatus(error, currentVersion()));
+    return err(publicUpdateError("update.check_failed", correlationId));
+  }
+}
+
+export async function startUpdateNow(
+  correlationId: string,
+): Promise<Result<UpdateStarted>> {
+  // Idempotent: a download already running is a successful start.
+  if (downloadInFlight !== null) return ok({ started: true });
+
+  const status = getCurrentStatus();
+  if (status.kind !== "available") {
+    return err(
+      publicUpdateError(
+        "update.apply_failed",
+        correlationId,
+        "No update is available to download.",
+      ),
+    );
+  }
+
+  const gate = await canRestartForUpdate();
+  if (!gate.ok) {
+    setStatus({
+      kind: "blockedByOperation",
+      currentVersion: currentVersion(),
+      latestVersion: status.latestVersion,
+      reason: gate.message,
+    });
+    return err(
+      publicUpdateError("update.apply_failed", correlationId, gate.message),
+    );
+  }
+
+  try {
+    const token = new CancellationToken();
+    downloadInFlight = token;
+    setStatus({
+      kind: "downloading",
+      currentVersion: currentVersion(),
+      latestVersion: status.latestVersion,
+      percent: 0,
+    });
+    // Fire-and-forget: the IPC ack is non-blocking; progress + completion
+    // arrive via the autoUpdater event stream. The token ref keeps the
+    // operation cancellable and alive; both settle paths clear it so a later
+    // check -> download (e.g. a newer version after the user defers a restart)
+    // is not blocked by a permanently-stuck in-flight token.
+    void autoUpdater
+      .downloadUpdate(token)
+      .then(() => {
+        if (downloadInFlight === token) downloadInFlight = null;
+      })
+      .catch((error: unknown) => {
+        if (downloadInFlight === token) {
+          downloadInFlight = null;
+          log.warn(
+            `[updates] downloadUpdate failed correlationId=${correlationId}`,
+          );
+          setStatus(errorStatus(error, currentVersion()));
+        }
+      });
+    return ok({ started: true });
+  } catch (error) {
+    downloadInFlight = null;
+    setStatus(errorStatus(error, currentVersion()));
+    return err(publicUpdateError("update.download_failed", correlationId));
+  }
+}
+
+export async function cancelDownload(): Promise<Result<UpdateCancelled>> {
+  downloadInFlight?.cancel();
+  downloadInFlight = null;
+  const status = getCurrentStatus();
+  if (status.kind === "downloading") {
+    setStatus({
+      kind: "available",
+      currentVersion: currentVersion(),
+      latestVersion: status.latestVersion,
+      severity: "normal",
+    });
+  }
+  return ok({ cancelled: true });
+}
+
+export async function restartAndInstallNow(
+  correlationId: string,
+): Promise<Result<UpdateRestarting>> {
+  // Idempotent under double-click / hostile renderer: a restart already
+  // underway (or `installing`) is a successful no-op.
+  if (isUpdateRestartInProgress()) return ok({ restarting: true });
+
+  const status = getCurrentStatus();
+  if (status.kind === "installing") return ok({ restarting: true });
+  if (status.kind !== "downloaded") {
+    return err(
+      publicUpdateError(
+        "update.apply_failed",
+        correlationId,
+        "No downloaded update is ready to install.",
+      ),
+    );
+  }
+
+  const gate = await canRestartForUpdate();
+  if (!gate.ok) {
+    setStatus({
+      kind: "blockedByOperation",
+      currentVersion: currentVersion(),
+      latestVersion: status.latestVersion,
+      reason: gate.message,
+    });
+    return err(
+      publicUpdateError("update.apply_failed", correlationId, gate.message),
+    );
+  }
+
+  setStatus({
+    kind: "installing",
+    currentVersion: currentVersion(),
+    latestVersion: status.latestVersion,
+  });
+  prepareForUpdateRestart();
+  // Windows: true => silent installer after explicit Vex UI consent; second
+  // arg re-runs the app after install where supported.
+  autoUpdater.quitAndInstall(process.platform === "win32", true);
+  return ok({ restarting: true });
+}
+
+export async function openReleaseNotes(
+  correlationId: string,
+): Promise<Result<ReleaseNotesOpened>> {
+  try {
+    await shell.openExternal(RELEASE_NOTES_URL);
+    return ok({ opened: true });
+  } catch {
+    log.warn(`[updates] openExternal failed correlationId=${correlationId}`);
+    return err(
+      publicUpdateError(
+        "update.check_failed",
+        correlationId,
+        "Couldn't open the release notes page.",
+      ),
+    );
+  }
+}
+
+/** Test-only: reset module state. */
+export function __resetUpdateActionsForTests(): void {
+  downloadInFlight = null;
+}

--- a/vex-app/src/preload/__tests__/bridge-surface.test.ts
+++ b/vex-app/src/preload/__tests__/bridge-surface.test.ts
@@ -158,6 +158,13 @@ describe("preload bridge surface", () => {
       "CH.sessions.getModel",
       // Error-diagnostics phase (D-FOLDER) — "Open logs folder".
       "CH.support.openLogsFolder",
+      // Updater (M13) — user-triggered in-app update bridge.
+      "CH.updater.check",
+      "CH.updater.getStatus",
+      "CH.updater.startUpdateNow",
+      "CH.updater.cancelDownload",
+      "CH.updater.restartAndInstallNow",
+      "CH.updater.openReleaseNotes",
     ];
     const corpus = PRELOAD_FILES.map((f) => readFileSync(f, "utf8")).join("\n");
     for (const channel of expected) {

--- a/vex-app/src/preload/shell/index.ts
+++ b/vex-app/src/preload/shell/index.ts
@@ -24,6 +24,7 @@ import { settings } from "./settings.js";
 import { support } from "./support.js";
 import { system } from "./system.js";
 import { telemetry } from "./telemetry.js";
+import { updater } from "./updater.js";
 import { wallet } from "./wallet.js";
 
 export const shellBridge = {
@@ -37,4 +38,5 @@ export const shellBridge = {
   settings,
   telemetry,
   support,
+  updater,
 } satisfies VexShellBridge;

--- a/vex-app/src/preload/shell/updater.ts
+++ b/vex-app/src/preload/shell/updater.ts
@@ -1,0 +1,35 @@
+import { CH, EV } from "../../shared/ipc/channels.js";
+import { updateStatusSchema } from "../../shared/schemas/updater.js";
+import type { UpdaterBridge } from "../../shared/types/bridge/shell/updater.js";
+import { invokeWithSchema, subscribe } from "../_dispatch.js";
+
+/**
+ * vex.updater.* — user-triggered in-app update bridge (M13).
+ *
+ * Business methods only; the renderer never imports electron-updater / electron
+ * and never sees a raw channel. Status arrives via `onStatus` (main-pushed,
+ * Zod-validated at the preload boundary). Mirrors `shell/docker.ts`.
+ */
+export const updater = {
+  getStatus() {
+    return invokeWithSchema(CH.updater.getStatus, {});
+  },
+  checkNow() {
+    return invokeWithSchema(CH.updater.check, {});
+  },
+  startUpdateNow() {
+    return invokeWithSchema(CH.updater.startUpdateNow, {});
+  },
+  cancelDownload() {
+    return invokeWithSchema(CH.updater.cancelDownload, {});
+  },
+  restartAndInstallNow() {
+    return invokeWithSchema(CH.updater.restartAndInstallNow, {});
+  },
+  openReleaseNotes() {
+    return invokeWithSchema(CH.updater.openReleaseNotes, {});
+  },
+  onStatus(cb) {
+    return subscribe(EV.updater.status, updateStatusSchema, cb);
+  },
+} satisfies UpdaterBridge;

--- a/vex-app/src/renderer/App.tsx
+++ b/vex-app/src/renderer/App.tsx
@@ -12,7 +12,7 @@
  * they are not part of the user-facing flow.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type JSX } from "react";
 import { IntroScreen } from "./features/splash/IntroScreen.js";
 import { SystemCheck } from "./features/systemCheck/SystemCheck.js";
 import { BootstrapPanel } from "./features/docker/BootstrapPanel.js";
@@ -21,6 +21,7 @@ import { Migrations } from "./features/database/Migrations.js";
 import { WizardShell } from "./features/wizard/WizardShell.js";
 import { AppShell } from "./features/appShell/AppShell.js";
 import { UnlockScreen } from "./features/secrets/UnlockScreen.js";
+import { UpdateLayer } from "./features/updates/UpdateLayer.js";
 import { useUiStore, type View } from "./stores/uiStore.js";
 import type { Capabilities } from "../shared/schemas/capabilities.js";
 import type { HealthReport } from "../shared/schemas/system.js";
@@ -51,6 +52,9 @@ export function App(): JSX.Element {
   return (
     <>
       {views[currentView]()}
+      {/* Global, view-independent: a user-triggered update prompt can appear
+          over any screen. No-ops when the updater bridge is absent. */}
+      <UpdateLayer />
       {import.meta.env.DEV ? <DevDiagnostics /> : null}
     </>
   );

--- a/vex-app/src/renderer/features/updates/UpdateLayer.tsx
+++ b/vex-app/src/renderer/features/updates/UpdateLayer.tsx
@@ -1,0 +1,142 @@
+/**
+ * Global update layer (M13) — mounted once at the app root, above the view
+ * switch, so a "new update available" prompt can appear over any screen.
+ *
+ * Owns the live status subscription + the two-step action wiring; renders a
+ * discreet top banner that opens the detail modal. Defensive: a no-op when the
+ * updater bridge is absent (plain dev / no feed / isolated renderer tests that
+ * don't stub `window.vex.updater`).
+ */
+
+import { useState, type JSX } from "react";
+import type { UpdateStatus } from "@shared/schemas/updater.js";
+import { Button } from "../../components/ui/button.js";
+import {
+  openReleaseNotes,
+  useCancelDownload,
+  useCheckForUpdates,
+  useRestartAndInstall,
+  useStartUpdate,
+  useUpdateStatus,
+  useUpdaterLiveSync,
+} from "../../lib/api/updates.js";
+import { UpdateModal } from "./UpdateModal.js";
+
+export function UpdateLayer(): JSX.Element | null {
+  if (typeof window === "undefined" || !window.vex?.updater) return null;
+  return <UpdateLayerInner />;
+}
+
+function UpdateLayerInner(): JSX.Element | null {
+  useUpdaterLiveSync();
+  const statusQuery = useUpdateStatus();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
+
+  const checkMut = useCheckForUpdates();
+  const startMut = useStartUpdate();
+  const cancelMut = useCancelDownload();
+  const restartMut = useRestartAndInstall();
+  const busy =
+    checkMut.isPending ||
+    startMut.isPending ||
+    cancelMut.isPending ||
+    restartMut.isPending;
+
+  const status: UpdateStatus | null = statusQuery.data?.ok
+    ? statusQuery.data.data
+    : null;
+  if (status === null) return null;
+
+  const bannerVisible =
+    isBannerKind(status) &&
+    !(status.kind === "available" && dismissedVersion === status.latestVersion);
+
+  return (
+    <>
+      {bannerVisible ? (
+        <UpdateBanner
+          status={status}
+          onView={() => setModalOpen(true)}
+          {...(status.kind === "available"
+            ? { onDismiss: () => setDismissedVersion(status.latestVersion) }
+            : {})}
+        />
+      ) : null}
+      <UpdateModal
+        open={modalOpen}
+        status={status}
+        busy={busy}
+        onOpenChange={setModalOpen}
+        onDownload={() => startMut.mutate()}
+        onCancel={() => cancelMut.mutate()}
+        onRestart={() => restartMut.mutate()}
+        onCheck={() => checkMut.mutate()}
+        onReleaseNotes={openReleaseNotes}
+      />
+    </>
+  );
+}
+
+function isBannerKind(status: UpdateStatus): boolean {
+  return (
+    status.kind === "available" ||
+    status.kind === "downloading" ||
+    status.kind === "downloaded" ||
+    status.kind === "blockedByOperation" ||
+    status.kind === "error"
+  );
+}
+
+interface UpdateBannerProps {
+  readonly status: UpdateStatus;
+  readonly onView: () => void;
+  readonly onDismiss?: () => void;
+}
+
+function UpdateBanner({
+  status,
+  onView,
+  onDismiss,
+}: UpdateBannerProps): JSX.Element {
+  return (
+    <div
+      className="fixed inset-x-0 top-0 z-[60] flex items-center justify-center gap-3 border-b border-border bg-card/95 px-4 py-2 text-sm text-foreground backdrop-blur"
+      data-vex-screen="updateBanner"
+      role="status"
+    >
+      <span aria-hidden>⬆</span>
+      <span>{bannerLabel(status)}</span>
+      <Button size="sm" onClick={onView}>
+        Zobacz
+      </Button>
+      {onDismiss ? (
+        <button
+          type="button"
+          aria-label="Zamknij powiadomienie o aktualizacji"
+          onClick={onDismiss}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          ✕
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function bannerLabel(status: UpdateStatus): string {
+  switch (status.kind) {
+    case "available":
+      return `Vex ${status.latestVersion} jest dostępna`;
+    case "downloading":
+      return `Pobieranie Vex ${status.latestVersion}… ${Math.round(status.percent)}%`;
+    case "downloaded":
+      return `Vex ${status.latestVersion} gotowa do instalacji`;
+    case "blockedByOperation":
+      return "Aktualizacja wstrzymana";
+    case "error":
+      return "Aktualizacja nie powiodła się";
+    default:
+      return "Aktualizacja Vex";
+  }
+}

--- a/vex-app/src/renderer/features/updates/UpdateModal.tsx
+++ b/vex-app/src/renderer/features/updates/UpdateModal.tsx
@@ -1,0 +1,228 @@
+/**
+ * Update detail modal (M13) — the two-step flow surface.
+ *
+ * Presentational: it renders the current `UpdateStatus` and calls back into
+ * `UpdateLayer` for actions. Step 1 is an explicit "Pobierz aktualizację"
+ * (download); step 2 is a SEPARATE "Zrestartuj i zainstaluj" (restart) shown
+ * only once the download is ready. No auto-restart, no artifact paths/URLs.
+ */
+
+import type { JSX } from "react";
+import type { UpdateStatus } from "@shared/schemas/updater.js";
+import { Button } from "../../components/ui/button.js";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../components/ui/dialog.js";
+
+interface UpdateModalProps {
+  readonly open: boolean;
+  readonly status: UpdateStatus;
+  readonly busy: boolean;
+  readonly onOpenChange: (next: boolean) => void;
+  readonly onDownload: () => void;
+  readonly onCancel: () => void;
+  readonly onRestart: () => void;
+  readonly onCheck: () => void;
+  readonly onReleaseNotes: () => void;
+}
+
+export function UpdateModal({
+  open,
+  status,
+  busy,
+  onOpenChange,
+  onDownload,
+  onCancel,
+  onRestart,
+  onCheck,
+  onReleaseNotes,
+}: UpdateModalProps): JSX.Element {
+  const close = (): void => onOpenChange(false);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md" data-vex-screen="updateModal">
+        <DialogHeader>
+          <DialogTitle>{titleFor(status)}</DialogTitle>
+          <DialogDescription>{descriptionFor(status)}</DialogDescription>
+        </DialogHeader>
+
+        <DialogBody>
+          {status.kind === "available" && status.summary ? (
+            <p className="text-sm text-muted-foreground">{status.summary}</p>
+          ) : null}
+          {status.kind === "downloading" ? (
+            <UpdateProgress percent={status.percent} />
+          ) : null}
+          {status.kind === "error" ? (
+            <p className="text-sm text-muted-foreground">{status.message}</p>
+          ) : null}
+          {status.kind === "blockedByOperation" ? (
+            <p className="text-sm text-muted-foreground">{status.reason}</p>
+          ) : null}
+        </DialogBody>
+
+        <DialogFooter>
+          {renderFooter(status, {
+            busy,
+            close,
+            onDownload,
+            onCancel,
+            onRestart,
+            onCheck,
+            onReleaseNotes,
+          })}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface FooterActions {
+  readonly busy: boolean;
+  readonly close: () => void;
+  readonly onDownload: () => void;
+  readonly onCancel: () => void;
+  readonly onRestart: () => void;
+  readonly onCheck: () => void;
+  readonly onReleaseNotes: () => void;
+}
+
+function renderFooter(status: UpdateStatus, a: FooterActions): JSX.Element {
+  switch (status.kind) {
+    case "available":
+      return (
+        <>
+          <Button variant="ghost" onClick={a.onReleaseNotes}>
+            Informacje o wydaniu
+          </Button>
+          <Button variant="ghost" onClick={a.close}>
+            Później
+          </Button>
+          <Button onClick={a.onDownload} disabled={a.busy}>
+            Pobierz aktualizację
+          </Button>
+        </>
+      );
+    case "downloading":
+      return (
+        <Button variant="ghost" onClick={a.onCancel} disabled={a.busy}>
+          Anuluj
+        </Button>
+      );
+    case "downloaded":
+      return (
+        <>
+          <Button variant="ghost" onClick={a.close}>
+            Później
+          </Button>
+          <Button onClick={a.onRestart} disabled={a.busy}>
+            Zrestartuj i zainstaluj
+          </Button>
+        </>
+      );
+    case "blockedByOperation":
+      return (
+        <Button onClick={a.close}>Rozumiem</Button>
+      );
+    case "error":
+      return (
+        <>
+          <Button variant="ghost" onClick={a.onReleaseNotes}>
+            Otwórz stronę pobierania
+          </Button>
+          <Button onClick={a.onCheck} disabled={a.busy}>
+            Spróbuj ponownie
+          </Button>
+        </>
+      );
+    case "installing":
+      return <Button disabled>Instalowanie…</Button>;
+    case "checking":
+      return <Button disabled>Sprawdzanie…</Button>;
+    case "current":
+    case "idle":
+      return (
+        <Button variant="ghost" onClick={a.close}>
+          Zamknij
+        </Button>
+      );
+  }
+}
+
+function titleFor(status: UpdateStatus): string {
+  switch (status.kind) {
+    case "available":
+      return `Dostępna aktualizacja — Vex ${status.latestVersion}`;
+    case "downloading":
+      return `Pobieranie Vex ${status.latestVersion}`;
+    case "downloaded":
+      return "Aktualizacja gotowa do instalacji";
+    case "installing":
+      return "Instalowanie aktualizacji";
+    case "blockedByOperation":
+      return "Najpierw dokończ bieżącą operację";
+    case "error":
+      return "Aktualizacja nie powiodła się";
+    case "checking":
+      return "Sprawdzanie aktualizacji";
+    case "current":
+      return "Masz najnowszą wersję";
+    case "idle":
+      return "Aktualizacje";
+  }
+}
+
+function descriptionFor(status: UpdateStatus): string {
+  switch (status.kind) {
+    case "available":
+      return `Masz wersję ${status.currentVersion}. Pobranie nie uruchomi restartu — zrobisz to osobno.`;
+    case "downloading":
+      return "Vex pobiera aktualizację. Możesz dalej korzystać z aplikacji.";
+    case "downloaded":
+      return `Vex ${status.latestVersion} jest gotowa. Vex uruchomi się ponownie, aby zainstalować.`;
+    case "installing":
+      return "Vex zamyka się i uruchomi ponownie automatycznie.";
+    case "blockedByOperation":
+      return "Zaktualizuj, gdy bieżąca operacja się zakończy.";
+    case "error":
+      return "Sprawdź połączenie i spróbuj ponownie.";
+    case "checking":
+      return "Łączenie z kanałem aktualizacji…";
+    case "current":
+      return `Vex ${status.currentVersion} jest aktualna.`;
+    case "idle":
+      return "Brak aktywnej aktualizacji.";
+  }
+}
+
+function UpdateProgress({ percent }: { readonly percent: number }): JSX.Element {
+  const clamped = Math.min(100, Math.max(0, Math.round(percent)));
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between text-xs">
+        <span className="font-mono uppercase tracking-[0.2em] text-muted-foreground">
+          Pobieranie
+        </span>
+        <span className="font-mono tabular-nums">{clamped}%</span>
+      </div>
+      <div
+        className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-valuenow={clamped}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          className="h-full bg-primary transition-[width] duration-150 ease-out"
+          style={{ width: `${clamped}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/vex-app/src/renderer/features/updates/__tests__/UpdateLayer.test.tsx
+++ b/vex-app/src/renderer/features/updates/__tests__/UpdateLayer.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * UpdateLayer (M13). Verifies the defensive no-op when the updater bridge is
+ * absent (plain dev / isolated tests), and that an `available` status surfaces
+ * the banner when the bridge is stubbed.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import type { UpdateStatus } from "@shared/schemas/updater.js";
+import { UpdateLayer } from "../UpdateLayer.js";
+
+function stubUpdater(status: UpdateStatus): void {
+  Object.defineProperty(window, "vex", {
+    configurable: true,
+    writable: true,
+    value: {
+      updater: {
+        getStatus: vi.fn().mockResolvedValue({ ok: true, data: status }),
+        onStatus: vi.fn(() => () => {}),
+        checkNow: vi.fn(),
+        startUpdateNow: vi.fn(),
+        cancelDownload: vi.fn(),
+        restartAndInstallNow: vi.fn(),
+        openReleaseNotes: vi.fn(),
+      },
+    },
+  });
+}
+
+function withClient(children: ReactNode): ReactNode {
+  return createElement(QueryClientProvider, { client: new QueryClient() }, children);
+}
+
+afterEach(() => {
+  // @ts-expect-error — test cleanup
+  delete window.vex;
+});
+
+describe("UpdateLayer", () => {
+  it("renders nothing when the updater bridge is absent", () => {
+    const { container } = render(<UpdateLayer />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows the banner when an update is available", async () => {
+    stubUpdater({
+      kind: "available",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      severity: "normal",
+    });
+    render(withClient(<UpdateLayer />));
+    expect(await screen.findByText("Vex 1.1.0 jest dostępna")).toBeTruthy();
+  });
+});

--- a/vex-app/src/renderer/features/updates/__tests__/UpdateModal.test.tsx
+++ b/vex-app/src/renderer/features/updates/__tests__/UpdateModal.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * UpdateModal (M13) — presentational two-step surface. Asserts the step-1
+ * (download) vs step-2 (restart) buttons appear for the right states and that
+ * actions fire. No `window.vex` needed — the modal takes props.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { UpdateStatus } from "@shared/schemas/updater.js";
+import { UpdateModal } from "../UpdateModal.js";
+
+function renderModal(status: UpdateStatus) {
+  const props = {
+    open: true,
+    status,
+    busy: false,
+    onOpenChange: vi.fn(),
+    onDownload: vi.fn(),
+    onCancel: vi.fn(),
+    onRestart: vi.fn(),
+    onCheck: vi.fn(),
+    onReleaseNotes: vi.fn(),
+  };
+  render(<UpdateModal {...props} />);
+  return props;
+}
+
+describe("UpdateModal two-step buttons", () => {
+  it("available shows the Download CTA (step 1), not a restart", () => {
+    renderModal({
+      kind: "available",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      severity: "normal",
+    });
+    expect(screen.getByText("Pobierz aktualizację")).toBeTruthy();
+    expect(screen.queryByText("Zrestartuj i zainstaluj")).toBeNull();
+  });
+
+  it("downloading shows a progressbar at the right value + Cancel", () => {
+    renderModal({
+      kind: "downloading",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      percent: 40,
+    });
+    // jsdom doesn't implement <dialog>.showModal(), so the dialog stays
+    // `hidden`; query the accessibility tree with hidden:true.
+    expect(
+      screen
+        .getByRole("progressbar", { hidden: true })
+        .getAttribute("aria-valuenow"),
+    ).toBe("40");
+    expect(screen.getByText("Anuluj")).toBeTruthy();
+  });
+
+  it("downloaded shows the explicit Restart CTA (step 2)", () => {
+    renderModal({
+      kind: "downloaded",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+    });
+    expect(screen.getByText("Zrestartuj i zainstaluj")).toBeTruthy();
+  });
+
+  it("blockedByOperation surfaces the reason", () => {
+    renderModal({
+      kind: "blockedByOperation",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      reason: "A database migration is still running.",
+    });
+    expect(
+      screen.getByText("A database migration is still running."),
+    ).toBeTruthy();
+  });
+
+  it("fires onDownload from the step-1 CTA", () => {
+    const props = renderModal({
+      kind: "available",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      severity: "normal",
+    });
+    fireEvent.click(screen.getByText("Pobierz aktualizację"));
+    expect(props.onDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onRestart from the step-2 CTA", () => {
+    const props = renderModal({
+      kind: "downloaded",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+    });
+    fireEvent.click(screen.getByText("Zrestartuj i zainstaluj"));
+    expect(props.onRestart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vex-app/src/renderer/lib/api/queryKeys.ts
+++ b/vex-app/src/renderer/lib/api/queryKeys.ts
@@ -192,3 +192,12 @@ export const portfolioKeys = {
    */
   moves: (sessionId: string) => ["portfolio", "moves", sessionId] as const,
 };
+
+/**
+ * User-triggered updater (M13) — a single global status entry. Kept live by
+ * `useUpdaterLiveSync` (main-pushed `EV.updater.status` events → cache).
+ */
+export const updaterKeys = {
+  all: ["updater"] as const,
+  status: () => ["updater", "status"] as const,
+};

--- a/vex-app/src/renderer/lib/api/updates.ts
+++ b/vex-app/src/renderer/lib/api/updates.ts
@@ -1,0 +1,97 @@
+/**
+ * User-triggered updater (M13) data-access — TanStack Query hooks over the
+ * `window.vex.updater.*` bridge.
+ *
+ * Layering: main owns electron-updater and pushes sanitized `UpdateStatus`
+ * transitions; the renderer reads the initial value with `useUpdateStatus`,
+ * keeps it live with `useUpdaterLiveSync` (event → cache), and triggers the
+ * two-step flow (download, then restart) via the mutations below. The renderer
+ * never touches updater internals — main decides whether each action is safe.
+ */
+
+import { useEffect } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import type { Result } from "@shared/ipc/result.js";
+import type {
+  UpdateCancelled,
+  UpdateRestarting,
+  UpdateStarted,
+  UpdateStatus,
+} from "@shared/schemas/updater.js";
+import { updaterKeys } from "./queryKeys.js";
+
+/**
+ * Initial status read. Event-driven (no polling, no retry); `useUpdaterLiveSync`
+ * keeps the cache current after mount.
+ */
+export function useUpdateStatus(): UseQueryResult<Result<UpdateStatus>> {
+  return useQuery({
+    queryKey: updaterKeys.status(),
+    queryFn: () => window.vex.updater.getStatus(),
+    staleTime: Number.POSITIVE_INFINITY,
+    retry: 0,
+  });
+}
+
+/**
+ * Push main-emitted status transitions into the query cache. Mount ONCE near
+ * the root (in `UpdateLayer`). The event stream is the source of truth for
+ * transitions; the query is only the first read.
+ */
+export function useUpdaterLiveSync(): void {
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    const off = window.vex.updater.onStatus((status) => {
+      queryClient.setQueryData<Result<UpdateStatus>>(updaterKeys.status(), {
+        ok: true,
+        data: status,
+      });
+    });
+    return () => off();
+  }, [queryClient]);
+}
+
+export function useCheckForUpdates(): UseMutationResult<
+  Result<UpdateStatus>,
+  Error,
+  void
+> {
+  return useMutation({ mutationFn: () => window.vex.updater.checkNow() });
+}
+
+export function useStartUpdate(): UseMutationResult<
+  Result<UpdateStarted>,
+  Error,
+  void
+> {
+  return useMutation({ mutationFn: () => window.vex.updater.startUpdateNow() });
+}
+
+export function useCancelDownload(): UseMutationResult<
+  Result<UpdateCancelled>,
+  Error,
+  void
+> {
+  return useMutation({ mutationFn: () => window.vex.updater.cancelDownload() });
+}
+
+export function useRestartAndInstall(): UseMutationResult<
+  Result<UpdateRestarting>,
+  Error,
+  void
+> {
+  return useMutation({
+    mutationFn: () => window.vex.updater.restartAndInstallNow(),
+  });
+}
+
+/** Open the external release-notes page (main builds the URL). */
+export function openReleaseNotes(): void {
+  void window.vex.updater.openReleaseNotes();
+}

--- a/vex-app/src/shared/ipc/channels.ts
+++ b/vex-app/src/shared/ipc/channels.ts
@@ -252,9 +252,18 @@ export const CH = {
     setTelemetryConsent: "vex:settings:setTelemetryConsent",
   },
 
-  // Updater — manual check only (M13)
+  // Updater — user-triggered in-app update flow (M13). `check` may run on
+  // app start/focus or manually; download + restart happen ONLY after an
+  // explicit user action (skill vex-user-triggered-updates §"Non-negotiable
+  // rules": no silent download/install). Renderer never receives installer
+  // paths, artifact URLs, tokens, or raw metadata — only sanitized status.
   updater: {
     check: "vex:updater:check",
+    getStatus: "vex:updater:getStatus",
+    startUpdateNow: "vex:updater:startUpdateNow",
+    cancelDownload: "vex:updater:cancelDownload",
+    restartAndInstallNow: "vex:updater:restartAndInstallNow",
+    openReleaseNotes: "vex:updater:openReleaseNotes",
   },
 
   // Telemetry — renderer-side error reporting (Sentry, opt-in only)
@@ -289,7 +298,11 @@ export const EV = {
     migrateProgress: "vex:event:database:migrateProgress",
   },
   updater: {
-    available: "vex:event:updater:available",
+    // Full `UpdateStatus` discriminated union pushed on every updater state
+    // transition (checking → available → downloading → downloaded → … |
+    // error | blockedByOperation). Main is the source of truth; the payload
+    // is sanitized (versions + bounded progress + safe summary only).
+    status: "vex:event:updater:status",
   },
   /**
    * Engine spine (agent integration puzzle 2 + puzzle 3).

--- a/vex-app/src/shared/schemas/__tests__/updater.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/updater.test.ts
@@ -1,0 +1,134 @@
+/**
+ * UpdateStatus contract tests (M13). The discriminated union is validated at
+ * BOTH boundaries (main output + preload subscribe), so the redaction guarantee
+ * rides on `.strict()` rejecting any extra key (e.g. an artifact path that
+ * leaked through a mapping bug).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  releaseNotesOpenedSchema,
+  updateCancelledSchema,
+  updateRestartingSchema,
+  updateStartedSchema,
+  updateStatusSchema,
+} from "../updater.js";
+
+describe("updateStatusSchema", () => {
+  const valid = [
+    { kind: "idle", currentVersion: "1.0.0" },
+    { kind: "checking", currentVersion: "1.0.0" },
+    {
+      kind: "current",
+      currentVersion: "1.0.0",
+      checkedAt: "2026-01-01T00:00:00.000Z",
+    },
+    {
+      kind: "available",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      severity: "normal",
+    },
+    {
+      kind: "available",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      severity: "security",
+      releaseDate: "2026-01-01",
+      summary: "What's new",
+    },
+    {
+      kind: "blockedByOperation",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      reason: "An agent run is still in progress.",
+    },
+    {
+      kind: "downloading",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      percent: 42,
+    },
+    {
+      kind: "downloading",
+      currentVersion: "1.0.0",
+      latestVersion: "1.1.0",
+      percent: 0,
+      bytesPerSecond: 10,
+      transferred: 5,
+      total: 100,
+    },
+    { kind: "downloaded", currentVersion: "1.0.0", latestVersion: "1.1.0" },
+    { kind: "installing", currentVersion: "1.0.0", latestVersion: "1.1.0" },
+    { kind: "error", currentVersion: "1.0.0", message: "Update failed.", retryable: true },
+  ] as const;
+
+  it("accepts every documented variant", () => {
+    for (const variant of valid) {
+      expect(updateStatusSchema.safeParse(variant).success).toBe(true);
+    }
+  });
+
+  it("rejects an unknown kind", () => {
+    expect(
+      updateStatusSchema.safeParse({ kind: "boom", currentVersion: "1.0.0" })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects a missing required field (available without latestVersion)", () => {
+    expect(
+      updateStatusSchema.safeParse({
+        kind: "available",
+        currentVersion: "1.0.0",
+        severity: "normal",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an extra key — a leaked artifact path must not pass", () => {
+    expect(
+      updateStatusSchema.safeParse({
+        kind: "downloaded",
+        currentVersion: "1.0.0",
+        latestVersion: "1.1.0",
+        path: "/Users/x/Library/Caches/vex/Vex-1.1.0.dmg",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects out-of-range percent", () => {
+    expect(
+      updateStatusSchema.safeParse({
+        kind: "downloading",
+        currentVersion: "1.0.0",
+        latestVersion: "1.1.0",
+        percent: 150,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("updater ack schemas", () => {
+  it("accept the literal true ack", () => {
+    expect(updateStartedSchema.safeParse({ started: true }).success).toBe(true);
+    expect(updateCancelledSchema.safeParse({ cancelled: true }).success).toBe(
+      true,
+    );
+    expect(updateRestartingSchema.safeParse({ restarting: true }).success).toBe(
+      true,
+    );
+    expect(releaseNotesOpenedSchema.safeParse({ opened: true }).success).toBe(
+      true,
+    );
+  });
+
+  it("reject false or extra keys", () => {
+    expect(updateStartedSchema.safeParse({ started: false }).success).toBe(
+      false,
+    );
+    expect(
+      updateStartedSchema.safeParse({ started: true, extra: 1 }).success,
+    ).toBe(false);
+  });
+});

--- a/vex-app/src/shared/schemas/updater.ts
+++ b/vex-app/src/shared/schemas/updater.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared schema for the user-triggered in-app updater (M13).
+ *
+ * `updateStatusSchema` is the single source of truth for the renderer-visible
+ * update state machine (skill `vex-user-triggered-updates` §"Update UX
+ * states"). It is a discriminated union on `kind` so the UI can never drift
+ * into an impossible combination, and it is the Zod schema validated at BOTH
+ * boundaries: main `outputSchema` / event broadcast, and the preload
+ * `subscribe` payload check.
+ *
+ * Redaction contract: this shape carries ONLY version strings, a coarse
+ * severity, a short human summary, and bounded numeric progress. It MUST NOT
+ * carry installer paths, artifact URLs, tokens, raw `UpdateInfo` metadata, or
+ * release-notes HTML — those never cross the IPC boundary (skill
+ * §"Non-negotiable rules" 8 + §"Renderer implementation rules").
+ *
+ * `currentVersion` is present on every variant: main always knows
+ * `app.getVersion()`, so the UI can render "current → latest" in any state.
+ */
+
+import { z } from "zod";
+
+export const updateSeveritySchema = z.enum(["normal", "security", "critical"]);
+export type UpdateSeverity = z.infer<typeof updateSeveritySchema>;
+
+const currentVersion = z.string().min(1);
+const latestVersion = z.string().min(1);
+
+export const updateStatusSchema = z.discriminatedUnion("kind", [
+  // No update operation in progress; app is at `currentVersion`.
+  z.object({ kind: z.literal("idle"), currentVersion }).strict(),
+  // A check is running against the update feed.
+  z.object({ kind: z.literal("checking"), currentVersion }).strict(),
+  // Check completed; app is on the latest version. `checkedAt` is an ISO ts.
+  z
+    .object({ kind: z.literal("current"), currentVersion, checkedAt: z.string().min(1) })
+    .strict(),
+  // A newer version is available for the user to download.
+  z
+    .object({
+      kind: z.literal("available"),
+      currentVersion,
+      latestVersion,
+      releaseDate: z.string().min(1).optional(),
+      severity: updateSeveritySchema,
+      summary: z.string().optional(),
+    })
+    .strict(),
+  // The user asked to update, but a safe-restart gate is blocking (e.g. a
+  // Docker/DB operation or an active mission). `reason` is user-actionable.
+  z
+    .object({
+      kind: z.literal("blockedByOperation"),
+      currentVersion,
+      latestVersion,
+      reason: z.string().min(1),
+    })
+    .strict(),
+  // Download in progress after explicit consent. `percent` is bounded 0..100.
+  z
+    .object({
+      kind: z.literal("downloading"),
+      currentVersion,
+      latestVersion,
+      percent: z.number().min(0).max(100),
+      bytesPerSecond: z.number().nonnegative().optional(),
+      transferred: z.number().nonnegative().optional(),
+      total: z.number().nonnegative().optional(),
+    })
+    .strict(),
+  // Download finished; awaiting the user's restart-and-install action.
+  z.object({ kind: z.literal("downloaded"), currentVersion, latestVersion }).strict(),
+  // Restart-and-install is underway (app is quitting to apply the update).
+  z.object({ kind: z.literal("installing"), currentVersion, latestVersion }).strict(),
+  // A check/download/install failed. `message` is redacted + user-safe.
+  z
+    .object({
+      kind: z.literal("error"),
+      currentVersion,
+      message: z.string().min(1),
+      retryable: z.boolean(),
+    })
+    .strict(),
+]);
+export type UpdateStatus = z.infer<typeof updateStatusSchema>;
+
+/** `startUpdateNow()` ack — the download has been accepted/started. */
+export const updateStartedSchema = z.object({ started: z.literal(true) }).strict();
+export type UpdateStarted = z.infer<typeof updateStartedSchema>;
+
+/** `cancelDownload()` ack — any in-flight download was cancelled. */
+export const updateCancelledSchema = z.object({ cancelled: z.literal(true) }).strict();
+export type UpdateCancelled = z.infer<typeof updateCancelledSchema>;
+
+/** `restartAndInstallNow()` ack — the app is restarting to apply the update. */
+export const updateRestartingSchema = z.object({ restarting: z.literal(true) }).strict();
+export type UpdateRestarting = z.infer<typeof updateRestartingSchema>;
+
+/** `openReleaseNotes()` ack — the external release page was opened. */
+export const releaseNotesOpenedSchema = z.object({ opened: z.literal(true) }).strict();
+export type ReleaseNotesOpened = z.infer<typeof releaseNotesOpenedSchema>;

--- a/vex-app/src/shared/types/bridge/shell/index.ts
+++ b/vex-app/src/shared/types/bridge/shell/index.ts
@@ -20,6 +20,7 @@ import type { SettingsBridge } from "./settings.js";
 import type { SupportBridge } from "./support.js";
 import type { SystemBridge } from "./system.js";
 import type { TelemetryBridge } from "./telemetry.js";
+import type { UpdaterBridge } from "./updater.js";
 import type { WalletBridge } from "./wallet.js";
 
 export type { CapabilitiesBridge } from "./capabilities.js";
@@ -31,6 +32,7 @@ export type { SettingsBridge } from "./settings.js";
 export type { SupportBridge } from "./support.js";
 export type { SystemBridge } from "./system.js";
 export type { TelemetryBridge } from "./telemetry.js";
+export type { UpdaterBridge } from "./updater.js";
 export type { WalletBridge } from "./wallet.js";
 
 export interface VexShellBridge {
@@ -44,4 +46,5 @@ export interface VexShellBridge {
   readonly settings: SettingsBridge;
   readonly telemetry: TelemetryBridge;
   readonly support: SupportBridge;
+  readonly updater: UpdaterBridge;
 }

--- a/vex-app/src/shared/types/bridge/shell/updater.ts
+++ b/vex-app/src/shared/types/bridge/shell/updater.ts
@@ -1,0 +1,39 @@
+import type { Result } from "../../../ipc/result.js";
+import type {
+  ReleaseNotesOpened,
+  UpdateCancelled,
+  UpdateRestarting,
+  UpdateStarted,
+  UpdateStatus,
+} from "../../../schemas/updater.js";
+
+/**
+ * `vex.updater.*` — user-triggered in-app update surface (M13).
+ *
+ * Business methods only (skill `vex-user-triggered-updates` §"IPC contract").
+ * The renderer never imports `electron-updater`/`electron` and never calls an
+ * updater API directly — it asks main through these typed methods, and main
+ * decides whether an action is safe. `startUpdateNow` is the ONLY route that
+ * may begin a download; `quitAndInstall` happens only after the download
+ * completes AND a safe-restart gate passes (both enforced in main).
+ */
+export interface UpdaterBridge {
+  /** Last-known status from main's cache (no network call). */
+  readonly getStatus: () => Promise<Result<UpdateStatus>>;
+  /** Trigger a check against the update feed; resolves to the new status. */
+  readonly checkNow: () => Promise<Result<UpdateStatus>>;
+  /** User clicked "Update now" — the only path that may start a download. */
+  readonly startUpdateNow: () => Promise<Result<UpdateStarted>>;
+  /** Cancel an in-flight download (allowed only while still safe). */
+  readonly cancelDownload: () => Promise<Result<UpdateCancelled>>;
+  /** Step 2: user explicitly restarts to install the already-downloaded update. */
+  readonly restartAndInstallNow: () => Promise<Result<UpdateRestarting>>;
+  /** Open the external release-notes page in the user's browser. */
+  readonly openReleaseNotes: () => Promise<Result<ReleaseNotesOpened>>;
+  /**
+   * Subscribe to main-pushed status transitions. Returns an idempotent
+   * unsubscribe — call it from the React effect cleanup (skill §11). The
+   * renderer never sees the raw IPC channel.
+   */
+  readonly onStatus: (cb: (status: UpdateStatus) => void) => () => void;
+}


### PR DESCRIPTION
## User-triggered in-app updater (M13)

In-app banner + modal with a **two-step** flow (download, then a separate explicit restart). Main owns `electron-updater`; the renderer gets only a typed, Zod-validated `window.vex.updater` bridge + a sanitized status event (no installer paths/URLs/tokens, no release-notes HTML). No silent download/install; no startup auto-check (manual only, per the existing `preferences` contract).

### Safe-restart gate
Blocks `quitAndInstall` while any of these is in flight:
- agent work — DB-backed, tri-state on DB availability (running mission / live runner lease / pending approval),
- Docker lifecycle or a DB migration,
- a keystore/secret-vault operation — gated at the shared `withWalletLock` / `withEnvWriteLock` chokepoints + the lock-less wallet-export handler.

`prepareForUpdateRestart` keeps updater listeners through `quitAndInstall` (so a synchronous `install()` error is still delivered) and clears the restart flag on an updater error so a failed install can be retried.

### Scope
- Shared updater schema + bridge contract; main `updates/` module set + IPC handlers; preload bridge; renderer banner/modal + TanStack hooks; dev-only opt-in feed harness (`dev-app-update.yml`); tests.
- **Out of scope (separate release track):** code signing, macOS notarization, release CI matrix, feed hosting + `publish` URL, versioning out of `0.1.0-dev`.

### Review & verification
- Designed + reviewed via a Claude + Codex pair-review loop (2 plan rounds + 3 final-review rounds; all blockers resolved).
- `pnpm --dir vex-app lint` (tsc shared+e2e + `check:boundaries` — renderer imports no privileged updater module) passes.
- 803/803 tests across 113 files in the affected surface; updater + gate + guard suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
