### PR TITLE
fix(uniswap): use fee-on-transfer-safe V2 functions for token-input sells

### DIFF
--- a/src/__tests__/tools/uniswap/uniswap-fot-sell.test.ts
+++ b/src/__tests__/tools/uniswap/uniswap-fot-sell.test.ts
@@ -1,0 +1,65 @@
+/**
+ * V2 sells must use the fee-on-transfer-SUPPORTING router functions.
+ *
+ * A fee-on-transfer (FoT) token delivers fewer tokens to the pair than were
+ * sent, so Uniswap V2's plain `swapExactTokensForETH` / `swapExactTokensForTokens`
+ * revert with `UniswapV2: K` — the pair's post-swap reserves break the constant-
+ * product invariant. This is indistinguishable, from the outside, from an
+ * allowance failure and makes such tokens un-sellable in-band (observed with
+ * ROODFI on Robinhood Chain).
+ *
+ * Uniswap ships `...SupportingFeeOnTransferTokens` variants that settle against
+ * the ACTUAL received balances. They are behaviourally identical for non-FoT
+ * tokens (received == sent), so using them for every token-input V2 sell is safe
+ * and makes FoT exits possible. The native-input BUY path is unaffected.
+ */
+
+import { describe, it, expect } from "vitest";
+import { decodeFunctionData, getAddress, type Address } from "viem";
+
+import { buildV2SwapTx, type BuildSwapArgs } from "@tools/uniswap/execute.js";
+import { UNISWAP_V2_ROUTER_ABI } from "@tools/uniswap/abis.js";
+import type { UniswapDeployment } from "@tools/uniswap/deployments.js";
+import type { UniswapRoute } from "@tools/uniswap/types.js";
+
+const TOKEN = getAddress("0xc7c9341765C3bEebf0Ea2aB05e69b68991A9A470"); // ROODFI
+const VIRTUAL = getAddress("0xc6911796042b15d7Fa4F6CDe69e245DdCd3d9c31");
+const WETH = getAddress("0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73");
+const RECIPIENT = getAddress("0x9ed25bdedceB28Adf9E3C7fCa34511e78e47C77f");
+
+const deployment = {
+  v2: { router02: "0x89e5db8b5aa49aa85ac63f691524311aeb649eba" as Address },
+} as unknown as UniswapDeployment;
+
+function args(route: UniswapRoute, tokenOutIsNative: boolean, tokenInIsNative = false): BuildSwapArgs {
+  return {
+    deployment, route, amountIn: 100n, minAmountOut: 90n,
+    recipient: RECIPIENT, deadline: 111n, tokenInIsNative, tokenOutIsNative,
+  };
+}
+
+function fn(data: `0x${string}`): string {
+  return decodeFunctionData({ abi: UNISWAP_V2_ROUTER_ABI, data }).functionName;
+}
+
+describe("buildV2SwapTx — fee-on-transfer-safe sells", () => {
+  it("token → ETH uses swapExactTokensForETHSupportingFeeOnTransferTokens", () => {
+    const route: UniswapRoute = { version: "v2", path: [TOKEN, VIRTUAL, WETH], amountOut: 100n };
+    const tx = buildV2SwapTx(args(route, /* tokenOutIsNative */ true));
+    expect(fn(tx.data)).toBe("swapExactTokensForETHSupportingFeeOnTransferTokens");
+    expect(tx.value).toBe(0n);
+  });
+
+  it("token → token uses swapExactTokensForTokensSupportingFeeOnTransferTokens", () => {
+    const route: UniswapRoute = { version: "v2", path: [TOKEN, WETH], amountOut: 100n };
+    const tx = buildV2SwapTx(args(route, /* tokenOutIsNative */ false));
+    expect(fn(tx.data)).toBe("swapExactTokensForTokensSupportingFeeOnTransferTokens");
+  });
+
+  it("native input (a BUY) is unchanged — swapExactETHForTokens", () => {
+    const route: UniswapRoute = { version: "v2", path: [WETH, TOKEN], amountOut: 100n };
+    const tx = buildV2SwapTx(args(route, /* tokenOutIsNative */ false, /* tokenInIsNative */ true));
+    expect(fn(tx.data)).toBe("swapExactETHForTokens");
+    expect(tx.value).toBe(100n);
+  });
+});

