### PR TITLE
fix(wallet): surface approval after preparing transfers

### DIFF
--- a/src/__tests__/vex-agent/engine/core/prepared-action-approval-intent.test.ts
+++ b/src/__tests__/vex-agent/engine/core/prepared-action-approval-intent.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const enqueueWith = vi.fn();
+const createWith = vi.fn();
+const updateStatus = vi.fn();
+
+vi.mock("@vex-agent/db/repos/approvals.js", () => ({ enqueueWith }));
+vi.mock("@vex-agent/db/repos/approval-intents.js", () => ({ createWith }));
+vi.mock("@vex-agent/db/repos/mission-runs.js", () => ({ updateStatus }));
+vi.mock("@vex-agent/db/client.js", () => ({
+  withTransaction: async (fn: (client: object) => Promise<unknown>) => fn({}),
+}));
+
+const { enqueueApprovalIntent } = await import(
+  "../../../../vex-agent/engine/core/turn-loop-tool-batch/approval-stop.js"
+);
+
+const PREPARED_EXPIRY = "2026-07-12T10:10:00.000Z";
+const TRUSTED_PREVIEW = {
+  toolName: "wallet_send_confirm",
+  criticalArgs: {
+    network: "solana",
+    chain: null,
+    to: "3SnLmaqoEczS2ft7RLQ1BRhtsLuAauWnx9K7pDjSRQrp",
+    amount: "32.813008",
+    token: "ANSEM",
+  },
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-12T10:00:00.000Z"));
+  vi.clearAllMocks();
+});
+
+afterEach(() => vi.useRealTimers());
+
+describe("prepared-action approval intent", () => {
+  it("uses the trusted wallet preview and never outlives the prepared intent", async () => {
+    await enqueueApprovalIntent({
+      context: {
+        sessionId: "session-1",
+        sessionPermission: "restricted",
+        missionRunId: null,
+      } as any,
+      toolCall: {
+        id: "confirm-call",
+        name: "wallet_send_confirm",
+        arguments: {
+          network: "solana",
+          intentId: "intent-00000000-0000-4000-8000-000000000001",
+          to: "model-spoofed-recipient",
+          amount: "999999",
+        },
+      },
+      result: {
+        success: false,
+        output: "approval required",
+        pendingApproval: true,
+        actionKind: "user_wallet_broadcast",
+      },
+      toolContext: {
+        sessionPermission: "restricted",
+        sessionKind: "agent",
+        missionRunId: null,
+        missionId: null,
+        role: "parent",
+        contextUsageBand: "normal",
+      } as any,
+      intentActionKind: "user_wallet_broadcast",
+      trustedPreview: TRUSTED_PREVIEW,
+      trustedExpiresAt: PREPARED_EXPIRY,
+    });
+
+    expect(createWith).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        previewJson: TRUSTED_PREVIEW,
+        expiresAt: PREPARED_EXPIRY,
+      }),
+    );
+    const stored = createWith.mock.calls[0]![1];
+    expect(JSON.stringify(stored.previewJson)).not.toContain(
+      "model-spoofed-recipient",
+    );
+    expect(JSON.stringify(stored.previewJson)).not.toContain("999999");
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/prepared-action-follow-up.test.ts
+++ b/src/__tests__/vex-agent/engine/core/prepared-action-follow-up.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dispatchTool = vi.fn();
+const persistBatchTranscript = vi.fn().mockResolvedValue(undefined);
+const enqueueApprovalIntent = vi.fn().mockResolvedValue("approval-1");
+
+vi.mock("@vex-agent/tools/dispatcher.js", () => ({
+  dispatchTool: (...args: unknown[]) => dispatchTool(...args),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/execute.js", () => ({
+  buildToolContext: (context: Record<string, unknown>) => ({
+    ...context,
+    approved: false,
+    contextUsageBand: "normal",
+  }),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/approval-stop.js", () => ({
+  assertApprovalActionKind: (result: { actionKind?: string }) => {
+    if (!result.actionKind) throw new Error("missing actionKind");
+    return result.actionKind;
+  },
+  enqueueApprovalIntent: (...args: unknown[]) => enqueueApprovalIntent(...args),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/results.js", () => ({
+  BATCH_ABORTED_BY_COMPACT_OUTPUT: "aborted",
+  persistBatchTranscript: (...args: unknown[]) => persistBatchTranscript(...args),
+  mapBatchOutcome: (args: {
+    batchStopReason: string | null;
+    approvalId: string | null;
+    toolCallsExecuted: number;
+    lastText: string | null;
+  }) => args.batchStopReason === "approval_required"
+    ? {
+        kind: "approval_break",
+        pendingApprovalId: args.approvalId,
+        toolCallsExecuted: args.toolCallsExecuted,
+        lastText: args.lastText,
+      }
+    : {
+        kind: "normal_complete",
+        toolCallsExecuted: args.toolCallsExecuted,
+        lastText: args.lastText,
+      },
+}));
+
+const { processTurnToolBatch } = await import(
+  "../../../../vex-agent/engine/core/turn-loop-tool-batch.js"
+);
+
+const INTENT_ID = "intent-00000000-0000-4000-8000-000000000001";
+const EXPIRES_AT = "2030-01-01T00:00:00.000Z";
+const trustedPreview = {
+  toolName: "wallet_send_confirm",
+  criticalArgs: {
+    network: "solana",
+    chain: null,
+    to: "3SnLmaqoEczS2ft7RLQ1BRhtsLuAauWnx9K7pDjSRQrp",
+    amount: "32.813008",
+    token: "ANSEM",
+  },
+};
+
+function prepareResult(overrides: Record<string, unknown> = {}) {
+  return {
+    success: true,
+    output: "prepared",
+    actionKind: "approval_prepare",
+    preparedActionFollowUp: {
+      toolName: "wallet_send_confirm",
+      args: { network: "solana", intentId: INTENT_ID },
+      expiresAt: EXPIRES_AT,
+      approvalPreview: trustedPreview,
+    },
+    ...overrides,
+  };
+}
+
+function context(permission: "restricted" | "full") {
+  return {
+    sessionId: "session-1",
+    sessionKind: "agent",
+    sessionPermission: permission,
+    missionId: null,
+    missionRunId: null,
+    isSubagent: false,
+    loadedDocuments: new Map(),
+    walletPolicy: { kind: "none" },
+  } as any;
+}
+
+async function run(permission: "restricted" | "full") {
+  return processTurnToolBatch({
+    context: context(permission),
+    turnResult: {
+      content: "Preparing transfer.",
+      toolCalls: [
+        {
+          id: "prepare-call",
+          name: "wallet_send_prepare",
+          arguments: {
+            network: "solana",
+            to: "model-recipient-must-not-feed-preview",
+            amount: "999999",
+          },
+        },
+      ],
+    },
+    liveMessages: [],
+    currentTokenCount: 0,
+    contextLimit: 128_000,
+    lastTextSoFar: null,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enqueueApprovalIntent.mockResolvedValue("approval-1");
+  persistBatchTranscript.mockResolvedValue(undefined);
+});
+
+describe("prepared-action follow-up handoff", () => {
+  it("restricted sessions persist prepare, synthesize confirm, and immediately enqueue its trusted preview", async () => {
+    dispatchTool
+      .mockResolvedValueOnce(prepareResult())
+      .mockResolvedValueOnce({
+        success: false,
+        output: "approval required",
+        pendingApproval: true,
+        actionKind: "user_wallet_broadcast",
+      });
+
+    const outcome = await run("restricted");
+    expect(outcome).toMatchObject({
+      kind: "approval_break",
+      pendingApprovalId: "approval-1",
+      toolCallsExecuted: 2,
+    });
+    expect(dispatchTool).toHaveBeenCalledTimes(2);
+    expect(dispatchTool.mock.calls[1]![0]).toMatchObject({
+      name: "wallet_send_confirm",
+      args: { network: "solana", intentId: INTENT_ID },
+    });
+    expect(enqueueApprovalIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trustedPreview,
+        trustedExpiresAt: EXPIRES_AT,
+        toolCall: expect.objectContaining({ name: "wallet_send_confirm" }),
+      }),
+    );
+    expect(persistBatchTranscript).toHaveBeenCalledTimes(2);
+    expect(persistBatchTranscript.mock.calls[0]![0]).toMatchObject({
+      content: "Preparing transfer.",
+      executedCalls: [expect.objectContaining({ name: "wallet_send_prepare" })],
+      executedResults: [expect.objectContaining({ output: "prepared" })],
+    });
+    expect(persistBatchTranscript.mock.calls[1]![0]).toMatchObject({
+      content: null,
+      executedCalls: [expect.objectContaining({ name: "wallet_send_confirm" })],
+      executedResults: [],
+    });
+  });
+
+  it("full-permission sessions execute confirm immediately and persist its paired result", async () => {
+    dispatchTool
+      .mockResolvedValueOnce(prepareResult())
+      .mockResolvedValueOnce({ success: true, output: "transfer confirmed" });
+
+    const outcome = await run("full");
+    expect(outcome).toMatchObject({ kind: "normal_complete", toolCallsExecuted: 2 });
+    expect(enqueueApprovalIntent).not.toHaveBeenCalled();
+    expect(persistBatchTranscript.mock.calls[1]![0]).toMatchObject({
+      content: null,
+      executedCalls: [expect.objectContaining({ name: "wallet_send_confirm" })],
+      executedResults: [
+        expect.objectContaining({ output: "transfer confirmed", success: true }),
+      ],
+    });
+  });
+
+  it.each(["restricted", "full"] as const)(
+    "hands off validated EVM transfers in %s sessions",
+    async (permission) => {
+      const evmPreview = {
+        toolName: "wallet_send_confirm",
+        criticalArgs: {
+          network: "eip155",
+          chain: "base",
+          to: "0xfedcba0987654321fedcba0987654321fedcba09",
+          amount: "1.5",
+          token: null,
+        },
+      };
+      dispatchTool
+        .mockResolvedValueOnce(
+          prepareResult({
+            preparedActionFollowUp: {
+              toolName: "wallet_send_confirm",
+              args: { network: "eip155", intentId: INTENT_ID },
+              expiresAt: EXPIRES_AT,
+              approvalPreview: evmPreview,
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          permission === "restricted"
+            ? {
+                success: false,
+                output: "approval required",
+                pendingApproval: true,
+                actionKind: "user_wallet_broadcast",
+              }
+            : { success: true, output: "transfer confirmed" },
+        );
+
+      const outcome = await run(permission);
+      expect(dispatchTool.mock.calls[1]![0]).toMatchObject({
+        name: "wallet_send_confirm",
+        args: { network: "eip155", intentId: INTENT_ID },
+      });
+      if (permission === "restricted") {
+        expect(outcome.kind).toBe("approval_break");
+        expect(enqueueApprovalIntent).toHaveBeenCalledWith(
+          expect.objectContaining({ trustedPreview: evmPreview }),
+        );
+      } else {
+        expect(outcome.kind).toBe("normal_complete");
+        expect(enqueueApprovalIntent).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("rejects unknown mappings without dispatching a second tool", async () => {
+    dispatchTool.mockResolvedValueOnce(
+      prepareResult({
+        preparedActionFollowUp: {
+          ...prepareResult().preparedActionFollowUp,
+          toolName: "swap",
+        },
+      }),
+    );
+
+    const outcome = await run("restricted");
+    expect(outcome).toMatchObject({ kind: "normal_complete", toolCallsExecuted: 1 });
+    expect(dispatchTool).toHaveBeenCalledOnce();
+    expect(persistBatchTranscript.mock.calls[0]![0]).toMatchObject({
+      executedResults: [
+        expect.objectContaining({
+          success: false,
+          output: expect.stringContaining("rejected by the trusted registry"),
+        }),
+      ],
+    });
+  });
+
+  it("rejects recursive chains after one follow-up and never dispatches a third tool", async () => {
+    dispatchTool
+      .mockResolvedValueOnce(prepareResult())
+      .mockResolvedValueOnce(prepareResult());
+
+    const outcome = await run("full");
+    expect(outcome).toMatchObject({ kind: "normal_complete", toolCallsExecuted: 2 });
+    expect(dispatchTool).toHaveBeenCalledTimes(2);
+    expect(persistBatchTranscript.mock.calls[1]![0]).toMatchObject({
+      executedResults: [
+        expect.objectContaining({
+          success: false,
+          output: expect.stringContaining("Recursive"),
+        }),
+      ],
+    });
+  });
+});

--- a/src/__tests__/vex-agent/tools/internal/wallet/send/prepare.test.ts
+++ b/src/__tests__/vex-agent/tools/internal/wallet/send/prepare.test.ts
@@ -187,6 +187,18 @@ describe("handleWalletSendPrepare", () => {
         token: null,
       },
     });
+    expect(result.preparedActionFollowUp).toEqual({
+      toolName: "wallet_send_confirm",
+      args: {
+        network: "eip155",
+        intentId: createArgs.intentId,
+      },
+      expiresAt: createArgs.expiresAt,
+      approvalPreview: {
+        toolName: "wallet_send_confirm",
+        criticalArgs: createArgs.previewJson.criticalArgs,
+      },
+    });
   });
 
   it("rejects missing required fields", async () => {
@@ -218,7 +230,7 @@ describe("handleWalletSendPrepare", () => {
   });
 
   it("uses solana wallet address for solana network", async () => {
-    await handleWalletSendPrepare(
+    const result = await handleWalletSendPrepare(
       { network: "solana", to: "SoLAdr11111111111111111111111111111111", amount: "0.5" },
       makeContext(),
     );
@@ -226,5 +238,17 @@ describe("handleWalletSendPrepare", () => {
       "SoLanaAddr1111111111111111111111111111111",
     );
     expect(mockCreate.mock.calls[0][0].chainAlias).toBeNull();
+    expect(result.preparedActionFollowUp).toMatchObject({
+      args: { network: "solana" },
+      approvalPreview: {
+        criticalArgs: {
+          network: "solana",
+          chain: null,
+          to: "SoLAdr11111111111111111111111111111111",
+          amount: "0.5",
+          token: null,
+        },
+      },
+    });
   });
 });

--- a/src/__tests__/vex-agent/tools/registry-prepared-action-follow-ups.test.ts
+++ b/src/__tests__/vex-agent/tools/registry-prepared-action-follow-ups.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { validatePreparedActionFollowUp } from "../../../vex-agent/tools/registry/prepared-action-follow-ups.js";
+
+const INTENT_ID = "intent-00000000-0000-4000-8000-000000000001";
+const EXPIRES_AT = "2030-01-01T00:00:00.000Z";
+
+function candidate() {
+  return {
+    toolName: "wallet_send_confirm",
+    args: { network: "solana", intentId: INTENT_ID },
+    expiresAt: EXPIRES_AT,
+    approvalPreview: {
+      toolName: "wallet_send_confirm",
+      criticalArgs: {
+        network: "solana",
+        chain: null,
+        to: "3SnLmaqoEczS2ft7RLQ1BRhtsLuAauWnx9K7pDjSRQrp",
+        amount: "32.813008",
+        token: "ANSEM",
+      },
+    },
+  };
+}
+
+describe("prepared-action follow-up registry", () => {
+  it("allows and canonicalizes wallet_send_prepare → wallet_send_confirm", () => {
+    const input = candidate();
+    const result = validatePreparedActionFollowUp("wallet_send_prepare", input);
+    expect(result).toEqual({
+      ok: true,
+      followUp: input,
+    });
+  });
+
+  it("rejects unknown source→target pairs", () => {
+    expect(
+      validatePreparedActionFollowUp("token_find", candidate()),
+    ).toEqual({ ok: false, reason: "unknown_mapping" });
+    expect(
+      validatePreparedActionFollowUp("wallet_send_prepare", {
+        ...candidate(),
+        toolName: "swap",
+      }),
+    ).toEqual({ ok: false, reason: "unknown_mapping" });
+  });
+
+  it("rejects extra confirm args and spoofed or malformed trusted previews", () => {
+    expect(
+      validatePreparedActionFollowUp("wallet_send_prepare", {
+        ...candidate(),
+        args: { ...candidate().args, to: "model-supplied" },
+      }),
+    ).toEqual({ ok: false, reason: "invalid_contract" });
+    expect(
+      validatePreparedActionFollowUp("wallet_send_prepare", {
+        ...candidate(),
+        approvalPreview: {
+          ...candidate().approvalPreview,
+          criticalArgs: {
+            ...candidate().approvalPreview.criticalArgs,
+            network: "eip155",
+          },
+        },
+      }),
+    ).toEqual({ ok: false, reason: "invalid_contract" });
+  });
+});

--- a/src/vex-agent/engine/core/turn-loop-tool-batch.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch.ts
@@ -36,7 +36,8 @@
  * `./turn-loop-tool-batch/outcome.ts`, the per-call tool-context builder in
  * `./turn-loop-tool-batch/execute.ts`, the approval-enqueue helpers in
  * `./turn-loop-tool-batch/approval-stop.ts`, and the deferred-save +
- * outcome-mapping helpers in `./turn-loop-tool-batch/results.ts`.
+ * outcome-mapping helpers in `./turn-loop-tool-batch/results.ts`. Trusted
+ * prepare→execute handoffs live in `./turn-loop-tool-batch/prepared-follow-up.ts`.
  * `processTurnToolBatch` stays here as the orchestrator: it keeps the
  * per-batch mutable state and the dispatch/approval/persistence ordering
  * bit-for-bit.
@@ -58,6 +59,10 @@ import {
   mapBatchOutcome,
   persistBatchTranscript,
 } from "./turn-loop-tool-batch/results.js";
+import {
+  dispatchPreparedActionFollowUp,
+  resolvePreparedActionFollowUp,
+} from "./turn-loop-tool-batch/prepared-follow-up.js";
 
 export type { StopPayload, ToolBatchOutcome } from "./turn-loop-tool-batch/outcome.js";
 
@@ -90,6 +95,7 @@ export async function processTurnToolBatch(args: {
 
   for (let i = 0; i < turnResult.toolCalls.length; i++) {
     const toolCall = turnResult.toolCalls[i];
+    if (toolCall === undefined) continue;
     toolCallsExecuted++;
 
     const toolContext = buildToolContext(context, dispatchBand);
@@ -99,9 +105,14 @@ export async function processTurnToolBatch(args: {
       toolContext,
     );
 
+    const { resultForTranscript, followUp } = resolvePreparedActionFollowUp(
+      toolCall.name,
+      result,
+    );
+
     // ── Approval break: call was dispatched but has no result in messages ──
     // "awaiting approval" state lives in approval_queue, not in transcript.
-    if (result.pendingApproval) {
+    if (resultForTranscript.pendingApproval) {
       // Puzzle 5 phase 2: approval_intents.action_kind is NOT NULL with a
       // CHECK constraint over the 8 canonical ActionKind variants. The
       // dispatcher's `withActionKindFallback` MUST have stamped a kind
@@ -109,14 +120,14 @@ export async function processTurnToolBatch(args: {
       // registration or in the dispatcher fallback. Fail fast (Codex
       // 2/1B ruling) instead of silently inserting a pseudo-kind or
       // downgrading to a default — neither preserves the policy invariant.
-      const intentActionKind = assertApprovalActionKind(result, toolCall);
+      const intentActionKind = assertApprovalActionKind(resultForTranscript, toolCall);
 
       executedCalls.push(toolCall);
 
       approvalId = await enqueueApprovalIntent({
         context,
         toolCall,
-        result,
+        result: resultForTranscript,
         toolContext,
         intentActionKind,
       });
@@ -129,22 +140,36 @@ export async function processTurnToolBatch(args: {
     executedResults.push({
       toolCallId: toolCall.id,
       toolName: toolCall.name,
-      output: result.output,
-      success: result.success,
+      output: resultForTranscript.output,
+      success: resultForTranscript.success,
     });
 
+    if (followUp !== null) {
+      return dispatchPreparedActionFollowUp({
+        context,
+        toolContext,
+        content: turnResult.content,
+        executedCalls,
+        executedResults,
+        liveMessages,
+        followUp,
+        toolCallsExecuted,
+        lastText: turnResult.content ?? args.lastTextSoFar,
+      });
+    }
+
     // ── Engine signals: result tracked, then stop ──
-    if (result.engineSignal) {
-      const sig = result.engineSignal;
+    if (resultForTranscript.engineSignal) {
+      const sig = resultForTranscript.engineSignal;
       if (sig.type === "stop_mission" || sig.type === "complete_subagent") {
         batchStopReason = sig.reason as StopReason;
-        batchStopOutput = result.output;
+        batchStopOutput = resultForTranscript.output;
         batchStopPayload = { summary: sig.summary, evidence: sig.evidence };
         break;
       }
       if (sig.type === "wait_for_parent") {
         batchStopReason = "waiting_for_parent";
-        batchStopOutput = result.output;
+        batchStopOutput = resultForTranscript.output;
         break;
       }
       if (sig.type === "plan_pause") {
@@ -155,7 +180,7 @@ export async function processTurnToolBatch(args: {
         // (don't wait for an execution attempt — mission text does not break the
         // loop).
         batchStopReason = "plan_acceptance_required";
-        batchStopOutput = result.output;
+        batchStopOutput = resultForTranscript.output;
         batchStopPayload = { summary: sig.summary, evidence: { reason: sig.reason } };
         break;
       }
@@ -165,7 +190,7 @@ export async function processTurnToolBatch(args: {
         // Evidence carries dueAt + reason so PR-7 executor / PR-10 ingress
         // have the hints they need without re-reading the wake row.
         batchStopReason = "waiting_for_wake";
-        batchStopOutput = result.output;
+        batchStopOutput = resultForTranscript.output;
         batchStopPayload = {
           summary: sig.summary,
           evidence: {
@@ -184,6 +209,7 @@ export async function processTurnToolBatch(args: {
         compactCommittedThisBatch = true;
         for (let j = i + 1; j < turnResult.toolCalls.length; j++) {
           const skipped = turnResult.toolCalls[j];
+          if (skipped === undefined) continue;
           executedCalls.push(skipped);
           executedResults.push({
             toolCallId: skipped.id,

--- a/src/vex-agent/engine/core/turn-loop-tool-batch/approval-stop.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch/approval-stop.ts
@@ -19,14 +19,19 @@ import * as approvalIntentsRepo from "@vex-agent/db/repos/approval-intents.js";
 import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
 import { withTransaction } from "@vex-agent/db/client.js";
 import { riskLevelFromActionKind } from "@vex-agent/tools/risk-level.js";
-import { buildIntentPreview, buildPolicySnapshot } from "../approval-intent-preview.js";
+import {
+  buildIntentPreview,
+  buildPolicySnapshot,
+  type IntentPreview,
+} from "../approval-intent-preview.js";
 
 /**
  * Puzzle 5 phase 3 — TTL stamped at enqueue (not at approve). The approve
  * gate (`prepareApprove` snapshot) and the scheduled sweep both rely on a
  * DB-visible `expires_at` so a stale approval gets auto-rejected even
- * without operator action. Single 1h default for all action kinds; phase 7
- * will introduce per-kind TTLs if real workloads need them.
+ * without operator action. One hour is the default; a trusted prepared action
+ * can supply an earlier expiry so its approval never outlives the underlying
+ * wallet intent.
  */
 const APPROVAL_TTL_MS = 60 * 60 * 1000;
 
@@ -66,34 +71,58 @@ export async function enqueueApprovalIntent(args: {
   readonly result: ToolResult;
   readonly toolContext: InternalToolContext;
   readonly intentActionKind: ActionKind;
+  /** Handler-authored preview for a registry-validated prepared follow-up. */
+  readonly trustedPreview?: IntentPreview;
+  /** Optional prepared-action expiry; approval must not outlive it. */
+  readonly trustedExpiresAt?: string;
 }): Promise<string> {
-  const { context, toolCall, result, toolContext, intentActionKind } = args;
+  const {
+    context,
+    toolCall,
+    result,
+    toolContext,
+    intentActionKind,
+    trustedPreview,
+    trustedExpiresAt,
+  } = args;
 
   const approvalId = `approval-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const intentRiskLevel = riskLevelFromActionKind(intentActionKind);
   // Stage 7 R5: carry the gate-matched swap safety verdict (typed, off the
   // ToolResult — NOT raw args) into the preview so restricted-mode approval
   // surfaces `pass` / `unknown` ("UNVERIFIED") before the human approves.
-  const intentPreview = buildIntentPreview(
-    toolCall.name,
-    toolCall.arguments,
-    result.prequote
-      ? {
-          prequoteVerdict: result.prequote.verdict,
-          fotTax: result.prequote.fotTax,
-          // Wave 5 (Pendle): the term-lock maturity rides the same typed channel;
-          // buildIntentPreview renders the fixed lock warning (never from args).
-          termLock: result.prequote.termLock,
-        }
-      : undefined,
-  );
+  const intentPreview = trustedPreview ??
+    buildIntentPreview(
+      toolCall.name,
+      toolCall.arguments,
+      result.prequote
+        ? {
+            prequoteVerdict: result.prequote.verdict,
+            fotTax: result.prequote.fotTax,
+            // Wave 5 (Pendle): the term-lock maturity rides the same typed channel;
+            // buildIntentPreview renders the fixed lock warning (never from args).
+            termLock: result.prequote.termLock,
+          }
+        : undefined,
+    );
   const intentPolicy = buildPolicySnapshot(toolContext);
   // Phase 3: stamp `expires_at` at enqueue so the approve gate +
   // scheduled sweep have a DB-visible TTL boundary (see APPROVAL_TTL_MS
   // header). `CreateIntentInput.previewJson/policyJson` were widened in
   // phase 3 to accept the structured builder shapes directly — no
   // `as unknown as Record<string, unknown>` cast needed.
-  const intentExpiresAt = new Date(Date.now() + APPROVAL_TTL_MS).toISOString();
+  const defaultExpiresAtMs = Date.now() + APPROVAL_TTL_MS;
+  const trustedExpiresAtMs = trustedExpiresAt === undefined
+    ? Number.POSITIVE_INFINITY
+    : Date.parse(trustedExpiresAt);
+  const intentExpiresAt = new Date(
+    Math.min(
+      defaultExpiresAtMs,
+      Number.isFinite(trustedExpiresAtMs)
+        ? trustedExpiresAtMs
+        : defaultExpiresAtMs,
+    ),
+  ).toISOString();
 
   // Single transaction: queue + intent + mission-status flip. A
   // partial state (queue without intent, or queue+intent without

--- a/src/vex-agent/engine/core/turn-loop-tool-batch/prepared-follow-up.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch/prepared-follow-up.ts
@@ -1,0 +1,158 @@
+/** Trusted, one-hop prepared-action dispatch inside a tool batch. */
+
+import { randomUUID } from "node:crypto";
+import type { Message } from "@vex-agent/db/repos/messages.js";
+import type { ParsedToolCall } from "@vex-agent/inference/types.js";
+import { dispatchTool } from "@vex-agent/tools/dispatcher.js";
+import type { InternalToolContext } from "@vex-agent/tools/internal/types.js";
+import {
+  validatePreparedActionFollowUp,
+  type ValidatedPreparedActionFollowUp,
+} from "@vex-agent/tools/registry/prepared-action-follow-ups.js";
+import type { ToolResult } from "@vex-agent/tools/types.js";
+import type { EngineContext } from "../../types.js";
+import {
+  assertApprovalActionKind,
+  enqueueApprovalIntent,
+} from "./approval-stop.js";
+import type { ToolBatchOutcome } from "./outcome.js";
+import { mapBatchOutcome, persistBatchTranscript } from "./results.js";
+
+export interface PreparedFollowUpResolution {
+  readonly resultForTranscript: ToolResult;
+  readonly followUp: ValidatedPreparedActionFollowUp | null;
+}
+
+/** Validate the handler contract; unknown or malformed mappings fail closed. */
+export function resolvePreparedActionFollowUp(
+  sourceToolName: string,
+  result: ToolResult,
+): PreparedFollowUpResolution {
+  const candidate = result.preparedActionFollowUp;
+  if (candidate === undefined) {
+    return { resultForTranscript: result, followUp: null };
+  }
+  const validation = result.success
+    ? validatePreparedActionFollowUp(sourceToolName, candidate)
+    : null;
+  if (validation === null || !validation.ok) {
+    return {
+      resultForTranscript: {
+        ...result,
+        success: false,
+        output:
+          "Prepared-action follow-up rejected by the trusted registry; no automatic action was dispatched.",
+        preparedActionFollowUp: undefined,
+      },
+      followUp: null,
+    };
+  }
+  return { resultForTranscript: result, followUp: validation.followUp };
+}
+
+/**
+ * Persist prepare, synthesize and dispatch confirm, then either enqueue the
+ * existing approval flow or persist the immediate full-permission result.
+ */
+export async function dispatchPreparedActionFollowUp(args: {
+  readonly context: EngineContext;
+  readonly toolContext: InternalToolContext;
+  readonly content: string | null;
+  readonly executedCalls: ParsedToolCall[];
+  readonly executedResults: Array<{
+    readonly toolCallId: string;
+    readonly toolName: string;
+    readonly output: string;
+    readonly success: boolean;
+  }>;
+  readonly liveMessages: Message[];
+  readonly followUp: ValidatedPreparedActionFollowUp;
+  readonly toolCallsExecuted: number;
+  readonly lastText: string | null;
+}): Promise<ToolBatchOutcome> {
+  await persistBatchTranscript({
+    sessionId: args.context.sessionId,
+    content: args.content,
+    executedCalls: args.executedCalls,
+    executedResults: args.executedResults,
+    liveMessages: args.liveMessages,
+  });
+
+  const syntheticCall: ParsedToolCall = {
+    id: `prepared-follow-up-${randomUUID()}`,
+    name: args.followUp.toolName,
+    arguments: args.followUp.args,
+  };
+  let result = await dispatchTool(
+    {
+      name: syntheticCall.name,
+      args: syntheticCall.arguments,
+      toolCallId: syntheticCall.id,
+    },
+    args.toolContext,
+  );
+
+  // Only one trusted hop is permitted. Never dispatch recursively.
+  if (result.preparedActionFollowUp !== undefined) {
+    result = {
+      ...result,
+      success: false,
+      pendingApproval: false,
+      output:
+        "Recursive prepared-action follow-up rejected; no additional action was dispatched.",
+      preparedActionFollowUp: undefined,
+    };
+  }
+
+  const toolCallsExecuted = args.toolCallsExecuted + 1;
+  if (result.pendingApproval) {
+    const intentActionKind = assertApprovalActionKind(result, syntheticCall);
+    const approvalId = await enqueueApprovalIntent({
+      context: args.context,
+      toolCall: syntheticCall,
+      result,
+      toolContext: args.toolContext,
+      intentActionKind,
+      trustedPreview: args.followUp.approvalPreview,
+      trustedExpiresAt: args.followUp.expiresAt,
+    });
+    await persistBatchTranscript({
+      sessionId: args.context.sessionId,
+      content: null,
+      executedCalls: [syntheticCall],
+      executedResults: [],
+      liveMessages: args.liveMessages,
+    });
+    return mapBatchOutcome({
+      batchStopReason: "approval_required",
+      batchStopOutput: null,
+      batchStopPayload: undefined,
+      compactCommittedThisBatch: false,
+      approvalId,
+      toolCallsExecuted,
+      lastText: args.lastText,
+    });
+  }
+
+  await persistBatchTranscript({
+    sessionId: args.context.sessionId,
+    content: null,
+    executedCalls: [syntheticCall],
+    executedResults: [{
+      toolCallId: syntheticCall.id,
+      toolName: syntheticCall.name,
+      output: result.output,
+      success: result.success,
+    }],
+    liveMessages: args.liveMessages,
+  });
+  return mapBatchOutcome({
+    batchStopReason: null,
+    batchStopOutput: null,
+    batchStopPayload: undefined,
+    compactCommittedThisBatch: false,
+    approvalId: null,
+    toolCallsExecuted,
+    lastText: args.lastText,
+  });
+}

--- a/src/vex-agent/tools/internal/wallet/send/prepare.ts
+++ b/src/vex-agent/tools/internal/wallet/send/prepare.ts
@@ -64,7 +64,7 @@ export async function handleWalletSendPrepare(
     idempotencyKey: intentId,
   });
 
-  return ok({
+  const result = ok({
     intentId,
     network,
     chain: chain ?? undefined,
@@ -75,4 +75,16 @@ export async function handleWalletSendPrepare(
     expiresAt,
     message: "Use wallet_send_confirm to broadcast this transfer.",
   });
+  return {
+    ...result,
+    preparedActionFollowUp: {
+      toolName: "wallet_send_confirm",
+      args: { network, intentId },
+      expiresAt,
+      approvalPreview: {
+        toolName: "wallet_send_confirm",
+        criticalArgs: { ...previewJson.criticalArgs },
+      },
+    },
+  };
 }

--- a/src/vex-agent/tools/registry/prepared-action-follow-ups.ts
+++ b/src/vex-agent/tools/registry/prepared-action-follow-ups.ts
@@ -1,0 +1,111 @@
+/** Explicit allow-list for trusted prepare → execute handoffs. */
+
+import type {
+  ApprovalPreviewScalar,
+  PreparedActionFollowUp,
+} from "../types.js";
+
+export interface ValidatedPreparedActionFollowUp {
+  readonly toolName: "wallet_send_confirm";
+  readonly args: {
+    readonly network: "eip155" | "solana";
+    readonly intentId: string;
+  };
+  readonly expiresAt: string;
+  readonly approvalPreview: {
+    readonly toolName: "wallet_send_confirm";
+    readonly criticalArgs: Record<string, ApprovalPreviewScalar>;
+  };
+}
+
+export type PreparedActionFollowUpValidation =
+  | { readonly ok: true; readonly followUp: ValidatedPreparedActionFollowUp }
+  | { readonly ok: false; readonly reason: "unknown_mapping" | "invalid_contract" };
+
+const INTENT_ID_RE = /^intent-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PREVIEW_KEYS = ["network", "chain", "to", "amount", "token"] as const;
+
+function isScalar(value: unknown): value is ApprovalPreviewScalar {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+/**
+ * Validate and canonicalize a handler-authored follow-up. Unknown pairs fail
+ * closed. For wallet sends, only network + intentId cross into confirm args;
+ * the richer preview is validated independently and never rebuilt from args.
+ */
+export function validatePreparedActionFollowUp(
+  sourceToolName: string,
+  candidate: PreparedActionFollowUp,
+): PreparedActionFollowUpValidation {
+  if (
+    sourceToolName !== "wallet_send_prepare" ||
+    candidate.toolName !== "wallet_send_confirm"
+  ) {
+    return { ok: false, reason: "unknown_mapping" };
+  }
+
+  const argKeys = Object.keys(candidate.args).sort();
+  if (argKeys.join(",") !== "intentId,network") {
+    return { ok: false, reason: "invalid_contract" };
+  }
+  const network = candidate.args.network;
+  const intentId = candidate.args.intentId;
+  if (
+    (network !== "eip155" && network !== "solana") ||
+    typeof intentId !== "string" ||
+    !INTENT_ID_RE.test(intentId)
+  ) {
+    return { ok: false, reason: "invalid_contract" };
+  }
+
+  const preview = candidate.approvalPreview;
+  if (preview.toolName !== "wallet_send_confirm") {
+    return { ok: false, reason: "invalid_contract" };
+  }
+  if (!Number.isFinite(Date.parse(candidate.expiresAt))) {
+    return { ok: false, reason: "invalid_contract" };
+  }
+  const criticalArgs: Record<string, ApprovalPreviewScalar> = {};
+  for (const key of PREVIEW_KEYS) {
+    const value = preview.criticalArgs[key];
+    if (!isScalar(value)) return { ok: false, reason: "invalid_contract" };
+    criticalArgs[key] = value;
+  }
+  if (
+    criticalArgs.network !== network ||
+    typeof criticalArgs.to !== "string" ||
+    criticalArgs.to.length === 0 ||
+    typeof criticalArgs.amount !== "string" ||
+    criticalArgs.amount.length === 0 ||
+    !(criticalArgs.chain === null || typeof criticalArgs.chain === "string") ||
+    !(criticalArgs.token === null || typeof criticalArgs.token === "string")
+  ) {
+    return { ok: false, reason: "invalid_contract" };
+  }
+  if (
+    (network === "eip155" &&
+      !(typeof criticalArgs.chain === "string" && criticalArgs.chain.length > 0)) ||
+    (network === "solana" && criticalArgs.chain !== null)
+  ) {
+    return { ok: false, reason: "invalid_contract" };
+  }
+
+  return {
+    ok: true,
+    followUp: {
+      toolName: "wallet_send_confirm",
+      args: { network, intentId },
+      expiresAt: candidate.expiresAt,
+      approvalPreview: {
+        toolName: "wallet_send_confirm",
+        criticalArgs,
+      },
+    },
+  };
+}

--- a/src/vex-agent/tools/types.ts
+++ b/src/vex-agent/tools/types.ts
@@ -230,6 +230,27 @@ export interface ToolResult {
      */
     readonly termLock?: { readonly maturityIso: string };
   };
+  /**
+   * Trusted one-step handoff from a successful non-mutating prepare tool to
+   * its mutating execution tool. The turn loop validates the source→target
+   * pair and canonicalizes the args through the registry before dispatch.
+   * This is handler-authored data; it is never populated from model output.
+   */
+  preparedActionFollowUp?: PreparedActionFollowUp;
+}
+
+export type ApprovalPreviewScalar = string | number | boolean | null;
+
+export interface PreparedActionFollowUp {
+  readonly toolName: string;
+  readonly args: Record<string, unknown>;
+  /** Earliest expiry of the prepared action, carried into approval TTL. */
+  readonly expiresAt: string;
+  /** Trusted, renderer-safe preview sourced from validated prepared state. */
+  readonly approvalPreview: {
+    readonly toolName: string;
+    readonly criticalArgs: Record<string, ApprovalPreviewScalar>;
+  };
 }
 
 /**

--- a/vex-app/src/renderer/features/appShell/ToolLedger/ToolActRow.tsx
+++ b/vex-app/src/renderer/features/appShell/ToolLedger/ToolActRow.tsx
@@ -1,10 +1,10 @@
 /**
  * THE ACT LEDGER — one registered act (S5): a tool call plus its merged
- * output. The transcript shows REGISTERED FACTS: the DTO carries no per-call
- * status or duration, so the row is quiet — name + Args (+ Output when a
- * result paired in the same run). The only stamp the data supports is
- * "Awaiting signature": a pending approval whose `toolCallId` matches this
- * act (rendered as a sibling link, see `ApprovalLinkStamp`).
+ * output. The transcript shows REGISTERED FACTS: most rows stay quiet — name
+ * + Args (+ Output when a result paired in the same run). Two deterministic
+ * stamps are supported: "Awaiting signature" from the approval queue, and
+ * "Confirmed" when a `wallet_send_confirm` result carries the tool's strict
+ * `{ status: "confirmed", txHash }` output contract.
  *
  * Collapsed by default (today's disclosure contract). The expanded body is a
  * recessed well; args/output are sanitized strings rendered as TEXT (`<pre>`
@@ -15,11 +15,51 @@
 
 import { useId, useState, type JSX } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import {
+  ArrowRight01Icon,
+  CheckmarkCircle01Icon,
+} from "@hugeicons/core-free-icons";
 import { cn } from "../../../lib/utils.js";
 import type { ToolCallActView } from "../transcriptRowModel.js";
 import { ApprovalLinkStamp } from "./ApprovalLinkStamp.js";
 import { toolGlyph } from "./toolGlyph.js";
+
+/**
+ * Recognise only the successful wallet-confirm output contract. Tool output
+ * is still treated as untrusted text: malformed JSON, lookalike tools, a
+ * missing hash, or any non-confirmed status all fail closed to no stamp.
+ */
+function isConfirmedWalletTransfer(act: ToolCallActView): boolean {
+  if (act.toolName !== "wallet_send_confirm" || act.output === null) return false;
+  try {
+    const parsed: unknown = JSON.parse(act.output);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return false;
+    }
+    const record = parsed as Record<string, unknown>;
+    return (
+      record["status"] === "confirmed" &&
+      typeof record["txHash"] === "string" &&
+      record["txHash"].length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+function ConfirmedStamp(): JSX.Element {
+  return (
+    <span
+      role="status"
+      aria-label="Transaction confirmed"
+      data-vex-transaction-status="confirmed"
+      className="inline-flex shrink-0 items-center gap-1 rounded-[3px] border border-[color-mix(in_oklab,var(--color-success)_40%,transparent)] px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--color-success)]"
+    >
+      <HugeiconsIcon icon={CheckmarkCircle01Icon} size={12} aria-hidden />
+      Confirmed
+    </span>
+  );
+}
 
 /** Section label inside the expanded well — mono microtype (10px floor). */
 function SectionHeading({
@@ -73,6 +113,7 @@ export function ToolActRow({
 }): JSX.Element {
   const [open, setOpen] = useState(false);
   const bodyId = useId();
+  const confirmed = isConfirmedWalletTransfer(act);
   return (
     <div
       // Semantic contract: every visible tool row keeps the role attr.
@@ -107,7 +148,9 @@ export function ToolActRow({
             )}
           />
         </button>
-        {pendingApprovalId !== null ? (
+        {confirmed ? (
+          <ConfirmedStamp />
+        ) : pendingApprovalId !== null ? (
           <ApprovalLinkStamp approvalId={pendingApprovalId} />
         ) : null}
       </div>

--- a/vex-app/src/renderer/features/appShell/__tests__/ToolLedger.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/ToolLedger.test.tsx
@@ -116,6 +116,56 @@ describe("ToolActRow", () => {
   it("renders no stamp at rest (the persisted ledger row is quiet)", () => {
     render(createElement(ToolActRow, { act: act() }));
     expect(screen.queryByText(/awaiting signature/i)).toBeNull();
+    expect(screen.queryByRole("status", { name: /transaction confirmed/i })).toBeNull();
+  });
+
+  it("marks a confirmed wallet transfer with a visible check state", () => {
+    const { container } = render(
+      createElement(ToolActRow, {
+        act: act({
+          toolName: "wallet_send_confirm",
+          output: JSON.stringify({
+            txHash: "solana-signature",
+            chain: "solana",
+            status: "confirmed",
+          }),
+        }),
+      }),
+    );
+
+    expect(
+      screen.getByRole("status", { name: "Transaction confirmed" }),
+    ).not.toBeNull();
+    expect(screen.getByText("Confirmed")).not.toBeNull();
+    expect(
+      container.querySelector('[data-vex-transaction-status="confirmed"]'),
+    ).not.toBeNull();
+  });
+
+  it("does not infer confirmation from malformed, failed, or unrelated output", () => {
+    const cases = [
+      act({ toolName: "wallet_send_confirm", output: "not json" }),
+      act({
+        toolName: "wallet_send_confirm",
+        output: JSON.stringify({ txHash: "hash", status: "failed" }),
+      }),
+      act({
+        toolName: "wallet_send_confirm",
+        output: JSON.stringify({ status: "confirmed" }),
+      }),
+      act({
+        toolName: "wallet_balances",
+        output: JSON.stringify({ txHash: "hash", status: "confirmed" }),
+      }),
+    ];
+
+    for (const candidate of cases) {
+      const view = render(createElement(ToolActRow, { act: candidate }));
+      expect(
+        screen.queryByRole("status", { name: /transaction confirmed/i }),
+      ).toBeNull();
+      view.unmount();
+    }
   });
 
   it("Awaiting-signature stamp links to the approval card and focuses it", () => {

--- a/vex-app/src/renderer/lib/api/__tests__/chat.test.ts
+++ b/vex-app/src/renderer/lib/api/__tests__/chat.test.ts
@@ -20,7 +20,7 @@ import { createElement } from "react";
 
 import { useSubmitChat } from "../chat.js";
 import { sessionKeys } from "../sessions.js";
-import { usageKeys } from "../queryKeys.js";
+import { approvalsKeys, usageKeys } from "../queryKeys.js";
 
 const SESSION = "00000000-0000-4000-8000-0000000000c2";
 const submitMock = vi.fn();
@@ -108,6 +108,30 @@ describe("useSubmitChat onSuccess invalidation", () => {
     await result.current.mutateAsync({ sessionId: SESSION, message: "hello" });
 
     expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("immediately refreshes inline and global approvals when the turn enqueues one", async () => {
+    submitMock.mockReturnValue({
+      promise: Promise.resolve({
+        ok: true,
+        data: { text: null, pendingApprovals: ["approval-1"] },
+      }),
+      cancel: vi.fn(),
+    });
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(() => useSubmitChat(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await result.current.mutateAsync({ sessionId: SESSION, message: "send it" });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: approvalsKeys.pending(SESSION),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: approvalsKeys.pendingAll(),
+    });
   });
 });
 

--- a/vex-app/src/renderer/lib/api/chat.ts
+++ b/vex-app/src/renderer/lib/api/chat.ts
@@ -9,7 +9,7 @@ import type {
   ChatSubmitInput,
   ChatSubmitResult,
 } from "@shared/schemas/chat.js";
-import { isUsageQueryForSession } from "./queryKeys.js";
+import { approvalsKeys, isUsageQueryForSession } from "./queryKeys.js";
 import { sessionKeys } from "./sessions.js";
 
 /**
@@ -62,6 +62,17 @@ export function useSubmitChat(): UseSubmitChatResult {
       void queryClient.invalidateQueries({
         queryKey: sessionKeys.plan(variables.sessionId),
       });
+      // A restricted turn can enqueue an approval before chat.submit returns.
+      // Refresh both the inline card and the app-wide inbox immediately instead
+      // of waiting for their polling fallback.
+      if (result.data.pendingApprovals?.length > 0) {
+        void queryClient.invalidateQueries({
+          queryKey: approvalsKeys.pending(variables.sessionId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: approvalsKeys.pendingAll(),
+        });
+      }
       // A completed turn advances usage rows + the session token_count, so
       // refresh the runtime bar immediately (usage totals, last-turn, and
       // context window). The transcript-append live-sync is the backstop


### PR DESCRIPTION
## Problem solved

A prepared wallet transfer could stop before the user ever received an approval card. wallet_send_prepare is intentionally non-mutating; only wallet_send_confirm enters the restricted-session approval flow. The agent depended on another model round trip to call confirm, so Solana and EVM transfers could remain parked after preparation with no actionable approval UI. After broadcast, a successful confirmation was also visible only inside the expanded raw tool output, making a completed transfer look unfinished.

## What changed

- Adds a typed prepared-action follow-up contract to ToolResult.
- Adds an explicit trusted registry with one allowed mapping: wallet_send_prepare → wallet_send_confirm.
- Canonicalizes confirm args to the validated network and intentId only; extra or malformed fields fail closed.
- Carries the prepared recipient, amount, token, chain, network, and expiry through a separate trusted approval-preview channel. These fields are never rebuilt from model-supplied confirm args.
- Persists the normal prepare call/result, then synthesizes a transcript-safe confirm call and dispatches it without another inference round trip.
- Restricted sessions enqueue the existing approval flow; full-permission sessions execute confirm immediately.
- Caps the handoff at one hop and rejects unknown mappings, malformed contracts, and recursive chains.
- Keeps assistant/tool pairing intact so the existing approval runtime can append the matching confirm result after approval or rejection.
- Makes the approval expire no later than the underlying prepared wallet intent.
- Immediately refreshes the inline approval card and global approval inbox when chat.submit returns a pending approval.
- Shows a semantic green checkmark and Confirmed stamp on wallet_send_confirm only when its trusted result reports status confirmed with a transaction hash.
- Fails the completion stamp closed for malformed JSON, missing hashes, unsuccessful statuses, and unrelated tool output.

## User impact

After Vex prepares a Solana or EVM transfer in a restricted session, the approval card appears immediately. The user no longer has to prompt the agent with messages such as “ok and then?” to reach the actual confirmation step. Once the approved broadcast confirms, the collapsed tool ledger visibly marks the transaction as Confirmed instead of requiring the user to inspect raw output. Full-permission behavior remains automatic.

## Test coverage

- Solana and EVM handoffs
- Restricted and full-permission behavior
- Canonical network/intent confirm args
- Trusted recipient/token/amount/chain/network preview integrity
- Prepared-intent expiry propagation
- Assistant/tool transcript pairing
- Immediate inline and global approval refresh
- Confirmed wallet-transfer check state
- Malformed, failed, missing-hash, and unrelated output rejection
- Unknown mapping and malformed contract rejection
- One-hop limit and recursive follow-up rejection
- Existing wallet prepare validation and preview creation

## Validation

- 15 focused engine handoff, registry, wallet, preview, expiry, and transcript checks pass
- 5 focused desktop approval-refresh checks pass
- 37 focused desktop tool-ledger and transcript-model checks pass
- 6,420 engine tests pass with 7 skipped when excluding the unrelated Polymarket live-network test file
- Full engine run reaches 6,470 passing tests; one unrelated bridge.assets test fails on a live fetch
- 1,694 desktop main-process tests pass
- Root TypeScript build passes
- Desktop lint, type ratchet, and process-boundary checks pass
- Main, preload, and renderer production builds pass
- Build artifact and CSP checks pass
- React Doctor changed-scope scan: 100/100, no issues
