### PR TITLE
feat(sessions): add search and filters to session library

### DIFF
--- a/vex-app/src/renderer/features/appShell/SessionsLibrary.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionsLibrary.tsx
@@ -15,12 +15,13 @@
  * rule), with the session count as a mono microtype counter on the right.
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { JSX } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   AlertCircleIcon,
   ArrowLeft01Icon,
+  Search01Icon,
 } from "@hugeicons/core-free-icons";
 import type {
   SessionDeleteOutcome,
@@ -36,14 +37,19 @@ import { SessionDeleteDialog } from "./SessionDeleteDialog.js";
 import { SessionGroups } from "./SessionRows.js";
 import {
   filterSessionsByMode,
+  filterSessionsByTitle,
   groupSessions,
+  SESSION_MODE_FILTERS,
 } from "./sessionListModel.js";
+
+const EMPTY_SESSIONS: readonly SessionListItem[] = [];
 
 export function SessionsLibrary(): JSX.Element {
   const activeSessionId = useUiStore((s) => s.activeSessionId);
   const setActiveSessionId = useUiStore((s) => s.setActiveSessionId);
   const setAppShellView = useUiStore((s) => s.setAppShellView);
   const sessionModeFilter = useUiStore((s) => s.sessionModeFilter);
+  const setSessionModeFilter = useUiStore((s) => s.setSessionModeFilter);
   const query = useSessionsList();
   const pinMutation = useSetSessionPinned();
   const deleteMutation = useDeleteSession();
@@ -54,18 +60,43 @@ export function SessionsLibrary(): JSX.Element {
   const [removeTarget, setRemoveTarget] = useState<SessionListItem | null>(null);
   const [removeBlocked, setRemoveBlocked] =
     useState<SessionDeleteOutcome | null>(null);
+  const [search, setSearch] = useState("");
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  const allRows = query.data?.ok === true ? query.data.data : EMPTY_SESSIONS;
+  const totalRows = allRows.length;
+  const filteredRows = useMemo(
+    () =>
+      filterSessionsByTitle(
+        filterSessionsByMode(allRows, sessionModeFilter),
+        search,
+      ),
+    [allRows, search, sessionModeFilter],
+  );
 
   const groups = useMemo(() => {
-    if (!query.data?.ok) return [];
-    return groupSessions(
-      filterSessionsByMode(query.data.data, sessionModeFilter),
-    );
-  }, [query.data, sessionModeFilter]);
+    return groupSessions(filteredRows);
+  }, [filteredRows]);
 
-  const totalRows = useMemo(
-    () => groups.reduce((sum, g) => sum + g.rows.length, 0),
-    [groups],
-  );
+  const visibleRows = filteredRows.length;
+  const searchActive = search.trim().length > 0;
+  const filtersActive = searchActive || sessionModeFilter !== "all";
+  const countLabel =
+    totalRows === 0
+      ? "No sessions yet"
+      : filtersActive
+        ? `${visibleRows} of ${totalRows} sessions`
+        : `${totalRows} session${totalRows === 1 ? "" : "s"} stored locally`;
+
+  const clearFilters = useCallback((): void => {
+    setSearch("");
+    setSessionModeFilter("all");
+    searchRef.current?.focus();
+  }, [setSessionModeFilter]);
 
   const handleBack = useCallback((): void => {
     setAppShellView("session");
@@ -135,10 +166,12 @@ export function SessionsLibrary(): JSX.Element {
         <h1 className="font-mono text-[13px] font-medium uppercase tracking-[0.3em] text-foreground">
           All sessions
         </h1>
-        <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vex-text-2)]">
-          {totalRows === 0
-            ? "No sessions yet"
-            : `${totalRows} session${totalRows === 1 ? "" : "s"} stored locally`}
+        <span
+          aria-live="polite"
+          aria-atomic="true"
+          className="ml-auto font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vex-text-2)]"
+        >
+          {countLabel}
         </span>
       </header>
 
@@ -146,7 +179,67 @@ export function SessionsLibrary(): JSX.Element {
         aria-label="Sessions library"
         className="vex-scroll min-h-0 flex-1 overflow-y-auto px-6 py-6"
       >
-        <div className="mx-auto w-full max-w-[760px]">
+        <div className="mx-auto flex w-full max-w-[760px] flex-col gap-5">
+          <div
+            data-vex-sessions-library-toolbar
+            className="flex flex-wrap items-center gap-3 border-b border-[var(--vex-line)] pb-4"
+          >
+            <div
+              role="group"
+              aria-label="Filter sessions by mode"
+              className="flex items-center gap-1"
+            >
+              {SESSION_MODE_FILTERS.map((filter) => {
+                const active = sessionModeFilter === filter.value;
+                return (
+                  <button
+                    key={filter.value}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => setSessionModeFilter(filter.value)}
+                    className={`rounded-[3px] px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)] ${
+                      active
+                        ? "bg-[var(--vex-accent-fill-12)] text-[var(--vex-accent-text)]"
+                        : "text-[var(--vex-text-2)] hover:bg-white/[0.04] hover:text-foreground"
+                    }`}
+                  >
+                    {filter.label}
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="relative ml-auto min-w-[220px] flex-1 sm:max-w-[320px]">
+              <HugeiconsIcon
+                icon={Search01Icon}
+                size={14}
+                aria-hidden
+                className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--vex-text-3)]"
+              />
+              <input
+                ref={searchRef}
+                type="search"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search session titles"
+                aria-label="Search session titles"
+                className="h-8 w-full rounded-[6px] border border-[var(--vex-line-strong)] bg-[var(--vex-surface-down)] py-1 pl-8 pr-14 text-xs text-foreground placeholder:text-[var(--vex-text-3)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--vex-accent)]"
+              />
+              {searchActive ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSearch("");
+                    searchRef.current?.focus();
+                  }}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 font-mono text-[9px] uppercase tracking-[0.12em] text-[var(--vex-text-2)] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)]"
+                >
+                  Clear
+                </button>
+              ) : null}
+            </div>
+          </div>
+
           {query.isLoading ? (
             <p className="text-sm text-[var(--vex-text-2)]">
               Loading sessions…
@@ -160,6 +253,19 @@ export function SessionsLibrary(): JSX.Element {
             <p className="text-sm text-[var(--vex-text-3)]">
               Create a session from the sidebar to get started.
             </p>
+          ) : visibleRows === 0 ? (
+            <div className="flex flex-col items-start gap-2 py-3">
+              <p className="text-sm text-[var(--vex-text-2)]">
+                No sessions match your current search and filters.
+              </p>
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--vex-accent-text)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)]"
+              >
+                Reset filters
+              </button>
+            </div>
           ) : (
             <SessionGroups
               groups={groups}

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionsLibrary.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionsLibrary.test.tsx
@@ -1,0 +1,187 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionListItem } from "@shared/schemas/sessions.js";
+import type { SessionModeFilter } from "../../../stores/uiStore.js";
+
+interface MockStoreState {
+  readonly activeSessionId: string | null;
+  readonly sessionModeFilter: SessionModeFilter;
+  readonly setActiveSessionId: (id: string | null) => void;
+  readonly setAppShellView: (view: "session" | "sessionsLibrary") => void;
+  readonly setSessionModeFilter: (filter: SessionModeFilter) => void;
+}
+
+const harness = vi.hoisted(() => ({
+  listeners: new Set<() => void>(),
+  rows: [] as SessionListItem[],
+  state: null as MockStoreState | null,
+}));
+
+function publishState(next: MockStoreState): void {
+  harness.state = next;
+  for (const listener of harness.listeners) listener();
+}
+
+function resetStore(filter: SessionModeFilter = "all"): void {
+  const makeState = (sessionModeFilter: SessionModeFilter): MockStoreState => ({
+    activeSessionId: null,
+    sessionModeFilter,
+    setActiveSessionId: (activeSessionId) => {
+      publishState({ ...makeState(sessionModeFilter), activeSessionId });
+    },
+    setAppShellView: () => {},
+    setSessionModeFilter: (nextFilter) => {
+      publishState(makeState(nextFilter));
+    },
+  });
+  harness.state = makeState(filter);
+}
+
+vi.mock("../../../stores/uiStore.js", async () => {
+  const { useSyncExternalStore } = await import("react");
+  return {
+    useUiStore: <T,>(selector: (state: MockStoreState) => T): T =>
+      useSyncExternalStore(
+        (listener) => {
+          harness.listeners.add(listener);
+          return () => harness.listeners.delete(listener);
+        },
+        () => selector(harness.state!),
+        () => selector(harness.state!),
+      ),
+  };
+});
+
+vi.mock("../../../lib/api/sessions.js", () => ({
+  useSessionsList: () => ({
+    isLoading: false,
+    data: { ok: true, data: harness.rows },
+  }),
+  useSetSessionPinned: () => ({
+    isPending: false,
+    variables: undefined,
+    mutate: vi.fn(),
+  }),
+  useDeleteSession: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+vi.mock("../SessionRows.js", () => ({
+  SessionGroups: ({
+    groups,
+  }: {
+    readonly groups: ReadonlyArray<{
+      readonly rows: readonly SessionListItem[];
+    }>;
+  }) => (
+    <ul aria-label="Filtered session rows">
+      {groups.flatMap((group) => group.rows).map((row) => (
+        <li key={row.id}>{row.title ?? row.initialGoal}</li>
+      ))}
+    </ul>
+  ),
+}));
+
+vi.mock("../SessionDeleteDialog.js", () => ({
+  SessionDeleteDialog: () => null,
+}));
+
+vi.mock("@hugeicons/react", () => ({
+  HugeiconsIcon: () => null,
+}));
+
+const { SessionsLibrary } = await import("../SessionsLibrary.js");
+
+describe("SessionsLibrary search and filters", () => {
+  beforeEach(() => {
+    harness.listeners.clear();
+    harness.rows = [
+      makeRow("one", "Arbitrum LP Rebalance", "agent"),
+      makeRow("two", "Daily gas report", "mission"),
+      makeRow("three", "Token research", "agent"),
+    ];
+    resetStore();
+  });
+
+  it("focuses title search and filters the register with an accurate count", () => {
+    render(<SessionsLibrary />);
+
+    const search = screen.getByRole("searchbox", {
+      name: "Search session titles",
+    });
+    expect(document.activeElement).toBe(search);
+    expect(screen.getByText("3 sessions stored locally")).toBeTruthy();
+
+    fireEvent.change(search, { target: { value: "gas" } });
+
+    expect(screen.getByText("1 of 3 sessions")).toBeTruthy();
+    expect(screen.getByText("Daily gas report")).toBeTruthy();
+    expect(screen.queryByText("Arbitrum LP Rebalance")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect((search as HTMLInputElement).value).toBe("");
+    expect(document.activeElement).toBe(search);
+    expect(screen.getByText("3 sessions stored locally")).toBeTruthy();
+  });
+
+  it("shows and updates the shared All / Agent / Mission filter", () => {
+    resetStore("agent");
+    render(<SessionsLibrary />);
+
+    expect(
+      screen.getByRole("button", { name: "Agent" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(screen.getByText("2 of 3 sessions")).toBeTruthy();
+    expect(screen.queryByText("Daily gas report")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Mission" }));
+
+    expect(
+      screen.getByRole("button", { name: "Mission" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(screen.getByText("1 of 3 sessions")).toBeTruthy();
+    expect(screen.getByText("Daily gas report")).toBeTruthy();
+    expect(screen.queryByText("Token research")).toBeNull();
+  });
+
+  it("offers one reset action when search and mode filters have no results", () => {
+    resetStore("mission");
+    render(<SessionsLibrary />);
+
+    const search = screen.getByRole("searchbox", {
+      name: "Search session titles",
+    });
+    fireEvent.change(search, { target: { value: "arbitrum" } });
+
+    expect(
+      screen.getByText("No sessions match your current search and filters."),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Reset filters" }));
+
+    expect((search as HTMLInputElement).value).toBe("");
+    expect(
+      screen.getByRole("button", { name: "All" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(screen.getByText("3 sessions stored locally")).toBeTruthy();
+  });
+});
+
+function makeRow(
+  id: string,
+  title: string,
+  mode: SessionListItem["mode"],
+): SessionListItem {
+  return {
+    id,
+    mode,
+    permission: "restricted",
+    title,
+    initialGoal: null,
+    startedAt: "2026-07-12T10:00:00.000Z",
+    endedAt: null,
+    missionStatus: null,
+    pinnedAt: null,
+  };
+}

--- a/vex-app/src/renderer/features/appShell/__tests__/sessionListModel.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/sessionListModel.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatSessionTime } from "../sessionListModel.js";
+import type { SessionListItem } from "@shared/schemas/sessions.js";
+import {
+  filterSessionsByTitle,
+  formatSessionTime,
+} from "../sessionListModel.js";
 
 describe("formatSessionTime", () => {
   it("formats older dates with an English (en-US) month, not the OS locale", () => {
@@ -15,3 +19,49 @@ describe("formatSessionTime", () => {
     expect(formatSessionTime("not-a-date")).toBe("");
   });
 });
+
+describe("filterSessionsByTitle", () => {
+  const rows: readonly SessionListItem[] = [
+    makeRow({ title: "Arbitrum LP Rebalance" }),
+    makeRow({ title: "Daily gas report", mode: "mission" }),
+    makeRow({ title: null, initialGoal: "Watch ETH funding rates" }),
+  ];
+
+  it("matches rendered titles case-insensitively and trims the query", () => {
+    expect(filterSessionsByTitle(rows, "  GAS ")).toEqual([rows[1]]);
+  });
+
+  it("keeps legacy sessions searchable through their rendered goal fallback", () => {
+    expect(filterSessionsByTitle(rows, "funding")).toEqual([rows[2]]);
+  });
+
+  it("searches the complete title rather than only its truncated display label", () => {
+    const longTitle = makeRow({
+      title: `${"A".repeat(60)} hidden-keyword`,
+    });
+    expect(filterSessionsByTitle([longTitle], "hidden-keyword")).toEqual([
+      longTitle,
+    ]);
+  });
+
+  it("returns the original rows for an empty query", () => {
+    expect(filterSessionsByTitle(rows, "   ")).toBe(rows);
+  });
+});
+
+function makeRow(
+  overrides: Partial<SessionListItem>,
+): SessionListItem {
+  return {
+    id: crypto.randomUUID(),
+    mode: "agent",
+    permission: "restricted",
+    title: "Session",
+    initialGoal: null,
+    startedAt: "2026-07-12T10:00:00.000Z",
+    endedAt: null,
+    missionStatus: null,
+    pinnedAt: null,
+    ...overrides,
+  };
+}

--- a/vex-app/src/renderer/features/appShell/sessionListModel.ts
+++ b/vex-app/src/renderer/features/appShell/sessionListModel.ts
@@ -48,6 +48,22 @@ export function filterSessionsByMode(
   return rows.filter((row) => row.mode === filter);
 }
 
+/**
+ * Case-insensitive title search for the sessions register. Search the same
+ * resolved title the row renders so legacy missions (which fall back to their
+ * initial goal) remain discoverable without exposing a second naming rule.
+ */
+export function filterSessionsByTitle(
+  rows: readonly SessionListItem[],
+  search: string,
+): readonly SessionListItem[] {
+  const needle = search.trim().toLowerCase();
+  if (needle.length === 0) return rows;
+  return rows.filter((row) =>
+    resolveSessionTitle(row).toLowerCase().includes(needle),
+  );
+}
+
 export function groupSessions(rows: readonly SessionListItem[]): readonly SessionGroup[] {
   // Pinned rows live in their own bucket and are excluded from the time
   // buckets — a pinned row should not appear twice. Within the bucket we
@@ -101,13 +117,17 @@ const SESSION_TITLE_DISPLAY_MAX = 48;
  * keeps tooltips / aria-labels predictable.
  */
 export function getSessionTitle(row: SessionListItem): string {
+  return truncateForDisplay(resolveSessionTitle(row));
+}
+
+function resolveSessionTitle(row: SessionListItem): string {
   if (row.title !== null) {
     const trimmed = row.title.trim();
-    if (trimmed.length > 0) return truncateForDisplay(trimmed);
+    if (trimmed.length > 0) return trimmed;
   }
   if (row.initialGoal !== null) {
     const trimmed = row.initialGoal.trim();
-    if (trimmed.length > 0) return truncateForDisplay(trimmed);
+    if (trimmed.length > 0) return trimmed;
   }
   return row.mode === "mission" ? "Mission setup" : "Agent session";
 }


### PR DESCRIPTION
## Problem solved

Allow users to search and filter their local session history rather than manually scanning up to 100 sessions.

Previously, the **All sessions** library had no search and silently inherited the Agent / Mission filter from the sidebar. That made older sessions difficult to find and could make the header claim that a filtered subset was the complete number of sessions stored locally.

## What changed

### Searchable sessions register

- Added an auto-focused session-title search field when the library opens.
- Searches case-insensitively across the complete resolved title, including legacy mission sessions that use their initial goal as a title.
- Keeps text beyond the visually truncated 48-character row label searchable.
- Added an inline **Clear** action that empties the query and returns focus to search.

### Visible, synchronized mode filters

- Added explicit **All**, **Agent**, and **Mission** controls to the library toolbar.
- Reuses the existing shared session mode state, so the library and sidebar stay synchronized instead of introducing competing filters.
- Exposes the active filter through `aria-pressed` for keyboard and assistive-technology users.

### Accurate result state

- Shows the full local count when no filters are active.
- Shows **X of Y sessions** whenever search or a mode filter narrows the register.
- Announces count changes through a polite live region.
- Added a useful no-results state with one **Reset filters** action that clears both search and mode filtering.

### Existing behavior preserved

- Session loading still uses the existing bounded `useSessionsList()` result; no new IPC, database query, or network path was introduced.
- Existing date grouping, pinning, deletion, mission status, row selection, and sidebar synchronization remain unchanged.
- The toolbar follows the existing flat Signal Desk ledger grammar: hairline separation, restrained cobalt active state, and no additional card surface.

## User impact

Returning users can now find a session by name immediately, understand which session mode is active, and distinguish visible matches from their complete local history. The common path no longer requires scanning grouped rows or remembering a filter selected elsewhere in the interface.

## Screenshot

![Search and filter the Sessions Library](https://raw.githubusercontent.com/alexastro01/Vex/56ff5e977cecb70ad790e84be674f3b228051c27/.github/pr-assets/session-library-search.png)

## Test coverage

Added focused coverage for:

- Case-insensitive and whitespace-tolerant title matching.
- Legacy initial-goal title fallback.
- Search terms beyond the truncated display label.
- Search focus, filtering, and inline clearing.
- Shared All / Agent / Mission filter state.
- Accurate filtered and total counts.
- Empty-result recovery through the combined reset action.

## Validation

- `pnpm test` in `vex-app` under the CI Node 22 runtime: **2,559 / 2,559 tests passed** across 295 files.
- Focused session-library suite: **9 / 9 tests passed**.
- `pnpm run lint`: passed, including the type ratchet and process-boundary checks.
- `pnpm run build` in `vex-app`: passed for main, preload, and renderer bundles plus artifact/CSP checks.
- React Doctor: **100 / 100**, with no issues found in the changed React code.
