### PR TITLE
fix(execution): treat a reverted approve/swap/bridge receipt as a failure

### DIFF
--- a/src/__tests__/kyberswap/kyberswap-receipt-status.test.ts
+++ b/src/__tests__/kyberswap/kyberswap-receipt-status.test.ts
@@ -1,0 +1,67 @@
+/**
+ * KyberSwap execution — a MINED-BUT-REVERTED receipt must FAIL, never pass.
+ *
+ * Same class of bug as the Uniswap path: viem's `waitForTransactionReceipt`
+ * RESOLVES on a reverted transaction (`status: "reverted"`, no throw), so a
+ * reverted `approve()` was silently treated as a successful approval and a
+ * reverted swap was reported as executed. The execution path must assert
+ * `receipt.status === "success"`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { Address, Hex } from "viem";
+
+import { ensureKyberAllowance, sendKyberTransaction } from "@tools/kyberswap/evm/erc20.js";
+import { META_AGGREGATION_ROUTER_V2 } from "@tools/kyberswap/constants.js";
+import { ErrorCodes } from "../../errors.js";
+
+const TOKEN = "0x8Ff92566f2e81BDd68EDfAa8cde73942A723796b" as Address;
+const OWNER = "0x1111111111111111111111111111111111111111" as Address;
+const TX_HASH = `0x${"cd".repeat(32)}` as Hex;
+
+function clients(receiptStatus: "success" | "reverted", currentAllowance = 0n) {
+  const publicClient = {
+    readContract: vi.fn().mockResolvedValue(currentAllowance),
+    waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: receiptStatus, logs: [] }),
+  } as unknown as Parameters<typeof ensureKyberAllowance>[0];
+  const walletClient = {
+    account: { address: OWNER },
+    chain: { id: 1 },
+    writeContract: vi.fn().mockResolvedValue(TX_HASH),
+    sendTransaction: vi.fn().mockResolvedValue(TX_HASH),
+  } as unknown as Parameters<typeof ensureKyberAllowance>[1];
+  return { publicClient, walletClient };
+}
+
+describe("ensureKyberAllowance — reverted approve", () => {
+  it("throws APPROVAL_FAILED when the approve tx mines reverted", async () => {
+    const { publicClient, walletClient } = clients("reverted");
+    await expect(
+      ensureKyberAllowance(publicClient, walletClient, TOKEN, META_AGGREGATION_ROUTER_V2, 100n),
+    ).rejects.toMatchObject({ code: ErrorCodes.APPROVAL_FAILED });
+  });
+
+  it("succeeds when the approve tx mines successfully", async () => {
+    const { publicClient, walletClient } = clients("success");
+    const result = await ensureKyberAllowance(
+      publicClient,
+      walletClient,
+      TOKEN,
+      META_AGGREGATION_ROUTER_V2,
+      100n,
+    );
+    expect(result?.txHash).toBe(TX_HASH);
+  });
+});
+
+describe("sendKyberTransaction — reverted swap", () => {
+  it("throws SWAP_FAILED when the swap tx mines reverted", async () => {
+    const { publicClient, walletClient } = clients("reverted");
+    await expect(
+      sendKyberTransaction(publicClient, walletClient, {
+        to: META_AGGREGATION_ROUTER_V2,
+        data: "0x" as Hex,
+      }),
+    ).rejects.toMatchObject({ code: ErrorCodes.SWAP_FAILED });
+  });
+});

--- a/src/__tests__/tools/relay/execute.test.ts
+++ b/src/__tests__/tools/relay/execute.test.ts
@@ -157,4 +157,27 @@ describe("executeRelayBridge — ordered broadcast (PHASE 2)", () => {
     expect(result.txHashes).toEqual(["0xaaa", "0xbbb"]);
     expect(result.finalStatus).toBe("pending"); // no requestId → no poll
   });
+
+  it("(c) a step that mines REVERTED aborts the bridge — no further steps broadcast", async () => {
+    // First step (approve) mines reverted; viem's waitForTransactionReceipt
+    // RESOLVES with status "reverted" rather than throwing. Treating it as
+    // success would broadcast the deposit step against an unapproved allowance —
+    // a fund-safety hazard. The bridge must abort on the reverted step.
+    sendTransaction.mockResolvedValueOnce("0xaaa").mockResolvedValueOnce("0xbbb");
+    waitForTransactionReceipt.mockReset();
+    waitForTransactionReceipt.mockResolvedValueOnce({ status: "reverted" });
+    const quote = {
+      steps: [
+        step("approve", ORIGIN, APPROVE_TO, "0", "0x"),
+        step("deposit", DESTINATION, DEPOSIT_TO, "1000", "0xabcd"),
+      ],
+    } as unknown as RelayQuoteResponse;
+
+    await expect(
+      executeRelayBridge({ quote, signer, originChainId: ORIGIN, destinationChainId: DESTINATION }),
+    ).rejects.toMatchObject({ code: "RELAY_BRIDGE_FAILED" });
+
+    // The deposit step must NOT have broadcast after the approve reverted.
+    expect(sendTransaction).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/__tests__/tools/uniswap/uniswap-receipt-status.test.ts
+++ b/src/__tests__/tools/uniswap/uniswap-receipt-status.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Uniswap execution — a MINED-BUT-REVERTED receipt must FAIL, never pass.
+ *
+ * viem's `waitForTransactionReceipt` RESOLVES on a reverted transaction (it
+ * returns the receipt with `status: "reverted"`; it does NOT throw). So awaiting
+ * the receipt is not enough — the execution path must assert
+ * `receipt.status === "success"`, exactly as the generic wallet send path already
+ * does (`tools/internal/wallet/send-execute-evm.ts`).
+ *
+ * Regression guard for the Robinhood sell bug: an ERC-20 `approve()` that mines
+ * REVERTED was silently treated as a successful approval, so the swap was sent
+ * with zero allowance and reverted at `transferFrom` (STF / TRANSFER_FROM_FAILED)
+ * — masking that the APPROVE is what failed. The swap send had the same gap: a
+ * reverted swap was reported as an executed trade.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { Address, Hex } from "viem";
+
+import { ensureUniswapAllowanceExact } from "@tools/uniswap/erc20.js";
+import { sendUniswapTransaction } from "@tools/uniswap/execute.js";
+import { ErrorCodes, VexError } from "../../../errors.js";
+
+// A registered Robinhood router (in UNISWAP_KNOWN_SPENDERS) so spender validation
+// passes and we reach the receipt check. V3 SwapRouter02 on 4663.
+const ROBINHOOD_V3_ROUTER = "0xcaf681a66d020601342297493863e78c959e5cb2" as Address;
+const TOKEN = "0x8Ff92566f2e81BDd68EDfAa8cde73942A723796b" as Address;
+const OWNER = "0x1111111111111111111111111111111111111111" as Address;
+const TX_HASH = `0x${"ab".repeat(32)}` as Hex;
+
+function clients(receiptStatus: "success" | "reverted", currentAllowance = 0n) {
+  const waitForTransactionReceipt = vi.fn().mockResolvedValue({ status: receiptStatus });
+  const publicClient = {
+    readContract: vi.fn().mockResolvedValue(currentAllowance),
+    waitForTransactionReceipt,
+  } as unknown as Parameters<typeof ensureUniswapAllowanceExact>[0];
+  const walletClient = {
+    account: { address: OWNER },
+    chain: { id: 4663 },
+    writeContract: vi.fn().mockResolvedValue(TX_HASH),
+    sendTransaction: vi.fn().mockResolvedValue(TX_HASH),
+  } as unknown as Parameters<typeof ensureUniswapAllowanceExact>[1];
+  return { publicClient, walletClient, waitForTransactionReceipt };
+}
+
+describe("ensureUniswapAllowanceExact — reverted approve", () => {
+  it("throws APPROVAL_FAILED when the approve tx mines reverted", async () => {
+    const { publicClient, walletClient } = clients("reverted");
+    await expect(
+      ensureUniswapAllowanceExact(publicClient, walletClient, TOKEN, ROBINHOOD_V3_ROUTER, 100n),
+    ).rejects.toMatchObject({ code: ErrorCodes.APPROVAL_FAILED });
+  });
+
+  it("succeeds when the approve tx mines successfully", async () => {
+    const { publicClient, walletClient } = clients("success");
+    const result = await ensureUniswapAllowanceExact(
+      publicClient,
+      walletClient,
+      TOKEN,
+      ROBINHOOD_V3_ROUTER,
+      100n,
+    );
+    expect(result?.txHash).toBe(TX_HASH);
+  });
+});
+
+describe("sendUniswapTransaction — reverted swap", () => {
+  it("throws SWAP_FAILED when the swap tx mines reverted", async () => {
+    const { publicClient, walletClient } = clients("reverted");
+    await expect(
+      sendUniswapTransaction(
+        publicClient as never,
+        walletClient as never,
+        { to: ROBINHOOD_V3_ROUTER, data: "0x" as Hex, value: 0n },
+      ),
+    ).rejects.toBeInstanceOf(VexError);
+  });
+});

--- a/src/tools/kyberswap/evm/erc20.ts
+++ b/src/tools/kyberswap/evm/erc20.ts
@@ -162,8 +162,16 @@ export async function ensureKyberAllowance(
         functionName: "approve",
         args: [spender, 0n],
       });
-      await publicClient.waitForTransactionReceipt({ hash: resetTxHash });
+      const resetReceipt = await publicClient.waitForTransactionReceipt({ hash: resetTxHash });
+      if (resetReceipt.status !== "success") {
+        throw new VexError(
+          ErrorCodes.APPROVAL_FAILED,
+          `Allowance-reset transaction ${resetTxHash} reverted on-chain (status: ${resetReceipt.status}).`,
+          "The existing allowance was not cleared, so the follow-up approve would be blocked. Retry or check gas.",
+        );
+      }
     } catch (err) {
+      if (err instanceof VexError) throw err;
       throw new VexError(ErrorCodes.APPROVAL_FAILED, `Failed to reset allowance: ${err instanceof Error ? err.message : err}`);
     }
   }
@@ -179,9 +187,21 @@ export async function ensureKyberAllowance(
       functionName: "approve",
       args: [spender, approveAmount],
     });
-    await publicClient.waitForTransactionReceipt({ hash: txHash });
+    // viem's waitForTransactionReceipt RESOLVES on a reverted tx (status
+    // "reverted") — it does not throw. A reverted approve grants NO allowance, so
+    // treating it as success sends the swap into a transferFrom revert that masks
+    // the real cause. Fail loud on the approve.
+    const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    if (receipt.status !== "success") {
+      throw new VexError(
+        ErrorCodes.APPROVAL_FAILED,
+        `Approval transaction ${txHash} reverted on-chain (status: ${receipt.status}).`,
+        "The router was not granted an allowance; the swap would fail at transferFrom. Retry or check gas.",
+      );
+    }
     return { txHash, resetTxHash };
   } catch (err) {
+    if (err instanceof VexError) throw err;
     throw new VexError(ErrorCodes.APPROVAL_FAILED, `Failed to approve: ${err instanceof Error ? err.message : err}`);
   }
 }
@@ -206,9 +226,19 @@ export async function sendKyberTransaction(
       value: params.value ?? 0n,
       chain: walletClient.chain,
     });
-    await publicClient.waitForTransactionReceipt({ hash: txHash });
+    // waitForTransactionReceipt RESOLVES on a reverted tx — assert success so a
+    // reverted swap is never reported as executed.
+    const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    if (receipt.status !== "success") {
+      throw new VexError(
+        ErrorCodes.SWAP_FAILED,
+        `Transaction ${txHash} reverted on-chain (status: ${receipt.status}).`,
+        "No tokens were swapped. Common causes: slippage/min-out, insufficient allowance, or a fee-on-transfer token.",
+      );
+    }
     return txHash;
   } catch (err) {
+    if (err instanceof VexError) throw err;
     throw new VexError(ErrorCodes.SWAP_FAILED, `Transaction failed: ${err instanceof Error ? err.message : err}`);
   }
 }
@@ -231,6 +261,13 @@ export async function sendKyberTransactionWithReceipt(
       chain: walletClient.chain,
     });
     const receipt = await publicClient.waitForTransactionReceipt({ hash });
+    if (receipt.status !== "success") {
+      throw new VexError(
+        ErrorCodes.SWAP_FAILED,
+        `Transaction ${hash} reverted on-chain (status: ${receipt.status}).`,
+        "The zap did not execute. Common causes: slippage/min-out, insufficient allowance, or a fee-on-transfer token.",
+      );
+    }
     return {
       hash,
       receipt: {
@@ -242,6 +279,7 @@ export async function sendKyberTransactionWithReceipt(
       },
     };
   } catch (err) {
+    if (err instanceof VexError) throw err;
     throw new VexError(ErrorCodes.SWAP_FAILED, `Transaction failed: ${err instanceof Error ? err.message : err}`);
   }
 }

--- a/src/tools/relay/execute.ts
+++ b/src/tools/relay/execute.ts
@@ -208,8 +208,19 @@ export async function executeRelayBridge(args: RelayExecuteArgs): Promise<RelayE
       data: tx.data,
       value: tx.value,
     });
-    await publicClient.waitForTransactionReceipt({ hash });
+    // viem's waitForTransactionReceipt RESOLVES on a reverted tx (status
+    // "reverted") — it does not throw. A reverted step (e.g. a reverted approve)
+    // must ABORT the bridge: broadcasting the next step against unmet on-chain
+    // preconditions is a fund-safety hazard.
+    const receipt = await publicClient.waitForTransactionReceipt({ hash });
     txHashes.push(hash);
+    if (receipt.status !== "success") {
+      throw new VexError(
+        ErrorCodes.RELAY_BRIDGE_FAILED,
+        `Relay step "${tx.stepId}" (tx ${hash}) reverted on-chain (status: ${receipt.status}); bridge aborted.`,
+        "No further steps were broadcast. Re-quote and retry; check gas and balances on the origin chain.",
+      );
+    }
     logger.info("relay.bridge.step_broadcast", { stepId: tx.stepId, chainId: tx.chainId });
   }
 

--- a/src/tools/uniswap/erc20.ts
+++ b/src/tools/uniswap/erc20.ts
@@ -104,8 +104,16 @@ export async function ensureUniswapAllowanceExact(
         functionName: "approve",
         args: [spender, 0n],
       });
-      await publicClient.waitForTransactionReceipt({ hash: resetTxHash });
+      const resetReceipt = await publicClient.waitForTransactionReceipt({ hash: resetTxHash });
+      if (resetReceipt.status !== "success") {
+        throw new VexError(
+          ErrorCodes.APPROVAL_FAILED,
+          `Allowance-reset transaction ${resetTxHash} reverted on-chain (status: ${resetReceipt.status}).`,
+          "The existing allowance was not cleared, so the follow-up approve would be blocked. Retry or check gas.",
+        );
+      }
     } catch (err) {
+      if (err instanceof VexError) throw err;
       throw new VexError(ErrorCodes.APPROVAL_FAILED, `Failed to reset allowance: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
@@ -119,9 +127,21 @@ export async function ensureUniswapAllowanceExact(
       functionName: "approve",
       args: [spender, requiredAmount],
     });
-    await publicClient.waitForTransactionReceipt({ hash: txHash });
+    // viem's waitForTransactionReceipt RESOLVES on a reverted tx (status
+    // "reverted") — it does not throw. A reverted approve grants NO allowance, so
+    // treating it as success sends the swap into a transferFrom revert (STF /
+    // TRANSFER_FROM_FAILED) that masks the real cause. Fail loud on the approve.
+    const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    if (receipt.status !== "success") {
+      throw new VexError(
+        ErrorCodes.APPROVAL_FAILED,
+        `Approval transaction ${txHash} reverted on-chain (status: ${receipt.status}).`,
+        "The router was not granted an allowance; the swap would fail at transferFrom. Retry or check gas.",
+      );
+    }
     return resetTxHash ? { txHash, resetTxHash } : { txHash };
   } catch (err) {
+    if (err instanceof VexError) throw err;
     throw new VexError(ErrorCodes.APPROVAL_FAILED, `Failed to approve: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/tools/uniswap/execute.ts
+++ b/src/tools/uniswap/execute.ts
@@ -187,9 +187,20 @@ export async function sendUniswapTransaction(
       data: tx.data,
       value: tx.value,
     });
-    await publicClient.waitForTransactionReceipt({ hash });
+    // viem's waitForTransactionReceipt RESOLVES on a reverted tx (status
+    // "reverted") — it does not throw. Reporting a reverted swap as executed
+    // would open a phantom lot in the trade capture, so assert success here.
+    const receipt = await publicClient.waitForTransactionReceipt({ hash });
+    if (receipt.status !== "success") {
+      throw new VexError(
+        ErrorCodes.SWAP_FAILED,
+        `Swap transaction ${hash} reverted on-chain (status: ${receipt.status}).`,
+        "No tokens were swapped. Common causes: slippage/min-out, insufficient allowance, or a fee-on-transfer token.",
+      );
+    }
     return hash;
   } catch (err) {
+    if (err instanceof VexError) throw err;
     throw new VexError(ErrorCodes.SWAP_FAILED, `Transaction failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 }


### PR DESCRIPTION
## Problem solved

Make a mined-but-reverted approve/swap/bridge transaction fail loudly at the layer that caused it, instead of being silently reported as success.

viem's `waitForTransactionReceipt` **resolves** on a reverted transaction — it returns the receipt with `status: "reverted"` and does **not** throw. The DEX execution paths awaited the receipt but never inspected `status`, so a reverted transaction was treated as if it had succeeded.

This produced a confusing, hard-to-diagnose failure when **selling an ERC-20 on Robinhood Chain** (an Arbitrum-Orbit L2 whose gas carries a fluctuating L1-data-fee component, where an `approve()` can mine-but-revert):

1. The ERC-20 `approve()` inside the swap handler mines with `status: "reverted"`.
2. `ensureUniswapAllowanceExact` awaits the receipt, ignores the status, and returns as if the approval **succeeded**.
3. The allowance is still `0`, so the swap is broadcast and reverts at `transferFrom` — `STF` (V3 `SwapRouter02`) / `TRANSFER_FROM_FAILED` (V2 `Router02`).
4. The only surfaced error is the downstream swap revert, **masking that the approve is what actually failed** — i.e. the "auto-approve isn't executing, for no clear reason" symptom.

The same gap had two further consequences: a reverted **swap** was reported as an executed trade (a phantom lot opened in the trade capture), and a reverted **Relay bridge step** (e.g. a reverted approve leg) let the *next* step broadcast against unmet on-chain preconditions — a fund-safety hazard.

## What changed

The correct pattern already existed in the generic wallet send path — [`send-execute-evm.ts`](https://github.com/Vex-Foundation/Vex/blob/main/src/vex-agent/tools/internal/wallet/send-execute-evm.ts) checks `receipt.status !== "success"` and returns `chain_failed`. The swap/approve/bridge paths never adopted it. This PR applies the same assertion consistently.

### Uniswap
- `ensureUniswapAllowanceExact` — the `approve()` and the USDT-style reset-to-zero now assert the receipt succeeded; a reverted receipt throws `APPROVAL_FAILED` with the tx hash.
- `sendUniswapTransaction` — a reverted swap now throws `SWAP_FAILED` instead of returning the hash of a failed tx.

### KyberSwap
- `ensureKyberAllowance` — approve + reset assert success (`APPROVAL_FAILED` on revert).
- `sendKyberTransaction` and `sendKyberTransactionWithReceipt` — assert success (`SWAP_FAILED` on revert).

### Relay
- `executeRelayBridge` — the per-step broadcast loop asserts each step's receipt succeeded; a reverted step throws `RELAY_BRIDGE_FAILED` and **aborts before broadcasting the next step**.

### Error fidelity preserved
- Existing `catch` blocks that re-wrap failures now re-throw `VexError` as-is, so the precise reason (reverted approve vs. generic send failure) is preserved rather than flattened into a generic message.
- No happy-path change: a successful receipt behaves exactly as before.

## User impact

A reverted approval now surfaces as `APPROVAL_FAILED` with its transaction hash — actionable, and pointing at the real cause — rather than masquerading as a downstream `transferFrom` revert. A reverted swap or bridge step can no longer be recorded as a successful, executed trade, and a reverted Relay leg can no longer cascade into a follow-on broadcast.

## Test coverage

Written test-first (TDD) and each observed failing against the old code before the fix:

- `src/__tests__/tools/uniswap/uniswap-receipt-status.test.ts` — reverted approve → `APPROVAL_FAILED`; reverted swap → `SWAP_FAILED`; the success path still returns the tx hash.
- `src/__tests__/kyberswap/kyberswap-receipt-status.test.ts` — the same for the KyberSwap approve + swap path.
- `src/__tests__/tools/relay/execute.test.ts` — a step that mines reverted aborts the bridge and does **not** broadcast the next step.

## Validation

- Root `pnpm exec tsc --noEmit`: **clean** (exit 0).
- Root `pnpm run build`: passed (`tsc` + `tsc-alias`).
- Root workspace test suite: **6,446 passed, 7 skipped** across **465 files**. The 7 skips and the network-dependent warnings (no `TAVILY_API_KEY`, registry unreachable in the sandbox) are pre-existing and unrelated to this change.

## Notes

Scope is limited to receipt-status verification. It intentionally does not touch gas estimation, nonce handling, or the exact-amount approval policy. *Why* an `approve()` reverts on Robinhood specifically (L1-data-fee gas underpricing vs. token-specific behavior) is a separate follow-up; this PR ensures that whenever it does, it surfaces as a clear `APPROVAL_FAILED` rather than a masked `transferFrom` revert.
