### PR TITLE
feat(mission): hard 1-hour deadline enforcer + deadline-aware flatten

### DIFF
--- a/src/__tests__/vex-agent/engine/core/mission-activation-message.test.ts
+++ b/src/__tests__/vex-agent/engine/core/mission-activation-message.test.ts
@@ -156,6 +156,8 @@ vi.mock("@vex-agent/db/repos/mission-runs.js", () => ({
   getActiveRunBySession: vi.fn().mockResolvedValue(null),
   getLatestFailedRunBySession: vi.fn().mockResolvedValue(null),
   updateStatus: vi.fn(),
+  // The deadline enforcer reads the run's started_at before building loopConfig.
+  getRun: vi.fn().mockResolvedValue({ startedAt: new Date().toISOString() }),
 }));
 
 vi.mock("@vex-agent/tools/registry.js", () => ({

--- a/src/__tests__/vex-agent/engine/core/turn-loop/mission-mode.test.ts
+++ b/src/__tests__/vex-agent/engine/core/turn-loop/mission-mode.test.ts
@@ -328,6 +328,33 @@ describe("turn-loop", () => {
       expect(mockIncrementIterations).toHaveBeenCalledWith("run-1");
     });
 
+    it("enforces the hard deadline — a past missionDeadlineMs stops with deadline_reached before any turn runs", async () => {
+      const provider = makeProvider([{ content: "should never run" }]);
+
+      const result = await runTurnLoop(
+        makeContext({ sessionKind: "mission", missionRunId: "run-1" }),
+        [], null, 0, provider as any, makeConfig() as any, [],
+        { ...defaultLoopConfig, maxIterations: 5, missionDeadlineMs: Date.now() - 1_000 },
+      );
+
+      expect(result.stopReason).toBe("deadline_reached");
+      // The check is the first thing each iteration — no inference is spent.
+      expect(provider.chatCompletion).not.toHaveBeenCalled();
+    });
+
+    it("does not false-stop when the deadline is still in the future", async () => {
+      const provider = makeProvider([{ content: "Working..." }]);
+
+      const result = await runTurnLoop(
+        makeContext({ sessionKind: "mission", missionRunId: "run-1" }),
+        [], null, 0, provider as any, makeConfig() as any, [],
+        { ...defaultLoopConfig, maxIterations: 1, missionDeadlineMs: Date.now() + 60_000 },
+      );
+
+      expect(result.stopReason).not.toBe("deadline_reached");
+      expect(provider.chatCompletion).toHaveBeenCalled();
+    });
+
     it("merges operator instructions before the next autonomous iteration", async () => {
       const provider = makeProvider([
         { content: "Working..." },

--- a/src/__tests__/vex-agent/engine/mission/mission-deadline.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/mission-deadline.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Hard mission deadline — computed from the run's immutable started_at + a
+ * configurable duration (default 60 min). The free-text contract `deadline` is
+ * intentionally NOT used (it proved unreliable — set-but-ignored, or prose).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  hardDeadlineMinutes,
+  computeHardDeadlineMs,
+} from "@vex-agent/engine/mission/mission-deadline.js";
+
+describe("hardDeadlineMinutes", () => {
+  it("defaults to 60 minutes with no override", () => {
+    expect(hardDeadlineMinutes({})).toBe(60);
+  });
+  it("honors a valid VEX_MISSION_HARD_DEADLINE_MIN override (e.g. a 2-min test box)", () => {
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "2" })).toBe(2);
+  });
+  it("falls back to 60 on a non-numeric or non-positive override", () => {
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "abc" })).toBe(60);
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "0" })).toBe(60);
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "-5" })).toBe(60);
+  });
+  it("clamps absurdly large values to a 24h ceiling", () => {
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "99999" })).toBe(1440);
+  });
+});
+
+describe("computeHardDeadlineMs", () => {
+  it("is started_at + duration in epoch ms", () => {
+    const start = "2026-07-12T19:00:00.000Z";
+    const startMs = Date.parse(start);
+    expect(computeHardDeadlineMs(start, 2)).toBe(startMs + 2 * 60_000);
+    expect(computeHardDeadlineMs(start, 60)).toBe(startMs + 60 * 60_000);
+  });
+  it("returns null for an unparseable start (fail-open: no false deadline)", () => {
+    expect(computeHardDeadlineMs("not-a-date", 60)).toBeNull();
+  });
+});

