### PR TITLE
feat(updater): ambient auto-check on start + window focus (throttled)

### DIFF
--- a/vex-app/src/main/index.ts
+++ b/vex-app/src/main/index.ts
@@ -32,6 +32,7 @@ import {
   configureUpdater,
   removeUpdaterEventListeners,
 } from "./updates/configureUpdater.js";
+import { installUpdaterAutoCheck } from "./updates/autoCheck.js";
 import { cleanupOnBoot, cleanupOnQuit } from "./lifecycle/secret-cleanup.js";
 import { globalCleanup } from "./lifecycle/cleanup-registry.js";
 import { makeOrderedQuitCleanup } from "./lifecycle/ordered-quit-cleanup.js";
@@ -151,13 +152,18 @@ app.whenReady().then(async () => {
   registerAllIpcHandlers();
 
   // 6-updater. User-triggered updater (M13): own the electron-updater event
-  // stream so the renderer's update card reflects live status. MANUAL check
-  // only — NO startup auto-check (preferences contract: "manual check only,
-  // no startup auto, no periodic poll"); download + restart are explicit user
-  // actions. Teardown removes our listeners on quit.
+  // stream so the renderer's update card reflects live status. Download +
+  // restart are always explicit user actions (autoDownload=false). Teardown
+  // removes our listeners on quit.
   configureUpdater();
   globalCleanup.add(() => {
     removeUpdaterEventListeners();
+  });
+  // Ambient auto-CHECK only (start + window focus, throttled). Surfaces a new
+  // version; never downloads. Skill-allowed (start/focus check, no download).
+  const stopUpdaterAutoCheck = installUpdaterAutoCheck();
+  globalCleanup.add(() => {
+    stopUpdaterAutoCheck();
   });
 
   // 6a. Agent integration stage 7-1: own the Track-2 compaction worker so

--- a/vex-app/src/main/updates/__tests__/autoCheck.test.ts
+++ b/vex-app/src/main/updates/__tests__/autoCheck.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Ambient auto-check scheduler (M13 follow-up). Verifies the guards: feed gate,
+ * quiet-state guard, persisted success throttle, focus debounce, and the
+ * in-memory failure backoff. Auto-check never downloads — this only governs
+ * WHEN checkForUpdates runs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let isPackaged = true;
+vi.mock("electron", () => ({
+  app: {
+    get isPackaged() {
+      return isPackaged;
+    },
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+let currentKind = "idle";
+vi.mock("../statusCache.js", () => ({
+  getCurrentStatus: () => ({ kind: currentKind, currentVersion: "1.0.0" }),
+}));
+
+let lastCheckedAt: string | null = null;
+vi.mock("../../preferences/store.js", () => ({
+  preferencesStore: { load: async () => ({ updater: { lastCheckedAt } }) },
+}));
+
+const silentCheck = vi.fn(async () => true);
+vi.mock("../updateActions.js", () => ({ silentCheck: () => silentCheck() }));
+
+vi.mock("../../logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { maybeAutoCheck, __resetAutoCheckForTests } = await import(
+  "../autoCheck.js"
+);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-06-28T12:00:00Z"));
+  isPackaged = true;
+  currentKind = "idle";
+  lastCheckedAt = null;
+  silentCheck.mockReset();
+  silentCheck.mockResolvedValue(true);
+  __resetAutoCheckForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("maybeAutoCheck", () => {
+  it("skips when no feed is configured (plain dev)", async () => {
+    isPackaged = false;
+    await maybeAutoCheck("startup");
+    expect(silentCheck).not.toHaveBeenCalled();
+  });
+
+  it("runs when feed configured, quiet, and no prior check", async () => {
+    await maybeAutoCheck("startup");
+    expect(silentCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips from an actionable state (downloaded)", async () => {
+    currentKind = "downloaded";
+    await maybeAutoCheck("focus");
+    expect(silentCheck).not.toHaveBeenCalled();
+  });
+
+  it("skips within the success throttle (recent lastCheckedAt)", async () => {
+    lastCheckedAt = new Date().toISOString();
+    await maybeAutoCheck("focus");
+    expect(silentCheck).not.toHaveBeenCalled();
+  });
+
+  it("runs once lastCheckedAt is older than the throttle window", async () => {
+    lastCheckedAt = new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString();
+    await maybeAutoCheck("focus");
+    expect(silentCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("debounces focus bursts within 60s", async () => {
+    await maybeAutoCheck("focus");
+    vi.advanceTimersByTime(30_000);
+    await maybeAutoCheck("focus");
+    expect(silentCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("backs off after a failure (no retry within the backoff window)", async () => {
+    silentCheck.mockResolvedValue(false);
+    await maybeAutoCheck("startup"); // fails -> backoff armed
+    expect(silentCheck).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(2 * 60 * 1000); // 2 min: past 60s debounce, within 20m backoff
+    await maybeAutoCheck("focus");
+    expect(silentCheck).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vex-app/src/main/updates/__tests__/configureUpdater.test.ts
+++ b/vex-app/src/main/updates/__tests__/configureUpdater.test.ts
@@ -51,6 +51,11 @@ vi.mock("../safeRestart.js", () => ({
   clearUpdateRestartInProgress: () => clearUpdateRestartInProgress(),
 }));
 
+let silentActive = false;
+vi.mock("../auto-check-state.js", () => ({
+  isSilentCheckActive: () => silentActive,
+}));
+
 const { configureUpdater, removeUpdaterEventListeners } = await import(
   "../configureUpdater.js"
 );
@@ -58,6 +63,7 @@ const { configureUpdater, removeUpdaterEventListeners } = await import(
 beforeEach(() => {
   vi.clearAllMocks();
   restartInProgress = false;
+  silentActive = false;
   for (const key of Object.keys(listeners)) delete listeners[key];
   // Reset the module-level `configured` guard so each test re-registers.
   removeUpdaterEventListeners();
@@ -86,6 +92,15 @@ describe("configureUpdater event wiring", () => {
     configureUpdater();
     restartInProgress = false;
     listeners["error"]?.(new Error("check failed"));
+    expect(clearUpdateRestartInProgress).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the error banner while an ambient (silent) check is active", () => {
+    configureUpdater();
+    silentActive = true;
+    listeners["error"]?.(new Error("no feed configured"));
+    // onError returns early: no status set, restart flag untouched.
+    expect(setStatus).not.toHaveBeenCalled();
     expect(clearUpdateRestartInProgress).not.toHaveBeenCalled();
   });
 });

--- a/vex-app/src/main/updates/__tests__/updateActions.test.ts
+++ b/vex-app/src/main/updates/__tests__/updateActions.test.ts
@@ -259,3 +259,37 @@ describe("cancelDownload / checkNow / openReleaseNotes", () => {
     expect(openExternal).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("silentCheck (ambient auto-check)", () => {
+  it("persists lastCheckedAt and returns true on success", async () => {
+    autoUpdater.checkForUpdates.mockResolvedValue(null);
+    await expect(actions.silentCheck()).resolves.toBe(true);
+    expect(prefUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updater: expect.objectContaining({ lastCheckedAt: expect.any(String) }),
+      }),
+    );
+  });
+
+  it("swallows a failure (no error status set) and returns false", async () => {
+    autoUpdater.checkForUpdates.mockRejectedValue(new Error("no feed"));
+    await expect(actions.silentCheck()).resolves.toBe(false);
+    expect(setStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "error" }),
+    );
+  });
+
+  it("restores the prior status when a failure leaves status stuck at 'checking'", async () => {
+    currentStatus = { kind: "idle", currentVersion: "1.0.0" };
+    autoUpdater.checkForUpdates.mockImplementation(async () => {
+      // Simulate the checking-for-update event flipping status, then the
+      // (suppressed) error leaving it there.
+      currentStatus = { kind: "checking", currentVersion: "1.0.0" };
+      throw new Error("no feed");
+    });
+    await expect(actions.silentCheck()).resolves.toBe(false);
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "idle" }),
+    );
+  });
+});

--- a/vex-app/src/main/updates/auto-check-state.ts
+++ b/vex-app/src/main/updates/auto-check-state.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared flag: is an AMBIENT (auto) update check in flight?
+ *
+ * electron-updater emits the `error` event (then rethrows) from
+ * `checkForUpdates()`. The `configureUpdater` error listener would otherwise
+ * map that to a user-facing error banner — but an ambient start/focus check
+ * (possibly against a not-yet-configured feed) must NOT nag. The listener
+ * consults this flag and suppresses the banner only while a silent check is
+ * active; manual check / download / install errors leave the flag false and
+ * surface normally.
+ */
+
+let silentCheckActive = false;
+
+export function setSilentCheckActive(value: boolean): void {
+  silentCheckActive = value;
+}
+
+export function isSilentCheckActive(): boolean {
+  return silentCheckActive;
+}

--- a/vex-app/src/main/updates/autoCheck.ts
+++ b/vex-app/src/main/updates/autoCheck.ts
@@ -1,0 +1,100 @@
+/**
+ * Ambient updater auto-check (M13 follow-up): check for a new version on app
+ * start + window focus, throttled. This NEVER downloads — auto-download stays
+ * off (`autoDownload=false`); it only surfaces availability so the banner can
+ * appear. Allowed by skill vex-user-triggered-updates: "checkForUpdates() may
+ * run on app start/focus, but must not download."
+ *
+ * Guards (Codex review):
+ *  - feed gate: skip entirely unless a feed is resolvable (packaged app, or dev
+ *    with VEX_UPDATER_DEV_FEED=1) — no error spam in plain dev;
+ *  - quiet-state guard: only check from idle/current/error — never clobber an
+ *    in-progress / actionable state (checking/available/downloading/
+ *    downloaded/installing/blockedByOperation);
+ *  - focus debounce: short in-memory window so focus bursts don't hammer prefs;
+ *  - success throttle: persisted `lastCheckedAt`, ≤ once per SUCCESS_THROTTLE;
+ *  - failure backoff: in-memory, so a bad feed doesn't retry on every focus.
+ */
+
+import { app } from "electron";
+import { log } from "../logger/index.js";
+import { preferencesStore } from "../preferences/store.js";
+import { getCurrentStatus } from "./statusCache.js";
+import { silentCheck } from "./updateActions.js";
+
+const FOCUS_DEBOUNCE_MS = 60 * 1000;
+const SUCCESS_THROTTLE_MS = 6 * 60 * 60 * 1000;
+const FAILURE_BACKOFF_MS = 20 * 60 * 1000;
+const STARTUP_DELAY_MS = 3 * 1000;
+
+let lastAttemptAt = 0;
+let lastFailureAt = 0;
+
+function feedConfigured(): boolean {
+  return app.isPackaged || process.env.VEX_UPDATER_DEV_FEED === "1";
+}
+
+/** Only run an ambient check from a quiet state — never clobber an in-progress
+ *  or user-actionable updater state. */
+function isQuiet(): boolean {
+  const kind = getCurrentStatus().kind;
+  return kind === "idle" || kind === "current" || kind === "error";
+}
+
+export async function maybeAutoCheck(
+  reason: "startup" | "focus",
+): Promise<void> {
+  if (!feedConfigured()) return;
+
+  const now = Date.now();
+  if (now - lastAttemptAt < FOCUS_DEBOUNCE_MS) return;
+  lastAttemptAt = now;
+
+  if (!isQuiet()) return;
+  if (now - lastFailureAt < FAILURE_BACKOFF_MS) return;
+
+  try {
+    const prefs = await preferencesStore.load();
+    const raw = prefs.updater.lastCheckedAt;
+    const last = raw ? Date.parse(raw) : 0;
+    if (Number.isFinite(last) && last > 0 && now - last < SUCCESS_THROTTLE_MS) {
+      return;
+    }
+  } catch (cause) {
+    log.warn("[updates] auto-check throttle read failed", cause);
+    return;
+  }
+
+  log.info(`[updates] ambient auto-check (${reason})`);
+  const ok = await silentCheck();
+  if (!ok) lastFailureAt = Date.now();
+}
+
+/**
+ * Wire the start + focus ambient checks. Returns a teardown that removes the
+ * focus listener and cancels the pending startup check.
+ */
+export function installUpdaterAutoCheck(): () => void {
+  const onFocus = (): void => {
+    void maybeAutoCheck("focus");
+  };
+  app.on("browser-window-focus", onFocus);
+
+  // Deferred so the first check never competes with window paint. `unref` so
+  // the timer can't keep the process alive on a fast quit.
+  const startupTimer = setTimeout(() => {
+    void maybeAutoCheck("startup");
+  }, STARTUP_DELAY_MS);
+  if (typeof startupTimer.unref === "function") startupTimer.unref();
+
+  return () => {
+    app.removeListener("browser-window-focus", onFocus);
+    clearTimeout(startupTimer);
+  };
+}
+
+/** Test-only: reset the in-memory throttles. */
+export function __resetAutoCheckForTests(): void {
+  lastAttemptAt = 0;
+  lastFailureAt = 0;
+}

--- a/vex-app/src/main/updates/configureUpdater.ts
+++ b/vex-app/src/main/updates/configureUpdater.ts
@@ -2,7 +2,8 @@
  * Main-process `electron-updater` configuration (M13).
  *
  * Policy (skill vex-user-triggered-updates §"Non-negotiable rules"):
- *   - check may be MANUAL only (no auto-download, no auto-install);
+ *   - check runs on app start + window focus and on manual request — never
+ *     auto-downloads or auto-installs;
  *   - download starts only via `updates.startUpdateNow()`;
  *   - restart/install happens only via `updates.restartAndInstallNow()`.
  *
@@ -21,6 +22,7 @@ import {
   errorStatus,
   filteredUpdaterLogger,
 } from "./sanitize.js";
+import { isSilentCheckActive } from "./auto-check-state.js";
 import {
   clearUpdateRestartInProgress,
   isUpdateRestartInProgress,
@@ -77,6 +79,9 @@ export function configureUpdater(): void {
     setStatus({ kind: "downloaded", currentVersion: currentVersion(), latestVersion });
   };
   const onError = (error: Error): void => {
+    // Ambient auto-check failures (e.g. no feed configured yet) must not nag
+    // with an error banner; only manual check / download / install errors do.
+    if (isSilentCheckActive()) return;
     setStatus(errorStatus(error, currentVersion()));
     // A failed quitAndInstall()/install() emits `error` while a restart is in
     // progress (the app stays open). Release the restart flag so

--- a/vex-app/src/main/updates/updateActions.ts
+++ b/vex-app/src/main/updates/updateActions.ts
@@ -19,6 +19,7 @@ import type {
 } from "@shared/schemas/updater.js";
 import { log } from "../logger/index.js";
 import { preferencesStore } from "../preferences/store.js";
+import { setSilentCheckActive } from "./auto-check-state.js";
 import { errorStatus, publicUpdateError } from "./sanitize.js";
 import {
   canRestartForUpdate,
@@ -56,6 +57,41 @@ export async function checkNow(
     log.warn(`[updates] checkForUpdates failed correlationId=${correlationId}`);
     setStatus(errorStatus(error, currentVersion()));
     return err(publicUpdateError("update.check_failed", correlationId));
+  }
+}
+
+/**
+ * Ambient (auto) check used by the start/focus scheduler. Unlike `checkNow` it
+ * NEVER surfaces an error: a failure (e.g. no feed configured yet) is swallowed
+ * (logged), and the updater `error` event is suppressed for its duration via
+ * the silent-check flag. The update-available / not-available events still
+ * drive the status cache, so a REAL update still raises the banner. Returns
+ * true when a check completed, false on failure.
+ */
+export async function silentCheck(): Promise<boolean> {
+  const priorStatus = getCurrentStatus();
+  setSilentCheckActive(true);
+  try {
+    await autoUpdater.checkForUpdates();
+    void preferencesStore
+      .update({ updater: { lastCheckedAt: new Date().toISOString() } })
+      .catch((cause) =>
+        log.warn("[updates] failed to persist updater.lastCheckedAt", cause),
+      );
+    return true;
+  } catch {
+    log.info("[updates] ambient auto-check failed (swallowed)");
+    // The `checking-for-update` event already flipped status to `checking`,
+    // and the suppressed `error` left it there. Restore the prior quiet status
+    // so future ambient checks aren't disabled (checking is non-quiet) — but
+    // only if still `checking`, to avoid clobbering a real available/current
+    // event that may have arrived first.
+    if (getCurrentStatus().kind === "checking") {
+      setStatus(priorStatus);
+    }
+    return false;
+  } finally {
+    setSilentCheckActive(false);
   }
 }
 

--- a/vex-app/src/shared/schemas/preferences.ts
+++ b/vex-app/src/shared/schemas/preferences.ts
@@ -32,7 +32,11 @@ export const preferencesSchema = z
       })
       .strict(),
 
-    /** Updater preferences. Manual check only — no startup auto, no periodic poll. */
+    /**
+     * Updater preferences. Ambient auto-CHECK runs on app start + window focus,
+     * throttled by `lastCheckedAt` (no periodic poll). Auto-DOWNLOAD is never
+     * enabled — download + restart stay explicit user actions.
+     */
     updater: z
       .object({
         lastCheckedAt: z.string().datetime().nullable(),


### PR DESCRIPTION
## Ambient auto-check (start + window focus, throttled)

Surfaces a new version proactively without changing the user-triggered model: `checkForUpdates()` runs on app start (deferred 3s) + on window focus, throttled by `preferences.updater.lastCheckedAt` (≤ once / 6h), with a 60s focus debounce and a 20m in-memory failure backoff. **`autoDownload` stays `false`** — download + restart remain explicit user actions.

### Safety (Codex pair-review — 4 rounds)
- **Silent failures**: an ambient check failure (e.g. no feed configured yet) is swallowed; the updater `error` event is suppressed via a silent-check flag, so no error banner. The prior status is restored if the failed check left it stuck at `checking` (won't clobber a real `available`/`current`).
- **Quiet-state guard**: ambient checks run only from idle/current/error — never clobber an in-progress/actionable state (downloading/downloaded/installing/…).
- **Feed gate**: ambient checks only in packaged builds or dev with `VEX_UPDATER_DEV_FEED=1`.
- Unchanged & enforced: no `checkForUpdatesAndNotify`; no auto-download/auto-install; download via `startUpdateNow`, restart via `restartAndInstallNow` + safe-restart gate.

### Contract change
`preferences.updater` policy: manual-only → auto-check on start/focus (still no auto-download, no periodic poll).

### Verification
`pnpm --dir vex-app lint` (tsc shared+e2e + `check:boundaries`) passes; updater unit suite 44/44; touched-file typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
