### PR TITLE
feat(moves): show token labels in activity feed

### DIFF
--- a/vex-app/src/main/database/__tests__/moves-db.test.ts
+++ b/vex-app/src/main/database/__tests__/moves-db.test.ts
@@ -24,7 +24,9 @@
  *  - the tolerant mapper passes through a row with `trade_side = null`,
  *    `capture_status = 'filled'`, and `value_usd = null`;
  *  - a failed session-scope read propagates (fail closed);
- *  - the SELECT projects ONLY bounded columns (never params/result/trade_capture).
+ *  - the SELECT projects ONLY bounded columns: never params/result or raw JSONB;
+ *    token symbols are type-checked, length-bounded scalar extractions from the
+ *    exact capture item.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -182,14 +184,21 @@ describe("moves-db getMovesForSession — scoping + binding", () => {
     expect(bound).not.toContain(WALLET_A.toLowerCase());
   });
 
-  it("projects ONLY bounded columns (never params/result/trade_capture)", async () => {
+  it("projects ONLY bounded columns and bounded capture-item symbol scalars", async () => {
     mocks.getSessionWalletScope.mockResolvedValue(scopeOk(WALLET_A, null));
     mocks.query.mockResolvedValueOnce({ rows: [] });
     await getMovesForSession(SESSION);
     const sql = String(mocks.query.mock.calls[0]?.[0] ?? "");
     expect(sql).not.toContain("params");
     expect(sql).not.toContain("result");
-    expect(sql).not.toContain("trade_capture");
+    expect(sql).not.toContain("SELECT ci.trade_capture");
+    expect(sql).toContain("jsonb_typeof(ci.trade_capture->'inputToken')");
+    expect(sql).toContain("LEFT(ci.trade_capture->>'inputToken', 64)");
+    expect(sql).toContain("jsonb_typeof(ci.trade_capture->'outputToken')");
+    expect(sql).toContain("LEFT(ci.trade_capture->>'outputToken', 64)");
+    expect(sql).toContain("LEFT JOIN protocol_capture_items ci");
+    expect(sql).toContain("ci.id = a.capture_item_id");
+    expect(sql).toContain("ci.execution_id = a.execution_id");
     expect(sql).toContain("LIMIT 50");
   });
 });
@@ -207,7 +216,7 @@ describe("moves-db getMovesForSession — strict per-session attribution (JOIN)"
 
     const sql = String(mocks.query.mock.calls[0]?.[0] ?? "");
     expect(sql).toContain("JOIN protocol_executions");
-    expect(sql).not.toContain("LEFT JOIN");
+    expect(sql).not.toContain("LEFT JOIN protocol_executions");
     expect(sql).toContain("a.execution_id");
   });
 