--- a/src/__tests__/vex-agent/engine/mission/mission-deadline.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/mission-deadline.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from "vitest";
 import {
   hardDeadlineMinutes,
+  resolveDurationMinutes,
   computeHardDeadlineMs,
 } from "@vex-agent/engine/mission/mission-deadline.js";
 
@@ -24,6 +25,25 @@ describe("hardDeadlineMinutes", () => {
   });
   it("clamps absurdly large values to a 24h ceiling", () => {
     expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "99999" })).toBe(1440);
+  });
+});
+
+describe("resolveDurationMinutes (per-mission > env > default)", () => {
+  it("uses the mission's own durationMinutes when set and valid", () => {
+    expect(resolveDurationMinutes(5, {})).toBe(5);
+    expect(resolveDurationMinutes(10, { VEX_MISSION_HARD_DEADLINE_MIN: "60" })).toBe(10);
+  });
+  it("clamps an absurd per-mission value to the 24h ceiling", () => {
+    expect(resolveDurationMinutes(99999, {})).toBe(1440);
+  });
+  it("falls back to the env override when the mission has no duration", () => {
+    expect(resolveDurationMinutes(null, { VEX_MISSION_HARD_DEADLINE_MIN: "2" })).toBe(2);
+    expect(resolveDurationMinutes(undefined, { VEX_MISSION_HARD_DEADLINE_MIN: "2" })).toBe(2);
+  });
+  it("falls back to 60 when neither mission nor env specifies one", () => {
+    expect(resolveDurationMinutes(null, {})).toBe(60);
+    expect(resolveDurationMinutes(0, {})).toBe(60);
+    expect(resolveDurationMinutes(-5, {})).toBe(60);
   });
 });
 

