### PR TITLE
feat(wallets): add inline address copy to review card

### DIFF
--- a/vex-app/src/renderer/components/common/AddressDisplay.tsx
+++ b/vex-app/src/renderer/components/common/AddressDisplay.tsx
@@ -20,6 +20,14 @@ export interface AddressDisplayProps {
   readonly address: string;
   readonly className?: string;
   readonly truncate?: boolean;
+  /**
+   * `chip` preserves the established wallet-management surface. `inline`
+   * removes the container chrome and uses a copy/checkmark icon with visible
+   * status text for compact summary rows.
+   */
+  readonly appearance?: "chip" | "inline";
+  readonly copyLabel?: string;
+  readonly copiedLabel?: string;
 }
 
 const COPY_FEEDBACK_MS = 1500;
@@ -29,6 +37,32 @@ const SUFFIX_LEN = 4;
 function truncateAddress(address: string): string {
   if (address.length <= PREFIX_LEN + SUFFIX_LEN + 1) return address;
   return `${address.slice(0, PREFIX_LEN)}…${address.slice(-SUFFIX_LEN)}`;
+}
+
+function CopyStateGlyph({ copied }: { readonly copied: boolean }): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="13"
+      height="13"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      data-vex-copy-glyph={copied ? "check" : "copy"}
+    >
+      {copied ? (
+        <path d="m3.5 8 3 3 6-6" />
+      ) : (
+        <>
+          <rect x="5" y="5" width="7.5" height="7.5" rx="1.2" />
+          <path d="M3.5 10.5H3a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1h6.5a1 1 0 0 1 1 1v.5" />
+        </>
+      )}
+    </svg>
+  );
 }
 
 /**
@@ -58,6 +92,9 @@ export function AddressDisplay({
   address,
   className,
   truncate = true,
+  appearance = "chip",
+  copyLabel = "Copy address",
+  copiedLabel = "Address copied",
 }: AddressDisplayProps): JSX.Element {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -88,6 +125,48 @@ export function AddressDisplay({
 
   const displayed = truncate ? truncateAddress(address) : address;
 
+  if (appearance === "inline") {
+    return (
+      <span
+        className={cn("inline-flex min-w-0 items-center gap-1.5", className)}
+        data-vex-address-copy={copied ? "copied" : "idle"}
+      >
+        <code
+          className="font-mono text-[11px] text-[var(--color-text-secondary)]"
+          title={truncate ? address : undefined}
+        >
+          {displayed}
+        </code>
+        <button
+          type="button"
+          onClick={() => {
+            void handleCopy();
+          }}
+          aria-label={copied ? copiedLabel : copyLabel}
+          className={cn(
+            "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[4px]",
+            "border border-white/[0.08] bg-white/[0.025]",
+            "text-[var(--color-text-muted)] transition-colors",
+            "hover:border-white/[0.16] hover:text-[var(--color-text-primary)]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-onboarding-accent)]",
+            copied &&
+              "border-[color-mix(in_oklab,var(--color-success)_35%,transparent)] text-[var(--color-success)]",
+          )}
+        >
+          <CopyStateGlyph copied={copied} />
+        </button>
+        <span
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="whitespace-nowrap font-mono text-[9px] uppercase tracking-[0.12em] text-[var(--color-success)]"
+        >
+          {copied ? copiedLabel : ""}
+        </span>
+      </span>
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -107,7 +186,7 @@ export function AddressDisplay({
         onClick={() => {
           void handleCopy();
         }}
-        aria-label={copied ? "Address copied" : "Copy address"}
+        aria-label={copied ? copiedLabel : copyLabel}
         className="rounded-sm px-1 text-[10px] font-mono uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         {copied ? "✓ copied" : "copy"}

--- a/vex-app/src/renderer/components/common/__tests__/AddressDisplay.test.tsx
+++ b/vex-app/src/renderer/components/common/__tests__/AddressDisplay.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { AddressDisplay } = await import("../AddressDisplay.js");
+
+const ADDRESS = "0x637d1234567890abcdef1234567890abcdef39C2";
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+beforeEach(() => {
+  writeText.mockReset();
+  writeText.mockResolvedValue();
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("AddressDisplay", () => {
+  it("copies the full address and swaps the inline copy glyph for a checkmark", async () => {
+    const view = render(
+      <AddressDisplay
+        address={ADDRESS}
+        appearance="inline"
+        copyLabel="Copy EVM wallet address"
+        copiedLabel="Address copied"
+      />,
+    );
+
+    const copy = screen.getByRole("button", {
+      name: "Copy EVM wallet address",
+    });
+    expect(
+      copy.querySelector('[data-vex-copy-glyph="copy"]'),
+    ).not.toBeNull();
+
+    fireEvent.click(copy);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(ADDRESS));
+    const copied = await screen.findByRole("button", {
+      name: "Address copied",
+    });
+    expect(
+      copied.querySelector('[data-vex-copy-glyph="check"]'),
+    ).not.toBeNull();
+    expect(screen.getByRole("status").textContent).toBe("Address copied");
+    expect(
+      view.container.querySelector('[data-vex-address-copy="copied"]'),
+    ).not.toBeNull();
+  });
+
+  it("uses the permissionless selection fallback before showing success", async () => {
+    writeText.mockRejectedValueOnce(new Error("clipboard permission denied"));
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+    render(<AddressDisplay address={ADDRESS} appearance="inline" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy address" }));
+
+    await screen.findByRole("button", { name: "Address copied" });
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("preserves the existing chip appearance by default", () => {
+    render(<AddressDisplay address={ADDRESS} />);
+
+    expect(screen.getByRole("button", { name: "Copy address" }).textContent).toBe(
+      "copy",
+    );
+    expect(screen.getByText(`${ADDRESS.slice(0, 6)}…${ADDRESS.slice(-4)}`)).toBeTruthy();
+  });
+});

--- a/vex-app/src/renderer/features/wizard/steps/review/cards/WalletsCard.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/review/cards/WalletsCard.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "react";
 import type { EnvState } from "@shared/schemas/onboarding.js";
 import type { WalletChain } from "@shared/schemas/wallets.js";
+import { AddressDisplay } from "../../../../../components/common/AddressDisplay.js";
 import { Button } from "../../../../../components/ui/button.js";
 import { SummaryCard } from "./SummaryCard.js";
 
@@ -22,12 +23,6 @@ export interface WalletsCardProps {
    * lifecycle to the parent (ReviewStep).
    */
   readonly onExport?: (chain: WalletChain) => void;
