### PR TITLE
feat(signals): ingest TrendRadar alpha feed into Vex's own DB (data plane)

### DIFF
--- a/src/__tests__/vex-agent/signals/executor.test.ts
+++ b/src/__tests__/vex-agent/signals/executor.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Signals-ingest executor loop — runs ingest on start, survives a tick failure,
+ * and stops cleanly. DI'd ingest, no timers-mocking needed (initial delay is 0).
+ */
+
+import { describe, it, expect } from "vitest";
+import { startSignalsIngestExecutor } from "@vex-agent/signals/executor.js";
+
+describe("startSignalsIngestExecutor", () => {
+  it("runs an ingest on start and stops cleanly", async () => {
+    let calls = 0;
+    let resolveFirst!: () => void;
+    const first = new Promise<void>((r) => (resolveFirst = r));
+    const handle = startSignalsIngestExecutor({
+      intervalMs: 1_000_000, // don't fire a second tick during the test
+      deps: { ingest: async () => { calls += 1; resolveFirst(); } },
+    });
+    await first;
+    expect(calls).toBe(1);
+    await handle.stop();
+  });
+
+  it("does not crash the loop when a tick throws", async () => {
+    let resolveFirst!: () => void;
+    const first = new Promise<void>((r) => (resolveFirst = r));
+    const handle = startSignalsIngestExecutor({
+      intervalMs: 1_000_000,
+      deps: { ingest: async () => { resolveFirst(); throw new Error("feed down"); } },
+    });
+    await first;
+    // stop() awaits the in-flight (rejected) tick without throwing
+    await expect(handle.stop()).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/vex-agent/signals/feed.test.ts
+++ b/src/__tests__/vex-agent/signals/feed.test.ts
@@ -1,0 +1,87 @@
+/**
+ * TrendRadar signal-feed parser — validates the published JSON contract and
+ * normalizes it into records Vex persists. The feed is UNTRUSTED input (fetched
+ * over HTTP), so parsing must be defensive: reject a wrong version, drop signals
+ * with no contract (the dedup key), and coerce loose numbers/nulls.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseSignalsFeed, SIGNAL_FEED_VERSION } from "@vex-agent/signals/feed.js";
+
+function feed(overrides: Record<string, unknown> = {}) {
+  return {
+    version: SIGNAL_FEED_VERSION,
+    generated_at: "2026-07-12T04:46:00+00:00",
+    window: { start: "2026-07-11T00:00:00+00:00", end: "2026-07-12T23:59:59+00:00" },
+    count: 1,
+    signals: [
+      {
+        symbol: "DATABEAR", contract: "0x90079857237dA767c38D1d261a39848ea424319E",
+        chain: "robinhood", action: "RESEARCH", score: 71,
+        today_mentions: 3, yesterday_mentions: 0, velocity_pct: 300,
+        liquidity_usd: 228579, volume_24h_usd: 15089843, price_usd: 0.002394,
+        first_seen_at: "2026-07-11T22:00:00+00:00", last_seen_at: "2026-07-12T00:00:00+00:00",
+        narratives: ["robinhood"], risk_flags: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("parseSignalsFeed", () => {
+  it("parses a valid feed into normalized records", () => {
+    const parsed = parseSignalsFeed(feed());
+    expect(parsed.version).toBe(SIGNAL_FEED_VERSION);
+    expect(parsed.generatedAt).toBe("2026-07-12T04:46:00+00:00");
+    expect(parsed.window).toEqual({ start: "2026-07-11T00:00:00+00:00", end: "2026-07-12T23:59:59+00:00" });
+    expect(parsed.signals).toHaveLength(1);
+    const s = parsed.signals[0]!;
+    expect(s.contract).toBe("0x90079857237dA767c38D1d261a39848ea424319E");
+    expect(s.symbol).toBe("DATABEAR");
+    expect(s.chain).toBe("robinhood");
+    expect(s.score).toBe(71);
+    expect(s.todayMentions).toBe(3);
+    expect(s.liquidityUsd).toBe(228579);
+    expect(s.narratives).toEqual(["robinhood"]);
+  });
+
+  it("rejects a feed whose version does not match the supported contract", () => {
+    expect(() => parseSignalsFeed(feed({ version: 999 }))).toThrow(/version/i);
+  });
+
+  it("drops signals with no contract (the dedup key) instead of failing the whole feed", () => {
+    const parsed = parseSignalsFeed(
+      feed({
+        signals: [
+          { symbol: "NOCA", contract: "", chain: "robinhood", score: 50 },
+          { symbol: "OK", contract: "0xabc0000000000000000000000000000000000001", chain: "robinhood", score: 60 },
+        ],
+      }),
+    );
+    expect(parsed.signals.map((s) => s.symbol)).toEqual(["OK"]);
+  });
+
+  it("coerces missing/null numeric fields to null and defaults arrays", () => {
+    const parsed = parseSignalsFeed(
+      feed({
+        signals: [
+          {
+            contract: "0xabc0000000000000000000000000000000000002", chain: "robinhood",
+            liquidity_usd: null, score: null,
+          },
+        ],
+      }),
+    );
+    const s = parsed.signals[0]!;
+    expect(s.liquidityUsd).toBeNull();
+    expect(s.score).toBeNull();
+    expect(s.narratives).toEqual([]);
+    expect(s.riskFlags).toEqual([]);
+    expect(s.symbol).toBeNull();
+  });
+
+  it("throws on structurally invalid input (not an object / missing signals)", () => {
+    expect(() => parseSignalsFeed(null)).toThrow();
+    expect(() => parseSignalsFeed({ version: SIGNAL_FEED_VERSION })).toThrow();
+  });
+});

--- a/src/__tests__/vex-agent/signals/ingest.test.ts
+++ b/src/__tests__/vex-agent/signals/ingest.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Signal ingestion — fetch → parse → upsert, with injected deps (no net, no DB).
+ * A parse/version failure must abort BEFORE any upsert (never write a feed we
+ * don't understand).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { ingestSignalsFeed } from "@vex-agent/signals/ingest.js";
+import { SIGNAL_FEED_VERSION } from "@vex-agent/signals/feed.js";
+import type { SignalUpsertInput } from "@vex-agent/db/repos/signals.js";
+
+function validFeed() {
+  return {
+    version: SIGNAL_FEED_VERSION,
+    generated_at: "2026-07-12T04:46:00+00:00",
+    window: { start: "2026-07-11T00:00:00+00:00", end: "2026-07-12T23:59:59+00:00" },
+    count: 2,
+    signals: [
+      { symbol: "DATABEAR", contract: "0x9007985723", chain: "robinhood", action: "RESEARCH", score: 71, today_mentions: 3, narratives: [], risk_flags: [] },
+      { symbol: "WALLET", contract: "0x0339f5459f", chain: "robinhood", action: "WATCH", score: 60, today_mentions: 0, narratives: [], risk_flags: [] },
+    ],
+  };
+}
+
+describe("ingestSignalsFeed", () => {
+  it("fetches, parses, and upserts the feed's signals", async () => {
+    let upserted: SignalUpsertInput[] = [];
+    const result = await ingestSignalsFeed("http://feed", {
+      fetchFeed: async () => validFeed(),
+      upsert: async (records) => { upserted = records; return records.length; },
+    });
+
+    expect(result.fetched).toBe(2);
+    expect(result.written).toBe(2);
+    expect(result.generatedAt).toBe("2026-07-12T04:46:00+00:00");
+    expect(upserted).toHaveLength(2);
+    expect(upserted[0]!.source).toBe("trendradar");
+    expect(upserted[0]!.feedGeneratedAt).toBe("2026-07-12T04:46:00+00:00");
+    expect(upserted.map((r) => r.symbol)).toEqual(["DATABEAR", "WALLET"]);
+  });
+
+  it("aborts on an unsupported feed version WITHOUT upserting", async () => {
+    const upsert = vi.fn(async () => 0);
+    await expect(
+      ingestSignalsFeed("http://feed", {
+        fetchFeed: async () => ({ ...validFeed(), version: 999 }),
+        upsert,
+      }),
+    ).rejects.toThrow(/version/i);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("propagates a fetch failure without upserting", async () => {
+    const upsert = vi.fn(async () => 0);
+    await expect(
+      ingestSignalsFeed("http://feed", {
+        fetchFeed: async () => { throw new Error("HTTP 404"); },
+        upsert,
+      }),
+    ).rejects.toThrow(/404/);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/vex-agent/db/migrations/037_signals.sql
+++ b/src/vex-agent/db/migrations/037_signals.sql
@@ -1,0 +1,47 @@
+-- Signal ingestion — TrendRadar crypto-alpha signals persisted in Vex's own DB.
+--
+-- The `signals-ingest` worker polls TrendRadar's published feed hourly and
+-- UPSERTS one row per (source, chain, contract). Keeping the LATEST row per
+-- token (not a per-poll history) means:
+--   - Vex owns the data it trades on (local-first, no external store at run time),
+--   - the "rolling window / overall alpha" is a plain query over `ingested_at`
+--     (WHERE ingested_at > now() - interval), and
+--   - it is offline-resilient: if TrendRadar misses an hour, the last-known rows
+--     persist and simply age out of the window.
+--
+-- The feed is already windowed (today+yesterday mention counts, deduped by
+-- contract), so a row carries the aggregated alpha, not a single mention.
+--
+-- Signals are DISCOVERY only. They never authorise a trade — a mission still
+-- runs the exit-safety scan and the human approval gate over any candidate.
+
+CREATE TABLE IF NOT EXISTS signals (
+  id                  BIGSERIAL PRIMARY KEY,
+  source              TEXT NOT NULL DEFAULT 'trendradar',
+  chain               TEXT NOT NULL,
+  contract            TEXT NOT NULL,
+  symbol              TEXT,
+  action              TEXT,
+  score               INTEGER,
+  today_mentions      INTEGER,
+  yesterday_mentions  INTEGER,
+  velocity_pct        INTEGER,
+  liquidity_usd       DOUBLE PRECISION,
+  volume_24h_usd      DOUBLE PRECISION,
+  price_usd           DOUBLE PRECISION,
+  narratives          JSONB NOT NULL DEFAULT '[]',
+  risk_flags          JSONB NOT NULL DEFAULT '[]',
+  raw                 JSONB,
+  first_seen_at       TIMESTAMPTZ,
+  last_seen_at        TIMESTAMPTZ,
+  feed_generated_at   TIMESTAMPTZ,
+  ingested_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One row per (source, chain, contract) — hex contracts dedupe case-insensitively.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_signals_identity
+  ON signals (source, chain, LOWER(contract));
+
+-- The rolling-window query orders/filters by freshness.
+CREATE INDEX IF NOT EXISTS idx_signals_ingested_at
+  ON signals (ingested_at DESC);

--- a/src/vex-agent/db/repos/signals.ts
+++ b/src/vex-agent/db/repos/signals.ts
@@ -1,0 +1,140 @@
+/**
+ * Signals repo — TrendRadar alpha signals persisted in Vex's own Postgres.
+ *
+ * `upsertSignals` keeps the LATEST row per (source, chain, contract); the
+ * `signals-ingest` worker calls it each hour with the parsed feed.
+ * `listRecentSignals` is the rolling-window read — "overall alpha over the last
+ * N hours" — used by the mission-time signal-radar block (which then runs the
+ * exit-safety scan on top). Signals are DISCOVERY only; they never authorise a
+ * trade.
+ */
+
+import { query, execute } from "../client.js";
+import { jsonb, nullableJsonb } from "../params.js";
+
+export interface SignalUpsertInput {
+  readonly source: string;
+  readonly chain: string;
+  readonly contract: string;
+  readonly symbol: string | null;
+  readonly action: string | null;
+  readonly score: number | null;
+  readonly todayMentions: number | null;
+  readonly yesterdayMentions: number | null;
+  readonly velocityPct: number | null;
+  readonly liquidityUsd: number | null;
+  readonly volume24hUsd: number | null;
+  readonly priceUsd: number | null;
+  readonly narratives: string[];
+  readonly riskFlags: string[];
+  readonly raw: unknown;
+  readonly firstSeenAt: string | null;
+  readonly lastSeenAt: string | null;
+  readonly feedGeneratedAt: string | null;
+}
+
+export interface SignalRow {
+  readonly source: string;
+  readonly chain: string;
+  readonly contract: string;
+  readonly symbol: string | null;
+  readonly action: string | null;
+  readonly score: number | null;
+  readonly todayMentions: number | null;
+  readonly yesterdayMentions: number | null;
+  readonly velocityPct: number | null;
+  readonly liquidityUsd: number | null;
+  readonly volume24hUsd: number | null;
+  readonly priceUsd: number | null;
+  readonly narratives: string[];
+  readonly riskFlags: string[];
+  readonly ingestedAt: string;
+}
+
+const UPSERT_SQL = `
+  INSERT INTO signals (
+    source, chain, contract, symbol, action, score,
+    today_mentions, yesterday_mentions, velocity_pct,
+    liquidity_usd, volume_24h_usd, price_usd,
+    narratives, risk_flags, raw, first_seen_at, last_seen_at, feed_generated_at, ingested_at
+  ) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+    $13::jsonb, $14::jsonb, $15::jsonb, $16, $17, $18, NOW()
+  )
+  ON CONFLICT (source, chain, LOWER(contract)) DO UPDATE SET
+    symbol             = EXCLUDED.symbol,
+    action             = EXCLUDED.action,
+    score              = EXCLUDED.score,
+    today_mentions     = EXCLUDED.today_mentions,
+    yesterday_mentions = EXCLUDED.yesterday_mentions,
+    velocity_pct       = EXCLUDED.velocity_pct,
+    liquidity_usd      = EXCLUDED.liquidity_usd,
+    volume_24h_usd     = EXCLUDED.volume_24h_usd,
+    price_usd          = EXCLUDED.price_usd,
+    narratives         = EXCLUDED.narratives,
+    risk_flags         = EXCLUDED.risk_flags,
+    raw                = EXCLUDED.raw,
+    first_seen_at      = EXCLUDED.first_seen_at,
+    last_seen_at       = EXCLUDED.last_seen_at,
+    feed_generated_at  = EXCLUDED.feed_generated_at,
+    ingested_at        = NOW()
+`;
+
+/** Upsert the latest signal per (source, chain, contract). Returns rows written. */
+export async function upsertSignals(records: readonly SignalUpsertInput[]): Promise<number> {
+  let written = 0;
+  for (const r of records) {
+    written += await execute(UPSERT_SQL, [
+      r.source, r.chain, r.contract, r.symbol, r.action, r.score,
+      r.todayMentions, r.yesterdayMentions, r.velocityPct,
+      r.liquidityUsd, r.volume24hUsd, r.priceUsd,
+      jsonb(r.narratives ?? []), jsonb(r.riskFlags ?? []),
+      nullableJsonb(r.raw ?? null), r.firstSeenAt, r.lastSeenAt, r.feedGeneratedAt,
+    ]);
+  }
+  return written;
+}
+
+export interface ListRecentSignalsOptions {
+  /** Rolling window in hours (e.g. 48 for "today + yesterday"). */
+  readonly withinHours: number;
+  readonly chain?: string;
+  readonly minScore?: number;
+  readonly limit?: number;
+}
+
+/** The rolling-window read: freshest, highest-scored signals first. */
+export async function listRecentSignals(opts: ListRecentSignalsOptions): Promise<SignalRow[]> {
+  const params: unknown[] = [opts.withinHours];
+  let where = "ingested_at > NOW() - make_interval(hours => $1::int)";
+  if (opts.chain) { params.push(opts.chain); where += ` AND chain = $${params.length}`; }
+  if (opts.minScore !== undefined) { params.push(opts.minScore); where += ` AND score >= $${params.length}`; }
+  params.push(opts.limit ?? 50);
+  const limitIdx = params.length;
+
+  const rows = await query<{
+    source: string; chain: string; contract: string; symbol: string | null;
+    action: string | null; score: number | null; today_mentions: number | null;
+    yesterday_mentions: number | null; velocity_pct: number | null;
+    liquidity_usd: number | null; volume_24h_usd: number | null; price_usd: number | null;
+    narratives: string[]; risk_flags: string[]; ingested_at: Date;
+  }>(
+    `SELECT source, chain, contract, symbol, action, score, today_mentions,
+            yesterday_mentions, velocity_pct, liquidity_usd, volume_24h_usd, price_usd,
+            narratives, risk_flags, ingested_at
+       FROM signals
+      WHERE ${where}
+      ORDER BY score DESC NULLS LAST, ingested_at DESC
+      LIMIT $${limitIdx}`,
+    params,
+  );
+
+  return rows.map((r) => ({
+    source: r.source, chain: r.chain, contract: r.contract, symbol: r.symbol,
+    action: r.action, score: r.score, todayMentions: r.today_mentions,
+    yesterdayMentions: r.yesterday_mentions, velocityPct: r.velocity_pct,
+    liquidityUsd: r.liquidity_usd, volume24hUsd: r.volume_24h_usd, priceUsd: r.price_usd,
+    narratives: r.narratives ?? [], riskFlags: r.risk_flags ?? [],
+    ingestedAt: r.ingested_at instanceof Date ? r.ingested_at.toISOString() : String(r.ingested_at),
+  }));
+}

--- a/src/vex-agent/signals/executor.ts
+++ b/src/vex-agent/signals/executor.ts
@@ -1,0 +1,80 @@
+/**
+ * Signals-ingest executor — process-lifetime loop that polls the TrendRadar feed
+ * hourly and upserts into Vex's `signals` table. Mirrors `sync/executor.ts`: a
+ * self-scheduling setTimeout loop, errors caught + logged (a bad fetch never
+ * kills the loop), and a `stop()` that settles any in-flight tick.
+ */
+
+import { ingestSignalsFeed, DEFAULT_SIGNALS_FEED_URL } from "./ingest.js";
+import logger from "@utils/logger.js";
+
+export interface SignalsIngestExecutorHandle {
+  stop(): Promise<void>;
+}
+
+export interface SignalsIngestDeps {
+  ingest(): Promise<void>;
+}
+
+export interface SignalsIngestStartOptions {
+  /** Poll cadence. Defaults to hourly — matches the feed's publish cadence. */
+  intervalMs?: number;
+  /** Feed URL override (env/tests). */
+  url?: string;
+  /** Dependency injection for tests. */
+  deps?: SignalsIngestDeps;
+}
+
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1000; // 1h
+
+export function startSignalsIngestExecutor(
+  options: SignalsIngestStartOptions = {},
+): SignalsIngestExecutorHandle {
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const url = options.url ?? DEFAULT_SIGNALS_FEED_URL;
+  const deps: SignalsIngestDeps = options.deps ?? {
+    ingest: async () => { await ingestSignalsFeed(url); },
+  };
+
+  let stopped = false;
+  let inFlight: Promise<void> | null = null;
+  let timer: NodeJS.Timeout | null = null;
+
+  const runOne = async (): Promise<void> => {
+    try {
+      await deps.ingest();
+    } catch (err) {
+      logger.warn("signals.executor.tick_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const schedule = (delayMs: number): void => {
+    if (stopped) return;
+    timer = setTimeout(() => {
+      inFlight = runOne().finally(() => {
+        inFlight = null;
+        schedule(intervalMs);
+      });
+    }, delayMs);
+  };
+
+  schedule(0);
+  logger.info("signals.executor.started", { intervalMs });
+
+  return {
+    async stop(): Promise<void> {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+      if (inFlight) {
+        try {
+          await inFlight;
+        } catch {
+          // already logged by runOne
+        }
+      }
+      logger.info("signals.executor.stopped");
+    },
+  };
+}

--- a/src/vex-agent/signals/feed.ts
+++ b/src/vex-agent/signals/feed.ts
@@ -1,0 +1,116 @@
+/**
+ * TrendRadar signal-feed parser.
+ *
+ * The feed (published by TrendRadar to a versioned `signals.json`) is UNTRUSTED
+ * input fetched over HTTP, so parsing is defensive: validate the envelope with
+ * zod, reject a version we don't understand, drop signals with no contract (the
+ * dedup key Vex stores on), and coerce loose/null numerics. This module owns the
+ * cross-repo contract shape — keep `SIGNAL_FEED_VERSION` in lockstep with
+ * TrendRadar's `SIGNAL_FEED_VERSION`.
+ */
+
+import { z } from "zod";
+
+/** Must match TrendRadar's `SIGNAL_FEED_VERSION`. Bump together on a breaking change. */
+export const SIGNAL_FEED_VERSION = 1;
+
+export interface ParsedSignal {
+  readonly contract: string;
+  readonly chain: string;
+  readonly symbol: string | null;
+  readonly action: string | null;
+  readonly score: number | null;
+  readonly todayMentions: number | null;
+  readonly yesterdayMentions: number | null;
+  readonly velocityPct: number | null;
+  readonly liquidityUsd: number | null;
+  readonly volume24hUsd: number | null;
+  readonly priceUsd: number | null;
+  readonly firstSeenAt: string | null;
+  readonly lastSeenAt: string | null;
+  readonly narratives: string[];
+  readonly riskFlags: string[];
+  /** The original feed signal object, preserved verbatim for forward-compat. */
+  readonly raw: unknown;
+}
+
+export interface ParsedFeed {
+  readonly version: number;
+  readonly generatedAt: string;
+  readonly window: { start: string; end: string };
+  readonly signals: ParsedSignal[];
+}
+
+const num = z.number().nullable().optional();
+const strArr = z
+  .array(z.string())
+  .optional()
+  .transform((v) => v ?? []);
+
+const signalSchema = z.object({
+  symbol: z.string().nullable().optional(),
+  contract: z.string().optional(),
+  chain: z.string().optional(),
+  action: z.string().nullable().optional(),
+  score: num,
+  today_mentions: num,
+  yesterday_mentions: num,
+  velocity_pct: num,
+  liquidity_usd: num,
+  volume_24h_usd: num,
+  price_usd: num,
+  first_seen_at: z.string().nullable().optional(),
+  last_seen_at: z.string().nullable().optional(),
+  narratives: strArr,
+  risk_flags: strArr,
+});
+
+const feedSchema = z.object({
+  version: z.number(),
+  generated_at: z.string(),
+  window: z.object({ start: z.string(), end: z.string() }),
+  signals: z.array(signalSchema),
+});
+
+export function parseSignalsFeed(raw: unknown): ParsedFeed {
+  const feed = feedSchema.parse(raw); // throws (ZodError) on a structurally invalid envelope
+  if (feed.version !== SIGNAL_FEED_VERSION) {
+    throw new Error(
+      `Unsupported signal feed version ${feed.version}; this build supports ${SIGNAL_FEED_VERSION}`,
+    );
+  }
+
+  // Preserve the ORIGINAL signal objects (zod strips unknown keys) for `raw`.
+  const originals = (raw as { signals?: unknown[] }).signals ?? [];
+
+  const signals: ParsedSignal[] = [];
+  feed.signals.forEach((s, i) => {
+    const contract = (s.contract ?? "").trim();
+    if (!contract) return; // no dedup key → skip this signal, keep the rest
+    signals.push({
+      contract,
+      chain: (s.chain ?? "").trim() || "unknown",
+      symbol: s.symbol ?? null,
+      action: s.action ?? null,
+      score: s.score ?? null,
+      todayMentions: s.today_mentions ?? null,
+      yesterdayMentions: s.yesterday_mentions ?? null,
+      velocityPct: s.velocity_pct ?? null,
+      liquidityUsd: s.liquidity_usd ?? null,
+      volume24hUsd: s.volume_24h_usd ?? null,
+      priceUsd: s.price_usd ?? null,
+      firstSeenAt: s.first_seen_at ?? null,
+      lastSeenAt: s.last_seen_at ?? null,
+      narratives: s.narratives,
+      riskFlags: s.risk_flags,
+      raw: originals[i] ?? s,
+    });
+  });
+
+  return {
+    version: feed.version,
+    generatedAt: feed.generated_at,
+    window: feed.window,
+    signals,
+  };
+}

--- a/src/vex-agent/signals/ingest.ts
+++ b/src/vex-agent/signals/ingest.ts
@@ -1,0 +1,65 @@
+/**
+ * Signal ingestion — fetch TrendRadar's published feed, parse/validate it, and
+ * upsert into Vex's own `signals` table. Dependencies (fetch + upsert) are
+ * injected so the logic is unit-tested with no network and no DB.
+ */
+
+import { parseSignalsFeed, type ParsedSignal } from "./feed.js";
+import { upsertSignals, type SignalUpsertInput } from "@vex-agent/db/repos/signals.js";
+import logger from "@utils/logger.js";
+
+const SOURCE = "trendradar";
+
+/** TrendRadar publishes its feed to this branch/path hourly (see trendradar CI). */
+export const DEFAULT_SIGNALS_FEED_URL =
+  "https://raw.githubusercontent.com/Nishant-Adhikari/trendradar/signals-feed/data/signals.json";
+
+export interface IngestSignalsDeps {
+  fetchFeed(url: string): Promise<unknown>;
+  upsert(records: SignalUpsertInput[]): Promise<number>;
+}
+
+export interface IngestSignalsResult {
+  readonly fetched: number;
+  readonly written: number;
+  readonly generatedAt: string;
+}
+
+function toUpsert(s: ParsedSignal, feedGeneratedAt: string): SignalUpsertInput {
+  return {
+    source: SOURCE, chain: s.chain, contract: s.contract, symbol: s.symbol,
+    action: s.action, score: s.score, todayMentions: s.todayMentions,
+    yesterdayMentions: s.yesterdayMentions, velocityPct: s.velocityPct,
+    liquidityUsd: s.liquidityUsd, volume24hUsd: s.volume24hUsd, priceUsd: s.priceUsd,
+    narratives: s.narratives, riskFlags: s.riskFlags, raw: s.raw,
+    firstSeenAt: s.firstSeenAt, lastSeenAt: s.lastSeenAt, feedGeneratedAt,
+  };
+}
+
+function productionDeps(): IngestSignalsDeps {
+  return {
+    fetchFeed: async (url) => {
+      const res = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+      if (!res.ok) throw new Error(`signal feed fetch failed: HTTP ${res.status}`);
+      return res.json();
+    },
+    upsert: (records) => upsertSignals(records),
+  };
+}
+
+/**
+ * Fetch → parse → upsert. Throws on fetch/parse failure (nothing is written on a
+ * bad or unsupported-version feed); the caller (executor) logs and retries next tick.
+ */
+export async function ingestSignalsFeed(
+  url: string = DEFAULT_SIGNALS_FEED_URL,
+  deps: IngestSignalsDeps = productionDeps(),
+): Promise<IngestSignalsResult> {
+  const raw = await deps.fetchFeed(url);
+  const feed = parseSignalsFeed(raw);
+  const written = await deps.upsert(feed.signals.map((s) => toUpsert(s, feed.generatedAt)));
+  logger.info("signals.ingest.completed", {
+    fetched: feed.signals.length, written, generatedAt: feed.generatedAt,
+  });
+  return { fetched: feed.signals.length, written, generatedAt: feed.generatedAt };
+}


### PR DESCRIPTION
## What

The **data plane** for TrendRadar → Vex signal ingestion (the Vex half of the approved design). Vex now ingests the [TrendRadar signals feed](https://github.com/Nishant-Adhikari/trendradar/pull/18) into **its own Postgres**, so it owns the alpha it will act on — no external store at run time.

This is **PR 1 of 2**. It adds the ingestion *capability* (schema + repo + parser + fetch/upsert + hourly executor) but does **not** change agent behaviour: the executor isn't wired into app startup, and mission-time consumption + the exit-safety veto are PR 2.

## Pieces

| File | Role |
|---|---|
| `037_signals.sql` | `signals` table — upsert one row per `(source, chain, contract)` (case-insensitive), indexed on `ingested_at` for the rolling window |
| `db/repos/signals.ts` | `upsertSignals` (idempotent) + `listRecentSignals` — the "overall alpha over the last N hours" read. JSONB via `db/params` |
| `signals/feed.ts` | defensive **zod** parser for the UNTRUSTED feed — rejects an unsupported `SIGNAL_FEED_VERSION`, drops signals with no contract, coerces nulls |
| `signals/ingest.ts` | fetch → parse → upsert (DI'd). Nothing is written on a bad/unsupported feed |
| `signals/executor.ts` | hourly self-scheduling loop (mirrors `sync/executor.ts`), errors caught + logged, clean `stop()` |

## Design notes

- **Vex owns the store.** The feed is already windowed (today+yesterday mentions, deduped by contract), so a row carries aggregated alpha. Keeping the *latest* row per token makes ingestion **offline-resilient** — if TrendRadar misses an hour, last-known rows persist and age out of the window naturally.
- **`SIGNAL_FEED_VERSION`** is the cross-repo contract; kept in lockstep with TrendRadar's.
- **Signals are DISCOVERY only** — they never authorise a trade. A mission still runs the exit-safety scan + human approval over any candidate (enforced in PR 2).

## Verification

- **Unit tests (10):** feed parse (version reject / drop-no-contract / null coercion / structural-invalid), ingest (fetch→parse→upsert; abort-before-write on bad version and on fetch failure), executor (runs on start, survives a failed tick, stops clean).
- **Real-Postgres validation:** applied the migration to a throwaway DB and exercised the repo SQL — confirmed the upsert is **case-insensitively idempotent** (`0X…` vs `0x…` updates, never duplicates) and the `make_interval` window query returns correctly.
- `tsc --noEmit` clean; full suite green.

## Next (PR 2, owner-supervised)

Wire the executor into app startup (`vex-app/src/main/agent/signals-worker.ts`), add the mission-time **signal-radar** block that reads `listRecentSignals` and runs the **exit-safety round-trip veto** (so a honeypot like ROODFI/RAXOL can't reach a mission even if it tops the alpha feed), and expose it in the agent prompt.
