### PR TITLE
feat(sessions): export session transcript as markdown

### DIFF
--- a/vex-app/src/main/database/__tests__/session-export-history.test.ts
+++ b/vex-app/src/main/database/__tests__/session-export-history.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  connect: vi.fn(),
+  end: vi.fn(),
+  buildPoolConfig: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("pg", () => ({
+  Client: function MockClient() {
+    return { query: mocks.query, connect: mocks.connect, end: mocks.end };
+  },
+}));
+vi.mock("../db-config.js", () => ({ buildPoolConfig: mocks.buildPoolConfig }));
+vi.mock("../../logger/index.js", () => ({
+  log: { warn: mocks.warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { getSessionExportMessages } = await import(
+  "../sessions/export-history.js"
+);
+
+const SESSION = "00000000-0000-4000-8000-0000000000e1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.buildPoolConfig.mockResolvedValue({
+    host: "127.0.0.1",
+    port: 5777,
+    database: "vex",
+    user: "vex",
+    password: "secret",
+  });
+  mocks.connect.mockResolvedValue(undefined);
+  mocks.end.mockResolvedValue(undefined);
+});
+
+describe("session export history", () => {
+  it("reads archive first, suppresses duplicate live ids, and orders chronologically", async () => {
+    mocks.query.mockResolvedValue({
+      rows: [
+        {
+          id: 8,
+          session_id: SESSION,
+          role: "user",
+          content: "archived original",
+          tool_call_id: null,
+          tool_calls: null,
+          created_at: "2026-07-12T10:00:00.000Z",
+          source: "user",
+          message_type: "chat",
+        },
+        {
+          id: 9,
+          session_id: SESSION,
+          role: "assistant",
+          content: "live answer",
+          tool_call_id: null,
+          tool_calls: null,
+          created_at: "2026-07-12T10:01:00.000Z",
+          source: "agent",
+          message_type: "chat",
+        },
+      ],
+    });
+
+    const result = await getSessionExportMessages(SESSION);
+    expect(result).toEqual({
+      ok: true,
+      data: expect.arrayContaining([
+        expect.objectContaining({ id: 8, content: "archived original" }),
+        expect.objectContaining({ id: 9, content: "live answer" }),
+      ]),
+    });
+    const [sql, params] = mocks.query.mock.calls[0]!;
+    expect(sql).toContain("FROM messages_archive");
+    expect(sql).toContain("NOT EXISTS");
+    expect(sql).toContain("a.id = m.id");
+    expect(sql).toContain("ORDER BY created_at ASC, id ASC");
+    expect(params).toEqual([SESSION]);
+  });
+});

