### PR TITLE
feat(wizard): add searchable OpenRouter model picker

### DIFF
--- a/vex-app/src/main/ipc/__tests__/ipc-channel-registration-reconciliation.test.ts
+++ b/vex-app/src/main/ipc/__tests__/ipc-channel-registration-reconciliation.test.ts
@@ -105,11 +105,9 @@ const RESERVED_UNREGISTERED: Readonly<Record<string, string>> = {
     "Reserved DB status responder — only database.migrate is wired; status is a future health-panel surface.",
 
   // Wizard provider step persists via the verify-then-persist
-  // `providerPersist` handler (verify happens inside persist). Standalone
-  // list-models / connection-test responders are declared for a future
-  // provider-management surface but are not wired yet.
-  [CH.onboarding.providerListModels]:
-    "Reserved provider model-list responder — provider step verifies inside providerPersist; standalone list is not wired yet.",
+  // `providerPersist` handler (verify happens inside persist). A standalone
+  // connection-test responder remains reserved; model listing is now wired
+  // for the provider picker.
   [CH.onboarding.providerTest]:
     "Reserved provider connection-test responder — verify is folded into providerPersist; standalone test is not wired yet.",
 };

--- a/vex-app/src/main/ipc/onboarding/__tests__/provider-models.test.ts
+++ b/vex-app/src/main/ipc/onboarding/__tests__/provider-models.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createTestWebContents,
+  createTrustedSender,
+  type TestIpcEvent,
+} from "../../__tests__/test-sender.js";
+
+type Handler = (event: TestIpcEvent, raw: unknown) => Promise<unknown>;
+
+const handlers = new Map<string, Handler>();
+const mockLoad = vi.fn();
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: (channel: string, fn: Handler) => handlers.set(channel, fn),
+    removeHandler: (channel: string) => handlers.delete(channel),
+  },
+  app: { isPackaged: true },
+}));
+
+vi.mock("../../../onboarding/provider-model-catalog.js", () => ({
+  loadProviderModelCatalog: (options: unknown) => mockLoad(options),
+}));
+
+vi.mock("../../../logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { CH } = await import("@shared/ipc/channels.js");
+const { registerProviderModelsHandler } = await import("../provider-models.js");
+
+const sender = createTrustedSender({ sender: createTestWebContents() });
+
+beforeEach(() => {
+  handlers.clear();
+  mockLoad.mockReset();
+});
+
+afterEach(() => {
+  handlers.clear();
+  vi.clearAllMocks();
+});
+
+describe("providerListModels handler", () => {
+  it("returns the sanitized catalogue through the reserved channel", async () => {
+    mockLoad.mockResolvedValue({
+      models: [
+        {
+          modelId: "openrouter/auto",
+          displayName: "OpenRouter Auto",
+          providerId: "openrouter",
+          contextLength: 2_000_000,
+          pricingInputPerMillion: null,
+          pricingOutputPerMillion: null,
+        },
+      ],
+      fetchedAt: "2026-07-11T12:00:00.000Z",
+    });
+    registerProviderModelsHandler();
+
+    const result = (await handlers.get(CH.onboarding.providerListModels)!(sender, {
+      requestId: "req-models",
+      payload: {},
+    })) as { ok: boolean; data?: { models: unknown[] } };
+
+    expect(result.ok).toBe(true);
+    expect(result.data?.models).toHaveLength(1);
+    expect(mockLoad).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
+  });
+
+  it("maps catalogue failures to a redacted retryable error", async () => {
+    mockLoad.mockRejectedValue(new Error("raw upstream body"));
+    registerProviderModelsHandler();
+
+    const result = (await handlers.get(CH.onboarding.providerListModels)!(sender, {
+      requestId: "req-fail",
+      payload: {},
+    })) as { ok: boolean; error?: { code: string; message: string } };
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("provider.unavailable");
+    expect(result.error?.message).not.toContain("raw upstream body");
+  });
+});

--- a/vex-app/src/main/ipc/onboarding/provider-models.ts
+++ b/vex-app/src/main/ipc/onboarding/provider-models.ts
@@ -1,0 +1,47 @@
+/** Read-only OpenRouter model catalogue for the provider setup picker. */
+
+import { CH } from "@shared/ipc/channels.js";
+import { err, ok, type Result } from "@shared/ipc/result.js";
+import {
+  providerListModelsInputSchema,
+  providerListModelsResultSchema,
+  type ProviderListModelsResult,
+} from "@shared/schemas/provider.js";
+import { loadProviderModelCatalog } from "../../onboarding/provider-model-catalog.js";
+import { log } from "../../logger/index.js";
+import { registerHandler } from "../register-handler.js";
+
+export function registerProviderModelsHandler(): () => void {
+  return registerHandler({
+    channel: CH.onboarding.providerListModels,
+    domain: "onboarding",
+    inputSchema: providerListModelsInputSchema,
+    outputSchema: providerListModelsResultSchema,
+    handle: async (_input, ctx): Promise<Result<ProviderListModelsResult>> => {
+      try {
+        const result = await loadProviderModelCatalog({ signal: ctx.signal });
+        log.info(
+          `[ipc:vex:onboarding:providerListModels] ok count=${result.models.length} ` +
+            `correlationId=${ctx.requestId}`,
+        );
+        return ok(result);
+      } catch (cause: unknown) {
+        const className =
+          cause instanceof Error ? cause.constructor.name : typeof cause;
+        log.warn(
+          `[ipc:vex:onboarding:providerListModels] failed class=${className} ` +
+            `correlationId=${ctx.requestId}`,
+        );
+        return err({
+          code: "provider.unavailable",
+          domain: "onboarding",
+          message: "The OpenRouter model catalogue is temporarily unavailable.",
+          retryable: true,
+          userActionable: true,
+          redacted: true,
+          correlationId: ctx.requestId,
+        });
+      }
+    },
+  });
+}

--- a/vex-app/src/main/ipc/register-all.ts
+++ b/vex-app/src/main/ipc/register-all.ts
@@ -30,6 +30,7 @@ import { registerFinalizeHandler } from "./onboarding/finalize.js";
 import { registerPolymarketConfiguredAddressesHandler } from "./onboarding/polymarket-configured-addresses.js";
 import { registerPolymarketSetupHandler } from "./onboarding/polymarket-setup.js";
 import { registerProviderHandler } from "./onboarding/provider.js";
+import { registerProviderModelsHandler } from "./onboarding/provider-models.js";
 import { registerWalletHandlers } from "./onboarding/wallets.js";
 import { registerRuntimeHandlers } from "./runtime.js";
 import { registerSessionsCreateHandler } from "./sessions/create.js";
@@ -67,6 +68,7 @@ export function registerAllIpcHandlers(): void {
   teardowns.push(registerEmbeddingHandler());
   teardowns.push(registerAgentCoreHandler());
   teardowns.push(registerProviderHandler());
+  teardowns.push(registerProviderModelsHandler());
   teardowns.push(registerFinalizeHandler());
   teardowns.push(registerSessionsCreateHandler());
   teardowns.push(registerSessionsListHandler());

--- a/vex-app/src/main/onboarding/__tests__/provider-model-catalog.test.ts
+++ b/vex-app/src/main/onboarding/__tests__/provider-model-catalog.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetProviderModelCatalogForTests,
+  loadProviderModelCatalog,
+} from "../provider-model-catalog.js";
+
+function model(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "anthropic/claude-sonnet-4.5",
+    name: "Anthropic: Claude Sonnet 4.5",
+    contextLength: 200_000,
+    supportedParameters: ["tools", "tool_choice"],
+    pricing: { prompt: "0.000003", completion: "0.000015" },
+    ...overrides,
+  };
+}
+
+function clientFactory(data: ReadonlyArray<ReturnType<typeof model>>) {
+  const list = vi.fn().mockResolvedValue({ data });
+  return {
+    list,
+    factory: () => ({ models: { list } }) as never,
+  };
+}
+
+beforeEach(() => __resetProviderModelCatalogForTests());
+
+describe("provider model catalogue", () => {
+  it("projects tool-capable models, prices, provider, and context", async () => {
+    const client = clientFactory([
+      model(),
+      model({
+        id: "legacy/text-only",
+        name: "Legacy text only",
+        supportedParameters: ["temperature"],
+      }),
+    ]);
+
+    const result = await loadProviderModelCatalog({
+      clientFactory: client.factory,
+      now: () => Date.parse("2026-07-11T12:00:00.000Z"),
+    });
+
+    expect(client.list).toHaveBeenCalledWith(
+      { outputModalities: "text", supportedParameters: "tools" },
+      expect.objectContaining({ timeoutMs: 15_000 }),
+    );
+    expect(result.models).toEqual([
+      {
+        modelId: "anthropic/claude-sonnet-4.5",
+        displayName: "Anthropic: Claude Sonnet 4.5",
+        providerId: "anthropic",
+        contextLength: 200_000,
+        pricingInputPerMillion: 3,
+        pricingOutputPerMillion: 15,
+      },
+    ]);
+    expect(result.fetchedAt).toBe("2026-07-11T12:00:00.000Z");
+  });
+
+  it("reuses a fresh cache and serves last-good data on refresh failure", async () => {
+    let now = 1_000;
+    const first = clientFactory([model()]);
+    const initial = await loadProviderModelCatalog({
+      clientFactory: first.factory,
+      now: () => now,
+    });
+
+    const ignored = clientFactory([model({ id: "openai/ignored" })]);
+    const cached = await loadProviderModelCatalog({
+      clientFactory: ignored.factory,
+      now: () => now + 500,
+    });
+    expect(cached).toBe(initial);
+    expect(ignored.list).not.toHaveBeenCalled();
+
+    now += 3_600_001;
+    const failingList = vi.fn().mockRejectedValue(new Error("offline"));
+    const stale = await loadProviderModelCatalog({
+      clientFactory: () => ({ models: { list: failingList } }) as never,
+      now: () => now,
+    });
+    expect(stale).toBe(initial);
+  });
+});

