### PR TITLE
feat(mission): mission results ledger — numbered missions + ETH PNL history

### DIFF
--- a/src/__tests__/vex-agent/db/repos/mission-results.test.ts
+++ b/src/__tests__/vex-agent/db/repos/mission-results.test.ts
@@ -1,0 +1,117 @@
+/**
+ * mission_results repo — open/close lifecycle + history reads (mocked pool).
+ *
+ * A ledger row is OPENED when a run starts (seq_no minted per wallet) and CLOSED
+ * when the run finalizes. Pins the SQL shape + params: per-wallet seq numbering,
+ * idempotent open, close-by-run_id, and newest-first history reads.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+type QMock = Mock<(sql: string, params?: unknown[]) => Promise<Record<string, unknown>[]>>;
+type EMock = Mock<(sql: string, params?: unknown[]) => Promise<number>>;
+
+let mockQuery: QMock;
+let mockQueryOne: Mock;
+let mockExecute: EMock;
+
+vi.mock("@vex-agent/db/client.js", () => ({
+  query: (sql: string, p?: unknown[]) => mockQuery(sql, p),
+  queryOne: (sql: string, p?: unknown[]) => mockQueryOne(sql, p),
+  execute: (sql: string, p?: unknown[]) => mockExecute(sql, p),
+  queryWith: vi.fn(),
+  queryOneWith: vi.fn(),
+  executeWith: vi.fn(),
+}));
+
+const repo = await import("@vex-agent/db/repos/mission-results.js");
+
+const norm = (s: string) => s.replace(/\s+/g, " ").trim();
+
+beforeEach(() => {
+  mockQuery = vi.fn(async () => []);
+  mockQueryOne = vi.fn(async () => null);
+  mockExecute = vi.fn(async () => 1);
+});
+
+const OPEN = {
+  id: "res-1",
+  missionId: "mission-1",
+  missionRunId: "run-1",
+  sessionId: "00000000-0000-4000-8000-000000000001",
+  walletAddress: "0xAbC",
+  chainId: 4663,
+  goalSnippet: "grow ETH +8%",
+  bankrollStartEth: 0.012,
+  ethPriceUsdStart: 3000,
+};
+
+describe("openMissionResult", () => {
+  it("inserts with a per-wallet seq_no minted from the row count", async () => {
+    await repo.openMissionResult(OPEN);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockExecute.mock.calls[0]!;
+    const s = norm(sql);
+    expect(s).toContain("INSERT INTO mission_results");
+    // seq_no = count+1 for THIS wallet (case-insensitive)
+    expect(s).toContain("SELECT COUNT(*)+1 FROM mission_results WHERE LOWER(wallet_address) = LOWER(");
+    expect(s).toContain("outcome");
+    expect(params).toContain("run-1");
+    expect(params).toContain("0xAbC");
+  });
+
+  it("is idempotent — a duplicate open for the same run does nothing", async () => {
+    await repo.openMissionResult(OPEN);
+    const s = norm(mockExecute.mock.calls[0]![0]);
+    expect(s).toContain("ON CONFLICT (mission_run_id) DO NOTHING");
+  });
+});
+
+describe("closeMissionResult", () => {
+  it("updates the row by run_id with terminal outcome, PNL, counts, and duration", async () => {
+    await repo.closeMissionResult({
+      missionRunId: "run-1",
+      outcome: "completed",
+      bankrollEndEth: 0.013,
+      ethPriceUsdEnd: 3100,
+      pnlEth: 0.001,
+      pnlPct: 8.33,
+      trades: 4,
+      wins: 3,
+      losses: 1,
+      rotations: 1,
+      vetoes: 2,
+      openPositions: [{ token: "NOXA", amount: "10" }],
+    });
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockExecute.mock.calls[0]!;
+    const s = norm(sql);
+    expect(s).toContain("UPDATE mission_results SET");
+    expect(s).toContain("WHERE mission_run_id =");
+    expect(s).toContain("ended_at = NOW()");
+    expect(s.toLowerCase()).toContain("duration_s");
+    expect(params).toContain("run-1");
+    expect(params).toContain("completed");
+    // open_positions serialized as jsonb text, not a raw object
+    expect(params!.some((p) => typeof p === "string" && p.includes("NOXA"))).toBe(true);
+  });
+});
+
+describe("history reads", () => {
+  it("listResultsForWallet reads newest-first for the wallet (case-insensitive)", async () => {
+    await repo.listResultsForWallet("0xAbC", 25);
+    const [sql, params] = mockQuery.mock.calls[0]!;
+    const s = norm(sql);
+    expect(s).toContain("FROM mission_results");
+    expect(s).toContain("LOWER(wallet_address) = LOWER(");
+    expect(s).toContain("ORDER BY seq_no DESC");
+    expect(params).toEqual(["0xAbC", 25]);
+  });
+
+  it("getResultForRun reads a single row by run_id", async () => {
+    await repo.getResultForRun("run-1");
+    const [sql, params] = mockQueryOne.mock.calls[0]!;
+    expect(norm(sql)).toContain("WHERE mission_run_id =");
+    expect(params).toEqual(["run-1"]);
+  });
+});

--- a/src/__tests__/vex-agent/engine/mission/bankroll.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/bankroll.test.ts
@@ -1,0 +1,57 @@
+/**
+ * ETH-equivalent bankroll from proj_balances rows. Native ETH + WETH make up the
+ * bankroll (the mission's unit of account); every other held token is an OPEN
+ * position, reported separately and excluded from the bankroll figure so an
+ * unsold bag never inflates PNL.
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeEthBankroll } from "@vex-agent/engine/mission/bankroll.js";
+import type { BalanceRow } from "@vex-agent/db/repos/balances/types.js";
+
+const NATIVE = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+function bal(over: Partial<BalanceRow>): BalanceRow {
+  return {
+    walletFamily: "eip155", walletAddress: "0xW", chainId: 4663,
+    tokenAddress: NATIVE, tokenSymbol: "ETH", tokenName: "Ether",
+    balanceRaw: "0", balanceUsd: null, priceUsd: null, decimals: 18, ...over,
+  };
+}
+
+describe("computeEthBankroll", () => {
+  it("sums native ETH + WETH into the bankroll", () => {
+    const r = computeEthBankroll([
+      bal({ tokenAddress: NATIVE, tokenSymbol: "ETH", balanceRaw: "10000000000000000", priceUsd: 3000 }), // 0.01
+      bal({ tokenAddress: "0x0Bd7", tokenSymbol: "WETH", balanceRaw: "5000000000000000", priceUsd: 3000 }), // 0.005
+    ]);
+    expect(r.bankrollEth).toBeCloseTo(0.015, 12);
+    expect(r.ethPriceUsd).toBe(3000);
+    expect(r.openPositions).toHaveLength(0);
+  });
+
+  it("treats other tokens as open positions, excluded from the bankroll", () => {
+    const r = computeEthBankroll([
+      bal({ tokenAddress: NATIVE, tokenSymbol: "ETH", balanceRaw: "10000000000000000", priceUsd: 3000 }),
+      bal({ tokenAddress: "0xNOXA", tokenSymbol: "NOXA", balanceRaw: "2000000000000000000", decimals: 18, balanceUsd: 42 }),
+    ]);
+    expect(r.bankrollEth).toBeCloseTo(0.01, 12); // NOXA excluded
+    expect(r.openPositions).toHaveLength(1);
+    expect(r.openPositions[0]).toMatchObject({ symbol: "NOXA", address: "0xNOXA", valueUsd: 42 });
+    expect(r.openPositions[0]!.amount).toBeCloseTo(2, 9);
+  });
+
+  it("ignores zero-balance non-ETH tokens (dust rows)", () => {
+    const r = computeEthBankroll([
+      bal({ tokenAddress: NATIVE, balanceRaw: "10000000000000000", priceUsd: 3000 }),
+      bal({ tokenAddress: "0xDUST", tokenSymbol: "DUST", balanceRaw: "0" }),
+    ]);
+    expect(r.openPositions).toHaveLength(0);
+  });
+
+  it("returns a zero bankroll for no rows", () => {
+    const r = computeEthBankroll([]);
+    expect(r.bankrollEth).toBe(0);
+    expect(r.ethPriceUsd).toBeNull();
+  });
+});

--- a/src/__tests__/vex-agent/engine/mission/mission-metrics.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/mission-metrics.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Per-mission trade count — successful fills recorded in proj_activity, bounded
+ * to the run by its session and time window. (A mission run maps 1:1 to a
+ * session; proj_activity links to a session via protocol_executions.)
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+let mockQueryOne: Mock;
+
+vi.mock("@vex-agent/db/client.js", () => ({
+  query: vi.fn(),
+  queryOne: (sql: string, p?: unknown[]) => mockQueryOne(sql, p),
+  execute: vi.fn(),
+  queryWith: vi.fn(),
+  queryOneWith: vi.fn(),
+  executeWith: vi.fn(),
+}));
+
+const { countMissionTrades } = await import(
+  "@vex-agent/engine/mission/mission-metrics.js"
+);
+
+const norm = (s: string) => s.replace(/\s+/g, " ").trim();
+
+beforeEach(() => {
+  mockQueryOne = vi.fn(async () => ({ trades: 4 }));
+});
+
+describe("countMissionTrades", () => {
+  it("counts fills for the session within the run window (joined via protocol_executions)", async () => {
+    const n = await countMissionTrades("sess-1", "2026-07-12T18:00:00Z", "2026-07-12T19:00:00Z");
+    expect(n).toBe(4);
+    const [sql, params] = mockQueryOne.mock.calls[0]!;
+    const s = norm(sql);
+    expect(s).toContain("FROM proj_activity");
+    expect(s).toContain("JOIN protocol_executions");
+    expect(s).toContain("session_id =");
+    expect(s).toContain("created_at BETWEEN");
+    expect(s.toLowerCase()).toContain("count(");
+    expect(params).toEqual(["sess-1", "2026-07-12T18:00:00Z", "2026-07-12T19:00:00Z"]);
+  });
+
+  it("is fail-soft — a query error yields 0, never throws (finalize must not break)", async () => {
+    mockQueryOne = vi.fn(async () => {
+      throw new Error("db down");
+    });
+    await expect(countMissionTrades("s", "a", "b")).resolves.toBe(0);
+  });
+});

--- a/src/__tests__/vex-agent/engine/mission/mission-results-capture.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/mission-results-capture.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Mission results capture — orchestration that opens the ledger row at run start
+ * and closes it at finalize. Deps are injected so this runs with no DB/network.
+ * Pins: wallet/chain resolution from the mission, PNL math, and fail-soft (a
+ * throwing dep never propagates — mission finalization must not break).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  computePnl,
+  captureMissionStart,
+  captureMissionFinal,
+  type CaptureDeps,
+} from "@vex-agent/engine/mission/mission-results-capture.js";
+
+const MISSION = {
+  id: "mission-1",
+  goal: "grow ETH +8% in 60 min",
+  allowedChains: ["robinhood"],
+  allowedWallets: ["0x9ed25bdedceB28Adf9E3C7fCa34511e78e47C77f"],
+};
+
+function deps(over: Partial<CaptureDeps> = {}): CaptureDeps {
+  return {
+    getMission: vi.fn(async () => MISSION as never),
+    readBankroll: vi.fn(async () => ({ bankrollEth: 0.01, ethPriceUsd: 3000, openPositions: [] })),
+    openResult: vi.fn(async () => {}),
+    closeResult: vi.fn(async () => {}),
+    getResult: vi.fn(async () => null),
+    countTrades: vi.fn(async () => 3),
+    ...over,
+  };
+}
+
+describe("computePnl", () => {
+  it("computes ETH delta and percent vs start", () => {
+    expect(computePnl(0.01, 0.011)).toEqual({ pnlEth: expect.closeTo(0.001, 9), pnlPct: expect.closeTo(10, 6) });
+  });
+  it("is null when either bankroll is unknown", () => {
+    expect(computePnl(null, 0.01)).toEqual({ pnlEth: null, pnlPct: null });
+    expect(computePnl(0.01, null)).toEqual({ pnlEth: null, pnlPct: null });
+  });
+  it("guards divide-by-zero when start is zero", () => {
+    expect(computePnl(0, 0.01).pnlPct).toBeNull();
+  });
+});
+
+describe("captureMissionStart", () => {
+  it("opens a ledger row with the mission's wallet, resolved chainId, and start bankroll", async () => {
+    const d = deps();
+    await captureMissionStart({ missionId: "mission-1", runId: "run-1", sessionId: "s-1" }, d);
+    expect(d.openResult).toHaveBeenCalledTimes(1);
+    const arg = (d.openResult as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(arg).toMatchObject({
+      missionRunId: "run-1",
+      walletAddress: "0x9ed25bdedceB28Adf9E3C7fCa34511e78e47C77f",
+      chainId: 4663,
+      bankrollStartEth: 0.01,
+      ethPriceUsdStart: 3000,
+    });
+    expect(arg.goalSnippet).toContain("grow ETH");
+  });
+
+  it("no-ops when the mission is missing (nothing to open)", async () => {
+    const d = deps({ getMission: vi.fn(async () => null) });
+    await captureMissionStart({ missionId: "x", runId: "r", sessionId: "s" }, d);
+    expect(d.openResult).not.toHaveBeenCalled();
+  });
+
+  it("is fail-soft — a throwing bankroll read never propagates", async () => {
+    const d = deps({ readBankroll: vi.fn(async () => { throw new Error("db down"); }) });
+    await expect(
+      captureMissionStart({ missionId: "mission-1", runId: "r", sessionId: "s" }, d),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("captureMissionFinal", () => {
+  it("closes with PNL vs the opened start bankroll, and the trade count", async () => {
+    const d = deps({
+      getResult: vi.fn(async () => ({ startedAt: "2026-07-12T18:00:00Z", bankrollStartEth: 0.01 } as never)),
+      readBankroll: vi.fn(async () => ({ bankrollEth: 0.011, ethPriceUsd: 3100, openPositions: [{ symbol: "NOXA", address: "0x", amount: 1, valueUsd: 5 }] })),
+    });
+    await captureMissionFinal({ missionId: "mission-1", runId: "run-1", sessionId: "s-1", outcome: "completed" }, d);
+    const arg = (d.closeResult as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(arg).toMatchObject({ missionRunId: "run-1", outcome: "completed", bankrollEndEth: 0.011, trades: 3 });
+    expect(arg.pnlEth).toBeCloseTo(0.001, 9);
+    expect(arg.openPositions).toHaveLength(1);
+  });
+
+  it("no-ops when no ledger row was opened for the run", async () => {
+    const d = deps({ getResult: vi.fn(async () => null) });
+    await captureMissionFinal({ missionId: "m", runId: "r", sessionId: "s", outcome: "failed" }, d);
+    expect(d.closeResult).not.toHaveBeenCalled();
+  });
+});

--- a/src/vex-agent/db/migrations/038_mission_results.sql
+++ b/src/vex-agent/db/migrations/038_mission_results.sql
@@ -1,0 +1,47 @@
+-- Mission results ledger. One row per mission RUN, opened when the run starts
+-- and closed when it reaches a terminal status. Gives every mission a stable
+-- per-wallet number (#N) and a persisted, comparable PNL record so performance
+-- can be tracked over time.
+--
+-- PNL is denominated in ETH (the bankroll's own unit): bankroll_end_eth minus
+-- bankroll_start_eth, where bankroll = native ETH + WETH read from proj_balances.
+-- This nets out gas/fees/slippage automatically (the honest number). Token bags
+-- still held at close are recorded in open_positions_json and EXCLUDED from the
+-- headline PNL so an unsold position never distorts it. USD-at-close prices are
+-- kept only for display tooltips.
+
+CREATE TABLE mission_results (
+  id TEXT PRIMARY KEY,
+  mission_id TEXT NOT NULL REFERENCES missions(id),
+  mission_run_id TEXT NOT NULL REFERENCES mission_runs(id),
+  session_id TEXT NOT NULL REFERENCES sessions(id),
+  wallet_address TEXT NOT NULL,
+  chain_id BIGINT NOT NULL,
+  seq_no INTEGER NOT NULL,                 -- per-wallet "Mission #N"
+  goal_snippet TEXT,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ended_at TIMESTAMPTZ,
+  duration_s INTEGER,
+  bankroll_start_eth NUMERIC,
+  bankroll_end_eth NUMERIC,
+  pnl_eth NUMERIC,
+  pnl_pct NUMERIC,
+  eth_price_usd_start NUMERIC,             -- display-only (USD tooltip)
+  eth_price_usd_end NUMERIC,               -- display-only (USD tooltip)
+  trades INTEGER NOT NULL DEFAULT 0,
+  wins INTEGER NOT NULL DEFAULT 0,
+  losses INTEGER NOT NULL DEFAULT 0,
+  rotations INTEGER NOT NULL DEFAULT 0,
+  vetoes INTEGER NOT NULL DEFAULT 0,
+  outcome TEXT NOT NULL DEFAULT 'running', -- running|completed|cancelled|failed|stopped
+  open_positions_json JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Exactly one ledger row per run (open/close lifecycle keys on this).
+CREATE UNIQUE INDEX mission_results_run_uidx ON mission_results (mission_run_id);
+
+-- Per-wallet numbering + history reads (newest first).
+CREATE INDEX mission_results_wallet_idx
+  ON mission_results (LOWER(wallet_address), seq_no DESC);

--- a/src/vex-agent/db/repos/mission-results.ts
+++ b/src/vex-agent/db/repos/mission-results.ts
@@ -1,0 +1,241 @@
+/**
+ * Mission results ledger repo — open/close lifecycle + history reads.
+ *
+ * A row is OPENED when a mission run starts (with a per-wallet seq_no and the
+ * start bankroll snapshot) and CLOSED when the run finalizes (end bankroll, PNL,
+ * trade counts, outcome). Open/close key on `mission_run_id`, so the start and
+ * finalize hooks — which run in different turns — address the same row without
+ * holding state in memory.
+ *
+ * PNL is in ETH (bankroll = native ETH + WETH). See migration 038 for the model.
+ */
+
+import { query, queryOne, execute } from "../client.js";
+import { nullableJsonb } from "../params.js";
+
+export type MissionOutcome =
+  | "running"
+  | "completed"
+  | "cancelled"
+  | "failed"
+  | "stopped";
+
+export interface MissionResultRow {
+  id: string;
+  missionId: string;
+  missionRunId: string;
+  sessionId: string;
+  walletAddress: string;
+  chainId: number;
+  seqNo: number;
+  goalSnippet: string | null;
+  startedAt: string;
+  endedAt: string | null;
+  durationS: number | null;
+  bankrollStartEth: number | null;
+  bankrollEndEth: number | null;
+  pnlEth: number | null;
+  pnlPct: number | null;
+  ethPriceUsdStart: number | null;
+  ethPriceUsdEnd: number | null;
+  trades: number;
+  wins: number;
+  losses: number;
+  rotations: number;
+  vetoes: number;
+  outcome: MissionOutcome;
+  openPositions: unknown;
+}
+
+export interface OpenMissionResultInput {
+  id: string;
+  missionId: string;
+  missionRunId: string;
+  sessionId: string;
+  walletAddress: string;
+  chainId: number;
+  goalSnippet: string | null;
+  bankrollStartEth: number | null;
+  ethPriceUsdStart: number | null;
+}
+
+export interface CloseMissionResultInput {
+  missionRunId: string;
+  outcome: Exclude<MissionOutcome, "running">;
+  bankrollEndEth: number | null;
+  ethPriceUsdEnd: number | null;
+  pnlEth: number | null;
+  pnlPct: number | null;
+  trades: number;
+  wins: number;
+  losses: number;
+  rotations: number;
+  vetoes: number;
+  openPositions: unknown;
+}
+
+const SELECT_COLUMNS = `
+  id, mission_id, mission_run_id, session_id, wallet_address, chain_id, seq_no,
+  goal_snippet, started_at, ended_at, duration_s,
+  bankroll_start_eth, bankroll_end_eth, pnl_eth, pnl_pct,
+  eth_price_usd_start, eth_price_usd_end,
+  trades, wins, losses, rotations, vetoes, outcome, open_positions_json`;
+
+interface Raw {
+  id: string;
+  mission_id: string;
+  mission_run_id: string;
+  session_id: string;
+  wallet_address: string;
+  chain_id: string | number;
+  seq_no: number;
+  goal_snippet: string | null;
+  started_at: Date | string;
+  ended_at: Date | string | null;
+  duration_s: number | null;
+  bankroll_start_eth: string | null;
+  bankroll_end_eth: string | null;
+  pnl_eth: string | null;
+  pnl_pct: string | null;
+  eth_price_usd_start: string | null;
+  eth_price_usd_end: string | null;
+  trades: number;
+  wins: number;
+  losses: number;
+  rotations: number;
+  vetoes: number;
+  outcome: MissionOutcome;
+  open_positions_json: unknown;
+}
+
+// pg returns NUMERIC as string to preserve precision; ETH/PNL fit safely in a
+// JS number for display.
+const num = (v: string | number | null): number | null =>
+  v === null ? null : Number(v);
+
+const iso = (v: Date | string): string =>
+  v instanceof Date ? v.toISOString() : String(v);
+
+function toRow(r: Raw): MissionResultRow {
+  return {
+    id: r.id,
+    missionId: r.mission_id,
+    missionRunId: r.mission_run_id,
+    sessionId: r.session_id,
+    walletAddress: r.wallet_address,
+    chainId: Number(r.chain_id),
+    seqNo: r.seq_no,
+    goalSnippet: r.goal_snippet,
+    startedAt: iso(r.started_at),
+    endedAt: r.ended_at === null ? null : iso(r.ended_at),
+    durationS: r.duration_s,
+    bankrollStartEth: num(r.bankroll_start_eth),
+    bankrollEndEth: num(r.bankroll_end_eth),
+    pnlEth: num(r.pnl_eth),
+    pnlPct: num(r.pnl_pct),
+    ethPriceUsdStart: num(r.eth_price_usd_start),
+    ethPriceUsdEnd: num(r.eth_price_usd_end),
+    trades: r.trades,
+    wins: r.wins,
+    losses: r.losses,
+    rotations: r.rotations,
+    vetoes: r.vetoes,
+    outcome: r.outcome,
+    openPositions: r.open_positions_json,
+  };
+}
+
+/**
+ * Open the ledger row for a run. `seq_no` is minted as the per-wallet row count
+ * + 1. Idempotent: a duplicate open for the same run is a no-op (the run-id
+ * unique index + ON CONFLICT), so a retried start never double-numbers.
+ */
+export async function openMissionResult(
+  input: OpenMissionResultInput,
+): Promise<void> {
+  const sql = `
+    INSERT INTO mission_results (
+      id, mission_id, mission_run_id, session_id, wallet_address, chain_id,
+      seq_no, goal_snippet, bankroll_start_eth, eth_price_usd_start, outcome
+    ) VALUES (
+      $1, $2, $3, $4, $5, $6,
+      (SELECT COUNT(*)+1 FROM mission_results WHERE LOWER(wallet_address) = LOWER($5)),
+      $7, $8, $9, 'running'
+    )
+    ON CONFLICT (mission_run_id) DO NOTHING`;
+  await execute(sql, [
+    input.id,
+    input.missionId,
+    input.missionRunId,
+    input.sessionId,
+    input.walletAddress,
+    input.chainId,
+    input.goalSnippet,
+    input.bankrollStartEth,
+    input.ethPriceUsdStart,
+  ]);
+}
+
+/** Close the ledger row at finalize. No-op if the row was never opened. */
+export async function closeMissionResult(
+  input: CloseMissionResultInput,
+): Promise<void> {
+  const sql = `
+    UPDATE mission_results SET
+      outcome = $2,
+      ended_at = NOW(),
+      duration_s = EXTRACT(EPOCH FROM (NOW() - started_at))::int,
+      bankroll_end_eth = $3,
+      eth_price_usd_end = $4,
+      pnl_eth = $5,
+      pnl_pct = $6,
+      trades = $7,
+      wins = $8,
+      losses = $9,
+      rotations = $10,
+      vetoes = $11,
+      open_positions_json = $12,
+      updated_at = NOW()
+    WHERE mission_run_id = $1`;
+  await execute(sql, [
+    input.missionRunId,
+    input.outcome,
+    input.bankrollEndEth,
+    input.ethPriceUsdEnd,
+    input.pnlEth,
+    input.pnlPct,
+    input.trades,
+    input.wins,
+    input.losses,
+    input.rotations,
+    input.vetoes,
+    nullableJsonb(input.openPositions),
+  ]);
+}
+
+/** Per-wallet mission history, newest first. */
+export async function listResultsForWallet(
+  walletAddress: string,
+  limit = 50,
+): Promise<MissionResultRow[]> {
+  const rows = await query<Raw>(
+    `SELECT ${SELECT_COLUMNS}
+       FROM mission_results
+      WHERE LOWER(wallet_address) = LOWER($1)
+      ORDER BY seq_no DESC
+      LIMIT $2`,
+    [walletAddress, limit],
+  );
+  return rows.map(toRow);
+}
+
+/** The ledger row for a single run (null if never opened). */
+export async function getResultForRun(
+  missionRunId: string,
+): Promise<MissionResultRow | null> {
+  const row = await queryOne<Raw>(
+    `SELECT ${SELECT_COLUMNS} FROM mission_results WHERE mission_run_id = $1`,
+    [missionRunId],
+  );
+  return row ? toRow(row) : null;
+}