--- a/vex-app/src/main/database/__tests__/sessions-db-surface.test.ts
+++ b/vex-app/src/main/database/__tests__/sessions-db-surface.test.ts
@@ -32,6 +32,7 @@ const EXPECTED_FUNCTION_EXPORTS = [
   "setInitialMissionGoalIfUnset",
   "getSessionById",
   "listSessions",
+  "getSessionExportMessages",
   "softDeleteSessionWithClient",
   "softDeleteSession",
   "setSessionPinnedWithClient",

--- a/vex-app/src/main/database/sessions-db.ts
+++ b/vex-app/src/main/database/sessions-db.ts
@@ -38,5 +38,6 @@ export {
 } from "./sessions/wallet-scope.js";
 export { setInitialMissionGoalIfUnset } from "./sessions/mission-goal.js";
 export { getSessionById, listSessions } from "./sessions/read.js";
+export { getSessionExportMessages } from "./sessions/export-history.js";
 export { softDeleteSessionWithClient, softDeleteSession } from "./sessions/delete.js";
 export { setSessionPinnedWithClient, setSessionPinned } from "./sessions/pin.js";

--- a/vex-app/src/main/database/sessions/export-history.ts
+++ b/vex-app/src/main/database/sessions/export-history.ts
@@ -1,0 +1,41 @@
+/** Canonical archive + live transcript read for Markdown export. */
+
+import { ok, type Result, type VexError } from "@shared/ipc/result.js";
+import type { SessionMessageDto } from "@shared/schemas/messages.js";
+import {
+  MESSAGE_ROW_COLUMNS,
+  toDto,
+  type MessageRow,
+} from "../messages/mappers.js";
+import { withClient, dbError } from "./connection.js";
+
+/**
+ * Return the complete transcript in chronological order. When compaction has
+ * copied a message into `messages_archive`, the archived original wins over
+ * the live placeholder with the same id.
+ */
+export async function getSessionExportMessages(
+  sessionId: string,
+): Promise<Result<readonly SessionMessageDto[], VexError>> {
+  return withClient(async (client) => {
+    try {
+      const result = await client.query<MessageRow>(
+        `SELECT ${MESSAGE_ROW_COLUMNS}
+           FROM messages_archive
+          WHERE session_id = $1
+         UNION ALL
+         SELECT ${MESSAGE_ROW_COLUMNS}
+           FROM messages m
+          WHERE m.session_id = $1
+            AND NOT EXISTS (
+              SELECT 1 FROM messages_archive a WHERE a.id = m.id
+            )
+         ORDER BY created_at ASC, id ASC`,
+        [sessionId],
+      );
+      return ok(result.rows.map(toDto));
+    } catch (cause) {
+      return dbError("getSessionExportMessages failed", cause);
+    }
+  });
+}

--- a/vex-app/src/main/ipc/__tests__/sessions-export-markdown.test.ts
+++ b/vex-app/src/main/ipc/__tests__/sessions-export-markdown.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createTestWebContents,
+  createTrustedSender,
+  type TestIpcEvent,
+} from "./test-sender.js";
+
+type Handler = (event: TestIpcEvent, raw: unknown) => Promise<unknown>;
+const handlers = vi.hoisted(() => new Map<string, Handler>());
+const mocks = vi.hoisted(() => ({
+  showSaveDialog: vi.fn(),
+  getSessionById: vi.fn(),
+  getSessionExportMessages: vi.fn(),
+  writeMarkdownAtomically: vi.fn(),
+  renderSessionMarkdown: vi.fn(() => "# transcript"),
+  defaultFilename: vi.fn(() => "Research-2026-07-12.md"),
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("electron", () => ({
+  app: { isPackaged: true },
+  ipcMain: {
+    handle: (channel: string, handler: Handler) => handlers.set(channel, handler),
+    removeHandler: (channel: string) => handlers.delete(channel),
+  },
+  BrowserWindow: { fromWebContents: vi.fn(() => undefined) },
+  dialog: { showSaveDialog: mocks.showSaveDialog },
+}));
+vi.mock("../../database/sessions-db.js", () => ({
+  getSessionById: mocks.getSessionById,
+  getSessionExportMessages: mocks.getSessionExportMessages,
+}));
+vi.mock("../../sessions/markdown-export.js", () => ({
+  writeMarkdownAtomically: mocks.writeMarkdownAtomically,
+  renderSessionMarkdown: mocks.renderSessionMarkdown,
+  defaultSessionMarkdownFilename: mocks.defaultFilename,
+}));
+vi.mock("../../logger/index.js", () => ({ log: mocks.log }));
+
+const { CH } = await import("@shared/ipc/channels.js");
+const { registerSessionsExportMarkdownHandler } = await import(
+  "../sessions/export-markdown.js"
+);
+
+const SESSION_ID = "00000000-0000-4000-8000-0000000000e1";
+const session = {
+  id: SESSION_ID,
+  mode: "agent",
+  permission: "restricted",
+  title: "Research",
+  initialGoal: null,
+  startedAt: "2026-07-12T10:00:00.000Z",
+  endedAt: null,
+  missionStatus: null,
+  pinnedAt: null,
+};
+const sender = createTrustedSender({ sender: createTestWebContents() });
+
+async function invoke(payload: unknown): Promise<any> {
+  const handler = handlers.get(CH.sessions.exportMarkdown)!;
+  return handler(sender, { requestId: "export-test", payload });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  handlers.clear();
+  registerSessionsExportMarkdownHandler();
+  mocks.getSessionById.mockResolvedValue({ ok: true, data: session });
+  mocks.getSessionExportMessages.mockResolvedValue({ ok: true, data: [] });
+  mocks.writeMarkdownAtomically.mockResolvedValue(undefined);
+});
+
+describe("sessions.exportMarkdown IPC", () => {
+  it("returns cancelled without reading history or writing a file", async () => {
+    mocks.showSaveDialog.mockResolvedValue({ canceled: true, filePath: undefined });
+
+    await expect(invoke({ id: SESSION_ID })).resolves.toEqual({
+      ok: true,
+      data: { outcome: "cancelled" },
+    });
+    expect(mocks.getSessionExportMessages).not.toHaveBeenCalled();
+    expect(mocks.writeMarkdownAtomically).not.toHaveBeenCalled();
+  });
+
+  it("writes the selected file but never returns its path", async () => {
+    mocks.showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: "/private/transcript.md",
+    });
+
+    const result = await invoke({ id: SESSION_ID });
+    expect(result).toEqual({ ok: true, data: { outcome: "saved" } });
+    expect(JSON.stringify(result)).not.toContain("/private/transcript.md");
+    expect(mocks.writeMarkdownAtomically).toHaveBeenCalledWith(
+      "/private/transcript.md",
+      "# transcript",
+    );
+  });
+
+  it("rejects malformed renderer input before opening the dialog", async () => {
+    const result = await invoke({ id: "not-a-uuid" });
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("validation.invalid_input");
+    expect(mocks.showSaveDialog).not.toHaveBeenCalled();
+  });
+
+  it("returns a safe error when the atomic write fails", async () => {
+    mocks.showSaveDialog.mockResolvedValue({
+      canceled: false,
+      filePath: "/private/transcript.md",
+    });
+    mocks.writeMarkdownAtomically.mockRejectedValue(
+      new Error("EACCES /private/transcript.md"),
+    );
+
+    const result = await invoke({ id: SESSION_ID });
+    expect(result.ok).toBe(false);
+    expect(result.error.message).toBe("Unable to save the session transcript.");
+    expect(JSON.stringify(result)).not.toContain("/private/transcript.md");
+    expect(mocks.log.warn).toHaveBeenCalledWith(
+      expect.not.stringContaining("/private/transcript.md"),
+    );
+  });
+});