-}
-
-function shortAddr(addr: string | null): string {
-  if (!addr) return "—";
-  if (addr.length <= 12) return addr;
-  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
 }
 
 export function WalletsCard({
@@ -66,7 +61,19 @@ export function WalletsCard({
     >
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between gap-2">
-          <span>EVM: {evmOk ? shortAddr(evmAddr) : "missing"}</span>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span>EVM:</span>
+            {evmOk && evmAddr !== null ? (
+              <AddressDisplay
+                address={evmAddr}
+                appearance="inline"
+                copyLabel="Copy EVM wallet address"
+                copiedLabel="Address copied"
+              />
+            ) : (
+              <span>{evmOk ? "—" : "missing"}</span>
+            )}
+          </div>
           {evmExportShown ? (
             <Button
               type="button"
@@ -82,7 +89,19 @@ export function WalletsCard({
           ) : null}
         </div>
         <div className="flex items-center justify-between gap-2">
-          <span>Solana: {solOk ? shortAddr(solAddr) : "missing"}</span>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span>Solana:</span>
+            {solOk && solAddr !== null ? (
+              <AddressDisplay
+                address={solAddr}
+                appearance="inline"
+                copyLabel="Copy Solana wallet address"
+                copiedLabel="Address copied"
+              />
+            ) : (
+              <span>{solOk ? "—" : "missing"}</span>
+            )}
+          </div>
           {solExportShown ? (
             <Button
               type="button"

--- a/vex-app/src/renderer/features/wizard/steps/review/cards/__tests__/WalletsCard.test.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/review/cards/__tests__/WalletsCard.test.tsx
@@ -1,0 +1,134 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EnvState } from "@shared/schemas/onboarding.js";
+
+const { WalletsCard } = await import("../WalletsCard.js");
+
+const EVM_ADDRESS = "0x637d1234567890abcdef1234567890abcdef39C2";
+const SOLANA_ADDRESS = "9T9weh1234567890abcdefghijkLmnoPqrstuvbTpE";
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+beforeEach(() => {
+  writeText.mockReset();
+  writeText.mockResolvedValue();
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("WalletsCard address copy", () => {
+  it("copies a public address inline without entering Edit or export", async () => {
+    const onEdit = vi.fn();
+    const onExport = vi.fn();
+    render(
+      <WalletsCard
+        envState={makeEnvState()}
+        onEdit={onEdit}
+        editDisabled={false}
+        mode="reconfigure"
+        onExport={onExport}
+      />,
+    );
+
+    const copyEvm = screen.getByRole("button", {
+      name: "Copy EVM wallet address",
+    });
+    expect(
+      screen.getByRole("button", { name: "Copy Solana wallet address" }),
+    ).toBeTruthy();
+
+    fireEvent.click(copyEvm);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(EVM_ADDRESS));
+    expect(await screen.findByText("Address copied")).toBeTruthy();
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(onExport).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Export EVM private key" }),
+    );
+    expect(onExport).toHaveBeenCalledWith("evm");
+  });
+
+  it("offers address copy during setup while keeping private-key export gated", () => {
+    render(
+      <WalletsCard
+        envState={makeEnvState()}
+        onEdit={() => {}}
+        editDisabled={false}
+        mode="setup"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Copy EVM wallet address" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Copy Solana wallet address" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Export EVM private key" }),
+    ).toBeNull();
+  });
+
+  it("does not render a copy action when a wallet address is unavailable", () => {
+    render(
+      <WalletsCard
+        envState={makeEnvState({ evm: null })}
+        onEdit={() => {}}
+        editDisabled={false}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Copy EVM wallet address" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Copy Solana wallet address" }),
+    ).toBeTruthy();
+  });
+});
+
+function makeEnvState(
+  addresses: Partial<{
+    readonly evm: string | null;
+    readonly solana: string | null;
+  }> = {},
+): EnvState {
+  return {
+    hasKeystorePassword: true,
+    hasJupiterApiKey: false,
+    apiKeys: {
+      jupiterConfigured: false,
+      tavilyConfigured: false,
+      rettiwtConfigured: false,
+      polymarketStatus: "missing",
+    },
+    secrets: { vaultConfigured: true, unlocked: true },
+    embeddings: {
+      configured: true,
+      reachable: true,
+      baseUrlRedacted: "http://127.0.0.1:27134/v1",
+      allFieldsConfigured: true,
+      dbReachable: true,
+    },
+    walletStatus: { evm: "present", solana: "present" },
+    walletAddresses: {
+      evm: EVM_ADDRESS,
+      solana: SOLANA_ADDRESS,
+      ...addresses,
+    },
+    provider: {
+      configured: true,
+      name: "openrouter",
+      modelLabel: "openrouter/auto",
+    },
+    setupCompleteFlag: true,
+  };
+}


### PR DESCRIPTION
## Problem solved

Allow users to copy their public EVM or Solana wallet address directly from the Wallets review card rather than entering **Edit** just to reach a copyable address.

Previously, the read-only summary displayed truncated addresses with no action. The nearby controls led to wallet editing or private-key export, even when the operator only needed the safe public address for a deposit, allowlist, explorer, or transfer form.

## What changed

### Inline public-address copy

- Added a compact copy icon beside each available EVM and Solana address in the Wallets review summary.
- Copies the full, untruncated address while preserving the compact `0x1234…abcd` display.
- Keeps the action available in both initial setup review and later infrastructure reconfiguration.
- Does not render a copy control when the corresponding public address is unavailable.

### Clear success feedback

- Swaps the copy glyph to a checkmark only after a real copy succeeds.
- Shows a visible **Address copied** status for 1.5 seconds.
- Changes the accessible button label from the chain-specific action, such as **Copy EVM wallet address**, to **Address copied**.
- Announces success through a polite live region without adding a toast or another card surface.

### Existing clipboard safety reused

- Extends the existing `AddressDisplay` primitive instead of duplicating clipboard behavior inside the review card.
- Tries the standard Clipboard API first, then uses the established permissionless selection fallback required by the renderer's deny-all permission posture.
- Shows success only after one of those paths confirms the copy.
- Preserves the existing hairline chip appearance as the default for every current `AddressDisplay` consumer; the new icon treatment is an opt-in inline appearance.

### Private-key behavior unchanged

- Public-address copy never enters the wallet editor, decrypts a keystore, or invokes privileged IPC.
- Existing **Export EVM key** and **Export Solana key** actions remain independently gated to reconfigure mode.
- Export callbacks, password confirmation, clipboard lease, and private-key scrub behavior are unchanged.

## User impact

Operators can recover a deposit-safe public address with one click from the screen where it is already visible. The interaction clearly distinguishes harmless address copy from sensitive private-key export and confirms exactly when the address reached the clipboard.

## Current friction

![Wallet addresses previously required entering Edit to copy](https://raw.githubusercontent.com/alexastro01/Vex/9d7cdcbda0cd85e59fe5ef1d029a5957aefb100d/.github/pr-assets/wallet-address-copy-before.png)

## Test coverage

Added focused coverage for:

- Copying the full address instead of the truncated display value.
- Copy-icon to checkmark transition.
- Visible and assistive-technology success feedback.
- Clipboard API rejection followed by the permissionless fallback.
- Preserving the existing default chip appearance.
- EVM and Solana copy controls in setup and reconfigure modes.
- Missing-address behavior.
- Separation between public-address copy and private-key export callbacks.

## Validation

- `pnpm test` in `vex-app` under the CI Node 22 runtime: **2,558 / 2,558 tests passed** across 296 files.
- Focused address-copy suites: **6 / 6 tests passed**.
- `pnpm run lint`: passed, including the type ratchet and process-boundary checks.
- `pnpm run build` in `vex-app`: passed for main, preload, and renderer bundles plus artifact/CSP checks.
- React Doctor: **100 / 100**, with no issues found in the changed React code.