--- a/vex-app/src/main/onboarding/provider-model-catalog.ts
+++ b/vex-app/src/main/onboarding/provider-model-catalog.ts
@@ -1,0 +1,152 @@
+/**
+ * OpenRouter model-catalogue loader for the onboarding picker.
+ *
+ * The SDK request runs in Electron main, never in the renderer. Only text
+ * models that advertise tool support are projected because Vex's agent loop
+ * depends on tool calls. The last successful catalogue is cached for an hour;
+ * once stale, a failed refresh serves that last-good copy so setup remains
+ * usable during a transient OpenRouter metadata outage.
+ */
+
+import { OpenRouter } from "@vex-lib/openrouter-client.js";
+import type {
+  ProviderListModelsResult,
+  ProviderModelOption,
+} from "@shared/schemas/provider.js";
+
+const CATALOG_TTL_MS = 3_600_000;
+const CATALOG_TIMEOUT_MS = 15_000;
+
+const NOOP_LOGGER = {
+  group: () => {},
+  groupEnd: () => {},
+  log: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+type ModelsClient = Pick<OpenRouter["models"], "list">;
+
+export interface LoadProviderModelCatalogOptions {
+  readonly signal?: AbortSignal;
+  readonly now?: () => number;
+  readonly clientFactory?: () => { readonly models: ModelsClient };
+}
+
+let cached: ProviderListModelsResult | null = null;
+let cachedAtMs = 0;
+let inFlight: Promise<ProviderListModelsResult> | null = null;
+
+function defaultClientFactory(): OpenRouter {
+  return new OpenRouter({
+    httpReferer: "https://vexlabs.ai",
+    appTitle: "Vex Agent",
+    timeoutMs: CATALOG_TIMEOUT_MS,
+    retryConfig: { strategy: "none" },
+    debugLogger: NOOP_LOGGER,
+  });
+}
+
+function parsePricePerMillion(raw: unknown): number | null {
+  if (raw === undefined || raw === null || raw === "") return null;
+  const perToken = Number(raw);
+  if (!Number.isFinite(perToken) || perToken < 0) return null;
+  const perMillion = perToken * 1_000_000;
+  return Number.isFinite(perMillion) ? perMillion : null;
+}
+
+function providerIdFor(modelId: string): string {
+  const slash = modelId.indexOf("/");
+  const raw = slash > 0 ? modelId.slice(0, slash) : "openrouter";
+  return raw.replace(/^~/, "").slice(0, 64) || "openrouter";
+}
+
+function isSafeCatalogueString(value: string): boolean {
+  return value.trim().length > 0 && value.length <= 200;
+}
+
+function compareModels(a: ProviderModelOption, b: ProviderModelOption): number {
+  const byProvider = a.providerId.localeCompare(b.providerId, undefined, {
+    sensitivity: "base",
+  });
+  if (byProvider !== 0) return byProvider;
+  return a.displayName.localeCompare(b.displayName, undefined, {
+    sensitivity: "base",
+  });
+}
+
+async function fetchCatalogue(
+  options: LoadProviderModelCatalogOptions,
+): Promise<ProviderListModelsResult> {
+  const client = (options.clientFactory ?? defaultClientFactory)();
+  const response = await client.models.list(
+    {
+      outputModalities: "text",
+      supportedParameters: "tools",
+    },
+    {
+      signal: options.signal,
+      timeoutMs: CATALOG_TIMEOUT_MS,
+      retries: { strategy: "none" },
+    },
+  );
+
+  const models = response.data
+    .filter(
+      (model) =>
+        model.supportedParameters.includes("tools") &&
+        isSafeCatalogueString(model.id) &&
+        isSafeCatalogueString(model.name),
+    )
+    .map<ProviderModelOption>((model) => ({
+      modelId: model.id.trim(),
+      displayName: model.name.trim(),
+      providerId: providerIdFor(model.id),
+      contextLength:
+        typeof model.contextLength === "number" &&
+        Number.isInteger(model.contextLength) &&
+        model.contextLength > 0
+          ? model.contextLength
+          : null,
+      pricingInputPerMillion: parsePricePerMillion(model.pricing.prompt),
+      pricingOutputPerMillion: parsePricePerMillion(model.pricing.completion),
+    }))
+    .sort(compareModels);
+
+  return {
+    models,
+    fetchedAt: new Date((options.now ?? Date.now)()).toISOString(),
+  };
+}
+
+export async function loadProviderModelCatalog(
+  options: LoadProviderModelCatalogOptions = {},
+): Promise<ProviderListModelsResult> {
+  const now = (options.now ?? Date.now)();
+  if (cached !== null && now - cachedAtMs < CATALOG_TTL_MS) return cached;
+  if (inFlight !== null) return inFlight;
+
+  inFlight = fetchCatalogue(options)
+    .then((result) => {
+      cached = result;
+      cachedAtMs = (options.now ?? Date.now)();
+      return result;
+    })
+    .catch((error: unknown) => {
+      if (cached !== null) return cached;
+      throw error;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+
+  return inFlight;
+}
+
+export function __resetProviderModelCatalogForTests(): void {
+  cached = null;
+  cachedAtMs = 0;
+  inFlight = null;
+}

--- a/vex-app/src/preload/__tests__/bridge-surface.test.ts
+++ b/vex-app/src/preload/__tests__/bridge-surface.test.ts
@@ -139,6 +139,7 @@ describe("preload bridge surface", () => {
       "CH.wallets.getPreparedIntent",
       "CH.wallets.cancelPreparedIntent",
       "CH.models.listAvailable",
+      "CH.onboarding.providerListModels",
       "CH.usage.getSessionTotals",
       "CH.usage.getLastTurn",
       "CH.usage.getContextWindow",

--- a/vex-app/src/preload/shell/onboarding.ts
+++ b/vex-app/src/preload/shell/onboarding.ts
@@ -13,8 +13,14 @@ import { embeddingConfigureInputSchema } from "../../shared/schemas/embedding.js
 import type { EmbeddingConfigureInput } from "../../shared/schemas/embedding.js";
 import { completeSetupInputSchema } from "../../shared/schemas/finalize.js";
 import type { CompleteSetupInput } from "../../shared/schemas/finalize.js";
-import { providerPersistInputSchema } from "../../shared/schemas/provider.js";
-import type { ProviderPersistInput } from "../../shared/schemas/provider.js";
+import {
+  providerListModelsInputSchema,
+  providerPersistInputSchema,
+} from "../../shared/schemas/provider.js";
+import type {
+  ProviderListModelsInput,
+  ProviderPersistInput,
+} from "../../shared/schemas/provider.js";
 import {
   walletAddInputSchema,
   walletExportAllInputSchema,
@@ -195,6 +201,13 @@ export const onboarding = {
       CH.onboarding.providerPersist,
       input,
       providerPersistInputSchema
+    );
+  },
+  providerListModels(input: ProviderListModelsInput = {}) {
+    return invokeWithSchema(
+      CH.onboarding.providerListModels,
+      input,
+      providerListModelsInputSchema,
     );
   },
   completeSetup(input: CompleteSetupInput) {

--- a/vex-app/src/renderer/features/wizard/steps/ProviderStep.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/ProviderStep.tsx
@@ -42,12 +42,12 @@ import { useCallback, useRef, useState, type JSX } from "react";
 import { type ProviderPersistInput } from "@shared/schemas/provider.js";
 import { type WizardStepId } from "@shared/schemas/wizard.js";
 import { Button } from "../../../components/ui/button.js";
-import { Input } from "../../../components/ui/input.js";
 import { Label } from "../../../components/ui/label.js";
 import { PasswordField } from "../../../components/common/PasswordField.js";
 import { useEnvState } from "../../../lib/api/onboarding.js";
 import {
   persistProvider,
+  useProviderModels,
   useInvalidateEnvStateAfterProviderWrite,
 } from "../../../lib/api/provider.js";
 import {
@@ -58,6 +58,7 @@ import { WIZARD_STEP_META } from "../wizard-icons.js";
 import { WizardStepPanel } from "../WizardStepPanel.js";
 import { CAUSE_HINTS, uiCopyFor, type ServerError } from "./provider/error-ui.js";
 import { ModelBrandIcon } from "./provider/ModelBrandIcon.js";
+import { ModelPicker } from "./provider/ModelPicker.js";
 
 export interface ProviderStepProps {
   readonly completedSteps: ReadonlyArray<WizardStepId>;
@@ -89,6 +90,12 @@ export function ProviderStep({
   const configured = providerState?.configured ?? false;
   const effectiveName = providerState?.name ?? null;
   const effectiveModel = providerState?.modelLabel ?? null;
+  const providerModels = useProviderModels(!configured || showOverride);
+  const providerModelsResult = providerModels.data;
+  const catalogueModels =
+    providerModelsResult?.ok === true ? providerModelsResult.data.models : [];
+  const catalogueFailed =
+    providerModels.isError || providerModelsResult?.ok === false;
 
   const openLogsFolder = useCallback(() => {
     // Fire-and-forget one-shot action: opening the OS file manager has no
@@ -327,17 +334,21 @@ export function ProviderStep({
             <ModelBrandIcon modelId={model} size={16} />
             Model id
           </Label>
-          <Input
+          <ModelPicker
             id="vex-provider-model"
-            type="text"
-            autoComplete="off"
-            spellCheck={false}
-            placeholder="anthropic/claude-sonnet-4.5"
             value={model}
-            onChange={(e) => setModel(e.target.value)}
+            models={catalogueModels}
+            loading={providerModels.isLoading}
+            failed={catalogueFailed}
+            disabled={submitting || stepAdvance.isPending}
+            onChange={setModel}
+            onRetry={() => {
+              void providerModels.refetch();
+            }}
           />
           <p className="text-xs text-[var(--color-text-muted)]">
-            Browse model ids at{" "}
+            Browse tool-capable models or enter any OpenRouter model id. View
+            the full catalogue at{" "}
             <a
               href="https://openrouter.ai/models"
               target="_blank"

--- a/vex-app/src/renderer/features/wizard/steps/__tests__/ProviderStep.test.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/__tests__/ProviderStep.test.tsx
@@ -12,7 +12,7 @@
  *  - Success card with latencyMs + advance to "review".
  *  - External `<a target="_blank">` to openrouter.ai/models (no
  *    bridge call).
- *  - `providerListModels` NOT exposed on window.vex.onboarding.
+ *  - Model catalogue is exposed through the typed onboarding bridge.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -27,6 +27,7 @@ import type { JSX } from "react";
 import type { Result } from "@shared/ipc/result.js";
 import type { EnvState } from "@shared/schemas/onboarding.js";
 import type {
+  ProviderListModelsResult,
   ProviderPersistInput,
   ProviderPersistResult,
 } from "@shared/schemas/provider.js";
@@ -37,6 +38,8 @@ import type {
 
 const mockUseEnvState = vi.fn();
 const mockPersistProvider = vi.fn();
+const mockUseProviderModels = vi.fn();
+const mockProviderModelsRefetch = vi.fn();
 const mockSetWizardMutate = vi.fn();
 const mockInvalidate = vi.fn();
 const mockOnAdvance = vi.fn();
@@ -48,6 +51,7 @@ vi.mock("../../../../lib/api/onboarding.js", () => ({
 vi.mock("../../../../lib/api/provider.js", () => ({
   persistProvider: (input: ProviderPersistInput) => mockPersistProvider(input),
   useInvalidateEnvStateAfterProviderWrite: () => mockInvalidate,
+  useProviderModels: (enabled: boolean) => mockUseProviderModels(enabled),
 }));
 
 vi.mock("../../../../lib/api/wizard.js", async () => {
@@ -109,6 +113,40 @@ function makeQueryResult(
   } as UseQueryResult<Result<EnvState>>;
 }
 
+function makeProviderModelsQuery(): UseQueryResult<
+  Result<ProviderListModelsResult>
+> {
+  return {
+    data: {
+      ok: true,
+      data: {
+        models: [
+          {
+            modelId: "anthropic/claude-sonnet-4.5",
+            displayName: "Anthropic: Claude Sonnet 4.5",
+            providerId: "anthropic",
+            contextLength: 200_000,
+            pricingInputPerMillion: 3,
+            pricingOutputPerMillion: 15,
+          },
+          {
+            modelId: "openai/gpt-5.2",
+            displayName: "OpenAI: GPT-5.2",
+            providerId: "openai",
+            contextLength: 400_000,
+            pricingInputPerMillion: 1.75,
+            pricingOutputPerMillion: 14,
+          },
+        ],
+        fetchedAt: "2026-07-11T12:00:00.000Z",
+      },
+    },
+    isLoading: false,
+    isError: false,
+    refetch: mockProviderModelsRefetch,
+  } as unknown as UseQueryResult<Result<ProviderListModelsResult>>;
+}
+
 function renderWithQuery(ui: JSX.Element) {
   const qc = new QueryClient({
     defaultOptions: {
@@ -122,6 +160,9 @@ function renderWithQuery(ui: JSX.Element) {
 beforeEach(() => {
   mockUseEnvState.mockReset();
   mockPersistProvider.mockReset();
+  mockUseProviderModels.mockReset();
+  mockUseProviderModels.mockReturnValue(makeProviderModelsQuery());
+  mockProviderModelsRefetch.mockReset();
   mockSetWizardMutate.mockReset();
   mockInvalidate.mockReset();
   mockOnAdvance.mockReset();
@@ -155,6 +196,7 @@ describe("ProviderStep", () => {
     expect(
       container.querySelector('[data-vex-wizard-provider="form"]'),
     ).toBeNull();
+    expect(mockUseProviderModels).toHaveBeenCalledWith(false);
     // Model label shown.
     expect(getByText(/anthropic\/claude-sonnet-4\.5/)).toBeTruthy();
   });
@@ -487,17 +529,14 @@ describe("ProviderStep", () => {
     ).not.toBeNull();
   });
 
-  it("does NOT expose providerListModels on window.vex.onboarding (M10 dropped IPC)", () => {
-    // Bridge surface assertion — `providerListModels` channel is
-    // declared in `channels.ts` but never wired into the preload bridge
-    // in M10. Renderer code can't reach it.
+  it("exposes providerListModels on window.vex.onboarding", () => {
     const onboarding = (
       globalThis as unknown as {
         readonly window?: { readonly vex?: { readonly onboarding?: Record<string, unknown> } };
       }
     ).window?.vex?.onboarding;
     if (onboarding) {
-      expect(onboarding.providerListModels).toBeUndefined();
+      expect(onboarding.providerListModels).toBeTypeOf("function");
       expect(onboarding.providerTest).toBeUndefined();
     }
   });

--- a/vex-app/src/renderer/features/wizard/steps/provider/ModelPicker.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/provider/ModelPicker.tsx
@@ -1,0 +1,281 @@
+/** Searchable, editable OpenRouter model combobox for provider setup. */
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+  type KeyboardEvent,
+} from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  ArrowDown01Icon,
+  RefreshIcon,
+} from "@hugeicons/core-free-icons";
+import type { ProviderModelOption } from "@shared/schemas/provider.js";
+import { Input } from "../../../../components/ui/input.js";
+import { cn } from "../../../../lib/utils.js";
+import { ModelBrandIcon } from "./ModelBrandIcon.js";
+
+const MAX_VISIBLE_RESULTS = 60;
+
+function compactNumber(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`;
+  if (value >= 1_000) return `${Math.round(value / 1_000)}k`;
+  return String(value);
+}
+
+function compactPrice(value: number | null): string | null {
+  if (value === null) return null;
+  if (value === 0) return "$0";
+  if (value < 0.01) return `$${value.toFixed(3)}`;
+  if (value < 1) return `$${value.toFixed(2)}`;
+  return `$${value.toFixed(value < 10 ? 2 : 0)}`;
+}
+
+function modelMeta(model: ProviderModelOption): string {
+  const parts: string[] = [];
+  if (model.contextLength !== null) {
+    parts.push(`${compactNumber(model.contextLength)} context`);
+  }
+  const input = compactPrice(model.pricingInputPerMillion);
+  const output = compactPrice(model.pricingOutputPerMillion);
+  if (input !== null && output !== null) {
+    parts.push(`${input} in · ${output} out / 1m`);
+  }
+  return parts.join(" · ");
+}
+
+function searchableText(model: ProviderModelOption): string {
+  return `${model.displayName} ${model.modelId} ${model.providerId}`.toLowerCase();
+}
+
+export interface ModelPickerProps {
+  readonly id: string;
+  readonly value: string;
+  readonly models: ReadonlyArray<ProviderModelOption>;
+  readonly loading: boolean;
+  readonly failed: boolean;
+  readonly disabled?: boolean;
+  readonly onChange: (modelId: string) => void;
+  readonly onRetry: () => void;
+}
+
+export function ModelPicker({
+  id,
+  value,
+  models,
+  loading,
+  failed,
+  disabled = false,
+  onChange,
+  onRetry,
+}: ModelPickerProps): JSX.Element {
+  const listboxId = useId();
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const normalizedQuery = value.trim().toLowerCase();
+  const filtered = useMemo(() => {
+    const matches =
+      normalizedQuery.length === 0
+        ? models
+        : models.filter((model) => searchableText(model).includes(normalizedQuery));
+    return matches.slice(0, MAX_VISIBLE_RESULTS);
+  }, [models, normalizedQuery]);
+
+  const selected = useMemo(
+    () => models.find((model) => model.modelId === value) ?? null,
+    [models, value],
+  );
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDocumentMouseDown = (event: MouseEvent): void => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocumentMouseDown);
+    return () => document.removeEventListener("mousedown", onDocumentMouseDown);
+  }, [open]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [normalizedQuery]);
+
+  const choose = useCallback(
+    (model: ProviderModelOption): void => {
+      onChange(model.modelId);
+      setOpen(false);
+    },
+    [onChange],
+  );
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>): void => {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        if (!open) setOpen(true);
+        else if (filtered.length > 0) {
+          setActiveIndex((index) => (index + 1) % filtered.length);
+        }
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        if (!open) setOpen(true);
+        else if (filtered.length > 0) {
+          setActiveIndex(
+            (index) => (index - 1 + filtered.length) % filtered.length,
+          );
+        }
+        return;
+      }
+      if (event.key === "Enter" && open && filtered[activeIndex] !== undefined) {
+        event.preventDefault();
+        choose(filtered[activeIndex]);
+        return;
+      }
+      if (event.key === "Escape" && open) {
+        event.preventDefault();
+        setOpen(false);
+      }
+    },
+    [activeIndex, choose, filtered, open],
+  );
+
+  const showPanel = open && !disabled;
+
+  return (
+    <div ref={rootRef} className="relative">
+      <div className="relative">
+        <Input
+          id={id}
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-autocomplete="list"
+          aria-expanded={showPanel}
+          aria-controls={showPanel ? listboxId : undefined}
+          aria-activedescendant={
+            showPanel && filtered[activeIndex] !== undefined
+              ? `${listboxId}-option-${activeIndex}`
+              : undefined
+          }
+          type="text"
+          autoComplete="off"
+          spellCheck={false}
+          placeholder={loading ? "Loading tool-capable models…" : "Search models or enter an id"}
+          value={value}
+          disabled={disabled}
+          onFocus={() => setOpen(true)}
+          onClick={() => setOpen(true)}
+          onChange={(event) => {
+            onChange(event.target.value);
+            setOpen(true);
+          }}
+          onKeyDown={onKeyDown}
+          className="pr-10 font-mono text-[12px]"
+        />
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-[var(--color-text-muted)]"
+        >
+          <HugeiconsIcon
+            icon={ArrowDown01Icon}
+            size={15}
+            className={cn("transition-transform", showPanel && "rotate-180")}
+          />
+        </span>
+      </div>
+
+      {selected !== null && !showPanel ? (
+        <p className="mt-1.5 flex items-center gap-1.5 text-[11px] text-[var(--color-text-muted)]">
+          <ModelBrandIcon modelId={selected.modelId} size={13} />
+          <span>{selected.displayName}</span>
+          {modelMeta(selected) ? <span>· {modelMeta(selected)}</span> : null}
+        </p>
+      ) : null}
+
+      {showPanel ? (
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label="OpenRouter models"
+          className="absolute left-0 right-0 top-full z-30 mt-1 max-h-64 overflow-y-auto rounded-lg border border-white/[0.1] bg-[var(--color-bg-overlay)] p-1"
+        >
+          {loading ? (
+            <p className="px-3 py-3 text-xs text-[var(--color-text-muted)]">
+              Loading tool-capable models from OpenRouter…
+            </p>
+          ) : failed ? (
+            <div className="flex items-center justify-between gap-3 px-3 py-2.5">
+              <p className="text-xs text-[var(--color-text-secondary)]">
+                Catalogue unavailable. You can still enter a model id manually.
+              </p>
+              <button
+                type="button"
+                onClick={onRetry}
+                className="inline-flex shrink-0 items-center gap-1 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--vex-onboarding-accent)] hover:underline"
+              >
+                <HugeiconsIcon icon={RefreshIcon} size={12} aria-hidden />
+                Retry
+              </button>
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="px-3 py-3 text-xs text-[var(--color-text-muted)]">
+              No catalogue match. Keep typing to use a custom model id.
+            </p>
+          ) : (
+            filtered.map((model, index) => {
+              const active = index === activeIndex;
+              const isSelected = model.modelId === value;
+              const meta = modelMeta(model);
+              return (
+                <div
+                  key={model.modelId}
+                  id={`${listboxId}-option-${index}`}
+                  role="option"
+                  aria-selected={isSelected}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => choose(model)}
+                  className={cn(
+                    "flex cursor-pointer items-start gap-3 rounded-md px-3 py-2",
+                    active
+                      ? "bg-[color-mix(in_oklab,var(--vex-onboarding-accent)_12%,transparent)]"
+                      : "hover:bg-white/[0.035]",
+                  )}
+                >
+                  <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-white/[0.08] bg-white/[0.025]">
+                    <ModelBrandIcon modelId={model.modelId} size={16} />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm text-[var(--color-text-primary)]">
+                      {model.displayName}
+                    </span>
+                    <span className="block truncate font-mono text-[10px] text-[var(--color-text-muted)]">
+                      {model.modelId}
+                    </span>
+                    {meta ? (
+                      <span className="mt-0.5 block font-mono text-[9px] uppercase tracking-[0.08em] text-[var(--color-text-muted)]">
+                        {meta}
+                      </span>
+                    ) : null}
+                  </span>
+                  {isSelected ? (
+                    <span
+                      aria-hidden
+                      className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--vex-onboarding-accent)]"
+                    />
+                  ) : null}
+                </div>
+              );
+            })
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/vex-app/src/renderer/features/wizard/steps/provider/__tests__/ModelPicker.test.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/provider/__tests__/ModelPicker.test.tsx
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useState, type JSX } from "react";
+import type { ProviderModelOption } from "@shared/schemas/provider.js";
+import { ModelPicker } from "../ModelPicker.js";
+
+const MODELS: ReadonlyArray<ProviderModelOption> = [
+  {
+    modelId: "anthropic/claude-sonnet-4.5",
+    displayName: "Anthropic: Claude Sonnet 4.5",
+    providerId: "anthropic",
+    contextLength: 200_000,
+    pricingInputPerMillion: 3,
+    pricingOutputPerMillion: 15,
+  },
+  {
+    modelId: "openai/gpt-5.2",
+    displayName: "OpenAI: GPT-5.2",
+    providerId: "openai",
+    contextLength: 400_000,
+    pricingInputPerMillion: 1.75,
+    pricingOutputPerMillion: 14,
+  },
+];
+
+function Harness({
+  loading = false,
+  failed = false,
+  onRetry = vi.fn(),
+}: {
+  readonly loading?: boolean;
+  readonly failed?: boolean;
+  readonly onRetry?: () => void;
+}): JSX.Element {
+  const [value, setValue] = useState("");
+  return (
+    <>
+      <label htmlFor="model-picker">Model id</label>
+      <ModelPicker
+        id="model-picker"
+        value={value}
+        models={MODELS}
+        loading={loading}
+        failed={failed}
+        onChange={setValue}
+        onRetry={onRetry}
+      />
+    </>
+  );
+}
+
+afterEach(() => cleanup());
+
+describe("ModelPicker", () => {
+  it("opens the catalogue and selects a friendly-name result", () => {
+    render(<Harness />);
+    const input = screen.getByLabelText("Model id") as HTMLInputElement;
+
+    fireEvent.focus(input);
+    expect(screen.getAllByRole("option")).toHaveLength(2);
+    fireEvent.click(
+      screen.getByRole("option", { name: /Anthropic: Claude Sonnet 4.5/i }),
+    );
+
+    expect(input.value).toBe("anthropic/claude-sonnet-4.5");
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(screen.getByText("Anthropic: Claude Sonnet 4.5")).toBeTruthy();
+  });
+
+  it("filters by display name and supports keyboard selection", () => {
+    render(<Harness />);
+    const input = screen.getByLabelText("Model id") as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "gpt" } });
+    expect(screen.getAllByRole("option")).toHaveLength(1);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(input.value).toBe("openai/gpt-5.2");
+  });
+
+  it("keeps arbitrary text as a manual model id when there is no match", () => {
+    render(<Harness />);
+    const input = screen.getByLabelText("Model id") as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "vendor/new-model" } });
+
+    expect(input.value).toBe("vendor/new-model");
+    expect(screen.getByText(/Keep typing to use a custom model id/i)).toBeTruthy();
+  });
+
+  it("surfaces catalogue failure without disabling manual entry", () => {
+    const onRetry = vi.fn();
+    render(<Harness failed onRetry={onRetry} />);
+    const input = screen.getByLabelText("Model id") as HTMLInputElement;
+
+    fireEvent.focus(input);
+    expect(screen.getByText(/Catalogue unavailable/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Retry/i }));
+    fireEvent.change(input, { target: { value: "openrouter/auto" } });
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(input.value).toBe("openrouter/auto");
+  });
+
+  it("announces loading while retaining an editable field", () => {
+    render(<Harness loading />);
+    const input = screen.getByLabelText("Model id") as HTMLInputElement;
+
+    fireEvent.focus(input);
+    expect(screen.getByText(/Loading tool-capable models from OpenRouter/i)).toBeTruthy();
+    fireEvent.change(input, { target: { value: "openrouter/auto" } });
+    expect(input.value).toBe("openrouter/auto");
+  });
+});

--- a/vex-app/src/renderer/lib/api/provider.ts
+++ b/vex-app/src/renderer/lib/api/provider.ts
@@ -17,11 +17,17 @@
  * model) pair BEFORE writing the 3 .env keys.
  */
 
-import { useQueryClient } from "@tanstack/react-query";
+import {
+  queryOptions,
+  useQuery,
+  useQueryClient,
+  type UseQueryResult,
+} from "@tanstack/react-query";
 import type { Result } from "@shared/ipc/result.js";
 import type {
   ProviderPersistInput,
   ProviderPersistResult,
+  ProviderListModelsResult,
 } from "@shared/schemas/provider.js";
 import { onboardingKeys } from "./queryKeys.js";
 
@@ -29,6 +35,24 @@ export async function persistProvider(
   input: ProviderPersistInput,
 ): Promise<Result<ProviderPersistResult>> {
   return window.vex.onboarding.providerPersist(input);
+}
+
+const PROVIDER_MODELS_STALE_MS = 3_600_000;
+
+function providerModelsOptions(enabled: boolean) {
+  return queryOptions({
+    queryKey: onboardingKeys.providerModels(),
+    queryFn: () => window.vex.onboarding.providerListModels({}),
+    staleTime: PROVIDER_MODELS_STALE_MS,
+    retry: false,
+    enabled,
+  });
+}
+
+export function useProviderModels(
+  enabled: boolean = true,
+): UseQueryResult<Result<ProviderListModelsResult>> {
+  return useQuery(providerModelsOptions(enabled));
 }
 
 export function useInvalidateEnvStateAfterProviderWrite(): () => void {

--- a/vex-app/src/renderer/lib/api/queryKeys.ts
+++ b/vex-app/src/renderer/lib/api/queryKeys.ts
@@ -21,6 +21,7 @@ export const onboardingKeys = {
   all: ["onboarding"] as const,
   envState: () => ["onboarding", "envState"] as const,
   wizardState: () => ["onboarding", "wizardState"] as const,
+  providerModels: () => ["onboarding", "providerModels"] as const,
   // Puzzle 5 B-UI — lowercased EVM addresses with Polymarket creds configured.
   polymarketConfiguredAddresses: () =>
     ["onboarding", "polymarketConfiguredAddresses"] as const,

--- a/vex-app/src/shared/schemas/__tests__/provider.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/provider.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  providerListModelsResultSchema,
+  providerModelOptionSchema,
+} from "../provider.js";
+
+const validModel = {
+  modelId: "anthropic/claude-sonnet-4.5",
+  displayName: "Anthropic: Claude Sonnet 4.5",
+  providerId: "anthropic",
+  contextLength: 200_000,
+  pricingInputPerMillion: 3,
+  pricingOutputPerMillion: 15,
+};
+
+describe("provider model catalogue schemas", () => {
+  it("accepts renderer-safe model metadata", () => {
+    expect(providerModelOptionSchema.safeParse(validModel).success).toBe(true);
+    expect(
+      providerListModelsResultSchema.safeParse({
+        models: [validModel],
+        fetchedAt: "2026-07-11T12:00:00.000Z",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects unknown fields and invalid prices", () => {
+    expect(
+      providerModelOptionSchema.safeParse({
+        ...validModel,
+        rawProviderPayload: { secret: "nope" },
+      }).success,
+    ).toBe(false);
+    expect(
+      providerModelOptionSchema.safeParse({
+        ...validModel,
+        pricingInputPerMillion: -1,
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/vex-app/src/shared/schemas/provider.ts
+++ b/vex-app/src/shared/schemas/provider.ts
@@ -65,3 +65,39 @@ export const providerPersistResultSchema = z
   .strict();
 
 export type ProviderPersistResult = z.infer<typeof providerPersistResultSchema>;
+
+// ── OpenRouter model catalogue ─────────────────────────────────────────────
+
+/**
+ * Public, renderer-safe projection of an OpenRouter catalogue entry. The main
+ * process deliberately allow-lists only the metadata needed by the picker;
+ * provider routing details and raw API payloads never cross IPC.
+ */
+export const providerModelOptionSchema = z
+  .object({
+    modelId: z.string().trim().min(1).max(200),
+    displayName: z.string().trim().min(1).max(200),
+    providerId: z.string().trim().min(1).max(64),
+    contextLength: z.number().int().positive().nullable(),
+    pricingInputPerMillion: z.number().finite().nonnegative().nullable(),
+    pricingOutputPerMillion: z.number().finite().nonnegative().nullable(),
+  })
+  .strict();
+
+export type ProviderModelOption = z.infer<typeof providerModelOptionSchema>;
+
+export const providerListModelsInputSchema = z.object({}).strict();
+export type ProviderListModelsInput = z.infer<
+  typeof providerListModelsInputSchema
+>;
+
+export const providerListModelsResultSchema = z
+  .object({
+    models: z.array(providerModelOptionSchema).max(1_000).readonly(),
+    fetchedAt: z.string().datetime({ offset: true }),
+  })
+  .strict();
+
+export type ProviderListModelsResult = z.infer<
+  typeof providerListModelsResultSchema
+>;

--- a/vex-app/src/shared/types/bridge/shell/onboarding.ts
+++ b/vex-app/src/shared/types/bridge/shell/onboarding.ts
@@ -41,6 +41,8 @@ import type {
   AgentCoreConfigureResult,
 } from "../../../schemas/agent-core.js";
 import type {
+  ProviderListModelsInput,
+  ProviderListModelsResult,
   ProviderPersistInput,
   ProviderPersistResult,
 } from "../../../schemas/provider.js";
@@ -131,6 +133,9 @@ export interface OnboardingBridge {
   readonly providerPersist: (
     input: ProviderPersistInput
   ) => Promise<Result<ProviderPersistResult>>;
+  readonly providerListModels: (
+    input?: ProviderListModelsInput
+  ) => Promise<Result<ProviderListModelsResult>>;
   readonly completeSetup: (
     input: CompleteSetupInput
   ) => Promise<Result<CompleteSetupResult>>;


### PR DESCRIPTION
## Problem solved

Allow users to search & pick models rather than pasting in a model ID from OpenRouter.

Previously, the provider setup screen exposed a plain model-ID field and sent users to OpenRouter's catalogue. That meant leaving Vex, finding a compatible model, copying its exact slug, returning to the app, and pasting it correctly. The flow also gave no indication whether a model supported the tool-calling behavior Vex needs.

## What changed

### Searchable model picker

- Replaced the copy/paste-only field with an editable, keyboard-accessible combobox.
- Added search by model name, provider, and exact OpenRouter slug.
- Added provider logos plus context-window and input/output pricing metadata.
- Kept manual model-ID entry as a first-class fallback for new, custom, offline, or temporarily unavailable routes.
- Added clear loading, empty, error, retry, selected, and custom-value states.

### Safe OpenRouter catalogue loading

- Activated the reserved `onboarding.providerListModels` IPC channel across the shared schema, preload bridge, and Electron main process.
- Fetches the public OpenRouter model catalogue in the main process; the renderer never calls OpenRouter directly.
- Requests text models that advertise tool support, then filters and validates the response defensively before exposing it.
- Projects only allow-listed, Zod-validated display metadata across IPC instead of forwarding raw upstream payloads or errors.
- Caches successful catalogues for one hour, deduplicates concurrent requests, and serves the last good catalogue if a refresh fails transiently.
- Avoids fetching the catalogue on the configured-provider summary screen until the user chooses **Reconfigure**.
- Requires no API key to browse the catalogue.

### Existing security and persistence behavior preserved

- The API key remains an uncontrolled DOM-ref secret and is cleared synchronously before submission.
- Saving still follows the existing verify-then-persist path: Vex tests the selected model with the entered key before writing provider settings.
- Existing configured-global-model endpoint semantics remain unchanged.
- Catalogue failures do not block users from entering a model ID manually.

## User impact

Provider setup is now self-contained for the common case: users can discover a compatible model, compare the useful metadata, select it, and continue without leaving Vex or knowing OpenRouter's slug format. Advanced users can still type any model ID directly.

## Screenshot

![Searchable OpenRouter model picker](https://raw.githubusercontent.com/alexastro01/Vex/4c7018ee8d07497b323266cf55dbcea48dc8a172/.github/pr-assets/openrouter-model-picker.png)

## Test coverage

Added coverage for:

- OpenRouter catalogue projection, caching, request deduplication, and stale-on-error behavior.
- Strict shared-schema output validation and IPC error redaction.
- Preload bridge exposure.
- Picker mouse, keyboard, manual-entry, empty, error, and retry flows.
- Existing `ProviderStep` submission and error behavior.

## Validation

- `pnpm test` in `vex-app`: **2,540 / 2,540 tests passed** across 293 files.
- `pnpm run lint`: passed, including the type ratchet and process-boundary checks.
- `pnpm run build` in `vex-app`: passed for main, preload, and renderer bundles plus artifact/CSP checks.
- Root `pnpm run build`: passed.
- Live OpenRouter catalogue smoke test: returned **257 tool-capable text models**.
- React Doctor: **98 / 100**; the only note is the existing `ProviderStep` component-size warning.

The root workspace test suite was also run: 6,438 tests passed and 7 were skipped. One unrelated pre-existing Polymarket external-network test remains red and reproduces in isolation.