--- a/vex-app/src/main/ipc/register-all.ts
+++ b/vex-app/src/main/ipc/register-all.ts
@@ -35,6 +35,7 @@ import { registerWalletHandlers } from "./onboarding/wallets.js";
 import { registerRuntimeHandlers } from "./runtime.js";
 import { registerSessionsCreateHandler } from "./sessions/create.js";
 import { registerSessionsDeleteHandler } from "./sessions/delete.js";
+import { registerSessionsExportMarkdownHandler } from "./sessions/export-markdown.js";
 import { registerSessionsGetHandler } from "./sessions/get.js";
 import { registerSessionsGetModelHandler } from "./sessions/get-model.js";
 import { registerSessionsListHandler } from "./sessions/list.js";
@@ -75,6 +76,7 @@ export function registerAllIpcHandlers(): void {
   teardowns.push(registerSessionsGetHandler());
   teardowns.push(registerSessionsSetPinnedHandler());
   teardowns.push(registerSessionsDeleteHandler());
+  teardowns.push(registerSessionsExportMarkdownHandler());
   teardowns.push(...registerSessionPlanHandlers());
   // Agent integration puzzle 1: typed bridge surface for the chat panel,
   // runtime control, mission contract/commands, approvals, wallet scope,

--- a/vex-app/src/main/ipc/sessions/export-markdown.ts
+++ b/vex-app/src/main/ipc/sessions/export-markdown.ts
@@ -1,0 +1,88 @@
+/** vex.sessions.exportMarkdown — native, path-private transcript export. */
+
+import { BrowserWindow, dialog, type SaveDialogOptions } from "electron";
+import { CH } from "@shared/ipc/channels.js";
+import { err, ok, type Result } from "@shared/ipc/result.js";
+import {
+  sessionExportMarkdownInputSchema,
+  sessionExportMarkdownResultSchema,
+  type SessionExportMarkdownResult,
+} from "@shared/schemas/sessions.js";
+import {
+  getSessionById,
+  getSessionExportMessages,
+} from "../../database/sessions-db.js";
+import { log } from "../../logger/index.js";
+import {
+  defaultSessionMarkdownFilename,
+  renderSessionMarkdown,
+  writeMarkdownAtomically,
+} from "../../sessions/markdown-export.js";
+import { registerHandler } from "../register-handler.js";
+
+export function registerSessionsExportMarkdownHandler(): () => void {
+  return registerHandler({
+    channel: CH.sessions.exportMarkdown,
+    domain: "sessions",
+    inputSchema: sessionExportMarkdownInputSchema,
+    outputSchema: sessionExportMarkdownResultSchema,
+    handle: async (input, ctx): Promise<Result<SessionExportMarkdownResult>> => {
+      const sessionResult = await getSessionById(input.id);
+      if (!sessionResult.ok) return sessionResult;
+      if (sessionResult.data === null) {
+        return err({
+          code: "internal.unexpected",
+          domain: "sessions",
+          message: "Session not found.",
+          retryable: false,
+          userActionable: true,
+          redacted: true,
+          correlationId: ctx.requestId,
+        });
+      }
+
+      const session = sessionResult.data;
+      const parentWindow = BrowserWindow.fromWebContents(ctx.event.sender);
+      const saveOptions: SaveDialogOptions = {
+        title: "Export session as Markdown",
+        defaultPath: defaultSessionMarkdownFilename(
+          session.title ?? session.initialGoal,
+          session.startedAt,
+        ),
+        filters: [{ name: "Markdown", extensions: ["md"] }],
+        properties: ["showOverwriteConfirmation", "createDirectory"],
+      };
+      const dialogResult = parentWindow
+        ? await dialog.showSaveDialog(parentWindow, saveOptions)
+        : await dialog.showSaveDialog(saveOptions);
+      if (dialogResult.canceled || !dialogResult.filePath) {
+        return ok({ outcome: "cancelled" });
+      }
+
+      const messagesResult = await getSessionExportMessages(input.id);
+      if (!messagesResult.ok) return messagesResult;
+      try {
+        const markdown = renderSessionMarkdown(session, messagesResult.data);
+        await writeMarkdownAtomically(dialogResult.filePath, markdown);
+        log.info(
+          `[ipc:vex:sessions:exportMarkdown] saved messages=${messagesResult.data.length} correlationId=${ctx.requestId}`,
+        );
+        return ok({ outcome: "saved" });
+      } catch (cause) {
+        const causeType = cause instanceof Error ? cause.name : typeof cause;
+        log.warn(
+          `[ipc:vex:sessions:exportMarkdown] write failed causeType=${causeType} correlationId=${ctx.requestId}`,
+        );
+        return err({
+          code: "internal.unexpected",
+          domain: "sessions",
+          message: "Unable to save the session transcript.",
+          retryable: true,
+          userActionable: true,
+          redacted: true,
+          correlationId: ctx.requestId,
+        });
+      }
+    },
+  });
+}

--- a/vex-app/src/main/sessions/__tests__/markdown-export.test.ts
+++ b/vex-app/src/main/sessions/__tests__/markdown-export.test.ts
@@ -1,0 +1,127 @@
+import { mkdtemp, mkdir, readFile, readdir, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SessionMessageDto } from "@shared/schemas/messages.js";
+import type { SessionListItem } from "@shared/schemas/sessions.js";
+import {
+  defaultSessionMarkdownFilename,
+  renderSessionMarkdown,
+  writeMarkdownAtomically,
+} from "../markdown-export.js";
+
+const dirs: string[] = [];
+const SESSION: SessionListItem = {
+  id: "00000000-0000-4000-8000-0000000000e1",
+  mode: "agent",
+  permission: "restricted",
+  title: "Research / ANSEM",
+  initialGoal: null,
+  startedAt: "2026-07-12T10:00:00.000Z",
+  endedAt: null,
+  missionStatus: null,
+  pinnedAt: null,
+};
+
+function message(
+  overrides: Partial<SessionMessageDto> & Pick<SessionMessageDto, "id" | "role">,
+): SessionMessageDto {
+  return {
+    sessionId: SESSION.id,
+    kind: "text",
+    content: "",
+    createdAt: `2026-07-12T10:0${overrides.id}:00.000Z`,
+    toolCallId: null,
+    toolName: null,
+    toolCalls: null,
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    dirs.splice(0).map(async (dir) => {
+      const { rm } = await import("node:fs/promises");
+      await rm(dir, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("session Markdown export", () => {
+  it("renders readable prose and concise tool names in chronological input order", () => {
+    const markdown = renderSessionMarkdown(SESSION, [
+      message({ id: 1, role: "user", content: "Buy ANSEM." }),
+      message({
+        id: 2,
+        role: "assistant",
+        kind: "tool_call",
+        content: "I’ll verify it first.",
+        toolName: "token_find",
+        toolCalls: [
+          { toolCallId: "private-id", toolName: "token_find", toolArgs: '{"mint":"secret"}' },
+        ],
+      }),
+      message({ id: 3, role: "assistant", content: "Token confirmed." }),
+    ]);
+
+    expect(markdown).toContain("# Research / ANSEM");
+    expect(markdown).toContain("- Mode: Agent");
+    expect(markdown.indexOf("Buy ANSEM.")).toBeLessThan(
+      markdown.indexOf("I’ll verify it first."),
+    );
+    expect(markdown).toContain("> Tool: `token_find`");
+    expect(markdown).not.toContain("private-id");
+    expect(markdown).not.toContain("mint");
+  });
+
+  it("omits system, runtime, compaction, and raw tool-result rows and redacts secrets in prose", () => {
+    const apiKey = `sk-or-v1-${"a".repeat(32)}`;
+    const markdown = renderSessionMarkdown(SESSION, [
+      message({ id: 1, role: "system", content: "hidden system prompt" }),
+      message({ id: 2, role: "assistant", kind: "runtime_notice", content: "runtime noise" }),
+      message({ id: 3, role: "assistant", kind: "compaction", content: "compacted" }),
+      message({ id: 4, role: "tool", kind: "tool_result", content: "raw result" }),
+      message({ id: 5, role: "user", content: `Use ${apiKey}` }),
+    ]);
+
+    expect(markdown).not.toContain("hidden system prompt");
+    expect(markdown).not.toContain("runtime noise");
+    expect(markdown).not.toContain("compacted");
+    expect(markdown).not.toContain("raw result");
+    expect(markdown).not.toContain(apiKey);
+    expect(markdown).toContain("[redacted]");
+  });
+
+  it("sanitizes the default filename and appends the session date", () => {
+    expect(
+      defaultSessionMarkdownFilename('  Research: <ANSEM> / "swap".  ', SESSION.startedAt),
+    ).toBe("Research ANSEM swap-2026-07-12.md");
+    expect(
+      defaultSessionMarkdownFilename(
+        `key sk-or-v1-${"a".repeat(32)}`,
+        SESSION.startedAt,
+      ),
+    ).toBe("key [redacted]-2026-07-12.md");
+  });
+
+  it("writes a private temporary file and atomically renames it", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "vex-md-export-"));
+    dirs.push(dir);
+    const destination = path.join(dir, "session.md");
+    await writeMarkdownAtomically(destination, "# Session\n");
+
+    expect(await readFile(destination, "utf8")).toBe("# Session\n");
+    expect((await stat(destination)).mode & 0o777).toBe(0o600);
+    expect(await readdir(dir)).toEqual(["session.md"]);
+  });
+
+  it("cleans the temporary file when the final rename fails", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "vex-md-export-"));
+    dirs.push(dir);
+    const destination = path.join(dir, "occupied");
+    await mkdir(destination);
+
+    await expect(writeMarkdownAtomically(destination, "secret transcript")).rejects.toThrow();
+    expect(await readdir(dir)).toEqual(["occupied"]);
+  });
+});