--- a/src/__tests__/tools/uniswap/uniswap.test.ts
+++ b/src/__tests__/tools/uniswap/uniswap.test.ts
@@ -173,11 +173,11 @@ const RECIP: Address = "0x1111111111111111111111111111111111111111";
 const DEADLINE = 1_900_000_000n;
 
 describe("V2 calldata builders", () => {
-  it("token→token → swapExactTokensForTokens, value 0", () => {
+  it("token→token → swapExactTokensForTokensSupportingFeeOnTransferTokens, value 0", () => {
     const tx = buildV2SwapTx({ deployment: ROBINHOOD, route: V2_ROUTE, amountIn: 1000n, minAmountOut: 995n, recipient: RECIP, deadline: DEADLINE, tokenInIsNative: false, tokenOutIsNative: false });
     expect(tx.value).toBe(0n);
     const dec = decodeFunctionData({ abi: UNISWAP_V2_ROUTER_ABI, data: tx.data });
-    expect(dec.functionName).toBe("swapExactTokensForTokens");
+    expect(dec.functionName).toBe("swapExactTokensForTokensSupportingFeeOnTransferTokens");
     expect(dec.args?.[0]).toBe(1000n);
     expect(dec.args?.[1]).toBe(995n);
     expect(dec.args?.[3]).toBe(RECIP);
@@ -190,10 +190,10 @@ describe("V2 calldata builders", () => {
     expect(dec.functionName).toBe("swapExactETHForTokens");
   });
 
-  it("native output → swapExactTokensForETH, value 0", () => {
+  it("native output → swapExactTokensForETHSupportingFeeOnTransferTokens, value 0", () => {
     const tx = buildV2SwapTx({ deployment: ROBINHOOD, route: V2_ROUTE, amountIn: 1000n, minAmountOut: 995n, recipient: RECIP, deadline: DEADLINE, tokenInIsNative: false, tokenOutIsNative: true });
     expect(tx.value).toBe(0n);
-    expect(decodeFunctionData({ abi: UNISWAP_V2_ROUTER_ABI, data: tx.data }).functionName).toBe("swapExactTokensForETH");
+    expect(decodeFunctionData({ abi: UNISWAP_V2_ROUTER_ABI, data: tx.data }).functionName).toBe("swapExactTokensForETHSupportingFeeOnTransferTokens");
   });
 });
 

--- a/src/tools/uniswap/abis.ts
+++ b/src/tools/uniswap/abis.ts
@@ -132,6 +132,35 @@ export const UNISWAP_V2_ROUTER_ABI = [
     ],
     outputs: [{ name: "amounts", type: "uint256[]" }],
   },
+  // Fee-on-transfer-SAFE sell variants. Settle against ACTUAL received balances
+  // (no amounts[] return), so a FoT token whose transfer delivers less than sent
+  // does not trip `UniswapV2: K`. Behaviourally identical for non-FoT tokens.
+  {
+    type: "function",
+    name: "swapExactTokensForETHSupportingFeeOnTransferTokens",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "amountIn", type: "uint256" },
+      { name: "amountOutMin", type: "uint256" },
+      { name: "path", type: "address[]" },
+      { name: "to", type: "address" },
+      { name: "deadline", type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "swapExactTokensForTokensSupportingFeeOnTransferTokens",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "amountIn", type: "uint256" },
+      { name: "amountOutMin", type: "uint256" },
+      { name: "path", type: "address[]" },
+      { name: "to", type: "address" },
+      { name: "deadline", type: "uint256" },
+    ],
+    outputs: [],
+  },
 ] as const;
 
 // ── Uniswap V3 ──────────────────────────────────────────────────────────────

--- a/src/tools/uniswap/execute.ts
+++ b/src/tools/uniswap/execute.ts
@@ -84,13 +84,18 @@ export function buildV2SwapTx(args: BuildSwapArgs): BuiltSwapTx {
       }),
     };
   }
