### PR TITLE
fix(runtime): stop an idle 'running' run directly instead of stranding the request

### DIFF
--- a/vex-app/src/main/ipc/__tests__/mission/stop.test.ts
+++ b/vex-app/src/main/ipc/__tests__/mission/stop.test.ts
@@ -85,10 +85,10 @@ async function call(payload: unknown) {
   })) as { ok: boolean; data?: { outcome: string }; error?: { code: string } };
 }
 
-function activeState(status: string) {
+function activeState(status: string, leaseActive = true) {
   return {
     ok: true,
-    data: { hasActiveRun: true, missionRunId: "run-1", status },
+    data: { hasActiveRun: true, missionRunId: "run-1", status, leaseActive },
   };
 }
 
@@ -110,6 +110,22 @@ describe("mission.stop (runStopDispatch)", () => {
     expect(r.data?.outcome).toBe("queued");
     expect(mockEnqueueRequest).toHaveBeenCalledTimes(1);
     expect(mockAbortActiveMissionForSession).not.toHaveBeenCalled();
+  });
+
+  it("aborts a running run whose lease is NOT active — no live runner would observe a queued stop", async () => {
+    // Regression: a run can be status='running' with leaseActive=false (parked
+    // between autonomous slices, or an expired/released lease). Enqueue-only
+    // strands the stop forever, leaving the session un-stoppable/un-deletable.
+    mockGetActiveRunForSession.mockResolvedValueOnce(activeState("running", false));
+    mockAbortActiveMissionForSession.mockResolvedValueOnce({
+      aborted: true,
+      finalStatus: "cancelled",
+      rejectedApprovals: 0,
+    });
+    const r = await call({ sessionId: SESSION });
+    expect(r.data).toEqual({ outcome: "stopped" });
+    expect(mockAbortActiveMissionForSession).toHaveBeenCalledWith(SESSION);
+    expect(mockEnqueueRequest).not.toHaveBeenCalled();
   });
 
   it("aborts a paused_error run directly (stopped, no enqueue)", async () => {

--- a/vex-app/src/main/ipc/_shared/runtime-stop-dispatch.ts
+++ b/vex-app/src/main/ipc/_shared/runtime-stop-dispatch.ts
@@ -62,9 +62,13 @@ export async function runStopDispatch(
     ) {
       return ok({ outcome: "already_terminal", status });
     }
-    if (status === "running") {
-      // Graceful path: the live runner observes this queued stop_terminal
-      // request at its next iteration boundary and finalizes the run.
+    if (status === "running" && state.data.leaseActive) {
+      // Graceful path — ONLY when a live runner (active lease) is present: it
+      // observes this queued stop_terminal request at its next iteration
+      // boundary and finalizes the run. A `running` status alone is NOT enough:
+      // a run can be `running` with an expired/released lease (parked between
+      // autonomous slices), and then no runner would ever observe the request —
+      // it would strand the stop and leave the session un-stoppable/un-deletable.
       const { enqueueRequest } = await import(
         "@vex-agent/db/repos/runtime-control-requests.js"
       );
@@ -78,9 +82,11 @@ export async function runStopDispatch(
       await emitControlStateAfterChange(input.sessionId, ctx.requestId);
       return ok({ outcome: "queued", requestId: request.id });
     }
-    // Paused (approval/wake/error/user): no runner is observing, so a queued
-    // stop would never be applied. Abort directly — the engine finalizes the
-    // run to `cancelled` and rejects pending approvals + cancels wakes.
+    // No live runner is observing — either a paused run (approval/wake/error/
+    // user) OR a `running` run whose lease is not active (out-of-process /
+    // parked). A queued stop would never be applied, so abort directly: the
+    // engine finalizes the run to `cancelled` and rejects pending approvals +
+    // cancels wakes. (`abortMissionRun` already handles out-of-process running.)
     const { abortActiveMissionForSession } = await import(
       "@vex-agent/engine/index.js"
     );


### PR DESCRIPTION
## Problem solved

Make STOP actually stop a mission run that's `running` but idle — and unblock deleting the session afterward.

STOP has two paths:
- a **`running`** run enqueues a `stop_terminal` request that the live runner observes at its next iteration boundary, and
- a **paused** run (no runner observing) is aborted directly.

The `running` branch assumes a live runner always exists. But a run can be `status='running'` with an **expired/released lease** (`leaseActive=false`) — parked between autonomous mission slices. In that state the enqueue-only path **strands the stop forever**: no runner ever observes the request, the run never finalizes, and the session becomes un-stoppable and un-deletable (the UI blocks deleting a live session).

Observed live: a mission run sat at `status=running leaseActive=false pendingControl=stop_terminal` for **hours**, the STOP button doing nothing, and the session couldn't be deleted. The `stop_terminal` request was `pending` the entire time; the `runner_leases` row had expired ~2h earlier.

## Root cause

`runStopDispatch` (shared by `runtime.requestStop` and `mission.stop`) branches on `status` alone. `status === 'running'` does **not** imply a live runner — the lease can be expired. The graceful enqueue path then has no one to observe it.

## What changed

- Gate the graceful path on a **live lease**: `status === 'running' && state.data.leaseActive`. `getActiveRunForSession` already returns `leaseActive`, so no new query.
- Otherwise — paused **or** running-without-a-live-lease — abort directly via `abortActiveMissionForSession`. That path already handles the "out-of-process running" case (finalize → `cancelled`, reject pending approvals, cancel wakes) per `engine/core/runner/abort.ts`.
- Both STOP IPC handlers share this dispatch, so both are fixed with one change.

## User impact

STOP now terminates a parked/idle `running` run immediately instead of queuing a request nothing will ever act on, so the run finalizes and the session can be deleted. A genuinely-live run is unaffected — it still stops gracefully at the runner's next safe checkpoint.

## Test coverage

Written test-first (TDD), in `vex-app/src/main/ipc/__tests__/mission/stop.test.ts`:

- New: a `running` run with `leaseActive=false` aborts **directly** (`outcome: stopped`, no enqueue).
- The existing graceful-enqueue test now pins `leaseActive=true` explicitly; the paused-run and no-active-run cases are unchanged.

## Validation

- `vex-app` full test suite: **2,530 passed** across **289 files**.
- The stop/runtime/mission IPC surface: **313 passed** across 46 files.
- `tsc -p tsconfig.main.json`: no new errors from the change (two pre-existing, unrelated errors in `agent-bug-report-sink` / `sentry-lifecycle` remain).