--- a/vex-app/src/main/sessions/markdown-export.ts
+++ b/vex-app/src/main/sessions/markdown-export.ts
@@ -1,0 +1,116 @@
+/** Readable, privacy-preserving session Markdown export. */
+
+import { randomBytes } from "node:crypto";
+import { open, rename, unlink } from "node:fs/promises";
+import path from "node:path";
+import type { SessionMessageDto } from "@shared/schemas/messages.js";
+import type { SessionListItem } from "@shared/schemas/sessions.js";
+
+const REDACTED = "[redacted]";
+
+function redactSecrets(text: string): string {
+  return text
+    .replace(/\bsk-(?:or-v1-)?[A-Za-z0-9_-]{16,}\b/g, REDACTED)
+    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, REDACTED)
+    .replace(/\b0x[a-fA-F0-9]{64}\b/g, REDACTED)
+    .replace(/\b[A-Za-z0-9+/]{86}={0,2}\b/g, REDACTED)
+    .replace(/\b[1-9A-HJ-NP-Za-km-z]{50,}\b/g, REDACTED)
+    .replace(/\b(?:[a-z]+\s+){11,23}[a-z]+\b/g, REDACTED);
+}
+
+function safeToolName(name: string): string {
+  return name.replace(/[\r\n`]/g, "").trim().slice(0, 120) || "tool";
+}
+
+function entryFor(message: SessionMessageDto): string | null {
+  if (message.role !== "user" && message.role !== "assistant") return null;
+  if (
+    message.kind === "runtime_notice" ||
+    message.kind === "compaction" ||
+    message.kind === "error" ||
+    message.kind === "tool_result"
+  ) {
+    return null;
+  }
+
+  const prose = redactSecrets(message.content.trim());
+  const toolNames = (message.toolCalls ?? [])
+    .map((call) => safeToolName(call.toolName))
+    .filter((name, index, names) => names.indexOf(name) === index);
+  if (toolNames.length === 0 && message.toolName !== null) {
+    toolNames.push(safeToolName(message.toolName));
+  }
+  if (prose.length === 0 && toolNames.length === 0) return null;
+
+  const speaker = message.role === "user" ? "You" : "Vex";
+  const parts = [`## ${speaker} — ${message.createdAt}`];
+  if (prose.length > 0) parts.push(prose);
+  if (toolNames.length > 0) {
+    parts.push(toolNames.map((name) => `> Tool: \`${name}\``).join("\n"));
+  }
+  return parts.join("\n\n");
+}
+
+export function renderSessionMarkdown(
+  session: SessionListItem,
+  messages: readonly SessionMessageDto[],
+): string {
+  const title = session.title?.trim() || session.initialGoal?.trim() || "Vex session";
+  const entries: string[] = [];
+  for (const message of messages) {
+    const entry = entryFor(message);
+    if (entry !== null) entries.push(entry);
+  }
+  const mode = session.mode === "mission" ? "Mission" : "Agent";
+  return [
+    `# ${redactSecrets(title)}`,
+    `- Mode: ${mode}`,
+    `- Started: ${session.startedAt}`,
+    ...entries,
+    "",
+  ].join("\n\n");
+}
+
+export function defaultSessionMarkdownFilename(
+  title: string | null,
+  startedAt: string,
+): string {
+  const safeTitle = redactSecrets(title ?? "vex-session")
+    .normalize("NFKC")
+    .replace(/[<>:"/\\|?*\u0000-\u001F]/g, " ")
+    .replace(/\s+/g, " ")
+    .replace(/[ .]+$/g, "")
+    .trim()
+    .slice(0, 80)
+    .replace(/[ .]+$/g, "") || "vex-session";
+  const parsed = new Date(startedAt);
+  const date = Number.isNaN(parsed.getTime())
+    ? new Date().toISOString().slice(0, 10)
+    : parsed.toISOString().slice(0, 10);
+  return `${safeTitle}-${date}.md`;
+}
+
+/** Write a private temp file beside the destination, then atomically rename. */
+export async function writeMarkdownAtomically(
+  destination: string,
+  markdown: string,
+): Promise<void> {
+  const suffix = `${process.pid}.${randomBytes(6).toString("hex")}`;
+  const tempPath = path.join(
+    path.dirname(destination),
+    `.${path.basename(destination)}.${suffix}.tmp`,
+  );
+  let handle: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    handle = await open(tempPath, "wx", 0o600);
+    await handle.writeFile(markdown, { encoding: "utf8" });
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await rename(tempPath, destination);
+  } catch (cause) {
+    if (handle !== null) await handle.close().catch(() => undefined);
+    await unlink(tempPath).catch(() => undefined);
+    throw cause;
+  }
+}

--- a/vex-app/src/preload/__tests__/bridge-surface.test.ts
+++ b/vex-app/src/preload/__tests__/bridge-surface.test.ts
@@ -158,6 +158,7 @@ describe("preload bridge surface", () => {
       // Move 0.3 — read-only per-session executed-trade activity (MOVES).
       "CH.portfolio.listMoves",
       "CH.sessions.getModel",
+      "CH.sessions.exportMarkdown",
       // Error-diagnostics phase (D-FOLDER) — "Open logs folder".
       "CH.support.openLogsFolder",
       // Updater (M13) — user-triggered in-app update bridge.

--- a/vex-app/src/preload/agent/sessions.ts
+++ b/vex-app/src/preload/agent/sessions.ts
@@ -2,6 +2,7 @@ import { CH } from "../../shared/ipc/channels.js";
 import {
   sessionCreateInputSchema,
   sessionDeleteInputSchema,
+  sessionExportMarkdownInputSchema,
   sessionGetInputSchema,
   sessionGetModelInputSchema,
   sessionSetPinnedInputSchema,
@@ -9,6 +10,7 @@ import {
 import type {
   SessionCreateInput,
   SessionDeleteInput,
+  SessionExportMarkdownInput,
   SessionGetInput,
   SessionGetModelInput,
   SessionSetPinnedInput,
@@ -48,6 +50,13 @@ export const sessions = {
       CH.sessions.delete,
       input,
       sessionDeleteInputSchema
+    );
+  },
+  exportMarkdown(input: SessionExportMarkdownInput) {
+    return invokeWithSchema(
+      CH.sessions.exportMarkdown,
+      input,
+      sessionExportMarkdownInputSchema
     );
   },
   getModel(input: SessionGetModelInput) {

--- a/vex-app/src/renderer/features/appShell/SessionContext.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionContext.tsx
@@ -12,9 +12,15 @@
  * desk rule stays a single quiet title line.
  */
 
-import type { JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
+import {
+  CheckmarkCircle02Icon,
+  Download01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { SessionListItem } from "@shared/schemas/sessions.js";
 import { DotmHex3 } from "../../components/ui/dotm-hex-3.js";
+import { useExportSessionMarkdown } from "../../lib/api/sessions.js";
 import { Stamp } from "./SessionRows/Stamp.js";
 import { getSessionTitle } from "./sessionListModel.js";
 
@@ -31,6 +37,17 @@ export function SessionContext({
   loading,
   error,
 }: SessionContextProps): JSX.Element | null {
+  const exportMutation = useExportSessionMarkdown();
+  const [exportStatus, setExportStatus] = useState<"idle" | "saved" | "error">(
+    "idle",
+  );
+
+  useEffect(() => {
+    if (exportStatus === "idle") return;
+    const timeout = window.setTimeout(() => setExportStatus("idle"), 2_500);
+    return () => window.clearTimeout(timeout);
+  }, [exportStatus]);
+
   if (loading) {
     return (
       <div className="flex h-9 items-center gap-2 font-mono text-[10px] uppercase tracking-[0.28em] text-[var(--vex-text-3)]">
@@ -73,6 +90,46 @@ export function SessionContext({
         <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-foreground">
           {title}
         </span>
+        <span
+          aria-live="polite"
+          className="font-mono text-[9px] uppercase tracking-[0.18em] text-[var(--vex-text-3)]"
+        >
+          {exportStatus === "saved"
+            ? "Exported"
+            : exportStatus === "error"
+              ? "Export failed"
+              : ""}
+        </span>
+        <button
+          type="button"
+          aria-label="Export session as Markdown"
+          title="Export session as Markdown"
+          disabled={exportMutation.isPending}
+          onClick={() => {
+            setExportStatus("idle");
+            exportMutation.mutate(
+              { id: activeSession.id },
+              {
+                onSuccess: (result) => {
+                  if (result.ok && result.data.outcome === "saved") {
+                    setExportStatus("saved");
+                  } else if (!result.ok) {
+                    setExportStatus("error");
+                  }
+                },
+                onError: () => setExportStatus("error"),
+              },
+            );
+          }}
+          className="grid size-7 shrink-0 place-items-center rounded-sm text-[var(--vex-text-3)] transition-colors hover:bg-[var(--vex-surface-2)] hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--vex-accent)] disabled:cursor-wait disabled:opacity-50"
+        >
+          <HugeiconsIcon
+            icon={exportStatus === "saved" ? CheckmarkCircle02Icon : Download01Icon}
+            size={15}
+            aria-hidden
+            className={exportMutation.isPending ? "animate-pulse" : undefined}
+          />
+        </button>
         {activeSession.permission !== "full" ? (
           <Stamp tone="warn">restricted</Stamp>
         ) : null}

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionContext.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionContext.test.tsx
@@ -6,9 +6,10 @@
  * BOOK panel; the header now renders no runtime-status group (pinned below).
  */
 
-import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { SessionListItem } from "@shared/schemas/sessions.js";
 import { SessionContext, type SessionContextProps } from "../SessionContext.js";
 
@@ -25,16 +26,33 @@ const SESSION: SessionListItem = {
 };
 
 function renderCtx(overrides: Partial<SessionContextProps> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
   return render(
-    createElement(SessionContext, {
-      activeSession: SESSION,
-      activeSessionId: SESSION.id,
-      loading: false,
-      error: null,
-      ...overrides,
-    }),
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(SessionContext, {
+        activeSession: SESSION,
+        activeSessionId: SESSION.id,
+        loading: false,
+        error: null,
+        ...overrides,
+      }),
+    ),
   );
 }
+
+const exportMarkdown = vi.fn();
+
+beforeEach(() => {
+  exportMarkdown.mockReset();
+  Object.defineProperty(window, "vex", {
+    configurable: true,
+    value: { sessions: { exportMarkdown } },
+  });
+});
 
 describe("SessionContext header (slice C)", () => {
   it("marks the active-session strip with the session-header selector + labeled group", () => {
@@ -80,5 +98,30 @@ describe("SessionContext header (slice C)", () => {
     expect(
       notFound.container.querySelector('[data-vex-area="session-header"]'),
     ).toBeNull();
+  });
+
+  it("exports the active session and announces a successful save", async () => {
+    exportMarkdown.mockResolvedValue({ ok: true, data: { outcome: "saved" } });
+    renderCtx();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Export session as Markdown" }),
+    );
+
+    await waitFor(() => expect(exportMarkdown).toHaveBeenCalledWith({ id: SESSION.id }));
+    expect(await screen.findByText("Exported")).not.toBeNull();
+  });
+
+  it("keeps native-dialog cancellation silent", async () => {
+    exportMarkdown.mockResolvedValue({ ok: true, data: { outcome: "cancelled" } });
+    renderCtx();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Export session as Markdown" }),
+    );
+
+    await waitFor(() => expect(exportMarkdown).toHaveBeenCalledOnce());
+    expect(screen.queryByText("Exported")).toBeNull();
+    expect(screen.queryByText("Export failed")).toBeNull();
   });
 });

--- a/vex-app/src/renderer/lib/api/sessions.ts
+++ b/vex-app/src/renderer/lib/api/sessions.ts
@@ -26,6 +26,8 @@ import type {
   SessionCreateResult,
   SessionDeleteInput,
   SessionDeleteResult,
+  SessionExportMarkdownInput,
+  SessionExportMarkdownResult,
   SessionList,
   SessionListItem,
   SessionModelDto,
@@ -175,6 +177,17 @@ export function useDeleteSession(): UseMutationResult<
         useUiStore.getState().setActiveSessionId(null);
       }
     },
+  });
+}
+
+export function useExportSessionMarkdown(): UseMutationResult<
+  Result<SessionExportMarkdownResult>,
+  Error,
+  SessionExportMarkdownInput
+> {
+  return useMutation({
+    mutationFn: (input) => window.vex.sessions.exportMarkdown(input),
+    retry: false,
   });
 }
 

--- a/vex-app/src/shared/__tests__/session-export-schema.test.ts
+++ b/vex-app/src/shared/__tests__/session-export-schema.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  sessionExportMarkdownInputSchema,
+  sessionExportMarkdownResultSchema,
+} from "../schemas/sessions.js";
+
+describe("session Markdown export schema", () => {
+  it("accepts only a UUID session id", () => {
+    expect(
+      sessionExportMarkdownInputSchema.safeParse({
+        id: "00000000-0000-4000-8000-0000000000e1",
+      }).success,
+    ).toBe(true);
+    expect(
+      sessionExportMarkdownInputSchema.safeParse({ id: "bad", path: "/tmp/leak" })
+        .success,
+    ).toBe(false);
+  });
+
+  it("exposes only saved or cancelled outcomes", () => {
+    expect(sessionExportMarkdownResultSchema.parse({ outcome: "saved" })).toEqual({
+      outcome: "saved",
+    });
+    expect(
+      sessionExportMarkdownResultSchema.safeParse({
+        outcome: "saved",
+        path: "/tmp/leak",
+      }).success,
+    ).toBe(false);
+    expect(
+      sessionExportMarkdownResultSchema.safeParse({ outcome: "failed" }).success,
+    ).toBe(false);
+  });
+});

--- a/vex-app/src/shared/ipc/__tests__/channels.test.ts
+++ b/vex-app/src/shared/ipc/__tests__/channels.test.ts
@@ -85,6 +85,7 @@ describe("CH / EV channel constants", () => {
     expect(typeof CH.memory.listSession).toBe("string");
     expect(typeof CH.memory.getStats).toBe("string");
     expect(typeof CH.sessions.getModel).toBe("string");
+    expect(CH.sessions.exportMarkdown).toBe("vex:sessions:exportMarkdown");
   });
 
   it("channels are unique (no duplicate values across namespaces)", () => {

--- a/vex-app/src/shared/ipc/channels.ts
+++ b/vex-app/src/shared/ipc/channels.ts
@@ -87,6 +87,7 @@ export const CH = {
     get: "vex:sessions:get",
     setPinned: "vex:sessions:setPinned",
     delete: "vex:sessions:delete",
+    exportMarkdown: "vex:sessions:exportMarkdown",
     /**
      * Global runtime model resolution for a session. `getModel` is
      * read-only and reports the model the engine resolves from

--- a/vex-app/src/shared/schemas/sessions.ts
+++ b/vex-app/src/shared/schemas/sessions.ts
@@ -105,6 +105,24 @@ export const sessionGetInputSchema = z
 export type SessionGetInput = z.infer<typeof sessionGetInputSchema>;
 
 /**
+ * Native Markdown export. Main owns both the save dialog and the destination
+ * path; the renderer supplies only the session id and receives no path back.
+ */
+export const sessionExportMarkdownInputSchema = sessionGetInputSchema;
+export type SessionExportMarkdownInput = z.infer<
+  typeof sessionExportMarkdownInputSchema
+>;
+
+export const sessionExportMarkdownResultSchema = z
+  .object({
+    outcome: z.enum(["saved", "cancelled"]),
+  })
+  .strict();
+export type SessionExportMarkdownResult = z.infer<
+  typeof sessionExportMarkdownResultSchema
+>;
+
+/**
  * Single row in the sidebar list. Carries enough metadata for the
  * sidebar to render mode/permission badges + optional mission-run
  * status pill without a second IPC roundtrip.

--- a/vex-app/src/shared/types/bridge/agent/sessions.ts
+++ b/vex-app/src/shared/types/bridge/agent/sessions.ts
@@ -4,6 +4,8 @@ import type {
   SessionCreateResult,
   SessionDeleteInput,
   SessionDeleteResult,
+  SessionExportMarkdownInput,
+  SessionExportMarkdownResult,
   SessionGetInput,
   SessionGetModelInput,
   SessionList,
@@ -45,6 +47,10 @@ export interface SessionsBridge {
   readonly delete: (
     input: SessionDeleteInput
   ) => Promise<Result<SessionDeleteResult>>;
+  /** Open a native save dialog and export a readable, redacted transcript. */
+  readonly exportMarkdown: (
+    input: SessionExportMarkdownInput
+  ) => Promise<Result<SessionExportMarkdownResult>>;
   /**
    * Resolve the global runtime model for the session — `source:
    * "global_default"` (from `AGENT_PROVIDER`/`AGENT_MODEL`) or


### PR DESCRIPTION
## Problem solved

Session transcripts could only be read inside Vex. Operators had no safe way to save a complete, readable record of a session for research notes, handoff, or audit.

## What changed

- Adds a quiet export control to the active-session header with saved and failed feedback.
- Opens the native Electron save dialog and keeps the selected filesystem path inside main.
- Exports the complete chronological transcript across live messages and messages_archive, with archived originals winning duplicate message IDs.
- Includes the session title, mode, timestamps, user and Vex prose, and concise tool names.
- Excludes system messages, runtime and compaction notices, raw tool results, tool arguments, internal IDs, and secret-shaped values.
- Generates a sanitized title-and-date .md filename.
- Writes through a private 0600 temporary file, fsyncs it, and atomically renames it into place. Failed writes clean up the temporary file.
- Adds a typed sessions.exportMarkdown IPC contract that returns only saved or cancelled, or a redacted safe error. It never returns the selected path.

## User impact

Operators can export a session in one click and receive a clean Markdown transcript without copying chat content manually or exposing internal runtime data. Cancelling the native dialog is silent and leaves no file behind.

## Test coverage

- Readable Markdown formatting and chronological order
- Archive/live precedence and duplicate suppression query
- System, runtime, compaction, raw result, argument, ID, and secret omission
- Safe filenames and date suffixes
- Private 0600 atomic writes and temporary-file cleanup
- Native-dialog cancellation and write-failure safety
- Strict IPC input/output validation and path non-disclosure
- Accessible header interaction, saved feedback, and silent cancellation

## Validation

- 35 focused export, IPC, bridge, schema, database, and renderer checks pass
- 1,705 main-process tests pass
- pnpm run lint passes, including the type-error ratchet and process-boundary checks
- Main, preload, and renderer production bundles pass
- Build artifact and CSP checks pass
- React Doctor changed-scope scan: 100/100, no issues

<img width="863" height="42" alt="image" src="https://github.com/user-attachments/assets/4263a4c4-fcda-47c2-912a-9b0ef3fc8ecc" />
<img width="418" height="209" alt="image" src="https://github.com/user-attachments/assets/dc295980-1069-4a50-902a-99103230b6e0" />


The full renderer suite is currently blocked by the repository test environment localStorage shim (17 unrelated files fail with localStorage.clear/setItem not being functions). The focused SessionContext export tests pass.