### PR TITLE
fix(uniswap): reject over-balance sells with a clear INSUFFICIENT_BALANCE

### DIFF
--- a/src/__tests__/tools/uniswap/uniswap-balance-preflight.test.ts
+++ b/src/__tests__/tools/uniswap/uniswap-balance-preflight.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Uniswap sell pre-flight balance guard.
+ *
+ * Selling an ERC-20 for MORE than the wallet holds makes the router's
+ * `transferFrom` revert with `TransferHelper: TRANSFER_FROM_FAILED` (V2) / `STF`
+ * (V3) — indistinguishable, from the outside, from a missing allowance. That
+ * ambiguity sent an exit attempt down a multi-hour "auto-approve is broken" dead
+ * end when the real cause was `amountIn > balance` (a rounded/stale amount
+ * exceeding the on-chain balance by dust).
+ *
+ * The guard reads the on-chain balance BEFORE approving/swapping and fails with a
+ * clear INSUFFICIENT_BALANCE (have X, requested Y) so the caller can correct the
+ * amount instead of burning gas on a doomed, cryptic revert.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { Address } from "viem";
+
+import { ensureUniswapSufficientBalance } from "@tools/uniswap/erc20.js";
+import { ErrorCodes } from "../../../errors.js";
+
+const TOKEN = "0x8Ff92566f2e81BDd68EDfAa8cde73942A723796b" as Address;
+const OWNER = "0x9ed25bdedceB28Adf9E3C7fCa34511e78e47C77f" as Address;
+
+// The real VEX numbers from the incident: balance 184.9855e18, sell 184.99e18.
+const BALANCE = 184985498895318795602n;
+const OVER = 184990000000000000000n; // 184.99 — the rounded amount that reverted
+const UNDER = 184980000000000000000n; // 184.98 — the amount that succeeded
+
+function client(balance: bigint) {
+  return {
+    readContract: vi.fn().mockResolvedValue(balance),
+  } as unknown as Parameters<typeof ensureUniswapSufficientBalance>[0];
+}
+
+describe("ensureUniswapSufficientBalance", () => {
+  it("throws INSUFFICIENT_BALANCE when the requested amount exceeds the balance", async () => {
+    await expect(
+      ensureUniswapSufficientBalance(client(BALANCE), TOKEN, OWNER, OVER, "VEX"),
+    ).rejects.toMatchObject({ code: ErrorCodes.INSUFFICIENT_BALANCE });
+  });
+
+  it("names the token and both amounts so the caller can correct it", async () => {
+    await expect(
+      ensureUniswapSufficientBalance(client(BALANCE), TOKEN, OWNER, OVER, "VEX"),
+    ).rejects.toThrow(/VEX/);
+  });
+
+  it("passes when the amount is under the balance", async () => {
+    await expect(
+      ensureUniswapSufficientBalance(client(BALANCE), TOKEN, OWNER, UNDER, "VEX"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes when the amount exactly equals the balance", async () => {
+    await expect(
+      ensureUniswapSufficientBalance(client(BALANCE), TOKEN, OWNER, BALANCE, "VEX"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/tools/uniswap/abis.ts
+++ b/src/tools/uniswap/abis.ts
@@ -33,6 +33,13 @@ export const UNISWAP_ERC20_ABI = [
   },
   {
     type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
     name: "decimals",
     stateMutability: "view",
     inputs: [],

--- a/src/tools/uniswap/erc20.ts
+++ b/src/tools/uniswap/erc20.ts
@@ -9,6 +9,7 @@
 
 import {
   getAddress,
+  formatUnits,
   type Address,
   type Chain,
   type Hex,
@@ -52,6 +53,38 @@ export async function readUniswapErc20Metadata(
     logger.debug({ event: "uniswap.erc20.symbol_failed", address });
   }
   return { address, symbol, decimals, isNative: false };
+}
+
+/**
+ * Pre-flight: ensure `owner` holds at least `requiredAmount` of `token` BEFORE
+ * approving/swapping. A sell for more than the balance makes the router's
+ * `transferFrom` revert with an opaque `TRANSFER_FROM_FAILED` / `STF` that reads
+ * exactly like a missing allowance — so guard it here and fail with a clear,
+ * actionable INSUFFICIENT_BALANCE (have X, requested Y) instead of burning gas on
+ * a doomed swap. `decimals`/`symbol` are for the human-readable message only.
+ */
+export async function ensureUniswapSufficientBalance(
+  publicClient: PublicClient<Transport, Chain>,
+  token: Address,
+  owner: Address,
+  requiredAmount: bigint,
+  symbol: string,
+  decimals = 18,
+): Promise<void> {
+  const balance = (await publicClient.readContract({
+    address: token,
+    abi: UNISWAP_ERC20_ABI,
+    functionName: "balanceOf",
+    args: [owner],
+  })) as bigint;
+
+  if (balance < requiredAmount) {
+    throw new VexError(
+      ErrorCodes.INSUFFICIENT_BALANCE,
+      `Insufficient ${symbol} balance: have ${formatUnits(balance, decimals)}, requested ${formatUnits(requiredAmount, decimals)}.`,
+      "Reduce the amount to at most the wallet balance (or use the max/available balance) and retry.",
+    );
+  }
 }
 
 /** Verify a spender is an allowlisted Uniswap router. Throws otherwise. */

--- a/src/vex-agent/tools/protocols/uniswap/handlers/swap.ts
+++ b/src/vex-agent/tools/protocols/uniswap/handlers/swap.ts
@@ -18,7 +18,7 @@ import { parseUnits, formatUnits, getAddress, isAddress, type Address, type Hex 
 import { resolveUniswapDeployment } from "@tools/uniswap/chains.js";
 import { getUniswapPublicClient, getUniswapEvmClients } from "@tools/uniswap/evm-client.js";
 import { readUniswapErc20Metadata } from "@tools/uniswap/erc20.js";
-import { ensureUniswapAllowanceExact } from "@tools/uniswap/erc20.js";
+import { ensureUniswapAllowanceExact, ensureUniswapSufficientBalance } from "@tools/uniswap/erc20.js";
 import { quoteBestRoute, applySlippage } from "@tools/uniswap/quote.js";
 import { buildSwapTx, sendUniswapTransaction, NATIVE_TOKEN_ADDRESS } from "@tools/uniswap/execute.js";
 import { checkRouteFactories, probeFotSignal, UNISWAP_MIN_LIQUIDITY_USD } from "@tools/uniswap/safety.js";
@@ -242,8 +242,13 @@ async function executeUniswapSwap(
   const { publicClient, walletClient } = getUniswapEvmClients(deployment, signer.privateKey as Hex);
   const router = routerFor(deployment, quoted.route);
 
-  // EXACT-amount allowance to an allowlisted router (native input needs none).
+  // Non-native input (a sell): guard balance BEFORE approving/swapping, then set
+  // the EXACT-amount allowance to the allowlisted router. Over-balance amounts
+  // otherwise revert at the router's transferFrom with an opaque STF /
+  // TRANSFER_FROM_FAILED that mimics a missing allowance. Native input needs
+  // neither (the tx value carries the ETH).
   if (!tokenIn.isNative) {
+    await ensureUniswapSufficientBalance(publicClient, tokenIn.address, getAddress(signer.address), amountIn, tokenIn.symbol, tokenIn.decimals);
     await ensureUniswapAllowanceExact(publicClient, walletClient, tokenIn.address, router, amountIn);
   }
 


### PR DESCRIPTION
## Problem solved

Give an over-balance ERC-20 sell a clear, actionable error instead of an on-chain revert that looks like a broken approval.

Selling slightly more of a token than the wallet holds makes the Uniswap router's `transferFrom` revert with `TransferHelper: TRANSFER_FROM_FAILED` (V2) / `STF` (V3). From the outside that is **indistinguishable from a missing allowance**. In practice this bit a Robinhood-Chain exit: a position of `184.985498…` VEX was sold as `184.99` (a rounded amount, ~7e15 wei over the real balance). Every attempt reverted at `transferFrom`, across both the V2 and V3 routers, which read as "the auto-approve isn't firing" — when in fact the approval had **succeeded** and the allowance was sitting on-chain. The real cause was simply `amountIn > balance`.

## Root cause

`executeUniswapSwap` resolves the amount and goes straight to approve → swap. It never checks the wallet's `tokenIn` balance, so `amountIn > balance` is only discovered when the router reverts on-chain — after gas is spent, and with an error string (`TRANSFER_FROM_FAILED` / `STF`) that points at the allowance subsystem rather than the balance.

## Screenshot
### Before
<img width="821" height="281" alt="image" src="https://github.com/user-attachments/assets/fda307b2-dd2d-4103-a700-a8651e698495" />

### After
<img width="830" height="450" alt="image" src="https://github.com/user-attachments/assets/fd2df7cc-513b-49e0-9fc2-43fb599bacca" />

## What changed

### Pre-flight balance guard
- Added `ensureUniswapSufficientBalance(publicClient, token, owner, requiredAmount, symbol, decimals)` in `tools/uniswap/erc20.ts`. It reads the on-chain balance and, when short, throws `INSUFFICIENT_BALANCE` with a human-readable message naming the token and both amounts — e.g. *"Insufficient VEX balance: have 184.9855, requested 184.99."* — plus a hint to reduce the amount to at most the balance.
- Added `balanceOf` to `UNISWAP_ERC20_ABI`.

### Wired into the sell/buy path
- `executeUniswapSwap` now calls the guard for **non-native** input, **before** the allowance + swap. A doomed over-balance sell fails fast, before any approve or swap is broadcast (no wasted gas). Native input is unaffected — the tx value carries the ETH.

## User impact

An over-balance sell now returns *"Insufficient VEX balance: have X, requested Y"* immediately, so the caller (or agent) can correct the amount and retry — instead of a cryptic `transferFrom` revert that misattributes the failure to approvals and burns gas on every attempt.

## Test coverage

Written test-first (TDD), each observed failing before the fix:

- `src/__tests__/tools/uniswap/uniswap-balance-preflight.test.ts` — uses the real incident numbers (`184.985498…` balance): over-balance (`184.99`) → `INSUFFICIENT_BALANCE`; the message names the token and both amounts; under-balance (`184.98`) and exact-balance both pass.

## Validation

- On-chain confirmation: an `eth_call` simulation of the router's own `transferFrom` at these amounts reverts for `184.99` and succeeds for `184.98` / exact balance — the same boundary the guard enforces. (The `184.98` sell then went through on-chain and cleared the position.)
- Root `pnpm exec tsc --noEmit`: **clean** (exit 0).
- Root workspace test suite: **6,443 passed, 7 skipped** across **464 files**.