@@ -252,8 +261,10 @@ describe("moves-db getMovesForSession — strict per-session attribution (JOIN)"
           product_type: "spot",
           venue: "uniswap",
           input_token: "USDC",
+          input_token_symbol: "USDC",
           input_amount: "50",
           output_token: "ETH",
+          output_token_symbol: "ETH",
           output_amount: "0.02",
           value_usd: "50",
           capture_status: "executed",
@@ -274,6 +285,8 @@ describe("moves-db getMovesForSession — strict per-session attribution (JOIN)"
     expect(result.data[0]?.txRef).toBe("0xfeed");
     expect(result.data[0]?.productType).toBe("spot");
     expect(result.data[0]?.venue).toBe("uniswap");
+    expect(result.data[0]?.inputTokenSymbol).toBe("USDC");
+    expect(result.data[0]?.outputTokenSymbol).toBe("ETH");
   });
 
   it("selects product_type and namespace-as-venue for the chip derivation", async () => {
@@ -287,6 +300,38 @@ describe("moves-db getMovesForSession — strict per-session attribution (JOIN)"
 });
 
 describe("moves-db getMovesForSession — tolerant mapping", () => {
+  it("trims valid capture symbols and drops symbols containing control characters", async () => {
+    mocks.getSessionWalletScope.mockResolvedValue(scopeOk(WALLET_A, null));
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 6,
+          trade_side: "buy",
+          product_type: "spot",
+          venue: "jupiter",
+          input_token: SOL_ADDR,
+          input_token_symbol: "  SOL  ",
+          input_amount: "100",
+          output_token: "7jk8UbH339rCgnohpBvqiss4a7bXWmicMPCUCFmDrmYK",
+          output_token_symbol: "BAD\nSYMBOL",
+          output_amount: "1",
+          value_usd: null,
+          capture_status: "executed",
+          instrument_key: null,
+          chain: "solana",
+          tx_ref: null,
+          created_at: "2026-05-21T10:00:00.000Z",
+        },
+      ],
+    });
+
+    const result = await getMovesForSession(SESSION);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data[0]?.inputTokenSymbol).toBe("SOL");
+    expect(result.data[0]?.outputTokenSymbol).toBeNull();
+  });
+
   it("maps a tolerant row (trade_side=null, capture_status='filled', value_usd=null)", async () => {
     mocks.getSessionWalletScope.mockResolvedValue(scopeOk(WALLET_A, null));
     mocks.query.mockResolvedValueOnce({
@@ -297,8 +342,10 @@ describe("moves-db getMovesForSession — tolerant mapping", () => {
           product_type: null,
           venue: null,
           input_token: "USDC",
+          input_token_symbol: null,
           input_amount: "100",
           output_token: "SOL",
+          output_token_symbol: null,
           output_amount: "1.2",
           value_usd: null,
           capture_status: "filled",
@@ -320,8 +367,10 @@ describe("moves-db getMovesForSession — tolerant mapping", () => {
         productType: null,
         venue: null,
         inputToken: "USDC",
+        inputTokenSymbol: null,
         inputAmount: "100",
         outputToken: "SOL",
+        outputTokenSymbol: null,
         outputAmount: "1.2",
         valueUsd: null,
         captureStatus: "filled",
@@ -343,8 +392,10 @@ describe("moves-db getMovesForSession — tolerant mapping", () => {
           product_type: "bridge",
           venue: "relay",
           input_token: "ETH",
+          input_token_symbol: "ETH",
           input_amount: "0.001714",
           output_token: "ETH",
+          output_token_symbol: "ETH",
           output_amount: "0.001693",
           value_usd: null,
           capture_status: "executed",
@@ -363,6 +414,7 @@ describe("moves-db getMovesForSession — tolerant mapping", () => {
     expect(row?.productType).toBe("bridge");
     expect(row?.venue).toBe("relay");
     expect(row?.inputToken).toBe("ETH");
+    expect(row?.inputTokenSymbol).toBe("ETH");
     expect(row?.inputAmount).toBe("0.001714");
     expect(row?.outputAmount).toBe("0.001693");
   });

--- a/vex-app/src/main/database/moves-db.ts
+++ b/vex-app/src/main/database/moves-db.ts
@@ -39,11 +39,11 @@
  *  - join key is the raw ADDRESS string — DO NOT lowercase (the engine stores
  *    raw checksum/base58 addresses).
  *  - The SELECT projects ONLY bounded, renderer-safe columns. It NEVER selects
- *    `params`, `result`, `trade_capture`, `meta`, or the raw `external_refs`
- *    JSONB. The single sanctioned extraction from `external_refs` is the
- *    on-chain tx reference scalar (`->>'txHash'` for EVM, `->>'signature'`
- *    for Solana) — public on-chain data powering the renderer's
- *    block-explorer deep links; never the whole blob.
+ *    `params`, `result`, `meta`, or any raw JSONB blob. The sanctioned scalar
+ *    extractions are the on-chain tx reference from `external_refs`, plus the
+ *    input/output token symbols from the activity row's exact capture item.
+ *    Symbol extraction is string-type checked and SQL-bounded to 64 chars;
+ *    neither raw `trade_capture` nor raw `external_refs` crosses IPC.
  *  - logging records sessionId + the row COUNT only; NEVER raw addresses,
  *    USD figures, token symbols, or tx hashes.
  */
@@ -52,6 +52,7 @@ import { Client, type ClientConfig } from "pg";
 import { err, ok, type Result, type VexError } from "@shared/ipc/result.js";
 import {
   MOVES_MAX,
+  MOVE_TOKEN_SYMBOL_MAX,
   type MovesDto,
 } from "@shared/schemas/portfolio-moves.js";
 import { getSessionWalletScope } from "./sessions-db.js";
@@ -132,8 +133,10 @@ interface MoveRow {
   readonly product_type: string | null;
   readonly venue: string | null;
   readonly input_token: string | null;
+  readonly input_token_symbol: string | null;
   readonly input_amount: string | null;
   readonly output_token: string | null;
+  readonly output_token_symbol: string | null;
   readonly output_amount: string | null;
   readonly value_usd: number | string | null;
   readonly capture_status: string | null;
@@ -154,6 +157,26 @@ function toNumberOrNull(value: number | string | null): number | null {
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
   const parsed = Number.parseFloat(value);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+const CONTROL_CHARACTER = /[\u0000-\u001F\u007F]/;
+
+/**
+ * Capture JSON is trusted only as stored audit data, never as a renderer DTO.
+ * Keep its display symbol a small scalar: trim whitespace, reject control
+ * characters, and enforce the same bound as the shared output schema.
+ */
+function toTokenSymbolOrNull(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const symbol = value.trim();
+  if (
+    symbol.length === 0 ||
+    symbol.length > MOVE_TOKEN_SYMBOL_MAX ||
+    CONTROL_CHARACTER.test(symbol)
+  ) {
+    return null;
+  }
+  return symbol;
 }
 
 /** TIMESTAMPTZ comes back as a Date (node-postgres) or string; normalise to ISO. */
@@ -220,8 +243,22 @@ export async function getMovesForSession(
                 a.product_type,
                 a.namespace AS venue,
                 a.input_token,
+                CASE
+                  WHEN jsonb_typeof(ci.trade_capture->'inputToken') = 'string'
+                   AND char_length(ci.trade_capture->>'inputToken')
+                       BETWEEN 1 AND ${MOVE_TOKEN_SYMBOL_MAX}
+                  THEN LEFT(ci.trade_capture->>'inputToken', ${MOVE_TOKEN_SYMBOL_MAX})
+                  ELSE NULL
+                END AS input_token_symbol,
                 a.input_amount,
                 a.output_token,
+                CASE
+                  WHEN jsonb_typeof(ci.trade_capture->'outputToken') = 'string'
+                   AND char_length(ci.trade_capture->>'outputToken')
+                       BETWEEN 1 AND ${MOVE_TOKEN_SYMBOL_MAX}
+                  THEN LEFT(ci.trade_capture->>'outputToken', ${MOVE_TOKEN_SYMBOL_MAX})
+                  ELSE NULL
+                END AS output_token_symbol,
                 a.output_amount,
                 a.value_usd,
                 a.capture_status,
@@ -232,6 +269,9 @@ export async function getMovesForSession(
                 a.created_at
            FROM proj_activity a
            JOIN protocol_executions e ON e.id = a.execution_id
+           LEFT JOIN protocol_capture_items ci
+             ON ci.id = a.capture_item_id
+            AND ci.execution_id = a.execution_id
           WHERE a.wallet_address = ANY($1::text[])
             AND e.session_id = $2
           ORDER BY a.created_at DESC, a.id DESC
@@ -245,8 +285,10 @@ export async function getMovesForSession(
         productType: row.product_type,
         venue: row.venue,
         inputToken: row.input_token,
+        inputTokenSymbol: toTokenSymbolOrNull(row.input_token_symbol),
         inputAmount: row.input_amount,
         outputToken: row.output_token,
+        outputTokenSymbol: toTokenSymbolOrNull(row.output_token_symbol),
         outputAmount: row.output_amount,
         valueUsd: toNumberOrNull(row.value_usd),
         captureStatus: row.capture_status,

--- a/vex-app/src/renderer/features/appShell/__tests__/MovesBlock.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MovesBlock.test.tsx
@@ -47,8 +47,10 @@ function move(overrides: Partial<MoveItem> & { readonly id: string }): MoveItem 
     productType: null,
     venue: null,
     inputToken: null,
+    inputTokenSymbol: null,
     inputAmount: null,
     outputToken: null,
+    outputTokenSymbol: null,
     outputAmount: null,
     valueUsd: null,
     captureStatus: "executed",
@@ -72,6 +74,30 @@ beforeEach(() => {
 });
 
 describe("MovesBlock ledger display", () => {
+  it("prefers captured token symbols while preserving mint addresses on tooltips", () => {
+    mockMoves([
+      move({
+        id: "1",
+        tradeSide: "buy",
+        inputToken: SOL_MINT,
+        inputTokenSymbol: "SOL",
+        outputToken: LONG_MINT,
+        outputTokenSymbol: "ansem",
+      }),
+    ]);
+    render(<MovesBlock sessionId={SESSION} />);
+
+    expect(screen.getByText("SOL").parentElement?.getAttribute("title")).toBe(
+      SOL_MINT,
+    );
+    expect(screen.getByText("ANSEM").parentElement?.getAttribute("title")).toBe(
+      LONG_MINT,
+    );
+    expect(screen.queryByText("7jk8Ub…rmYK")).toBeNull();
+    // Unknown symbols use the app's offline monogram instead of a remote image.
+    expect(screen.getByText("a").getAttribute("aria-hidden")).not.toBeNull();
+  });
+
   it("resolves known mints to tickers and truncates address-like mints", () => {
     mockMoves([
       move({
@@ -85,10 +111,10 @@ describe("MovesBlock ledger display", () => {
 
     // Known mint → ticker, full mint kept on the tooltip.
     const sol = screen.getByText("SOL");
-    expect(sol.getAttribute("title")).toBe(SOL_MINT);
+    expect(sol.parentElement?.getAttribute("title")).toBe(SOL_MINT);
     // Address-like → truncateAddress shape, full mint on the tooltip.
     const truncated = screen.getByText("7jk8Ub…rmYK");
-    expect(truncated.getAttribute("title")).toBe(LONG_MINT);
+    expect(truncated.parentElement?.getAttribute("title")).toBe(LONG_MINT);
     // The raw base58 run never prints in full.
     expect(screen.queryByText(LONG_MINT)).toBeNull();
   });

--- a/vex-app/src/renderer/features/appShell/book/MovesBlock.tsx
+++ b/vex-app/src/renderer/features/appShell/book/MovesBlock.tsx
@@ -14,10 +14,13 @@
  * status dot · stamp (mono 9px chip: BUY success-tone / SELL paper-tone /
  * SWAP muted; `productType` takes priority — `bridge` → BRIDGE·VENUE,
  * `send`/`transfer` → TRANSFER, both muted) · `IN → OUT` legs · HH:MM. Raw
- * mint addresses never print in full: address-like token strings truncate to
- * `So1111…1112` (full mint on the tooltip) and a deliberately tiny
- * well-known-mint map resolves the unmissable tickers. Short token strings
- * render as uppercase symbols. A leg carries its amount (`0.0017 ETH`) ONLY
+ * mint addresses never print in full: a bounded symbol from the activity's
+ * exact capture item takes priority, with the full mint retained on the
+ * tooltip; address-like fallbacks truncate to `So1111…1112`. A deliberately
+ * tiny well-known-mint map resolves unmissable legacy tickers, and short token
+ * strings render as uppercase symbols. Resolved symbols reuse the app's
+ * offline token mark (brand icon when bundled, otherwise a monogram). A leg
+ * carries its amount (`0.0017 ETH`) ONLY
  * when the recorded amount is a dotted decimal — raw base-unit integers from
  * legacy captures (wei/lamports) and nulls render nothing.
  *
@@ -37,6 +40,7 @@ import type { JSX } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ArrowUpRight01Icon } from "@hugeicons/core-free-icons";
 import type { MoveItem } from "@shared/schemas/portfolio-moves.js";
+import { TokenIcon } from "../../../components/common/TokenIcon.js";
 import { useMoves } from "../../../lib/api/portfolio.js";
 import { moveExplorerUrl } from "../../../lib/explorer-links.js";
 import { formatClock, truncateAddress } from "../../../lib/format.js";
@@ -102,23 +106,36 @@ interface TokenDisplay {
   readonly text: string;
   /** Full value for the tooltip when `text` is lossy, else `null`. */
   readonly full: string | null;
+  /** Safe symbol used by the app's offline token mark; null for raw addresses. */
+  readonly iconSymbol: string | null;
 }
 
 /**
- * Display rule for one swap leg: known mint → ticker, address-like → the
- * canonical `truncateAddress` shortening (`So1111…1112`), short strings →
- * uppercase symbols. Legs are nullable in the tolerant DTO → `?`.
- * Truncated/known forms carry the full mint on the tooltip; symbols are
+ * Display rule for one swap leg: captured symbol → uppercase label with the
+ * address retained on the tooltip; known mint → ticker; address-like → the
+ * canonical `truncateAddress` shortening (`So1111…1112`); short strings →
+ * uppercase symbols. Legs are nullable in the tolerant DTO → `?`. Symbols are
  * uppercased in JS (not CSS) so base58 case in truncations stays intact.
  */
-function tokenDisplay(token: string | null): TokenDisplay {
-  if (token === null || token.length === 0) return { text: "?", full: null };
-  const ticker = KNOWN_MINTS.get(token);
-  if (ticker !== undefined) return { text: ticker, full: token };
-  if (ADDRESS_LIKE.test(token)) {
-    return { text: truncateAddress(token), full: token };
+function tokenDisplay(token: string | null, symbol: string | null): TokenDisplay {
+  if (symbol !== null && symbol.length > 0) {
+    return {
+      text: symbol.toUpperCase(),
+      full: token !== null && token !== symbol ? token : null,
+      iconSymbol: symbol,
+    };
   }
-  return { text: token.toUpperCase(), full: null };
+  if (token === null || token.length === 0) {
+    return { text: "?", full: null, iconSymbol: null };
+  }
+  const ticker = KNOWN_MINTS.get(token);
+  if (ticker !== undefined) {
+    return { text: ticker, full: token, iconSymbol: ticker };
+  }
+  if (ADDRESS_LIKE.test(token)) {
+    return { text: truncateAddress(token), full: token, iconSymbol: null };
+  }
+  return { text: token.toUpperCase(), full: null, iconSymbol: token };
 }
 
 /** ≤6 significant digits, no grouping — mono-ledger compact figures. */
@@ -242,8 +259,8 @@ export function MovesBlock({ sessionId }: { readonly sessionId: string }): JSX.E
 function MoveRow({ move }: { readonly move: MoveItem }): JSX.Element {
   const state = moveState(move.captureStatus);
   const side = sideStamp(move);
-  const input = tokenDisplay(move.inputToken);
-  const output = tokenDisplay(move.outputToken);
+  const input = tokenDisplay(move.inputToken, move.inputTokenSymbol);
+  const output = tokenDisplay(move.outputToken, move.outputTokenSymbol);
   const inputAmount = amountDisplay(move.inputAmount);
   const outputAmount = amountDisplay(move.outputAmount);
   const time = formatClock(move.createdAt);
@@ -272,12 +289,28 @@ function MoveRow({ move }: { readonly move: MoveItem }): JSX.Element {
         {side.text}
       </span>
       <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-[var(--vex-text-2)] transition-colors group-hover:text-[var(--vex-text)]">
-        <span title={input.full ?? undefined}>
-          {inputAmount !== null ? `${inputAmount} ${input.text}` : input.text}
+        <span
+          title={input.full ?? undefined}
+          className="inline-flex items-center gap-1"
+        >
+          {input.iconSymbol !== null ? (
+            <TokenIcon symbol={input.iconSymbol} size={12} />
+          ) : null}
+          <span>
+            {inputAmount !== null ? `${inputAmount} ${input.text}` : input.text}
+          </span>
         </span>
         <span className="text-[var(--vex-text-3)]">{" → "}</span>
-        <span title={output.full ?? undefined}>
-          {outputAmount !== null ? `${outputAmount} ${output.text}` : output.text}
+        <span
+          title={output.full ?? undefined}
+          className="inline-flex items-center gap-1"
+        >
+          {output.iconSymbol !== null ? (
+            <TokenIcon symbol={output.iconSymbol} size={12} />
+          ) : null}
+          <span>
+            {outputAmount !== null ? `${outputAmount} ${output.text}` : output.text}
+          </span>
         </span>
       </span>
       {time !== null ? (

--- a/vex-app/src/renderer/features/appShell/book/MovesBlock.tsx
+++ b/vex-app/src/renderer/features/appShell/book/MovesBlock.tsx
@@ -288,27 +288,27 @@ function MoveRow({ move }: { readonly move: MoveItem }): JSX.Element {
       >
         {side.text}
       </span>
-      <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-[var(--vex-text-2)] transition-colors group-hover:text-[var(--vex-text)]">
+      <span className="flex h-4 min-w-0 flex-1 items-center gap-1.5 overflow-hidden whitespace-nowrap font-mono text-[11px] leading-none text-[var(--vex-text-2)] transition-colors group-hover:text-[var(--vex-text)]">
         <span
           title={input.full ?? undefined}
-          className="inline-flex items-center gap-1"
+          className="inline-flex min-w-0 items-center gap-1"
         >
           {input.iconSymbol !== null ? (
             <TokenIcon symbol={input.iconSymbol} size={12} />
           ) : null}
-          <span>
+          <span className="truncate">
             {inputAmount !== null ? `${inputAmount} ${input.text}` : input.text}
           </span>
         </span>
-        <span className="text-[var(--vex-text-3)]">{" → "}</span>
+        <span className="shrink-0 text-[var(--vex-text-3)]">→</span>
         <span
           title={output.full ?? undefined}
-          className="inline-flex items-center gap-1"
+          className="inline-flex min-w-0 items-center gap-1"
         >
           {output.iconSymbol !== null ? (
             <TokenIcon symbol={output.iconSymbol} size={12} />
           ) : null}
-          <span>
+          <span className="truncate">
             {outputAmount !== null ? `${outputAmount} ${output.text}` : output.text}
           </span>
         </span>

--- a/vex-app/src/shared/schemas/__tests__/portfolio-moves.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/portfolio-moves.test.ts
@@ -41,8 +41,10 @@ describe("move item schema (tolerant)", () => {
       productType: "spot",
       venue: "kyberswap",
       inputToken: "USDC",
+      inputTokenSymbol: "USDC",
       inputAmount: "100",
       outputToken: "ETH",
+      outputTokenSymbol: "ETH",
       outputAmount: "0.03",
       valueUsd: 100,
       captureStatus: "executed",
@@ -105,8 +107,10 @@ describe("move item schema (tolerant)", () => {
           productType: null,
           venue: null,
           inputToken: null,
+          inputTokenSymbol: null,
           inputAmount: null,
           outputToken: null,
+          outputTokenSymbol: null,
           outputAmount: null,
           valueUsd: null,
           captureStatus: null,
@@ -120,6 +124,18 @@ describe("move item schema (tolerant)", () => {
     expect(
       moveItemSchema.safeParse(itemFixture({ txRef: null })).success,
     ).toBe(true);
+  });
+
+  it("accepts absent token symbols as null and bounds present symbols", () => {
+    expect(
+      moveItemSchema.safeParse(
+        itemFixture({ inputTokenSymbol: null, outputTokenSymbol: null }),
+      ).success,
+    ).toBe(true);
+    expect(
+      moveItemSchema.safeParse(itemFixture({ outputTokenSymbol: "x".repeat(65) }))
+        .success,
+    ).toBe(false);
   });
 
   it("rejects a missing chain (NOT NULL in the DDL)", () => {
@@ -147,8 +163,10 @@ describe("moves dto schema (array + cap)", () => {
     productType: null,
     venue: null,
     inputToken: "USDC",
+    inputTokenSymbol: null,
     inputAmount: "1",
     outputToken: "SOL",
+    outputTokenSymbol: null,
     outputAmount: "1",
     valueUsd: null,
     captureStatus: "filled",

--- a/vex-app/src/shared/schemas/portfolio-moves.ts
+++ b/vex-app/src/shared/schemas/portfolio-moves.ts
@@ -35,6 +35,9 @@ import { z } from "zod";
  */
 export const MOVES_MAX = 50;
 
+/** Maximum display-symbol length extracted from a capture item. */
+export const MOVE_TOKEN_SYMBOL_MAX = 64;
+
 /**
  * IPC input for `vex.portfolio.listMoves`. `.strict()` rejects any extra key;
  * `sessionId` MUST be a UUID. The renderer never supplies a wallet address —
@@ -62,7 +65,12 @@ export type MovesReadInput = z.infer<typeof movesReadInputSchema>;
  *                      distinguishes bridge venues in the chip. Nullable for
  *                      tolerance even though the DDL is NOT NULL.
  *  - `inputToken` / `inputAmount` / `outputToken` / `outputAmount` — the swap
- *                      legs as the engine recorded them (all nullable).
+ *                      legs as the activity projection recorded them (all
+ *                      nullable; spot token values are address-first).
+ *  - `inputTokenSymbol` / `outputTokenSymbol` — bounded, display-only symbols
+ *                      recovered from the activity row's exact capture item;
+ *                      nullable for historical/incomplete captures. These do
+ *                      not replace the address-first projection fields.
  *  - `valueUsd`      — notional USD; `null` when the engine could not price it.
  *  - `captureStatus` — the trade-capture lifecycle status string (tolerant).
  *  - `instrumentKey` — opaque instrument identifier; `null` when absent.
@@ -84,8 +92,10 @@ export const moveItemSchema = z
     productType: z.string().nullable(),
     venue: z.string().nullable(),
     inputToken: z.string().nullable(),
+    inputTokenSymbol: z.string().min(1).max(MOVE_TOKEN_SYMBOL_MAX).nullable(),
     inputAmount: z.string().nullable(),
     outputToken: z.string().nullable(),
+    outputTokenSymbol: z.string().min(1).max(MOVE_TOKEN_SYMBOL_MAX).nullable(),
     outputAmount: z.string().nullable(),
     valueUsd: z.number().nullable(),
     captureStatus: z.string().nullable(),


### PR DESCRIPTION
## Problem solved

Allow users to identify the tokens in the **Moves** feed rather than recognizing a truncated mint address copied from the address-first portfolio projection.

Previously, a Jupiter purchase could render as `SOL → 9cRCn9…pump` even though the successful swap capture already recorded the human-readable token symbol. The activity projection correctly retained mint addresses for portfolio discovery and accounting, but the renderer had no separate display label and therefore treated every unfamiliar mint as an address.

## What changed

### Human-readable move legs

- Shows the symbol recorded by the exact trade capture, such as `SOL → ANSEM`, ahead of the address fallback.
- Keeps the full mint address available on hover so the readable label never replaces the trustworthy on-chain identifier.
- Preserves the existing truncated-address display for historical or incomplete activity without a captured symbol.
- Applies the same behavior independently to both input and output legs.

### Existing offline token marks reused

- Reuses the app's existing `TokenIcon` primitive beside resolved symbols.
- Shows a bundled brand mark for supported assets such as SOL and a restrained mono monogram for other tokens such as ANSEM.
- Makes no renderer-side image or metadata request, so opening the Moves panel stays immediate and deterministic.

### Exact capture-item enrichment

- Resolves display symbols from each activity row's `capture_item_id`, including the correct item inside batch executions.
- Keeps the address-first `proj_activity.input_token` and `output_token` fields unchanged for portfolio tracking and cost-basis behavior.
- Adds only two nullable, display-only symbol fields to the bounded Moves DTO.
- Requires both the capture-item id and execution id to match before enrichment.

### Bounded and fail-safe data handling

- Extracts only string-valued symbol scalars from capture JSON; raw `trade_capture`, execution results, and metadata never cross IPC.
- Bounds symbols to 64 characters, trims harmless surrounding whitespace, and drops blank or control-character-containing values.
- Leaves session attribution, wallet scoping, transaction links, row limits, and error behavior unchanged.

### Remote logos intentionally remain separate

- The renderer CSP deliberately blocks third-party images to prevent image-request exfiltration.
- This PR therefore uses deterministic offline marks and does not weaken `img-src` or add Jupiter / DexScreener calls to a frequently rendered ledger.
- Provider-hosted token logos can be considered later behind a trusted same-origin proxy/cache and dedicated security review.

## User impact

Operators can understand what the agent bought or sold at a glance. A move now reads like `BUY · SOL → ANSEM` while retaining the exact mint for verification and gracefully degrading to the existing address representation when metadata is unavailable.

## Current friction

![Moves previously displayed an unfamiliar truncated mint address](https://raw.githubusercontent.com/alexastro01/Vex/5229be814a6e3ac6299e9a64f15df335498ddc95/.github/pr-assets/moves-token-metadata-before.png)

## Test coverage

Added focused coverage for:

- Preferring captured symbols over truncated mint addresses.
- Preserving full mint addresses on tooltips.
- Bundled token marks and offline monogram fallback.
- Exact capture-item and execution correlation.
- String-only, length-bounded symbol extraction.
- Whitespace normalization and control-character rejection.
- Nullable symbol tolerance for historical activity.
- Existing known-mint and truncated-address fallbacks.

## Validation

- `pnpm test` in `vex-app` under Node 24 (compatible with the required Node 22+ runtime): **2,554 / 2,554 tests passed** across 294 files.
- Focused Moves data-contract, database, and renderer suites: **49 / 49 tests passed**.
- `pnpm run lint`: passed, including the type ratchet and process-boundary checks.
- `pnpm run build` in `vex-app`: passed for main, preload, and renderer bundles plus artifact/CSP checks.
- React Doctor: **100 / 100**, with no issues found in the changed React code.
