### PR TITLE
fix(mission): stop Renew from cloning duplicate drafts (suppress spent renewable source)

### DIFF
--- a/vex-app/src/main/database/__tests__/missions-db.renewable-source.test.ts
+++ b/vex-app/src/main/database/__tests__/missions-db.renewable-source.test.ts
@@ -135,6 +135,23 @@ describe("getRenewableSourceForSession", () => {
     );
   });
 
+  it("suppresses the source while the session still has an un-started draft/ready mission (no double-renew)", async () => {
+    // Root cause of the duplicate-draft storm: once `mission.renew` clones a
+    // fresh draft, the OLD terminal accepted mission still satisfies every
+    // renewable predicate above — so without this guard the resolver keeps
+    // reporting it as renewable, the Renew button lingers, and each extra
+    // click clones ANOTHER duplicate draft. A finished mission is only
+    // renewable when there is nothing pending to act on: suppress it whenever
+    // the session already holds a draft/ready mission (which `getDraft`
+    // surfaces instead). Makes `getDraft` and `getRenewableSource` mutually
+    // exclusive at the source, not just in each renderer consumer.
+    mocks.query.mockResolvedValueOnce({ rows: [] });
+    await getRenewableSourceForSession(SESSION);
+    const sql = normaliseSql(mocks.query.mock.calls[0]?.[0] ?? "");
+    expect(sql).toContain("NOT EXISTS");
+    expect(sql).toContain("d.status IN ('draft', 'ready')");
+  });
+
   it("orders results by latest run's end-or-start time (newest first)", async () => {
     // Tie-break still flips to mission updated_at when run timestamps
     // collide. The outer SQL must preserve "newest finished first" so

--- a/vex-app/src/main/database/missions-db.ts
+++ b/vex-app/src/main/database/missions-db.ts
@@ -186,6 +186,14 @@ export async function getDraftForSession(
  * with a newer active run on top does NOT qualify — only the truly
  * finished missions surface.
  *
+ * Pending-draft exclusion: a source is ALSO suppressed while the session
+ * still holds a `draft`/`ready` mission. Renewal clones a finished mission
+ * into a fresh draft, but the source keeps satisfying every predicate above,
+ * so without this the Renew control lingered and repeat clicks cloned
+ * duplicate drafts. While a draft is pending, `getDraft` surfaces it instead —
+ * the two resolvers are mutually exclusive, so a renderer that shows one never
+ * simultaneously shows the other.
+ *
  * Returns `null` when no eligible mission exists; the renderer maps
  * that to the friendly "No completed mission to renew" notice without
  * round-tripping through the engine's `previous_mission_not_found`
@@ -212,6 +220,20 @@ export async function getRenewableSourceForSession(
             AND m.accepted_contract_by IS NOT NULL
             AND m.contract_hash_version IS NOT NULL
             AND latest.status IN ('completed', 'failed', 'stopped', 'cancelled')
+            -- Suppress the source once a fresh draft already exists for the
+            -- session. Otherwise the OLD terminal accepted mission keeps
+            -- satisfying every predicate above even after mission.renew
+            -- clones a draft from it, so the Renew control lingers and each
+            -- extra click clones ANOTHER duplicate draft. A finished mission
+            -- is renewable only when nothing is pending: while a draft/ready
+            -- mission exists, getDraft surfaces it instead. Keeps the two
+            -- resolvers mutually exclusive at the source.
+            AND NOT EXISTS (
+              SELECT 1
+                FROM missions d
+               WHERE d.root_session_id = m.root_session_id
+                 AND d.status IN ('draft', 'ready')
+            )
           ORDER BY COALESCE(latest.ended_at, latest.started_at) DESC,
                    m.updated_at DESC
           LIMIT 1`,

--- a/vex-app/src/renderer/features/appShell/MissionControls.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionControls.tsx
@@ -300,7 +300,14 @@ export function MissionControls({
   // into a fresh draft (the new contract must still be accepted before it runs,
   // so this is non-destructive and needs no confirm step).
   const renewSource = readRenewable(renewableQuery.data);
-  if (renewSource !== null) {
+  // `draft === null` guard mirrors MissionRail's load-bearing guard:
+  // `getRenewableSourceForSession` keeps returning the OLD terminal accepted
+  // mission even after `mission.renew` (or `edit`) inserts a fresh draft. Without
+  // this guard the Renew button LINGERS once a fresh draft exists — so a renew
+  // looks like it "does nothing", and each extra click clones ANOTHER duplicate
+  // draft. Gating on `draft === null` lets the fresh draft fall through to the
+  // acceptance-pending UI below (accept it, then Start).
+  if (renewSource !== null && draft === null) {
     const previousMissionId = renewSource.missionId;
     return (
       <div data-vex-area="mission-controls" className="mt-3">

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
@@ -315,6 +315,21 @@ describe("MissionControls", () => {
     expect(screen.queryByRole("button", { name: "Renew mission" })).toBeNull();
   });
 
+  it("hides Renew once a fresh draft exists (post-renew) — no duplicate-draft loop", async () => {
+    // After mission.renew, a fresh status='draft' mission exists, but
+    // getRenewableSource STILL returns the old terminal accepted mission. Renew
+    // must NOT linger — else it looks like it "did nothing" and each extra click
+    // clones another duplicate draft. The fresh draft's acceptance UI wins.
+    getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+    getDraftMock.mockResolvedValue(ok({ missionId: MISSION, status: "draft" }));
+    getDiffMock.mockResolvedValue(diffAccepted(false));
+    getRenewableMock.mockResolvedValue(ok({ missionId: "m-done" }));
+    renderControls();
+
+    await screen.findByText(/Mission contract not accepted/i);
+    expect(screen.queryByRole("button", { name: "Renew mission" })).toBeNull();
+  });
+
   it("surfaces a renew refusal (not_terminal_yet → notice)", async () => {
     getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
     getDraftMock.mockResolvedValue(ok(null));


### PR DESCRIPTION
## Problem solved

Fix the duplicate-draft storm behind the "**Renew mission does nothing**" report — clicking Renew appeared to do nothing while silently cloning a new draft on every click.

A mission's Renew control clones a finished (accepted + terminal) mission into a fresh draft. But after the first renew the button **stayed on screen**, so a user tapping it again (reasonably, since nothing visibly changed) cloned **another** draft each time. Observed live: a burst of ~10 renews/second against the same `previousMissionId` in the IPC log, and one session that accumulated **15 draft rows**, 14 stamped `renewed_from_mission_id`.

## Root cause

`getRenewableSourceForSession` decides "is there a mission to renew?" purely from acceptance + latest-run-terminal predicates. Renewal **doesn't change any of them** on the source — after `mission.renew` clones a draft, the source mission is still accepted and its latest run is still terminal, so the resolver keeps returning it as renewable indefinitely.

That means `getDraft` (which now returns the fresh draft) and `getRenewableSource` (which still returns the old source) are both non-null at the same time. The renderer is left to arbitrate, and any consumer that forgets to prioritise the draft re-offers Renew. `MissionControls` was exactly that consumer — it rendered Renew whenever `renewSource !== null`, with no draft check.

## What changed

Two layers, root cause first:

- **Database (root cause):** `getRenewableSourceForSession` now excludes a session that already holds a `draft`/`ready` mission, via `NOT EXISTS (SELECT 1 FROM missions d WHERE d.root_session_id = m.root_session_id AND d.status IN ('draft','ready'))`. A finished mission is renewable **only when nothing is pending**; while a draft exists, `getDraft` surfaces it instead. `getDraft` and `getRenewableSource` are now **mutually exclusive at the source**, so no renderer can be handed both at once.
- **Renderer (defense-in-depth):** gate `MissionControls`' Renew branch on `draft === null`, mirroring `MissionRail`'s existing "load-bearing" guard. This covers the brief window where the two React Query caches disagree right after a renew (draft cache updated, renewable cache not yet refetched).

## User impact

Renew now works as expected: the first click clones a draft, the draft's acceptance UI takes over immediately, and the Renew button is gone — so there's no way to spawn duplicates. A genuinely-finished mission with no pending draft still offers Renew exactly as before.

## Test coverage

Written test-first (TDD):

- `missions-db.renewable-source.test.ts` — new case asserting the resolver SQL suppresses the source while a `draft`/`ready` mission exists (the eight existing latest-run/acceptance cases are unchanged).
- `MissionControls.test.tsx` — new case: with a fresh `status='draft'` mission **and** a still-present renewable source, the acceptance-pending notice shows and the Renew button is absent.

## Validation

- `vex-app` full suite: **2,531 passed** across **289 files**.
- `tsc --noEmit -p tsconfig.json`: **0 errors**.

## Notes

Renewal is intentionally **not** idempotent at the engine layer (per the `renewMission` docstring — dedup would need a UI-carried token). This PR removes the *reason* repeat renews happened rather than making the engine dedup: once the resolver stops re-offering a spent source and the renderer prioritises the draft, the storm can't start.