+  // Token INPUT (a sell): use the fee-on-transfer-SUPPORTING variants. They
+  // settle on the ACTUAL balances received, so a FoT token (which delivers less
+  // than sent) does not revert `UniswapV2: K`. Identical output for non-FoT
+  // tokens, so this is safe to use unconditionally on the sell path. Callers must
+  // set `minAmountOut` with enough slippage to absorb the transfer fee.
   if (tokenOutIsNative) {
     return {
       to: router,
       value: 0n,
       data: encodeFunctionData({
         abi: UNISWAP_V2_ROUTER_ABI,
-        functionName: "swapExactTokensForETH",
+        functionName: "swapExactTokensForETHSupportingFeeOnTransferTokens",
         args: [amountIn, minAmountOut, path, recipient, deadline],
       }),
     };
@@ -100,7 +105,7 @@ export function buildV2SwapTx(args: BuildSwapArgs): BuiltSwapTx {
     value: 0n,
     data: encodeFunctionData({
       abi: UNISWAP_V2_ROUTER_ABI,
-      functionName: "swapExactTokensForTokens",
+      functionName: "swapExactTokensForTokensSupportingFeeOnTransferTokens",
       args: [amountIn, minAmountOut, path, recipient, deadline],
     }),
   };


### PR DESCRIPTION
## Problem solved

Make fee-on-transfer (FoT) tokens sellable on Uniswap V2 instead of reverting on every exit.

A FoT token delivers fewer tokens to the pair than were sent (a transfer tax), so Uniswap V2's plain `swapExactTokensForETH` / `swapExactTokensForTokens` revert with `UniswapV2: K` — the pair's post-swap reserves break the constant-product invariant. Vex built **every** V2 sell with these plain functions, so any FoT token was completely un-sellable in-band: the keyless `getAmountsOut` quote looked sane (it assumes no fee), but the actual swap always reverted.

Observed with **ROODFI** on Robinhood Chain — a ~1% transfer-fee token whose only liquid route is V2 (`ROODFI → VIRTUAL → WETH`). Every exit reverted `UniswapV2: K`, which from the outside looks exactly like an allowance failure and sent debugging in the wrong direction.

## Root cause

`buildV2SwapTx` hard-codes the non-FoT swap functions for token-input swaps. There is no code path that can move a token whose transfer is lossy.

## Screenshot
<img width="1024" height="672" alt="image" src="https://github.com/user-attachments/assets/f8e06920-5fae-48b9-9f20-f105eb17e669" />

## What changed

### Fee-on-transfer-safe sell functions
- `buildV2SwapTx` now builds token-input swaps with `swapExactTokensForETHSupportingFeeOnTransferTokens` (token → ETH) and `swapExactTokensForTokensSupportingFeeOnTransferTokens` (token → token). These settle against the **actual** balances received, so a FoT input no longer trips the `K` check.
- Added both function signatures to `UNISWAP_V2_ROUTER_ABI` (they return no `amounts[]`; Vex uses the separate quote for display and the on-chain `amountOutMin` for protection).

### Scope / safety
- Behaviourally identical for **non-FoT** tokens: received == sent ⇒ same output and same `amountOutMin` enforcement — so the variants are used unconditionally on the sell path, with no fragile FoT detection.
- The native-input **BUY** path (`swapExactETHForTokens`) is unchanged.
- The prequote match-hash keys on semantic fields (chain / tokens / amount / venue), **not** calldata, so changing the swap function does not affect quote↔execute binding.

## User impact

FoT tokens whose liquidity is on V2 can now be exited in-band. Callers must set `amountOutMin` with enough slippage to absorb the transfer fee — the no-fee `getAmountsOut` overstates the real output by the fee (measured ~1% for ROODFI, so a ≥1% slippage exits cleanly).

## Test coverage

Written test-first (TDD):

- `src/__tests__/tools/uniswap/uniswap-fot-sell.test.ts` — token→ETH and token→token sells encode the `...SupportingFeeOnTransferTokens` variants; the native-input buy path still encodes `swapExactETHForTokens`.
- Updated the existing V2-builder assertions in `uniswap.test.ts` to the new sell function names.

## Validation

- On-chain confirmation (read-only `eth_call` from the holder): plain `swapExactTokensForETH` for 94,621 ROODFI reverts `UniswapV2: K`; `swapExactTokensForETHSupportingFeeOnTransferTokens` succeeds. A binary search on `amountOutMin` measured the effective haircut at **0.99%**.
- Root `pnpm exec tsc --noEmit`: **clean** (exit 0).
- Root workspace test suite: **6,442 passed, 7 skipped** across **464 files**.