--- a/src/__tests__/vex-agent/engine/prompts/prompt-stack.test.ts
+++ b/src/__tests__/vex-agent/engine/prompts/prompt-stack.test.ts
@@ -496,7 +496,7 @@ describe("prompt-stack", () => {
       expect(turnJoined).toContain("Current time UTC: 2026-05-03T08:39:18.126Z");
       expect(turnJoined).toContain("Session started: 2026-05-03T08:01:02.000Z (elapsed: 38m 16s)");
       expect(turnJoined).toContain("Mission run started: 2026-05-03T08:10:00.000Z (elapsed: 29m 18s)");
-      expect(turnJoined).toContain("Mission deadline: 2026-05-03T14:10:00.000Z (in 5h 30m)");
+      expect(turnJoined).toContain("Mission deadline (HARD): 2026-05-03T14:10:00.000Z (in 5h 30m)");
       expect(turnJoined).toContain("loop_defer(after_ms, reason)");
       // The volatile clock must never leak into the static prefix.
       expect(stack.staticLayers.join("\n")).not.toContain("# Runtime Clock");

--- a/src/vex-agent/engine/core/hydrate.ts
+++ b/src/vex-agent/engine/core/hydrate.ts
@@ -143,6 +143,7 @@ export async function hydrateEngineSession(sessionId: string): Promise<HydratedS
       sessionStartedAt: session.startedAt,
       missionRunStartedAt: activeRun?.startedAt ?? null,
       missionDeadline: extractMissionDeadline(mission?.constraintsJson ?? null),
+      missionDurationMinutes: extractMissionDurationMinutes(mission?.constraintsJson ?? null),
       isSubagent,
       selectedEvmWallet: session.selectedEvmWallet,
       selectedSolanaWallet: session.selectedSolanaWallet,
@@ -164,4 +165,11 @@ export async function hydrateEngineSession(sessionId: string): Promise<HydratedS
 function extractMissionDeadline(constraints: Record<string, unknown> | null): string | null {
   const raw = constraints?.deadline;
   return typeof raw === "string" && raw.trim().length > 0 ? raw : null;
+}
+
+function extractMissionDurationMinutes(
+  constraints: Record<string, unknown> | null,
+): number | null {
+  const raw = constraints?.durationMinutes;
+  return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : null;
 }

--- a/src/vex-agent/engine/core/runner/mission-run.ts
+++ b/src/vex-agent/engine/core/runner/mission-run.ts
@@ -144,6 +144,11 @@ export async function runPreparedMissionStart(
     const missionDeadlineMs = computeHardDeadlineMs(
       (await missionRunsRepo.getRun(prepared.runId))?.startedAt ?? "",
     );
+    // Show the agent the SAME hard deadline the loop enforces (via the Runtime
+    // Clock), so it can flatten positions before the cutoff instead of being
+    // stopped mid-trade with open bags.
+    const missionDeadlineIso =
+      missionDeadlineMs != null ? new Date(missionDeadlineMs).toISOString() : null;
     const loopConfig: TurnLoopConfig = {
       ...DEFAULT_LOOP_CONFIG,
       contextLimit: prepared.config.contextLimit,
@@ -156,6 +161,7 @@ export async function runPreparedMissionStart(
         ...hydrated.context,
         missionRunId: prepared.runId,
         sessionKind: "mission",
+        missionDeadline: missionDeadlineIso ?? hydrated.context.missionDeadline ?? null,
       },
       hydrated.messages,
       hydrated.summary,
@@ -269,6 +275,11 @@ export async function resumePreparedMissionRun(
     const missionDeadlineMs = computeHardDeadlineMs(
       (await missionRunsRepo.getRun(prepared.runId))?.startedAt ?? "",
     );
+    // Show the agent the SAME hard deadline the loop enforces (via the Runtime
+    // Clock), so it can flatten positions before the cutoff instead of being
+    // stopped mid-trade with open bags.
+    const missionDeadlineIso =
+      missionDeadlineMs != null ? new Date(missionDeadlineMs).toISOString() : null;
     const loopConfig: TurnLoopConfig = {
       ...DEFAULT_LOOP_CONFIG,
       contextLimit: prepared.config.contextLimit,
@@ -281,6 +292,7 @@ export async function resumePreparedMissionRun(
         ...hydrated.context,
         missionRunId: prepared.runId,
         sessionKind: "mission",
+        missionDeadline: missionDeadlineIso ?? hydrated.context.missionDeadline ?? null,
       },
       hydrated.messages,
       hydrated.summary,

--- a/src/vex-agent/engine/core/runner/mission-run.ts
+++ b/src/vex-agent/engine/core/runner/mission-run.ts
@@ -36,7 +36,10 @@ import {
   type MissionRunContractSnapshot,
   resolveMissionPromptContext,
 } from "../../mission/run-contract.js";
-import { computeHardDeadlineMs } from "../../mission/mission-deadline.js";
+import {
+  computeHardDeadlineMs,
+  resolveDurationMinutes,
+} from "../../mission/mission-deadline.js";
 import type { PromptStackOptions } from "../../prompts/index.js";
 import { getOpenAITools, type ToolVisibilityBase } from "@vex-agent/tools/registry.js";
 import {
@@ -138,11 +141,13 @@ export async function runPreparedMissionStart(
       }),
     );
 
-    // Hard time-box anchored to the run's IMMUTABLE started_at (correct across
-    // wakes/resumes). Enforced at the turn-loop boundary. Fail-open: an absent
-    // run / unparseable timestamp yields null (no box) rather than a false stop.
+    // Hard time-box: the mission's own durationMinutes (→ env → 60), anchored to
+    // the run's IMMUTABLE started_at so it holds across wakes/resumes. Enforced
+    // at the turn-loop boundary. Fail-open: an unparseable timestamp yields null
+    // (no box) rather than a false early stop.
     const missionDeadlineMs = computeHardDeadlineMs(
       (await missionRunsRepo.getRun(prepared.runId))?.startedAt ?? "",
+      resolveDurationMinutes(hydrated.context.missionDurationMinutes),
     );
     // Show the agent the SAME hard deadline the loop enforces (via the Runtime
     // Clock), so it can flatten positions before the cutoff instead of being
@@ -269,11 +274,13 @@ export async function resumePreparedMissionRun(
       }),
     );
 
-    // Hard time-box anchored to the run's IMMUTABLE started_at (correct across
-    // wakes/resumes). Enforced at the turn-loop boundary. Fail-open: an absent
-    // run / unparseable timestamp yields null (no box) rather than a false stop.
+    // Hard time-box: the mission's own durationMinutes (→ env → 60), anchored to
+    // the run's IMMUTABLE started_at so it holds across wakes/resumes. Enforced
+    // at the turn-loop boundary. Fail-open: an unparseable timestamp yields null
+    // (no box) rather than a false early stop.
     const missionDeadlineMs = computeHardDeadlineMs(
       (await missionRunsRepo.getRun(prepared.runId))?.startedAt ?? "",
+      resolveDurationMinutes(hydrated.context.missionDurationMinutes),
     );
     // Show the agent the SAME hard deadline the loop enforces (via the Runtime
     // Clock), so it can flatten positions before the cutoff instead of being

--- a/src/vex-agent/engine/core/runner/mission-run.ts
+++ b/src/vex-agent/engine/core/runner/mission-run.ts
@@ -36,6 +36,7 @@ import {
   type MissionRunContractSnapshot,
   resolveMissionPromptContext,
 } from "../../mission/run-contract.js";
+import { computeHardDeadlineMs } from "../../mission/mission-deadline.js";
 import type { PromptStackOptions } from "../../prompts/index.js";
 import { getOpenAITools, type ToolVisibilityBase } from "@vex-agent/tools/registry.js";
 import {
@@ -137,10 +138,17 @@ export async function runPreparedMissionStart(
       }),
     );
 
+    // Hard time-box anchored to the run's IMMUTABLE started_at (correct across
+    // wakes/resumes). Enforced at the turn-loop boundary. Fail-open: an absent
+    // run / unparseable timestamp yields null (no box) rather than a false stop.
+    const missionDeadlineMs = computeHardDeadlineMs(
+      (await missionRunsRepo.getRun(prepared.runId))?.startedAt ?? "",
+    );
     const loopConfig: TurnLoopConfig = {
       ...DEFAULT_LOOP_CONFIG,
       contextLimit: prepared.config.contextLimit,
       baseVisibility,
+      missionDeadlineMs,
     };
 
     const result = await runTurnLoop(
@@ -255,10 +263,17 @@ export async function resumePreparedMissionRun(
       }),
     );
 
+    // Hard time-box anchored to the run's IMMUTABLE started_at (correct across
+    // wakes/resumes). Enforced at the turn-loop boundary. Fail-open: an absent
+    // run / unparseable timestamp yields null (no box) rather than a false stop.
+    const missionDeadlineMs = computeHardDeadlineMs(
+      (await missionRunsRepo.getRun(prepared.runId))?.startedAt ?? "",
+    );
     const loopConfig: TurnLoopConfig = {
       ...DEFAULT_LOOP_CONFIG,
       contextLimit: prepared.config.contextLimit,
       baseVisibility,
+      missionDeadlineMs,
     };
 
     const result = await runTurnLoop(

--- a/src/vex-agent/engine/core/turn-loop.ts
+++ b/src/vex-agent/engine/core/turn-loop.ts
@@ -28,6 +28,7 @@ import type { EngineContext, StopReason } from "../types.js";
 import type { InferenceProvider, InferenceConfig, ToolDefinition } from "@vex-agent/inference/types.js";
 import type { Message } from "@vex-agent/db/repos/messages.js";
 import type { PromptStackOptions } from "../prompts/index.js";
+import logger from "@utils/logger.js";
 import { executeTurn, saveAssistantMessage } from "./turn.js";
 import type { TurnLoopConfig, TurnLoopResult } from "./turn-loop/state.js";
 export type { TurnLoopConfig, TurnLoopResult } from "./turn-loop/state.js";
@@ -129,6 +130,23 @@ export async function runTurnLoop(
   }
 
   for (let iteration = 0; iteration < loopConfig.maxIterations; iteration++) {
+    // Hard mission deadline — the agent-independent time-box. Checked FIRST each
+    // iteration so an expired run stops with `deadline_reached` no matter what
+    // the agent would otherwise do (it has, historically, both blown past the
+    // box by hours and false-stopped early). Finalize maps it to a terminal run.
+    if (
+      loopConfig.missionDeadlineMs != null &&
+      Date.now() >= loopConfig.missionDeadlineMs
+    ) {
+      logger.info("engine.mission.deadline_enforced", {
+        missionRunId: context.missionRunId ?? null,
+        deadlineMs: loopConfig.missionDeadlineMs,
+        iteration,
+      });
+      stopReason = "deadline_reached";
+      break;
+    }
+
     // Iteration entry: abort → observe-control → runtime-stop, in that order.
     // Helper returns the outcome; caller emits + sets stopReason + breaks.
     const entry = await runIterationEntryGuards({

--- a/src/vex-agent/engine/core/turn-loop/state.ts
+++ b/src/vex-agent/engine/core/turn-loop/state.ts
@@ -21,6 +21,13 @@ export interface TurnLoopConfig {
    * `ToolVisibilityContext` that drives BOTH the tools array and the Tool Map.
    */
   baseVisibility?: ToolVisibilityBase;
+  /**
+   * Hard mission time-box as an absolute epoch (ms). When set, the turn loop
+   * stops with `deadline_reached` the moment `Date.now() >= missionDeadlineMs`,
+   * independent of the agent. Computed from the run's immutable `started_at` +
+   * the configured duration (see mission-deadline.ts). Null/undefined = no box.
+   */
+  missionDeadlineMs?: number | null;
 }
 
 export interface TurnLoopResult {

--- a/src/vex-agent/engine/mission/mapper.ts
+++ b/src/vex-agent/engine/mission/mapper.ts
@@ -26,6 +26,10 @@ export function missionToDraft(m: Mission): MissionDraft {
     successCriteria: m.successCriteriaJson.length > 0 ? m.successCriteriaJson : null,
     stopConditions: m.stopConditionsJson.length > 0 ? m.stopConditionsJson : null,
     deadline: constraints?.deadline as string ?? null,
+    durationMinutes:
+      typeof constraints?.durationMinutes === "number"
+        ? (constraints.durationMinutes as number)
+        : null,
   };
 }
 
@@ -54,8 +58,13 @@ export function domainToRow(draft: Partial<MissionDraft>): MissionDraftRow {
   // `stopConditionsAccepted` — acceptance lives on
   // `missions.accepted_contract_hash` (mig 023) and is written by the
   // host-only acceptance path, never by the model/draft update flow.
-  if (draft.deadline !== undefined) {
-    row.constraints_json = { deadline: draft.deadline };
+  if (draft.deadline !== undefined || draft.durationMinutes !== undefined) {
+    row.constraints_json = {
+      ...(draft.deadline !== undefined ? { deadline: draft.deadline } : {}),
+      ...(draft.durationMinutes !== undefined
+        ? { durationMinutes: draft.durationMinutes }
+        : {}),
+    };
   }
 
   return row;
@@ -116,6 +125,7 @@ export function draftToPromptContext(m: Mission): string {
     for (const s of draft.stopConditions) lines.push(`- ${s}`);
   }
   if (draft.deadline) lines.push(`**Deadline:** ${draft.deadline}`);
+  if (draft.durationMinutes) lines.push(`**Hard time-box:** ${draft.durationMinutes} min (run auto-stops at start + this)`);
 
   return lines.join("\n");
 }

--- a/src/vex-agent/engine/mission/mission-deadline.ts
+++ b/src/vex-agent/engine/mission/mission-deadline.ts
@@ -1,0 +1,42 @@
+/**
+ * Hard mission deadline — the agent-independent time-box.
+ *
+ * Missions are meant to run a fixed duration (default 60 min) and auto-stop. The
+ * contract's free-text `deadline` proved unreliable (set-but-ignored, prose, or
+ * absent), so the hard boundary is computed purely from the run's IMMUTABLE
+ * `started_at` + a configured duration — correct across wakes/resumes, and not
+ * something the model can talk itself out of. Enforcement lives at the turn-loop
+ * boundary (see turn-loop.ts): once `now >= deadline`, the run stops with
+ * `deadline_reached` regardless of what the agent is doing.
+ *
+ * The duration is overridable via `VEX_MISSION_HARD_DEADLINE_MIN` — used to run
+ * short (e.g. 2-minute) test boxes without waiting an hour.
+ */
+
+const DEFAULT_MINUTES = 60;
+const MAX_MINUTES = 1440; // 24h ceiling — a guard against a fat-fingered override
+
+/** Resolve the hard-deadline duration in minutes (default 60, env-overridable). */
+export function hardDeadlineMinutes(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env.VEX_MISSION_HARD_DEADLINE_MIN;
+  if (raw === undefined || raw === "") return DEFAULT_MINUTES;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_MINUTES;
+  return Math.min(n, MAX_MINUTES);
+}
+
+/**
+ * The absolute hard-deadline epoch (ms) for a run: `started_at + duration`.
+ * Returns null when `started_at` is unparseable — fail-open, so a bad timestamp
+ * never manufactures a spurious deadline that kills a run early.
+ */
+export function computeHardDeadlineMs(
+  startedAtIso: string,
+  durationMin: number = hardDeadlineMinutes(),
+): number | null {
+  const startMs = Date.parse(startedAtIso);
+  if (Number.isNaN(startMs)) return null;
+  return startMs + durationMin * 60_000;
+}

--- a/src/vex-agent/engine/mission/mission-deadline.ts
+++ b/src/vex-agent/engine/mission/mission-deadline.ts
@@ -28,6 +28,27 @@ export function hardDeadlineMinutes(
 }
 
 /**
+ * Resolve the box duration for a specific mission: the mission's own
+ * `durationMinutes` (a structured contract field the agent sets — "5-minute box"
+ * → 5, "one hour" → 60) when present and valid, else the env override, else the
+ * 60-minute default. So each mission runs for as long as IT asked, and 60 is a
+ * true last-resort fallback rather than a one-size-fits-all box.
+ */
+export function resolveDurationMinutes(
+  missionMinutes?: number | null,
+  env: Record<string, string | undefined> = process.env,
+): number {
+  if (
+    typeof missionMinutes === "number" &&
+    Number.isFinite(missionMinutes) &&
+    missionMinutes > 0
+  ) {
+    return Math.min(missionMinutes, MAX_MINUTES);
+  }
+  return hardDeadlineMinutes(env);
+}
+
+/**
  * The absolute hard-deadline epoch (ms) for a run: `started_at + duration`.
  * Returns null when `started_at` is unparseable — fail-open, so a bad timestamp
  * never manufactures a spurious deadline that kills a run early.

--- a/src/vex-agent/engine/mission/patch-parser.ts
+++ b/src/vex-agent/engine/mission/patch-parser.ts
@@ -19,7 +19,7 @@ import type { MissionDraft, MissionPatch } from "../types.js";
 
 const ALLOWED_STRING_KEYS = new Set<keyof MissionDraft>([
   "title", "goal", "capitalSource", "startingCapital",
-  "riskProfile", "deadline",
+  "riskProfile", "deadline", "durationMinutes",
 ]);
 
 const ALLOWED_ARRAY_KEYS = new Set<keyof MissionDraft>([

--- a/src/vex-agent/engine/runtime-clock.ts
+++ b/src/vex-agent/engine/runtime-clock.ts
@@ -87,7 +87,7 @@ export function buildRuntimeClockPrompt(snapshot: RuntimeClockSnapshot): string 
     ));
   }
   if (snapshot.missionDeadline) {
-    lines.push(`Mission deadline: ${snapshot.missionDeadline} (${snapshot.missionDeadlineState ?? "unknown"})`);
+    lines.push(`Mission deadline (HARD): ${snapshot.missionDeadline} (${snapshot.missionDeadlineState ?? "unknown"})`);
   }
   lines.push(snapshot.pendingWakeDueAt
     ? `Pending wake: ${snapshot.pendingWakeDueAt} (${snapshot.pendingWakeState ?? "unknown"}; reason: ${snapshot.pendingWakeReason ?? "none"})`
@@ -98,6 +98,9 @@ export function buildRuntimeClockPrompt(snapshot: RuntimeClockSnapshot): string 
   lines.push("- You do not observe time while deferred; a wake means the executor resumed you after real time passed.");
   lines.push("- To wait when `loop_defer` is available in your current mode, call `loop_defer(after_ms, reason)` for relative waits or `loop_defer(wake_at, reason)` for an exact ISO time.");
   lines.push("- Before using deadline_reached or scheduling another wake, compare live state against this Runtime Clock.");
+  if (snapshot.missionDeadline) {
+    lines.push("- The Mission deadline is HARD: the run AUTO-TERMINATES then, regardless of what you are doing. SELL/close ALL open positions BEFORE it — anything still held when it fires is abandoned. Start flattening with enough buffer for swaps to settle; do NOT open new positions you cannot exit in time.");
+  }
 
   return lines.join("\n");
 }

--- a/src/vex-agent/engine/types.ts
+++ b/src/vex-agent/engine/types.ts
@@ -203,6 +203,9 @@ export interface MissionDraft {
   stopConditions: string[] | null;
   /** Optional — mission may have no deadline. */
   deadline: string | null;
+  /** Optional hard time-box in minutes; the enforcer stops the run at
+   * started_at + this. Absent → env override → 60-minute default. */
+  durationMinutes: number | null;
 }
 
 /**
@@ -265,6 +268,9 @@ export interface EngineContext {
   missionRunStartedAt?: string | null;
   /** Optional mission deadline from the frozen mission constraints. */
   missionDeadline?: string | null;
+  /** Optional hard time-box (minutes) from the mission constraints; the
+   * deadline enforcer resolves this → env → 60. */
+  missionDurationMinutes?: number | null;
   isSubagent: boolean;
   /** Per-session selected wallets (id + address), hydrated from the session row. */
   selectedEvmWallet: { id: string; address: string } | null;

--- a/src/vex-agent/tools/internal/mission.ts
+++ b/src/vex-agent/tools/internal/mission.ts
@@ -41,6 +41,7 @@ const MissionDraftUpdateArgs = z
     successCriteria: z.array(z.string().trim().min(1).max(MAX_ARRAY_ITEM_LENGTH)).max(MAX_ARRAY_ITEMS).nullable().optional(),
     stopConditions: z.array(z.string().trim().min(1).max(MAX_ARRAY_ITEM_LENGTH)).max(MAX_ARRAY_ITEMS).nullable().optional(),
     deadline: z.string().trim().min(1).max(MAX_STRING_LENGTH).nullable().optional(),
+    durationMinutes: z.number().int().positive().max(1440).nullable().optional(),
   })
   .strict()
   .refine(

--- a/src/vex-agent/tools/registry/mission.ts
+++ b/src/vex-agent/tools/registry/mission.ts
@@ -21,6 +21,7 @@ export const MISSION_TOOLS: readonly ToolDef[] = [
       successCriteria: { type: "array", items: { type: "string" }, description: "Concrete success criteria" },
       stopConditions: { type: "array", items: { type: "string" }, description: "Proposed non-success stop conditions for the contract. The user owns this list — propose, refine with the user, and save updates here. Final acceptance happens via the host Accept contract step, not in chat" },
       deadline: { type: "string", description: "Optional deadline, preferably ISO8601 or an absolute date/time with timezone" },
+      durationMinutes: { type: "number", description: "The mission's time-box in whole minutes (e.g. 5, 60). The run HARD-STOPS at started_at + this many minutes, regardless of progress. Set this from the goal's stated duration; if omitted, a 60-minute default applies." },
     }, additionalProperties: false },
   },
   {


### PR DESCRIPTION
## Problem solved

Missions never actually honored their time-box. Deadlines were **agent-driven** (the model was trusted to call `mission_stop(deadline_reached)`), and that failed in **both** directions. Six consecutive "1-hour" runs on this wallet:

| ran | deadline set? | stopped by |
|---|---|---|
| 44m | none | user |
| **12m** | set | agent `deadline_reached` (48m early!) |
| 3m | set | user |
| **10m** | set | agent `deadline_reached` (50m early!) |
| **173m** 😱 | set | user (blew straight past a set deadline) |
| 32m | set | user |

None near 60. The free-text contract `deadline` was unreliable (set-but-ignored, or stored as prose). You couldn't compare runs, and a run could grind for ~3h or bail in 10min.

## What changed

**1. Hard, agent-independent enforcer.** The time-box is computed from the run's **immutable `started_at` + the mission's own duration** — not the free-text field — and enforced at the **turn-loop boundary**: once `now >= deadline`, the run stops with `deadline_reached` **before spending another inference call**. Correct across wakes/resumes; nothing the model can talk itself out of. Duration is overridable via `VEX_MISSION_HARD_DEADLINE_MIN` (used to run short test boxes).

**2. The agent can SEE the deadline (so it flattens in time).** The enforcer's computed deadline is threaded into `context.missionDeadline`, so the Runtime Clock shows the *real* cutoff as a live countdown — `Mission deadline (HARD): … (in Nm)` — with an explicit instruction: *auto-terminates then; SELL/close ALL positions before it; anything held is abandoned; don't open positions you can't exit in time.* Without this the enforcer would cut the agent off mid-trade holding bags.

**3. Per-mission duration.** The box is each mission's own **structured `durationMinutes`** (the agent sets it from the goal — "5-minute box" → 5, "one hour" → 60), threaded through the same contract path as `deadline`. `resolveDurationMinutes` picks **per-mission → `VEX_MISSION_HARD_DEADLINE_MIN` → 60**, so a *"2x in 10 mins"* and a *"1-hour run"* no longer get the same box, and 60 is a genuine last-resort fallback rather than the de-facto rule.

## Live validation (5-minute test box)

A real run with `VEX_MISSION_HARD_DEADLINE_MIN=5`:
- The agent read the hard deadline (`21:17:53Z`), computed its own **T-45s flat cutoff (`21:17:08Z`)**, and scheduled a `loop_defer` wake explicitly *"to re-quote sell and exit with buffer before the T-45s flat deadline"* — then *"Resuming then to close the trade flat."* (Before this change it had no idea a cutoff existed.)
- With ~41s to the flat cutoff and WISHBONE spiking **+17.55% (h1)**, the agent made the disciplined call — *"Chasing a tiny net-positive on a parabolic +17% meme in the final minute risks a reversal and missing the hard flat requirement. **Exit NOW to lock the clean enter→exit and guarantee flat with buffer.**"* — sold, then *"FLAT confirmed. WISHBONE is gone from the wallet."* (It also correctly separated the token's +17.55% h1 move from its own ~flat trade P&L, net of fees.)
- On-chain: **bought WISHBONE `21:15:03` → sold it back `21:16:53`** → **ended flat** (post-run WISHBONE balance = 0).
- Self-completed at **4m22s**, inside the box. (The enforcer is the backstop for when the agent does NOT self-stop in time — proven in the unit test below.)

## Screenshot
<img width="1139" height="807" alt="image" src="https://github.com/user-attachments/assets/04585165-c4a6-49c4-b6b2-7f9886f53a6a" />


## Test coverage (TDD)

- `mission-deadline.ts` helper: duration resolution (default/override/clamp) + `started_at + duration` math — 6 cases.
- Turn-loop enforcement, in the real `runTurnLoop` harness: a **past** `missionDeadlineMs` stops with `deadline_reached` and spends **zero** inference; a **future** one does not false-stop — 2 cases.
- Runtime-clock wording pinned; a mission-runs mock updated for the new `getRun` read.

## Validation
- **Root (engine) suite: 6,458 passed** / 7 skipped.
- `tsc`: 0 errors.

## Notes / follow-up
- `deadline_reached` currently maps to run status `failed` (pre-existing) — reclassifying a clean time-box as `completed` is a small follow-up.
- Agent-awareness is a **soft** flat guarantee (it complied here); the **hard** guarantee — a force-liquidate that auto-sells open bags when the deadline fires regardless of the agent — is a planned follow-up. (A prior no-awareness run left a stranded token bag; this run did not.)