--- a/src/vex-agent/engine/core/runner/mission-finalize.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize.ts
@@ -20,6 +20,7 @@ import * as missionsRepo from "@vex-agent/db/repos/missions.js";
 import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
 import logger from "@utils/logger.js";
 import { consumeMissionRunAbortIntent } from "./abort.js";
+import { captureMissionFinal } from "../../mission/mission-results-capture.js";
 import {
   isContinuableRuntimeStop,
   scheduleRuntimeContinuation,
@@ -88,6 +89,7 @@ export async function finalizeMissionRunStatus(
       await missionsRepo.clearApprovedAt(missionId);
       await missionsRepo.setStatus(missionId, "draft");
       await emitFinalizeControlState(sessionId, runId);
+      await captureMissionFinal({ missionId, runId, sessionId, outcome: "stopped" });
       return "draft";
     }
 
@@ -99,6 +101,7 @@ export async function finalizeMissionRunStatus(
     await missionsRepo.setStatus(missionId, status);
     await missionRunsRepo.updateStatus(runId, status, stopReason, stopPayload);
     await emitFinalizeControlState(sessionId, runId);
+    await captureMissionFinal({ missionId, runId, sessionId, outcome: status });
     return status;
   }
 
@@ -123,6 +126,7 @@ export async function finalizeMissionRunStatus(
     await missionsRepo.setStatus(missionId, "failed");
     await missionRunsRepo.updateStatus(runId, "failed", stopReason);
     await emitFinalizeControlState(sessionId, runId);
+    await captureMissionFinal({ missionId, runId, sessionId, outcome: "failed" });
     // Phase 2 BUG-REPORTING emit (puzzle 03): terminal `system_error`
     // is a hard failure surface — record the mission state. Fail-
     // closed so a sink outage cannot mask the terminal flip.

--- a/src/vex-agent/engine/core/runner/mission-run.ts
+++ b/src/vex-agent/engine/core/runner/mission-run.ts
@@ -36,6 +36,7 @@ import {
   type MissionRunContractSnapshot,
   resolveMissionPromptContext,
 } from "../../mission/run-contract.js";
+import { captureMissionStart } from "../../mission/mission-results-capture.js";
 import type { PromptStackOptions } from "../../prompts/index.js";
 import { getOpenAITools, type ToolVisibilityBase } from "@vex-agent/tools/registry.js";
 import {
@@ -103,6 +104,13 @@ export async function runPreparedMissionStart(
 ): Promise<TurnResult> {
   const controller = registerMissionRunAbortController(prepared.runId);
   try {
+    // Open the mission results ledger row (per-wallet #N + start bankroll
+    // snapshot). Fail-soft inside — never blocks the run.
+    await captureMissionStart({
+      missionId: prepared.missionId,
+      runId: prepared.runId,
+      sessionId: prepared.sessionId,
+    });
     await addMissionActivationMessage({
       sessionId: prepared.sessionId,
       missionId: prepared.missionId,

--- a/src/vex-agent/engine/mission/bankroll.ts
+++ b/src/vex-agent/engine/mission/bankroll.ts
@@ -1,0 +1,95 @@
+/**
+ * ETH-equivalent bankroll read for the mission results ledger.
+ *
+ * The bankroll is native ETH + WETH (they are 1:1 and price rides on wrapped
+ * native — see local-chain-balance-sync). Every other held token is an OPEN
+ * position: reported separately and EXCLUDED from the bankroll so an unsold bag
+ * never distorts a mission's PNL. Reads the `proj_balances` projection (no
+ * on-chain RPC) and is fail-soft — a read error yields null so mission
+ * finalization is never blocked by bankroll accounting.
+ */
+
+import { formatUnits } from "viem";
+import { getBalances } from "../../db/repos/balances/read.js";
+import type { BalanceRow } from "../../db/repos/balances/types.js";
+import { NATIVE_TOKEN_ADDRESS } from "../../../tools/kyberswap/constants.js";
+import logger from "@utils/logger.js";
+
+export interface OpenPosition {
+  symbol: string | null;
+  address: string;
+  amount: number;
+  valueUsd: number | null;
+}
+
+export interface EthBankroll {
+  /** Native ETH + WETH, in ETH. */
+  bankrollEth: number;
+  /** ETH/USD from the native/WETH row (display tooltip only); null if unpriced. */
+  ethPriceUsd: number | null;
+  /** Non-ETH tokens still held, excluded from the bankroll. */
+  openPositions: OpenPosition[];
+}
+
+function toAmount(raw: string, decimals: number | null): number {
+  try {
+    return Number(formatUnits(BigInt(raw), decimals ?? 18));
+  } catch {
+    return 0;
+  }
+}
+
+/** Pure: fold proj_balances rows into an ETH bankroll + open-position list. */
+export function computeEthBankroll(rows: readonly BalanceRow[]): EthBankroll {
+  let bankrollEth = 0;
+  let ethPriceUsd: number | null = null;
+  const openPositions: OpenPosition[] = [];
+
+  for (const r of rows) {
+    const isNative =
+      r.tokenAddress.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase();
+    const isWeth = (r.tokenSymbol ?? "").toUpperCase() === "WETH";
+    const amount = toAmount(r.balanceRaw, r.decimals);
+
+    if (isNative || isWeth) {
+      bankrollEth += amount;
+      if (ethPriceUsd === null && r.priceUsd !== null) ethPriceUsd = r.priceUsd;
+    } else if (amount > 0) {
+      openPositions.push({
+        symbol: r.tokenSymbol,
+        address: r.tokenAddress,
+        amount,
+        valueUsd: r.balanceUsd,
+      });
+    }
+  }
+
+  return { bankrollEth, ethPriceUsd, openPositions };
+}
+
+export interface BankrollDeps {
+  getBalances: typeof getBalances;
+}
+
+/**
+ * Read the wallet's ETH bankroll on a chain from `proj_balances`. Fail-soft:
+ * returns null on any read error (caller records a null snapshot rather than
+ * failing the run).
+ */
+export async function readEthBankroll(
+  walletAddress: string,
+  chainId: number,
+  deps: BankrollDeps = { getBalances },
+): Promise<EthBankroll | null> {
+  try {
+    const rows = await deps.getBalances(walletAddress, chainId);
+    return computeEthBankroll(rows);
+  } catch (err) {
+    logger.warn("mission.bankroll.read_failed", {
+      walletAddress,
+      chainId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/src/vex-agent/engine/mission/mission-metrics.ts
+++ b/src/vex-agent/engine/mission/mission-metrics.ts
@@ -1,0 +1,40 @@
+/**
+ * Per-mission trade metrics for the results ledger.
+ *
+ * proj_activity holds one row per successful fill; it links to a session via
+ * protocol_executions.execution_id → protocol_executions.session_id. A mission
+ * run maps 1:1 to a session, so bounding by (session_id, created_at within the
+ * run window) attributes fills to the run. Fail-soft: a read error yields 0 so
+ * mission finalization is never blocked by metrics.
+ *
+ * v1 computes the trade COUNT. Per-trade win/loss/rotation attribution is future
+ * work (the ledger columns exist); mission-level win-rate is derived in the UI
+ * from PNL sign, which needs no per-trade pairing.
+ */
+
+import { queryOne } from "../../db/client.js";
+import logger from "@utils/logger.js";
+
+export async function countMissionTrades(
+  sessionId: string,
+  startedAt: string,
+  endedAt: string,
+): Promise<number> {
+  try {
+    const row = await queryOne<{ trades: number }>(
+      `SELECT COUNT(*)::int AS trades
+         FROM proj_activity a
+         JOIN protocol_executions e ON a.execution_id = e.id
+        WHERE e.session_id = $1
+          AND a.created_at BETWEEN $2 AND $3`,
+      [sessionId, startedAt, endedAt],
+    );
+    return row?.trades ?? 0;
+  } catch (err) {
+    logger.warn("mission.metrics.count_trades_failed", {
+      sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return 0;
+  }
+}

--- a/src/vex-agent/engine/mission/mission-results-capture.ts
+++ b/src/vex-agent/engine/mission/mission-results-capture.ts
@@ -1,0 +1,147 @@
+/**
+ * Mission results capture — opens the ledger row when a run starts and closes it
+ * when the run finalizes. Both are FAIL-SOFT: any error is logged and swallowed
+ * so bankroll accounting can never break a mission's lifecycle. Deps are injected
+ * for tests; production wires the real repos/helpers.
+ *
+ * Start and finalize run in different turns, so nothing is held in memory — the
+ * row is keyed on `mission_run_id` and re-addressed at close.
+ */
+
+import { randomUUID } from "node:crypto";
+import { getMission, type Mission } from "../../db/repos/missions.js";
+import { LOCAL_CHAIN_ALIASES } from "../../../tools/evm-chains/registry.js";
+import { readEthBankroll } from "./bankroll.js";
+import { countMissionTrades } from "./mission-metrics.js";
+import {
+  openMissionResult,
+  closeMissionResult,
+  getResultForRun,
+  type MissionOutcome,
+} from "../../db/repos/mission-results.js";
+import logger from "@utils/logger.js";
+
+const GOAL_SNIPPET_MAX = 240;
+
+export interface CaptureDeps {
+  getMission: typeof getMission;
+  readBankroll: typeof readEthBankroll;
+  openResult: typeof openMissionResult;
+  closeResult: typeof closeMissionResult;
+  getResult: typeof getResultForRun;
+  countTrades: typeof countMissionTrades;
+}
+
+// Built lazily (inside each function's try) rather than at module load: some
+// runner tests partially-mock the repo modules, and a top-level object literal
+// would touch those bindings at import time. Resolving inside the try keeps the
+// access under the fail-soft guard.
+function productionDeps(): CaptureDeps {
+  return {
+    getMission,
+    readBankroll: readEthBankroll,
+    openResult: openMissionResult,
+    closeResult: closeMissionResult,
+    getResult: getResultForRun,
+    countTrades: countMissionTrades,
+  };
+}
+
+/** Pure PNL: ETH delta + percent vs start. Null when either side is unknown. */
+export function computePnl(
+  startEth: number | null,
+  endEth: number | null,
+): { pnlEth: number | null; pnlPct: number | null } {
+  if (startEth === null || endEth === null) return { pnlEth: null, pnlPct: null };
+  const pnlEth = endEth - startEth;
+  const pnlPct = startEth > 0 ? (pnlEth / startEth) * 100 : null;
+  return { pnlEth, pnlPct };
+}
+
+function resolveWalletChain(
+  mission: Pick<Mission, "allowedWallets" | "allowedChains">,
+): { wallet: string; chainId: number } | null {
+  const wallet = mission.allowedWallets?.[0];
+  const chainKey = mission.allowedChains?.[0]?.toLowerCase();
+  if (!wallet || !chainKey) return null;
+  const chainId = LOCAL_CHAIN_ALIASES[chainKey];
+  if (chainId === undefined) return null;
+  return { wallet, chainId };
+}
+
+/** Open the ledger row at run start (fail-soft). */
+export async function captureMissionStart(
+  args: { missionId: string; runId: string; sessionId: string },
+  injected?: CaptureDeps,
+): Promise<void> {
+  try {
+    const deps = injected ?? productionDeps();
+    const mission = await deps.getMission(args.missionId);
+    if (!mission) return;
+    const wc = resolveWalletChain(mission);
+    if (!wc) return;
+    const bankroll = await deps.readBankroll(wc.wallet, wc.chainId);
+    await deps.openResult({
+      id: `mres-${randomUUID()}`,
+      missionId: args.missionId,
+      missionRunId: args.runId,
+      sessionId: args.sessionId,
+      walletAddress: wc.wallet,
+      chainId: wc.chainId,
+      goalSnippet: mission.goal?.slice(0, GOAL_SNIPPET_MAX) ?? null,
+      bankrollStartEth: bankroll?.bankrollEth ?? null,
+      ethPriceUsdStart: bankroll?.ethPriceUsd ?? null,
+    });
+  } catch (err) {
+    logger.warn("mission.results.capture_start_failed", {
+      runId: args.runId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/** Close the ledger row at finalize with PNL + trade count (fail-soft). */
+export async function captureMissionFinal(
+  args: {
+    missionId: string;
+    runId: string;
+    sessionId: string;
+    outcome: Exclude<MissionOutcome, "running">;
+  },
+  injected?: CaptureDeps,
+): Promise<void> {
+  try {
+    const deps = injected ?? productionDeps();
+    const existing = await deps.getResult(args.runId);
+    if (!existing) return; // never opened → nothing to close
+    const mission = await deps.getMission(args.missionId);
+    const wc = mission ? resolveWalletChain(mission) : null;
+    const bankroll = wc ? await deps.readBankroll(wc.wallet, wc.chainId) : null;
+    const endEth = bankroll?.bankrollEth ?? null;
+    const { pnlEth, pnlPct } = computePnl(existing.bankrollStartEth, endEth);
+    const trades = await deps.countTrades(
+      args.sessionId,
+      existing.startedAt,
+      new Date().toISOString(),
+    );
+    await deps.closeResult({
+      missionRunId: args.runId,
+      outcome: args.outcome,
+      bankrollEndEth: endEth,
+      ethPriceUsdEnd: bankroll?.ethPriceUsd ?? null,
+      pnlEth,
+      pnlPct,
+      trades,
+      wins: 0,
+      losses: 0,
+      rotations: 0,
+      vetoes: 0,
+      openPositions: bankroll?.openPositions ?? null,
+    });
+  } catch (err) {
+    logger.warn("mission.results.capture_final_failed", {
+      runId: args.runId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/vex-app/src/main/database/mission-results-db.ts
+++ b/vex-app/src/main/database/mission-results-db.ts
@@ -1,0 +1,149 @@
+/**
+ * Mission results read for `mission.listResults`. Own `pg.Client` per call
+ * (mirrors `missions-db.ts`) — the app layer never imports `@vex-agent/db`. The
+ * ledger is WRITTEN by the engine (migration 038 + capture hooks); this is the
+ * renderer-facing read for the history view.
+ */
+
+import { Client, type ClientConfig } from "pg";
+import { err, ok, type Result, type VexError } from "@shared/ipc/result.js";
+import type {
+  MissionResultDto,
+  MissionListResultsResult,
+} from "@shared/schemas/mission.js";
+import { buildPoolConfig } from "./db-config.js";
+import { log } from "../logger/index.js";
+
+const CONNECT_TIMEOUT_MS = 2_000;
+const QUERY_TIMEOUT_MS = 5_000;
+
+function dbUnavailable(): Result<never, VexError> {
+  return err({
+    code: "internal.unexpected",
+    domain: "mission",
+    message: "Database unavailable. Verify services are running and retry.",
+    retryable: true,
+    userActionable: true,
+    redacted: true,
+  });
+}
+
+async function withClient<T>(
+  fn: (client: Client) => Promise<Result<T, VexError>>,
+): Promise<Result<T, VexError>> {
+  let cfg: Awaited<ReturnType<typeof buildPoolConfig>>;
+  try {
+    cfg = await buildPoolConfig();
+  } catch (cause) {
+    log.warn("[mission-results-db] buildPoolConfig threw", cause);
+    return dbUnavailable();
+  }
+  if (cfg === null) return dbUnavailable();
+
+  const clientConfig: ClientConfig = {
+    host: cfg.host,
+    port: cfg.port,
+    database: cfg.database,
+    user: cfg.user,
+    password: cfg.password,
+    connectionTimeoutMillis: CONNECT_TIMEOUT_MS,
+    statement_timeout: QUERY_TIMEOUT_MS,
+  };
+  const client = new Client(clientConfig);
+  try {
+    await client.connect();
+  } catch (cause) {
+    log.warn("[mission-results-db] client.connect failed", cause);
+    return dbUnavailable();
+  }
+  try {
+    return await fn(client);
+  } finally {
+    try {
+      await client.end();
+    } catch (cause) {
+      log.warn("[mission-results-db] client.end failed (non-fatal)", cause);
+    }
+  }
+}
+
+interface RawRow {
+  mission_run_id: string;
+  seq_no: number;
+  goal_snippet: string | null;
+  wallet_address: string;
+  chain_id: string | number;
+  started_at: Date | string;
+  ended_at: Date | string | null;
+  duration_s: number | null;
+  bankroll_start_eth: string | null;
+  bankroll_end_eth: string | null;
+  pnl_eth: string | null;
+  pnl_pct: string | null;
+  eth_price_usd_start: string | null;
+  eth_price_usd_end: string | null;
+  trades: number;
+  outcome: string;
+  open_positions_count: number;
+}
+
+const num = (v: string | number | null): number | null =>
+  v === null ? null : Number(v);
+const iso = (v: Date | string): string =>
+  v instanceof Date ? v.toISOString() : String(v);
+
+function toDto(r: RawRow): MissionResultDto {
+  return {
+    missionRunId: r.mission_run_id,
+    seqNo: r.seq_no,
+    goalSnippet: r.goal_snippet,
+    walletAddress: r.wallet_address,
+    chainId: Number(r.chain_id),
+    startedAt: iso(r.started_at),
+    endedAt: r.ended_at === null ? null : iso(r.ended_at),
+    durationS: r.duration_s,
+    bankrollStartEth: num(r.bankroll_start_eth),
+    bankrollEndEth: num(r.bankroll_end_eth),
+    pnlEth: num(r.pnl_eth),
+    pnlPct: num(r.pnl_pct),
+    ethPriceUsdStart: num(r.eth_price_usd_start),
+    ethPriceUsdEnd: num(r.eth_price_usd_end),
+    trades: r.trades,
+    outcome: r.outcome,
+    openPositionsCount: Number(r.open_positions_count ?? 0),
+  };
+}
+
+/** Mission history, newest first. */
+export async function listMissionResults(
+  limit = 50,
+): Promise<Result<MissionListResultsResult, VexError>> {
+  return withClient(async (client) => {
+    try {
+      const result = await client.query<RawRow>(
+        `SELECT mission_run_id, seq_no, goal_snippet, wallet_address, chain_id,
+                started_at, ended_at, duration_s,
+                bankroll_start_eth, bankroll_end_eth, pnl_eth, pnl_pct,
+                eth_price_usd_start, eth_price_usd_end, trades, outcome,
+                CASE WHEN jsonb_typeof(open_positions_json) = 'array'
+                     THEN jsonb_array_length(open_positions_json) ELSE 0 END
+                  AS open_positions_count
+           FROM mission_results
+          ORDER BY started_at DESC
+          LIMIT $1`,
+        [limit],
+      );
+      return ok(result.rows.map(toDto));
+    } catch (cause) {
+      log.warn("[mission-results-db] listMissionResults failed", cause);
+      return err({
+        code: "internal.unexpected",
+        domain: "mission",
+        message: "Unable to load mission history.",
+        retryable: true,
+        userActionable: false,
+        redacted: true,
+      });
+    }
+  });
+}

--- a/vex-app/src/main/database/mission-results-db.ts
+++ b/vex-app/src/main/database/mission-results-db.ts
@@ -11,6 +11,7 @@ import { err, ok, type Result, type VexError } from "@shared/ipc/result.js";
 import type {
   MissionResultDto,
   MissionListResultsResult,
+  MissionGetSessionResultResult,
 } from "@shared/schemas/mission.js";
 import { buildPoolConfig } from "./db-config.js";
 import { log } from "../logger/index.js";
@@ -144,6 +145,43 @@ export async function listMissionResults(
         code: "internal.unexpected",
         domain: "mission",
         message: "Unable to load mission history.",
+        retryable: true,
+        userActionable: false,
+        redacted: true,
+        correlationId: randomUUID(),
+      });
+    }
+  });
+}
+
+/** Latest finalized result for a session (newest first), or null. */
+export async function getSessionResult(
+  sessionId: string,
+): Promise<Result<MissionGetSessionResultResult, VexError>> {
+  return withClient(async (client) => {
+    try {
+      const result = await client.query<RawRow>(
+        `SELECT mission_run_id, seq_no, goal_snippet, wallet_address, chain_id,
+                started_at, ended_at, duration_s,
+                bankroll_start_eth, bankroll_end_eth, pnl_eth, pnl_pct,
+                eth_price_usd_start, eth_price_usd_end, trades, outcome,
+                CASE WHEN jsonb_typeof(open_positions_json) = 'array'
+                     THEN jsonb_array_length(open_positions_json) ELSE 0 END
+                  AS open_positions_count
+           FROM mission_results
+          WHERE session_id = $1
+          ORDER BY started_at DESC
+          LIMIT 1`,
+        [sessionId],
+      );
+      const row = result.rows[0];
+      return ok(row ? toDto(row) : null);
+    } catch (cause) {
+      log.warn("[mission-results-db] getSessionResult failed", cause);
+      return err({
+        code: "internal.unexpected",
+        domain: "mission",
+        message: "Unable to load mission result.",
         retryable: true,
         userActionable: false,
         redacted: true,

--- a/vex-app/src/main/database/mission-results-db.ts
+++ b/vex-app/src/main/database/mission-results-db.ts
@@ -5,6 +5,7 @@
  * renderer-facing read for the history view.
  */
 
+import { randomUUID } from "node:crypto";
 import { Client, type ClientConfig } from "pg";
 import { err, ok, type Result, type VexError } from "@shared/ipc/result.js";
 import type {
@@ -25,6 +26,9 @@ function dbUnavailable(): Result<never, VexError> {
     retryable: true,
     userActionable: true,
     redacted: true,
+    // The IPC wrapper (register-handler) overrides this with the request id;
+    // a self-generated id keeps the db-layer error well-formed on its own.
+    correlationId: randomUUID(),
   });
 }
 
@@ -143,6 +147,7 @@ export async function listMissionResults(
         retryable: true,
         userActionable: false,
         redacted: true,
+        correlationId: randomUUID(),
       });
     }
   });

--- a/vex-app/src/main/ipc/mission/get-session-result.ts
+++ b/vex-app/src/main/ipc/mission/get-session-result.ts
@@ -1,0 +1,40 @@
+/**
+ * `mission.getSessionResult` — read-only latest finalized result for a session.
+ * Reads the `mission_results` ledger (written by the engine capture hooks),
+ * returning the newest row for the session or null.
+ */
+
+import { CH } from "@shared/ipc/channels.js";
+import { type Result } from "@shared/ipc/result.js";
+import {
+  missionGetSessionResultInputSchema,
+  missionGetSessionResultResultSchema,
+  type MissionGetSessionResultResult,
+} from "@shared/schemas/mission.js";
+import { getSessionResult } from "../../database/mission-results-db.js";
+import { log } from "../../logger/index.js";
+import { registerHandler } from "../register-handler.js";
+
+export function registerMissionGetSessionResultHandler(): () => void {
+  return registerHandler({
+    channel: CH.mission.getSessionResult,
+    domain: "mission",
+    inputSchema: missionGetSessionResultInputSchema,
+    outputSchema: missionGetSessionResultResultSchema,
+    handle: async (input, ctx): Promise<Result<MissionGetSessionResultResult>> => {
+      const outcome = await getSessionResult(input.sessionId);
+      if (outcome.ok) {
+        log.info(
+          `[ipc:vex:mission:getSessionResult] ok found=${outcome.data !== null} ` +
+            `correlationId=${ctx.requestId}`,
+        );
+        return outcome;
+      }
+      log.info(
+        `[ipc:vex:mission:getSessionResult] errCode=${outcome.error.code} ` +
+          `correlationId=${ctx.requestId}`,
+      );
+      return outcome;
+    },
+  });
+}

--- a/vex-app/src/main/ipc/mission/index.ts
+++ b/vex-app/src/main/ipc/mission/index.ts
@@ -15,6 +15,7 @@ import { registerMissionEditHandler } from "./edit.js";
 import { registerMissionGetDiffHandler } from "./get-diff.js";
 import { registerMissionGetDraftHandler } from "./get-draft.js";
 import { registerMissionGetRenewableSourceHandler } from "./get-renewable-source.js";
+import { registerMissionListResultsHandler } from "./list-results.js";
 import { registerMissionRecoverHandler } from "./recover.js";
 import { registerMissionRenewHandler } from "./renew.js";
 import { registerMissionRetryHandler } from "./retry.js";
@@ -37,6 +38,7 @@ export function registerMissionHandlers(): ReadonlyArray<() => void> {
     registerMissionRenewHandler(),
     registerMissionStopHandler(),
     registerMissionGetRenewableSourceHandler(),
+    registerMissionListResultsHandler(),
     registerMissionSetAutoRetryHandler(),
   ];
 }

--- a/vex-app/src/main/ipc/mission/index.ts
+++ b/vex-app/src/main/ipc/mission/index.ts
@@ -15,6 +15,7 @@ import { registerMissionEditHandler } from "./edit.js";
 import { registerMissionGetDiffHandler } from "./get-diff.js";
 import { registerMissionGetDraftHandler } from "./get-draft.js";
 import { registerMissionGetRenewableSourceHandler } from "./get-renewable-source.js";
+import { registerMissionGetSessionResultHandler } from "./get-session-result.js";
 import { registerMissionListResultsHandler } from "./list-results.js";
 import { registerMissionRecoverHandler } from "./recover.js";
 import { registerMissionRenewHandler } from "./renew.js";
@@ -39,6 +40,7 @@ export function registerMissionHandlers(): ReadonlyArray<() => void> {
     registerMissionStopHandler(),
     registerMissionGetRenewableSourceHandler(),
     registerMissionListResultsHandler(),
+    registerMissionGetSessionResultHandler(),
     registerMissionSetAutoRetryHandler(),
   ];
 }

--- a/vex-app/src/main/ipc/mission/list-results.ts
+++ b/vex-app/src/main/ipc/mission/list-results.ts
@@ -1,0 +1,40 @@
+/**
+ * `mission.listResults` — read-only mission history for the results view.
+ * Reads the `mission_results` ledger (written by the engine capture hooks),
+ * newest first.
+ */
+
+import { CH } from "@shared/ipc/channels.js";
+import { type Result } from "@shared/ipc/result.js";
+import {
+  missionListResultsInputSchema,
+  missionListResultsResultSchema,
+  type MissionListResultsResult,
+} from "@shared/schemas/mission.js";
+import { listMissionResults } from "../../database/mission-results-db.js";
+import { log } from "../../logger/index.js";
+import { registerHandler } from "../register-handler.js";
+
+export function registerMissionListResultsHandler(): () => void {
+  return registerHandler({
+    channel: CH.mission.listResults,
+    domain: "mission",
+    inputSchema: missionListResultsInputSchema,
+    outputSchema: missionListResultsResultSchema,
+    handle: async (input, ctx): Promise<Result<MissionListResultsResult>> => {
+      const outcome = await listMissionResults(input.limit ?? 50);
+      if (outcome.ok) {
+        log.info(
+          `[ipc:vex:mission:listResults] ok count=${outcome.data.length} ` +
+            `correlationId=${ctx.requestId}`,
+        );
+        return outcome;
+      }
+      log.info(
+        `[ipc:vex:mission:listResults] errCode=${outcome.error.code} ` +
+          `correlationId=${ctx.requestId}`,
+      );
+      return outcome;
+    },
+  });
+}

--- a/vex-app/src/preload/agent/mission.ts
+++ b/vex-app/src/preload/agent/mission.ts
@@ -16,6 +16,7 @@ import {
   missionGetDiffInputSchema,
   missionGetDraftInputSchema,
   missionGetRenewableSourceInputSchema,
+  missionListResultsInputSchema,
   missionRecoverInputSchema,
   missionRenewInputSchema,
   missionEditInputSchema,
@@ -31,6 +32,7 @@ import type {
   MissionGetDiffInput,
   MissionGetDraftInput,
   MissionGetRenewableSourceInput,
+  MissionListResultsInput,
   MissionRecoverInput,
   MissionRenewInput,
   MissionEditInput,
@@ -126,6 +128,13 @@ export const mission = {
       CH.mission.getRenewableSource,
       input,
       missionGetRenewableSourceInputSchema,
+    );
+  },
+  listResults(input: MissionListResultsInput) {
+    return invokeWithSchema(
+      CH.mission.listResults,
+      input,
+      missionListResultsInputSchema,
     );
   },
   setAutoRetry(input: MissionSetAutoRetryInput) {

--- a/vex-app/src/preload/agent/mission.ts
+++ b/vex-app/src/preload/agent/mission.ts
@@ -16,6 +16,7 @@ import {
   missionGetDiffInputSchema,
   missionGetDraftInputSchema,
   missionGetRenewableSourceInputSchema,
+  missionGetSessionResultInputSchema,
   missionListResultsInputSchema,
   missionRecoverInputSchema,
   missionRenewInputSchema,
@@ -32,6 +33,7 @@ import type {
   MissionGetDiffInput,
   MissionGetDraftInput,
   MissionGetRenewableSourceInput,
+  MissionGetSessionResultInput,
   MissionListResultsInput,
   MissionRecoverInput,
   MissionRenewInput,
@@ -135,6 +137,13 @@ export const mission = {
       CH.mission.listResults,
       input,
       missionListResultsInputSchema,
+    );
+  },
+  getSessionResult(input: MissionGetSessionResultInput) {
+    return invokeWithSchema(
+      CH.mission.getSessionResult,
+      input,
+      missionGetSessionResultInputSchema,
     );
   },
   setAutoRetry(input: MissionSetAutoRetryInput) {

--- a/vex-app/src/renderer/features/appShell/AppShell.tsx
+++ b/vex-app/src/renderer/features/appShell/AppShell.tsx
@@ -43,6 +43,7 @@ import { SessionPanel } from "./SessionPanel.js";
 import { SessionsLibrary } from "./SessionsLibrary.js";
 import { SessionsList } from "./SessionsList.js";
 import { MemoryPanel } from "./MemoryPanel.js";
+import { MissionHistory } from "./MissionHistory.js";
 import { GlobalApprovals } from "./GlobalApprovals.js";
 import { SignalSky } from "./SignalSky.js";
 
@@ -127,6 +128,8 @@ export function AppShell(): JSX.Element {
             <SessionsLibrary />
           ) : appShellView === "memory" ? (
             <MemoryPanel />
+          ) : appShellView === "missionHistory" ? (
+            <MissionHistory />
           ) : (
             <SessionPanel />
           )}

--- a/vex-app/src/renderer/features/appShell/MissionControls.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionControls.tsx
@@ -34,7 +34,9 @@ import type {
   MissionDraftDto,
   MissionGetDiffResult,
   MissionGetRenewableSourceResult,
+  MissionGetSessionResultResult,
   MissionRenewResult,
+  MissionResultDto,
 } from "@shared/schemas/mission.js";
 import type { RuntimeStateDto } from "@shared/schemas/runtime.js";
 import {
@@ -44,12 +46,14 @@ import {
   useMissionDraft,
   useMissionRenew,
   useMissionRetry,
+  useMissionSessionResult,
   useMissionStart,
   useMissionStop,
   useRenewableMissionSource,
 } from "../../lib/api/mission.js";
 import { useRuntimeState } from "../../lib/api/runtime.js";
 import { cn } from "../../lib/utils.js";
+import { MissionSummaryCard } from "./MissionSummaryCard.js";
 
 /**
  * Primary mission action (Start/Renew) — the landing's solid cobalt CTA:
@@ -170,6 +174,15 @@ function readRenewable(
   return data && data.ok ? data.data : null;
 }
 
+/** The session's latest finalized ledger row, or null while it is still running / absent. */
+function readFinalizedResult(
+  data: Result<MissionGetSessionResultResult> | undefined,
+): MissionResultDto | null {
+  const result = data && data.ok ? data.data : null;
+  if (result === null || result.outcome === "running") return null;
+  return result;
+}
+
 export function MissionControls({
   sessionId,
 }: MissionControlsProps): JSX.Element | null {
@@ -178,6 +191,7 @@ export function MissionControls({
   const draft = readDraft(draftQuery.data);
   const diffQuery = useMissionDiff(sessionId, draft?.missionId ?? null);
   const renewableQuery = useRenewableMissionSource(sessionId);
+  const sessionResultQuery = useMissionSessionResult(sessionId);
 
   const start = useMissionStart();
   const cont = useMissionContinue();
@@ -302,8 +316,13 @@ export function MissionControls({
   const renewSource = readRenewable(renewableQuery.data);
   if (renewSource !== null) {
     const previousMissionId = renewSource.missionId;
+    // A terminal accepted mission has a finalized ledger row — surface its
+    // structured summary (sourced from the ledger, not the agent's prose)
+    // above the Renew key.
+    const summary = readFinalizedResult(sessionResultQuery.data);
     return (
       <div data-vex-area="mission-controls" className="mt-3">
+        {summary !== null ? <MissionSummaryCard result={summary} /> : null}
         {pendingAcceptance ? <AcceptancePendingNotice /> : null}
         <button
           type="button"

--- a/vex-app/src/renderer/features/appShell/MissionHistory.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionHistory.tsx
@@ -1,0 +1,355 @@
+/**
+ * Mission History — a read-only AppShell sub-view (mission-results-ledger).
+ *
+ * The per-wallet ledger of finalized mission runs: a summary register (total
+ * missions, win rate, cumulative ETH PnL) over a hand-rolled cumulative-PnL
+ * sparkline, then one row per mission newest-first. It mirrors the MemoryPanel
+ * shell grammar (h-12 register header + back key, hairline-separated ledger,
+ * `--vex-*` ink) so it reads as one surface with the rest of the desk.
+ *
+ * Data comes from `useMissionResults` (already wired IPC) — the list arrives
+ * newest-first, so rendering is a straight map; only the sparkline needs the
+ * oldest→newest running sum (`cumulativePnlSeries`). All arithmetic + formatting
+ * lives in `missionHistoryModel.ts`; this file is presentation over derived
+ * values. PnL is coloured by sign (success/destructive), USD is a tooltip only.
+ */
+
+import type { JSX } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
+import type { Result } from "@shared/ipc/result.js";
+import type {
+  MissionListResultsResult,
+  MissionResultDto,
+} from "@shared/schemas/mission.js";
+import { useUiStore } from "../../stores/uiStore.js";
+import { useMissionResults } from "../../lib/api/mission.js";
+import { formatPercentDelta, formatUsd } from "../../lib/format.js";
+import { cn } from "../../lib/utils.js";
+import { Empty, ErrorState, Loading } from "./MemoryPanelShared.js";
+import {
+  EM_DASH,
+  computeWinRate,
+  cumulativePnlSeries,
+  formatDurationS,
+  formatEth,
+  pnlUsd,
+  sparklinePoints,
+  sumPnlEth,
+} from "./missionHistoryModel.js";
+
+const SPARK_W = 240;
+const SPARK_H = 44;
+
+export function MissionHistory(): JSX.Element {
+  const setAppShellView = useUiStore((s) => s.setAppShellView);
+  const query = useMissionResults();
+
+  return (
+    <div
+      data-vex-screen="missionHistory"
+      className="flex h-full min-h-0 flex-col text-foreground"
+    >
+      {/* Register header — same h-12 datum + quiet back key as the Memory
+       * panel; the affordance is an icon, never a chrome pill. */}
+      <header className="flex h-12 shrink-0 items-center gap-3 border-b border-[var(--vex-line)] px-6">
+        <button
+          type="button"
+          onClick={() => setAppShellView("session")}
+          aria-label="Back to chat"
+          className="flex h-8 w-8 items-center justify-center rounded-[6px] text-[var(--vex-text-2)] transition-colors hover:bg-white/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)]"
+        >
+          <HugeiconsIcon icon={ArrowLeft01Icon} size={17} aria-hidden />
+        </button>
+        <h1 className="font-mono text-[13px] font-medium uppercase tracking-[0.3em] text-foreground">
+          Missions
+        </h1>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+        <div className="mx-auto flex w-full max-w-[760px] flex-col gap-6">
+          <Body query={query} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Query-state fork: pending → loading, thrown/transport error OR an `ok:false`
+ * Result envelope → error, empty array → friendly empty state, else the ledger.
+ * The `isPending`/`isError` guards narrow `query.data` to a defined `Result`.
+ */
+function Body({
+  query,
+}: {
+  readonly query: UseQueryResult<Result<MissionListResultsResult>>;
+}): JSX.Element {
+  if (query.isPending) return <Loading label="Loading missions…" />;
+  if (query.isError) return <ErrorState message={query.error.message} />;
+  const res = query.data;
+  if (!res.ok) return <ErrorState message={res.error.message} />;
+  if (res.data.length === 0) {
+    return <Empty label="No missions yet — finish a mission to see it here." />;
+  }
+  return <Ledger results={res.data} />;
+}
+
+function Ledger({
+  results,
+}: {
+  readonly results: readonly MissionResultDto[];
+}): JSX.Element {
+  const winRate = computeWinRate(results);
+  const cumulative = sumPnlEth(results);
+  const series = cumulativePnlSeries(results);
+
+  return (
+    <>
+      <SummaryHeader
+        total={results.length}
+        winRate={winRate}
+        cumulativeEth={cumulative}
+        series={series}
+      />
+      <ResultsTable results={results} />
+    </>
+  );
+}
+
+function SummaryHeader({
+  total,
+  winRate,
+  cumulativeEth,
+  series,
+}: {
+  readonly total: number;
+  readonly winRate: number | null;
+  readonly cumulativeEth: number;
+  readonly series: readonly number[];
+}): JSX.Element {
+  return (
+    <section className="flex flex-col gap-4 border-b border-[var(--vex-line)] pb-6">
+      <div className="flex flex-wrap items-end gap-x-10 gap-y-4">
+        <Stat label="Missions" value={String(total)} />
+        <Stat
+          label="Win rate"
+          value={winRate === null ? EM_DASH : `${winRate.toFixed(0)}%`}
+        />
+        <Stat
+          label="Cumulative PnL"
+          value={`${formatEth(cumulativeEth, { signed: true })} ETH`}
+          tone={pnlTone(cumulativeEth)}
+        />
+      </div>
+      <Sparkline series={series} />
+    </section>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly tone?: string;
+}): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vex-text-3)]">
+        {label}
+      </span>
+      <span
+        className={cn(
+          "font-mono text-lg tabular-nums",
+          tone ?? "text-foreground",
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Hand-rolled cumulative-PnL sparkline (no chart lib): a single polyline over
+ * the running total, plus a hairline zero baseline so a dip below break-even
+ * reads at a glance. The stroke takes the sign of the final cumulative value.
+ */
+function Sparkline({
+  series,
+}: {
+  readonly series: readonly number[];
+}): JSX.Element | null {
+  if (series.length === 0) return null;
+  const points = sparklinePoints(series, SPARK_W, SPARK_H, 3);
+  const last = series[series.length - 1] ?? 0;
+  const stroke =
+    last > 0
+      ? "var(--color-success)"
+      : last < 0
+        ? "var(--color-destructive)"
+        : "var(--vex-text-3)";
+  // Zero baseline in the same coordinate space as the polyline (a flat
+  // series maps every point to the vertical middle, so the line + baseline
+  // coincide — intentional).
+  const min = Math.min(...series, 0);
+  const max = Math.max(...series, 0);
+  const span = max === min ? 1 : max - min;
+  const zeroY = 3 + (SPARK_H - 6) * (1 - (0 - min) / span);
+
+  return (
+    <svg
+      viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+      width={SPARK_W}
+      height={SPARK_H}
+      role="img"
+      aria-label="Cumulative profit and loss over the mission history"
+      className="max-w-full overflow-visible"
+    >
+      <line
+        x1={0}
+        y1={zeroY}
+        x2={SPARK_W}
+        y2={zeroY}
+        stroke="var(--vex-line)"
+        strokeWidth={1}
+        strokeDasharray="2 3"
+      />
+      <polyline
+        points={points}
+        fill="none"
+        stroke={stroke}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ResultsTable({
+  results,
+}: {
+  readonly results: readonly MissionResultDto[];
+}): JSX.Element {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-left text-xs">
+        <thead>
+          <tr className="border-b border-[var(--vex-line)] font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--vex-text-3)]">
+            <Th>#</Th>
+            <Th>Goal</Th>
+            <Th>Outcome</Th>
+            <Th align="right">Duration</Th>
+            <Th align="right">Trades</Th>
+            <Th align="right">PnL</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {results.map((r) => (
+            <ResultRow key={r.missionRunId} result={r} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ResultRow({
+  result,
+}: {
+  readonly result: MissionResultDto;
+}): JSX.Element {
+  const usd = pnlUsd(result.pnlEth, result.ethPriceUsdEnd);
+  const pnlTitle =
+    usd === null ? undefined : `${formatUsd(usd)} at close`;
+
+  return (
+    <tr className="border-b border-[var(--vex-line)] last:border-b-0 hover:bg-white/[0.02]">
+      <td className="py-2.5 pr-3 font-mono tabular-nums text-[var(--vex-text-2)]">
+        #{result.seqNo}
+      </td>
+      <td className="max-w-[220px] truncate py-2.5 pr-3 text-foreground">
+        <span title={result.goalSnippet ?? undefined}>
+          {result.goalSnippet ?? EM_DASH}
+        </span>
+      </td>
+      <td className="py-2.5 pr-3">
+        <OutcomeBadge outcome={result.outcome} />
+      </td>
+      <td className="py-2.5 pr-3 text-right font-mono tabular-nums text-[var(--vex-text-2)]">
+        {formatDurationS(result.durationS)}
+      </td>
+      <td className="py-2.5 pr-3 text-right font-mono tabular-nums text-[var(--vex-text-2)]">
+        {result.trades}
+      </td>
+      <td className="py-2.5 text-right">
+        <span
+          title={pnlTitle}
+          className={cn("font-mono tabular-nums", pnlTone(result.pnlEth))}
+        >
+          {formatEth(result.pnlEth, { signed: true })} ETH
+        </span>
+        {result.pnlPct !== null ? (
+          <span className="ml-2 font-mono text-[10px] tabular-nums text-[var(--vex-text-3)]">
+            {formatPercentDelta(result.pnlPct)}
+          </span>
+        ) : null}
+      </td>
+    </tr>
+  );
+}
+
+/** Outcome → small colour-toned stamp. `completed` = success, `failed` =
+ * destructive, `running` = accent (still live), the rest stay muted. */
+function OutcomeBadge({ outcome }: { readonly outcome: string }): JSX.Element {
+  const tone =
+    outcome === "completed"
+      ? "border-[color-mix(in_oklab,var(--color-success)_40%,transparent)] text-[var(--color-success)]"
+      : outcome === "failed"
+        ? "border-destructive/40 text-destructive"
+        : outcome === "running"
+          ? "border-[var(--vex-accent-border)] text-[var(--vex-accent-text)]"
+          : "border-[var(--vex-line)] text-[var(--vex-text-2)]";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-[3px] border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em]",
+        tone,
+      )}
+    >
+      {outcome}
+    </span>
+  );
+}
+
+function Th({
+  children,
+  align,
+}: {
+  readonly children: string;
+  readonly align?: "right";
+}): JSX.Element {
+  return (
+    <th
+      className={cn(
+        "py-2 pr-3 font-normal",
+        align === "right" ? "text-right" : "text-left",
+      )}
+    >
+      {children}
+    </th>
+  );
+}
+
+/** Sign → PnL colour class: positive success, negative destructive, flat muted. */
+function pnlTone(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "text-[var(--vex-text-3)]";
+  if (value > 0) return "text-[var(--color-success)]";
+  if (value < 0) return "text-destructive";
+  return "text-[var(--vex-text-2)]";
+}

--- a/vex-app/src/renderer/features/appShell/MissionSummaryCard.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionSummaryCard.tsx
@@ -1,0 +1,113 @@
+/**
+ * MissionSummaryCard — the post-mission summary readout (mission-results-ledger).
+ *
+ * When a mission finalizes, its `mission_results` ledger row becomes the source
+ * of a crisp, structured card (NOT the agent's prose): outcome + duration, the
+ * signed ETH PnL headline, a trades/settlement meta line, and the goal snippet.
+ * It renders inline above the "Renew mission" branch in `MissionControls`.
+ *
+ * Presentation over derived values only — every string is formatted in
+ * `missionSummaryModel.ts` (pure + unit-tested); the `--vex-*`/`--color-*` ink
+ * matches the Mission History ledger so the two surfaces read as one register.
+ * PnL is coloured by sign (success/destructive), USD is a tooltip only.
+ */
+
+import type { JSX } from "react";
+import type { MissionResultDto } from "@shared/schemas/mission.js";
+import { cn } from "../../lib/utils.js";
+import { EM_DASH, formatDurationS } from "./missionHistoryModel.js";
+import {
+  formatMetaLine,
+  formatPnlEth,
+  formatPnlPct,
+  pnlToneClass,
+  pnlUsdTitle,
+} from "./missionSummaryModel.js";
+
+export interface MissionSummaryCardProps {
+  readonly result: MissionResultDto;
+}
+
+export function MissionSummaryCard({
+  result,
+}: MissionSummaryCardProps): JSX.Element {
+  const pnlTitle = pnlUsdTitle(result.pnlEth, result.ethPriceUsdEnd);
+  const pct = formatPnlPct(result.pnlPct);
+
+  return (
+    <section
+      data-vex-area="mission-summary"
+      aria-label="Mission summary"
+      className="mb-3 flex flex-col gap-2 rounded-[10px] border border-[var(--vex-line)] bg-white/[0.02] px-4 py-3"
+    >
+      {/* Line 1 — identity + outcome stamp + duration. */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--vex-text-2)]">
+        <span className="tabular-nums text-foreground">
+          Mission #{result.seqNo}
+        </span>
+        <span className="text-[var(--vex-text-3)]">·</span>
+        <OutcomeBadge outcome={result.outcome} />
+        <span className="text-[var(--vex-text-3)]">·</span>
+        <span className="tabular-nums">{formatDurationS(result.durationS)}</span>
+      </div>
+
+      {/* Line 2 — the signed ETH PnL headline (USD in the tooltip). */}
+      <div className="flex items-baseline gap-2">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vex-text-3)]">
+          PnL
+        </span>
+        <span
+          title={pnlTitle}
+          className={cn(
+            "font-mono text-lg tabular-nums",
+            pnlToneClass(result.pnlEth),
+          )}
+        >
+          {formatPnlEth(result.pnlEth)}
+          {pct.length > 0 ? (
+            <span className="ml-2 text-[11px]">{pct}</span>
+          ) : null}
+        </span>
+      </div>
+
+      {/* Line 3 — trades + settlement. */}
+      <p className="font-mono text-[11px] tabular-nums text-[var(--vex-text-2)]">
+        {formatMetaLine(result.trades, result.openPositionsCount)}
+      </p>
+
+      {/* Goal caption — truncated, only when present. */}
+      {result.goalSnippet !== null ? (
+        <p
+          title={result.goalSnippet}
+          className="truncate text-xs text-[var(--vex-text-3)]"
+        >
+          {result.goalSnippet}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+/** Outcome → small colour-toned stamp. Mirrors `MissionHistory`'s badge tones:
+ * `completed` = success, `failed` = destructive, `running` = accent, the rest
+ * stay muted. */
+function OutcomeBadge({ outcome }: { readonly outcome: string }): JSX.Element {
+  const tone =
+    outcome === "completed"
+      ? "border-[color-mix(in_oklab,var(--color-success)_40%,transparent)] text-[var(--color-success)]"
+      : outcome === "failed"
+        ? "border-destructive/40 text-destructive"
+        : outcome === "running"
+          ? "border-[var(--vex-accent-border)] text-[var(--vex-accent-text)]"
+          : "border-[var(--vex-line)] text-[var(--vex-text-2)]";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-[3px] border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em]",
+        tone,
+      )}
+    >
+      {outcome || EM_DASH}
+    </span>
+  );
+}

--- a/vex-app/src/renderer/features/appShell/MissionsButton.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionsButton.tsx
@@ -1,0 +1,41 @@
+/**
+ * Sidebar footer key — opens the Mission History ledger sub-view
+ * (mission-results-ledger). Mirrors `MemoryButton`: a quiet full-width registry
+ * row carrying its own border-t hairline so the footer stack stays separated.
+ */
+
+import { useCallback, type JSX } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { AnalyticsUpIcon } from "@hugeicons/core-free-icons";
+import { Button } from "../../components/ui/button.js";
+import { cn } from "../../lib/utils.js";
+import { useUiStore } from "../../stores/uiStore.js";
+
+interface MissionsButtonProps {
+  readonly compact?: boolean;
+}
+
+export function MissionsButton({
+  compact = false,
+}: MissionsButtonProps): JSX.Element {
+  const setAppShellView = useUiStore((s) => s.setAppShellView);
+  const onClick = useCallback((): void => {
+    setAppShellView("missionHistory");
+  }, [setAppShellView]);
+
+  return (
+    <Button
+      variant="ghost"
+      size={compact ? "icon" : "sm"}
+      onClick={onClick}
+      aria-label="Open mission history"
+      className={cn(
+        "h-9 w-full rounded-none border-0 border-t border-[var(--vex-line)] bg-transparent text-[10px] tracking-[0.18em] text-[var(--vex-text-2)] hover:bg-white/[0.035] hover:text-foreground",
+        compact ? "justify-center px-0" : "justify-start gap-2 px-4",
+      )}
+    >
+      <HugeiconsIcon icon={AnalyticsUpIcon} size={15} aria-hidden />
+      {compact ? null : <span>Missions</span>}
+    </Button>
+  );
+}

--- a/vex-app/src/renderer/features/appShell/SessionsList.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionsList.tsx
@@ -20,6 +20,7 @@ import {
 import { useUiStore } from "../../stores/uiStore.js";
 import { SessionDeleteDialog } from "./SessionDeleteDialog.js";
 import { MemoryButton } from "./MemoryButton.js";
+import { MissionsButton } from "./MissionsButton.js";
 import { RuntimeLedger } from "./RuntimeLedger.js";
 import { SettingsButton } from "./SettingsButton.js";
 import { SidebarHomeSigil } from "./SidebarHomeSigil.js";
@@ -377,6 +378,7 @@ export function SessionsList({ onCreate }: SessionsListProps): JSX.Element {
           sidebarOpen ? "" : "items-stretch",
         )}
       >
+        <MissionsButton compact={!sidebarOpen} />
         <MemoryButton compact={!sidebarOpen} />
         <SettingsButton compact={!sidebarOpen} />
         {/* Report issue intentionally hidden for now; ReportIssueButton/Dialog retained for re-enable. */}

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@hugeicons/core-free-icons", () => ({
   Fuel01Icon: "Fuel01Icon",
   FilterHorizontalIcon: "FilterHorizontalIcon",
   Brain01Icon: "Brain01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   MapPinIcon: "MapPinIcon",
   PanelLeftCloseIcon: "PanelLeftCloseIcon",
   PanelLeftOpenIcon: "PanelLeftOpenIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-send.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-send.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@hugeicons/core-free-icons", () => ({
   FilterHorizontalIcon: "FilterHorizontalIcon",
   Fuel01Icon: "Fuel01Icon",
   Brain01Icon: "Brain01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   MapPinIcon: "MapPinIcon",
   PanelLeftCloseIcon: "PanelLeftCloseIcon",
   PanelLeftOpenIcon: "PanelLeftOpenIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/pin.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/pin.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@hugeicons/core-free-icons", () => ({
   Fuel01Icon: "Fuel01Icon",
   FilterHorizontalIcon: "FilterHorizontalIcon",
   Brain01Icon: "Brain01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   MapPinIcon: "MapPinIcon",
   PanelLeftCloseIcon: "PanelLeftCloseIcon",
   PanelLeftOpenIcon: "PanelLeftOpenIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/remove-library.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/remove-library.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@hugeicons/core-free-icons", () => ({
   Fuel01Icon: "Fuel01Icon",
   FilterHorizontalIcon: "FilterHorizontalIcon",
   Brain01Icon: "Brain01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   MapPinIcon: "MapPinIcon",
   PanelLeftCloseIcon: "PanelLeftCloseIcon",
   PanelLeftOpenIcon: "PanelLeftOpenIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/shell-sidebar.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/shell-sidebar.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@hugeicons/core-free-icons", () => ({
   Fuel01Icon: "Fuel01Icon",
   FilterHorizontalIcon: "FilterHorizontalIcon",
   Brain01Icon: "Brain01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   MapPinIcon: "MapPinIcon",
   PanelLeftCloseIcon: "PanelLeftCloseIcon",
   PanelLeftOpenIcon: "PanelLeftOpenIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/welcome-create.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/welcome-create.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@hugeicons/core-free-icons", () => ({
   Fuel01Icon: "Fuel01Icon",
   FilterHorizontalIcon: "FilterHorizontalIcon",
   Brain01Icon: "Brain01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   MapPinIcon: "MapPinIcon",
   PanelLeftCloseIcon: "PanelLeftCloseIcon",
   PanelLeftOpenIcon: "PanelLeftOpenIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/missionHistoryModel.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/missionHistoryModel.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Pure derivation tests for the Mission History ledger. Locks the ETH/duration
+ * formatting, the null-aware win-rate denominator, the oldest→newest cumulative
+ * series, and the sparkline geometry.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { MissionResultDto } from "@shared/schemas/mission.js";
+import {
+  EM_DASH,
+  computeWinRate,
+  cumulativePnlSeries,
+  formatDurationS,
+  formatEth,
+  pnlUsd,
+  sparklinePoints,
+  sumPnlEth,
+} from "../missionHistoryModel.js";
+
+/** Minimal result row with only the fields a given assertion cares about. */
+function result(p: Partial<MissionResultDto>): MissionResultDto {
+  return {
+    missionRunId: "run-1",
+    seqNo: 1,
+    goalSnippet: null,
+    walletAddress: "0xabc",
+    chainId: 1,
+    startedAt: "2026-07-11T10:00:00.000Z",
+    endedAt: "2026-07-11T10:12:03.000Z",
+    durationS: 723,
+    bankrollStartEth: 1,
+    bankrollEndEth: 1,
+    pnlEth: 0,
+    pnlPct: 0,
+    ethPriceUsdStart: 3000,
+    ethPriceUsdEnd: 3000,
+    trades: 0,
+    outcome: "completed",
+    openPositionsCount: 0,
+    ...p,
+  };
+}
+
+describe("formatEth", () => {
+  it("trims to a 4-decimal floor", () => {
+    expect(formatEth(0.0012)).toBe("0.0012");
+  });
+
+  it("keeps up to 6 decimals for larger precision", () => {
+    expect(formatEth(1.23456789)).toBe("1.234568");
+  });
+
+  it("prefixes a + on non-negative values when signed", () => {
+    expect(formatEth(0.0012, { signed: true })).toBe("+0.0012");
+    expect(formatEth(0, { signed: true })).toBe("+0.0000");
+  });
+
+  it("keeps the native minus sign for negatives", () => {
+    expect(formatEth(-0.0034, { signed: true })).toBe("-0.0034");
+  });
+
+  it("renders an em dash for null / non-finite", () => {
+    expect(formatEth(null)).toBe(EM_DASH);
+    expect(formatEth(Number.NaN)).toBe(EM_DASH);
+  });
+});
+
+describe("formatDurationS", () => {
+  it("formats minutes and zero-padded seconds", () => {
+    expect(formatDurationS(723)).toBe("12m 03s");
+  });
+
+  it("promotes to hours past an hour", () => {
+    expect(formatDurationS(3723)).toBe("1h 02m 03s");
+  });
+
+  it("renders an em dash for null / negative", () => {
+    expect(formatDurationS(null)).toBe(EM_DASH);
+    expect(formatDurationS(-5)).toBe(EM_DASH);
+  });
+});
+
+describe("computeWinRate", () => {
+  it("ignores null-pnl rows in the denominator", () => {
+    const rows = [
+      result({ pnlEth: 0.5 }),
+      result({ pnlEth: -0.2 }),
+      result({ pnlEth: null }),
+    ];
+    // 1 win out of 2 computable rows.
+    expect(computeWinRate(rows)).toBe(50);
+  });
+
+  it("returns null when no row has a computable pnl", () => {
+    expect(computeWinRate([result({ pnlEth: null })])).toBeNull();
+    expect(computeWinRate([])).toBeNull();
+  });
+});
+
+describe("sumPnlEth", () => {
+  it("sums computable pnl and skips nulls", () => {
+    const rows = [
+      result({ pnlEth: 0.5 }),
+      result({ pnlEth: -0.2 }),
+      result({ pnlEth: null }),
+    ];
+    expect(sumPnlEth(rows)).toBeCloseTo(0.3, 10);
+  });
+});
+
+describe("cumulativePnlSeries", () => {
+  it("runs oldest→newest from a newest-first input", () => {
+    // newest-first: [+0.3 (newest), -0.2, +0.5 (oldest)]
+    const rows = [
+      result({ pnlEth: 0.3 }),
+      result({ pnlEth: -0.2 }),
+      result({ pnlEth: 0.5 }),
+    ];
+    const series = cumulativePnlSeries(rows);
+    expect(series.map((v) => Number(v.toFixed(2)))).toEqual([0.5, 0.3, 0.6]);
+  });
+
+  it("carries the running total flat across a null-pnl row", () => {
+    const rows = [
+      result({ pnlEth: 0.4 }), // newest
+      result({ pnlEth: null }),
+      result({ pnlEth: 0.1 }), // oldest
+    ];
+    const series = cumulativePnlSeries(rows);
+    expect(series.map((v) => Number(v.toFixed(2)))).toEqual([0.1, 0.1, 0.5]);
+  });
+});
+
+describe("sparklinePoints", () => {
+  it("maps a rising series with min at the bottom and max at the top", () => {
+    // Two points, height 100, pad 0: min→y=100, max→y=0, x spans full width.
+    expect(sparklinePoints([0, 1], 100, 100, 0)).toBe("0,100 100,0");
+  });
+
+  it("pins a flat series to the vertical middle", () => {
+    expect(sparklinePoints([2, 2, 2], 100, 100, 0)).toBe("0,50 50,50 100,50");
+  });
+
+  it("returns an empty string for no points", () => {
+    expect(sparklinePoints([], 100, 100)).toBe("");
+  });
+});
+
+describe("pnlUsd", () => {
+  it("multiplies pnl by the closing eth price", () => {
+    expect(pnlUsd(0.01, 3000)).toBeCloseTo(30, 10);
+  });
+
+  it("returns null when either input is missing", () => {
+    expect(pnlUsd(null, 3000)).toBeNull();
+    expect(pnlUsd(0.01, null)).toBeNull();
+  });
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/missionSummaryModel.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/missionSummaryModel.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure derivation tests for the post-mission summary card. Locks the signed ETH
+ * headline, the optional percent parenthetical, the trades/settlement meta line,
+ * the USD tooltip, and the sign-based PnL tone.
+ */
+
+import { describe, expect, it } from "vitest";
+import { EM_DASH } from "../missionHistoryModel.js";
+import {
+  formatMetaLine,
+  formatPnlEth,
+  formatPnlPct,
+  formatSettlement,
+  pnlToneClass,
+  pnlUsdTitle,
+} from "../missionSummaryModel.js";
+
+describe("formatPnlEth", () => {
+  it("signs the ETH figure and appends the unit", () => {
+    expect(formatPnlEth(0.0012)).toBe("+0.0012 ETH");
+    expect(formatPnlEth(-0.0034)).toBe("-0.0034 ETH");
+    expect(formatPnlEth(0)).toBe("+0.0000 ETH");
+  });
+
+  it("renders a bare em dash for null / non-finite", () => {
+    expect(formatPnlEth(null)).toBe(EM_DASH);
+    expect(formatPnlEth(Number.NaN)).toBe(EM_DASH);
+  });
+});
+
+describe("formatPnlPct", () => {
+  it("wraps a signed percent in parentheses", () => {
+    expect(formatPnlPct(1.2)).toBe("(+1.20%)");
+    expect(formatPnlPct(-3.4)).toBe("(-3.40%)");
+  });
+
+  it("returns an empty string for null / non-finite", () => {
+    expect(formatPnlPct(null)).toBe("");
+    expect(formatPnlPct(Number.NaN)).toBe("");
+  });
+});
+
+describe("formatSettlement", () => {
+  it("reads flat when no bags are held", () => {
+    expect(formatSettlement(0)).toBe("ended flat ✅");
+  });
+
+  it("pluralises held bags", () => {
+    expect(formatSettlement(1)).toBe("1 bag held ⚠");
+    expect(formatSettlement(3)).toBe("3 bags held ⚠");
+  });
+});
+
+describe("formatMetaLine", () => {
+  it("joins the trade count with the settlement clause", () => {
+    expect(formatMetaLine(4, 0)).toBe("4 trades · ended flat ✅");
+    expect(formatMetaLine(7, 2)).toBe("7 trades · 2 bags held ⚠");
+  });
+});
+
+describe("pnlUsdTitle", () => {
+  it("formats the closing USD value with a caption", () => {
+    expect(pnlUsdTitle(0.01, 3000)).toBe("$30.00 at close");
+  });
+
+  it("is undefined when either input is missing", () => {
+    expect(pnlUsdTitle(null, 3000)).toBeUndefined();
+    expect(pnlUsdTitle(0.01, null)).toBeUndefined();
+  });
+});
+
+describe("pnlToneClass", () => {
+  it("colours by sign", () => {
+    expect(pnlToneClass(0.5)).toBe("text-[var(--color-success)]");
+    expect(pnlToneClass(-0.5)).toBe("text-destructive");
+    expect(pnlToneClass(0)).toBe("text-[var(--vex-text-2)]");
+  });
+
+  it("is muted for null / non-finite", () => {
+    expect(pnlToneClass(null)).toBe("text-[var(--vex-text-3)]");
+    expect(pnlToneClass(Number.NaN)).toBe("text-[var(--vex-text-3)]");
+  });
+});

--- a/vex-app/src/renderer/features/appShell/missionHistoryModel.ts
+++ b/vex-app/src/renderer/features/appShell/missionHistoryModel.ts
@@ -1,0 +1,170 @@
+/**
+ * Pure derivations for the Mission History ledger (mission-results-ledger).
+ *
+ * Every figure the panel renders is computed here so the presentation layer
+ * (`MissionHistory.tsx`) stays a thin map over already-derived values and the
+ * arithmetic (win-rate denominator, cumulative running sum, sparkline geometry)
+ * is unit-testable in isolation. ETH is the native PnL unit; USD is display-only
+ * (`ethPriceUsdEnd`), so it never enters these totals.
+ *
+ * `null`/non-finite guards are deliberate and load-bearing: a finalized run may
+ * be missing bankroll snapshots (pnl null), and those rows must drop out of the
+ * win-rate denominator and the cumulative sum rather than poison them with NaN.
+ */
+
+import type { MissionResultDto } from "@shared/schemas/mission.js";
+
+/** Em dash used for every missing/uncomputable figure — one canonical glyph. */
+export const EM_DASH = "—";
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * Trim a fixed-decimal string's trailing zeros down to (but not past)
+ * `minDecimals` places. `"0.001200"` → `"0.0012"`; `"0.000000"` → `"0.0000"`.
+ */
+function trimDecimals(fixed: string, minDecimals: number): string {
+  const [intPart = "", decPart = ""] = fixed.split(".");
+  let dec = decPart;
+  while (dec.length > minDecimals && dec.endsWith("0")) {
+    dec = dec.slice(0, -1);
+  }
+  return dec.length > 0 ? `${intPart}.${dec}` : intPart;
+}
+
+/**
+ * ETH amount to ~4 significant / 4–6 decimals (trailing zeros trimmed to a
+ * 4-decimal floor): `0.0012`, `1.234568`. `signed` prefixes non-negative
+ * values with `+` for PnL columns. `null`/non-finite → em dash.
+ */
+export function formatEth(
+  value: number | null | undefined,
+  opts: { readonly signed?: boolean } = {},
+): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return EM_DASH;
+  }
+  const body = trimDecimals(value.toFixed(6), 4);
+  return opts.signed && value >= 0 ? `+${body}` : body;
+}
+
+/**
+ * Duration seconds → `12m 03s`, promoting to `1h 02m 03s` past an hour.
+ * `null`/non-finite/negative → em dash.
+ */
+export function formatDurationS(durationS: number | null | undefined): string {
+  if (
+    durationS === null ||
+    durationS === undefined ||
+    !Number.isFinite(durationS) ||
+    durationS < 0
+  ) {
+    return EM_DASH;
+  }
+  const total = Math.floor(durationS);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const ss = String(s).padStart(2, "0");
+  if (h > 0) {
+    return `${h}h ${String(m).padStart(2, "0")}m ${ss}s`;
+  }
+  return `${m}m ${ss}s`;
+}
+
+/**
+ * Win rate as a percentage (0–100): share of missions with `pnlEth > 0`,
+ * with null-pnl rows excluded from the denominator. `null` when no row has a
+ * computable pnl (so the caller can render an em dash, not `0%`).
+ */
+export function computeWinRate(
+  results: readonly MissionResultDto[],
+): number | null {
+  let wins = 0;
+  let denom = 0;
+  for (const r of results) {
+    if (r.pnlEth === null || !Number.isFinite(r.pnlEth)) continue;
+    denom += 1;
+    if (r.pnlEth > 0) wins += 1;
+  }
+  return denom === 0 ? null : (wins / denom) * 100;
+}
+
+/** Cumulative ETH PnL — sum of every computable `pnlEth` (nulls skipped). */
+export function sumPnlEth(results: readonly MissionResultDto[]): number {
+  let sum = 0;
+  for (const r of results) {
+    if (r.pnlEth !== null && Number.isFinite(r.pnlEth)) sum += r.pnlEth;
+  }
+  return sum;
+}
+
+/**
+ * Running cumulative-pnl series ordered OLDEST→NEWEST for the sparkline. Input
+ * is newest-first (as the query returns it), so this reverses it; null-pnl rows
+ * carry the running total forward flat rather than breaking the line.
+ */
+export function cumulativePnlSeries(
+  results: readonly MissionResultDto[],
+): number[] {
+  const series: number[] = [];
+  let running = 0;
+  for (let i = results.length - 1; i >= 0; i -= 1) {
+    const pnl = results[i]?.pnlEth ?? null;
+    if (pnl !== null && Number.isFinite(pnl)) running += pnl;
+    series.push(running);
+  }
+  return series;
+}
+
+/**
+ * Map a value series to an SVG polyline `points` string inside `width`×`height`
+ * with `pad` px of vertical breathing room. A flat series (all equal) pins to
+ * the vertical middle; a single point centres horizontally. Empty → `""`.
+ */
+export function sparklinePoints(
+  values: readonly number[],
+  width: number,
+  height: number,
+  pad = 2,
+): string {
+  if (values.length === 0) return "";
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const flat = max === min;
+  const span = flat ? 1 : max - min;
+  const innerH = height - pad * 2;
+  const n = values.length;
+  const stepX = n > 1 ? width / (n - 1) : 0;
+  return values
+    .map((v, i) => {
+      const x = n > 1 ? i * stepX : width / 2;
+      const y = flat ? height / 2 : pad + innerH * (1 - (v - min) / span);
+      return `${round2(x)},${round2(y)}`;
+    })
+    .join(" ");
+}
+
+/**
+ * USD value of a mission's ETH PnL at close (`pnlEth * ethPriceUsdEnd`) for the
+ * PnL tooltip. `null` when either input is missing — the tooltip is omitted, not
+ * fabricated.
+ */
+export function pnlUsd(
+  pnlEth: number | null | undefined,
+  ethPriceUsdEnd: number | null | undefined,
+): number | null {
+  if (pnlEth === null || pnlEth === undefined || !Number.isFinite(pnlEth)) {
+    return null;
+  }
+  if (
+    ethPriceUsdEnd === null ||
+    ethPriceUsdEnd === undefined ||
+    !Number.isFinite(ethPriceUsdEnd)
+  ) {
+    return null;
+  }
+  return pnlEth * ethPriceUsdEnd;
+}

--- a/vex-app/src/renderer/features/appShell/missionSummaryModel.ts
+++ b/vex-app/src/renderer/features/appShell/missionSummaryModel.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure derivations for the post-mission summary card (mission-results-ledger).
+ *
+ * The card is a glanceable readout of ONE finalized `MissionResultDto` — every
+ * string it prints is composed here so `MissionSummaryCard.tsx` stays a thin map
+ * over already-formatted values and the null-guarding is unit-testable. ETH is
+ * the native PnL unit; USD (`ethPriceUsdEnd`) is a tooltip only, never a headline
+ * figure. Shared ETH/duration/USD helpers are reused from `missionHistoryModel`
+ * so the two ledger surfaces format identically.
+ */
+
+import { EM_DASH, formatEth, pnlUsd } from "./missionHistoryModel.js";
+import { formatPercentDelta, formatUsd } from "../../lib/format.js";
+
+/**
+ * Headline PnL in ETH: `+0.0012 ETH`, `-0.0034 ETH`. `null`/non-finite → em
+ * dash (no `ETH` suffix — a missing figure prints nothing fabricated).
+ */
+export function formatPnlEth(pnlEth: number | null): string {
+  const body = formatEth(pnlEth, { signed: true });
+  return body === EM_DASH ? EM_DASH : `${body} ETH`;
+}
+
+/**
+ * Parenthetical percent for the PnL headline: `(+1.20%)`, `(-3.40%)`. `null` →
+ * empty string so the headline drops the parenthetical rather than showing a
+ * dash inside brackets.
+ */
+export function formatPnlPct(pnlPct: number | null): string {
+  if (pnlPct === null || !Number.isFinite(pnlPct)) return "";
+  return `(${formatPercentDelta(pnlPct)})`;
+}
+
+/**
+ * Settlement clause: `ended flat ✅` when no bags are held, else `N bag(s)
+ * held ⚠` with the noun pluralised. Flat = `openPositionsCount === 0`.
+ */
+export function formatSettlement(openPositionsCount: number): string {
+  if (openPositionsCount <= 0) return "ended flat ✅";
+  const noun = openPositionsCount === 1 ? "bag" : "bags";
+  return `${openPositionsCount} ${noun} held ⚠`;
+}
+
+/**
+ * Meta line: `{trades} trades · {settlement}` — the at-a-glance trade count and
+ * whether the mission closed clean.
+ */
+export function formatMetaLine(
+  trades: number,
+  openPositionsCount: number,
+): string {
+  return `${trades} trades · ${formatSettlement(openPositionsCount)}`;
+}
+
+/**
+ * USD value of the ETH PnL at close for the headline tooltip: `$30.00 at close`.
+ * `undefined` when either input is missing — the title attribute is omitted, not
+ * fabricated.
+ */
+export function pnlUsdTitle(
+  pnlEth: number | null,
+  ethPriceUsdEnd: number | null,
+): string | undefined {
+  const usd = pnlUsd(pnlEth, ethPriceUsdEnd);
+  return usd === null ? undefined : `${formatUsd(usd)} at close`;
+}
+
+/**
+ * Sign → PnL colour class: positive success, negative destructive, flat/unknown
+ * muted. Mirrors `MissionHistory`'s local `pnlTone` so both surfaces agree.
+ */
+export function pnlToneClass(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return "text-[var(--vex-text-3)]";
+  }
+  if (value > 0) return "text-[var(--color-success)]";
+  if (value < 0) return "text-destructive";
+  return "text-[var(--vex-text-2)]";
+}

--- a/vex-app/src/renderer/lib/api/mission.ts
+++ b/vex-app/src/renderer/lib/api/mission.ts
@@ -31,6 +31,7 @@ import type {
   MissionGetDiffInput,
   MissionGetDiffResult,
   MissionGetDraftResult,
+  MissionListResultsResult,
   MissionGetRenewableSourceResult,
   MissionRecoverInput,
   MissionRecoverResult,
@@ -71,6 +72,18 @@ export function useMissionDraft(
   sessionId: string | null,
 ): UseQueryResult<Result<MissionGetDraftResult>> {
   return useQuery(draftOptions(sessionId ?? ""));
+}
+
+export function useMissionResults(
+  limit = 50,
+): UseQueryResult<Result<MissionListResultsResult>> {
+  return useQuery(
+    queryOptions({
+      queryKey: missionKeys.results(),
+      queryFn: () => window.vex.mission.listResults({ limit }),
+      staleTime: STALE_MS,
+    }),
+  );
 }
 
 function diffOptions(input: { sessionId: string; missionId: string }) {

--- a/vex-app/src/renderer/lib/api/mission.ts
+++ b/vex-app/src/renderer/lib/api/mission.ts
@@ -31,6 +31,7 @@ import type {
   MissionGetDiffInput,
   MissionGetDiffResult,
   MissionGetDraftResult,
+  MissionGetSessionResultResult,
   MissionListResultsResult,
   MissionGetRenewableSourceResult,
   MissionRecoverInput,
@@ -82,6 +83,26 @@ export function useMissionResults(
       queryKey: missionKeys.results(),
       queryFn: () => window.vex.mission.listResults({ limit }),
       staleTime: STALE_MS,
+    }),
+  );
+}
+
+/**
+ * Latest finalized result for a session — the post-mission summary card
+ * source. Returns the newest `mission_results` row for the session (or null
+ * when none exists yet). Gated on a non-null sessionId so a fresh session
+ * fires no IPC.
+ */
+export function useMissionSessionResult(
+  sessionId: string | null,
+): UseQueryResult<Result<MissionGetSessionResultResult>> {
+  return useQuery(
+    queryOptions({
+      queryKey: missionKeys.sessionResult(sessionId ?? ""),
+      queryFn: () =>
+        window.vex.mission.getSessionResult({ sessionId: sessionId ?? "" }),
+      staleTime: STALE_MS,
+      enabled: !!sessionId,
     }),
   );
 }

--- a/vex-app/src/renderer/lib/api/queryKeys.ts
+++ b/vex-app/src/renderer/lib/api/queryKeys.ts
@@ -145,6 +145,8 @@ export const missionKeys = {
    */
   renewableSource: (sessionId: string) =>
     ["mission", "renewableSource", sessionId] as const,
+  /** Mission results ledger (history) — per-wallet PNL records. */
+  results: () => ["mission", "results"] as const,
 };
 
 export const approvalsKeys = {

--- a/vex-app/src/renderer/lib/api/queryKeys.ts
+++ b/vex-app/src/renderer/lib/api/queryKeys.ts
@@ -147,6 +147,9 @@ export const missionKeys = {
     ["mission", "renewableSource", sessionId] as const,
   /** Mission results ledger (history) — per-wallet PNL records. */
   results: () => ["mission", "results"] as const,
+  /** Latest finalized result for a session (post-mission summary card). */
+  sessionResult: (sessionId: string) =>
+    ["mission", "sessionResult", sessionId] as const,
 };
 
 export const approvalsKeys = {

--- a/vex-app/src/renderer/stores/uiStore.ts
+++ b/vex-app/src/renderer/stores/uiStore.ts
@@ -52,7 +52,9 @@ export type AppShellView =
   | "session"
   | "sessionsLibrary"
   // Read-only long-term + session-memory panel (stage 7-2a, S9 rewire).
-  | "memory";
+  | "memory"
+  // Read-only per-wallet ledger of finalized mission runs (mission-results-ledger).
+  | "missionHistory";
 
 export interface UiLogEntry {
   readonly id: string;

--- a/vex-app/src/shared/ipc/channels.ts
+++ b/vex-app/src/shared/ipc/channels.ts
@@ -150,6 +150,7 @@ export const CH = {
     stop: "vex:mission:stop",
     getRenewableSource: "vex:mission:getRenewableSource",
     listResults: "vex:mission:listResults",
+    getSessionResult: "vex:mission:getSessionResult",
     setAutoRetry: "vex:mission:setAutoRetry",
   },
 

--- a/vex-app/src/shared/ipc/channels.ts
+++ b/vex-app/src/shared/ipc/channels.ts
@@ -149,6 +149,7 @@ export const CH = {
     edit: "vex:mission:edit",
     stop: "vex:mission:stop",
     getRenewableSource: "vex:mission:getRenewableSource",
+    listResults: "vex:mission:listResults",
     setAutoRetry: "vex:mission:setAutoRetry",
   },
 

--- a/vex-app/src/shared/schemas/mission.ts
+++ b/vex-app/src/shared/schemas/mission.ts
@@ -14,3 +14,4 @@
 
 export * from "./mission/draft.js";
 export * from "./mission/commands.js";
+export * from "./mission/results.js";

--- a/vex-app/src/shared/schemas/mission/results.ts
+++ b/vex-app/src/shared/schemas/mission/results.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+/**
+ * Mission results ledger — read DTO + `mission.listResults` contract.
+ *
+ * One row per finalized mission run (see engine migration 038). PNL is in ETH
+ * (native + WETH bankroll delta, netting gas/fees); USD prices are display-only.
+ * `openPositionsCount` is the number of non-ETH bags still held at close (kept
+ * out of the PNL figure).
+ */
+export const missionResultDtoSchema = z
+  .object({
+    missionRunId: z.string(),
+    seqNo: z.number().int(),
+    goalSnippet: z.string().nullable(),
+    walletAddress: z.string(),
+    chainId: z.number().int(),
+    startedAt: z.string(),
+    endedAt: z.string().nullable(),
+    durationS: z.number().nullable(),
+    bankrollStartEth: z.number().nullable(),
+    bankrollEndEth: z.number().nullable(),
+    pnlEth: z.number().nullable(),
+    pnlPct: z.number().nullable(),
+    ethPriceUsdStart: z.number().nullable(),
+    ethPriceUsdEnd: z.number().nullable(),
+    trades: z.number().int(),
+    outcome: z.string(),
+    openPositionsCount: z.number().int(),
+  })
+  .strict();
+
+export type MissionResultDto = z.infer<typeof missionResultDtoSchema>;
+
+export const missionListResultsInputSchema = z
+  .object({ limit: z.number().int().min(1).max(200).optional() })
+  .strict();
+
+export type MissionListResultsInput = z.infer<typeof missionListResultsInputSchema>;
+
+export const missionListResultsResultSchema = z.array(missionResultDtoSchema);
+
+export type MissionListResultsResult = z.infer<typeof missionListResultsResultSchema>;

--- a/vex-app/src/shared/schemas/mission/results.ts
+++ b/vex-app/src/shared/schemas/mission/results.ts
@@ -41,3 +41,17 @@ export type MissionListResultsInput = z.infer<typeof missionListResultsInputSche
 export const missionListResultsResultSchema = z.array(missionResultDtoSchema);
 
 export type MissionListResultsResult = z.infer<typeof missionListResultsResultSchema>;
+
+export const missionGetSessionResultInputSchema = z
+  .object({ sessionId: z.string() })
+  .strict();
+
+export type MissionGetSessionResultInput = z.infer<
+  typeof missionGetSessionResultInputSchema
+>;
+
+export const missionGetSessionResultResultSchema = missionResultDtoSchema.nullable();
+
+export type MissionGetSessionResultResult = z.infer<
+  typeof missionGetSessionResultResultSchema
+>;

--- a/vex-app/src/shared/types/bridge/agent/mission.ts
+++ b/vex-app/src/shared/types/bridge/agent/mission.ts
@@ -10,6 +10,8 @@ import type {
   MissionGetDraftResult,
   MissionGetRenewableSourceInput,
   MissionGetRenewableSourceResult,
+  MissionGetSessionResultInput,
+  MissionGetSessionResultResult,
   MissionListResultsInput,
   MissionListResultsResult,
   MissionRecoverInput,
@@ -76,6 +78,9 @@ export interface MissionBridge {
   readonly listResults: (
     input: MissionListResultsInput,
   ) => Promise<Result<MissionListResultsResult>>;
+  readonly getSessionResult: (
+    input: MissionGetSessionResultInput,
+  ) => Promise<Result<MissionGetSessionResultResult>>;
   readonly setAutoRetry: (
     input: MissionSetAutoRetryInput,
   ) => Promise<Result<MissionSetAutoRetryResult>>;

--- a/vex-app/src/shared/types/bridge/agent/mission.ts
+++ b/vex-app/src/shared/types/bridge/agent/mission.ts
@@ -10,6 +10,8 @@ import type {
   MissionGetDraftResult,
   MissionGetRenewableSourceInput,
   MissionGetRenewableSourceResult,
+  MissionListResultsInput,
+  MissionListResultsResult,
   MissionRecoverInput,
   MissionRecoverResult,
   MissionRenewInput,
@@ -71,6 +73,9 @@ export interface MissionBridge {
   readonly getRenewableSource: (
     input: MissionGetRenewableSourceInput,
   ) => Promise<Result<MissionGetRenewableSourceResult>>;
+  readonly listResults: (
+    input: MissionListResultsInput,
+  ) => Promise<Result<MissionListResultsResult>>;
   readonly setAutoRetry: (
     input: MissionSetAutoRetryInput,
   ) => Promise<Result<MissionSetAutoRetryResult>>;


### PR DESCRIPTION
## Problem solved

Missions had no persisted, comparable record — you couldn't tell whether the agent was getting **better or worse over time**, and every run was identified by an opaque UUID. This adds a **mission results ledger**: every mission gets a stable per-wallet number (**Mission #N**) and a durable PNL record, surfaced in a **History** view so performance is trackable across runs.

## What changed

**PNL model (the honest number).** PNL is denominated in **ETH** — the bankroll's own unit — as `bankroll_end_eth − bankroll_start_eth`, where bankroll = native ETH + WETH read from the `proj_balances` projection. Taking the delta nets out gas, fees, and slippage automatically. Tokens still held at close are recorded as `open_positions` and **excluded** from the headline PNL, so an unsold bag never distorts it. USD-at-close is kept for display tooltips only.

**Lifecycle (open at start, close at finalize).** A run's start and finalize happen in different turns, so nothing is held in memory — a ledger row is **opened** at the top of `runPreparedMissionStart` (mints the per-wallet `seq_no`, snapshots the start bankroll) and **closed** at every terminal branch of `finalizeMissionRunStatus` (`completed`/`cancelled`/`failed`/`stopped`), keyed on `mission_run_id`. Both capture paths are **fail-soft** — any accounting error is logged and swallowed, so the ledger can never break a mission run.

**Layers:**
- **Data** — migration `038_mission_results` + engine repo (`open`/`close`/`list`/`getForRun`).
- **Valuation** — `computeEthBankroll` (folds `proj_balances` → ETH bankroll + open-position list) and `countMissionTrades` (fills via the `proj_activity → protocol_executions` session join, windowed to the run).
- **Read** — `mission.listResults` IPC end-to-end (schema → `withClient` DB read → handler → preload bridge → `useMissionResults` hook).
- **UI** — a **Mission History** panel (new sidebar entry): summary header (total missions, win-rate, cumulative PNL), a hand-rolled inline-SVG cumulative-PNL sparkline, and a newest-first table (`#N`, goal, outcome badge, duration, trades, sign-coloured ETH PNL + % with a USD-at-close tooltip). Empty/loading/error states handled.

## User impact

Finish a mission and it lands in History as **Mission #N** with its ETH PNL, duration, and trade count; the sparkline shows cumulative PNL trending over time and the header shows win-rate — so "is this strategy improving?" becomes answerable. Nothing is user-facing until a run finalizes; no behaviour changes for the agent.

## Test coverage (TDD throughout)

- Repo SQL shape + params (open seq numbering, idempotent open, close-by-run, history reads).
- `computeEthBankroll` (native+WETH sum, open-position split, dust/empty), `countMissionTrades` (session-join window + fail-soft).
- Capture orchestration via injected deps (wallet/chain resolution, PNL math, no-op on missing mission/row, fail-soft).
- UI model: 18 cases (ETH/duration formatting, win-rate with null-PNL excluded, cumulative series, sparkline geometry).

## Validation

- **Root (engine) suite: 6,458 passed** / 7 skipped.
- **vex-app suite: 2,547 passed.**
- `vex-app` lint (tsc + type-ratchet + process-boundaries): **green**.

## Notes / documented scope

- **v1 computes PNL + trades reliably.** Per-*trade* win/loss/rotation/veto attribution is intentionally deferred — the columns exist (default 0), and the History view derives **mission-level** win-rate from PNL sign, which needs no fragile round-trip pairing. Per-trade attribution + a per-move realized-PNL column in the Moves panel are the natural follow-ups.
- Migration numbered `038` to avoid colliding with the open signals-ingest PR's `037`.
- Bankroll reads the `proj_balances` projection (no on-chain RPC on the finalize path); it reflects the last sync, which is current by finalize given post-mutation sync.
