### PR TITLE
fix(agent): surface incomplete turn status

### DIFF
--- a/vex-app/src/renderer/features/appShell/DeskRuleTapeState.tsx
+++ b/vex-app/src/renderer/features/appShell/DeskRuleTapeState.tsx
@@ -5,9 +5,9 @@
  * the head of the tape.
  *
  * State precedence mirrors the streaming strip's circuit-break: a pending
- * approval FREEZES the run, so AWAITING wins over LIVE; otherwise LIVE while the
- * engine streams; then a non-streaming mission run reads PAUSED (paused_*) or
- * RUNNING (so a started, quiet run no longer looks idle); IDLE at rest. Blue is
+ * approval FREEZES the run, so AWAITING wins over LIVE; otherwise LIVE while a
+ * chat submit remains active (including quiet gaps between engine streams);
+ * then a mission run reads PAUSED (paused_*) or RUNNING; IDLE at rest. Blue is
  * rationed to the non-idle states.
  *
  * Landing hero-status treatment: the dot carries the `.vex-pulse-dot` ring
@@ -23,6 +23,7 @@
 
 import type { JSX } from "react";
 import { usePendingApprovals } from "../../lib/api/approvals.js";
+import { useIsChatSubmitting } from "../../lib/api/chat.js";
 import { useRuntimeState } from "../../lib/api/runtime.js";
 import { useStreamPreview } from "../../stores/streamStore.js";
 import { useUiStore } from "../../stores/uiStore.js";
@@ -32,6 +33,7 @@ export function DeskRuleTapeState(): JSX.Element | null {
   const activeSessionId = useUiStore((s) => s.activeSessionId);
   const appShellView = useUiStore((s) => s.appShellView);
   const preview = useStreamPreview(activeSessionId);
+  const chatSubmitting = useIsChatSubmitting(activeSessionId);
   const pending = usePendingApprovals(activeSessionId);
   const runtime = useRuntimeState(activeSessionId);
 
@@ -40,14 +42,15 @@ export function DeskRuleTapeState(): JSX.Element | null {
   const pendingData = pending.data;
   const hasPending =
     pendingData !== undefined && pendingData.ok && pendingData.data.length > 0;
-  const streaming = preview !== null && preview.phase === "streaming";
+  const live =
+    chatSubmitting || (preview !== null && preview.phase === "streaming");
   const run = runtime.data !== undefined && runtime.data.ok ? runtime.data.data : null;
   const hasActiveRun = run?.hasActiveRun === true;
   const paused = hasActiveRun && (run?.status?.startsWith("paused") ?? false);
 
   const state = hasPending
     ? "awaiting"
-    : streaming
+    : live
       ? "live"
       : paused
         ? "paused"

--- a/vex-app/src/renderer/features/appShell/SessionComposer.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionComposer.tsx
@@ -26,7 +26,8 @@
  * recolor from `--vex-accent`. The context strip is gone, so the two
  * transient states it carried survive as a tiny tag FLOATING above the pill:
  * amber "AWAITING SIGNATURE" while a run is parked for approval, muted
- * "Stopping…" while a stop settles (they cannot co-occur).
+ * "Stopping…" while a stop settles, or blue "Working…" while a chat submit
+ * remains active between visible stream updates.
  *
  * Pure helpers: gating reasons + placeholders in `composer-helpers.ts`.
  * Mission controls (start/continue/recover/stop/edit/renew) are buttons in
@@ -64,6 +65,7 @@ import {
   gatedReason,
   placeholderFor,
   readRunStatus,
+  submitFailureNotice,
   submitSuccessText,
 } from "./composer-helpers.js";
 import { ComposerQuickActions } from "./ComposerQuickActions.js";
@@ -239,6 +241,21 @@ export function SessionComposer({
           }
           return;
         }
+        const failure = submitFailureNotice(outcome.data);
+        if (failure !== null) {
+          const armRetry =
+            failure.retryable &&
+            activeSession?.id === targetSessionId &&
+            activeSession.mode === "agent";
+          setNotice({
+            tone: "error",
+            text: failure.text,
+            ...(armRetry && {
+              retry: { sessionId: targetSessionId, message },
+            }),
+          });
+          return;
+        }
         const successText = submitSuccessText(outcome.data);
         if (successText !== null) setNotice({ tone: "info", text: successText });
       } finally {
@@ -391,11 +408,11 @@ export function SessionComposer({
   return (
     <>
       <div className="relative mt-6">
-        {/* TRANSIENT SIGNAL TAG — floats above the pill's right side, carrying
-         * the two states the retired context strip held (they cannot co-occur:
-         * an approval pause freezes free-text submit, so nothing is in flight).
-         * amber "AWAITING SIGNATURE" while parked for a signature; muted
-         * "Stopping…" while a stop settles. Sibling of the form so the pill's
+        {/* TRANSIENT SIGNAL TAG — floats above the pill's right side. An
+         * approval pause wins, then a requested stop, then the submit-wide
+         * working state. The latter remains visible between inference streams
+         * and tool calls, when the tape preview can otherwise look idle even
+         * though the turn is still running. Sibling of the form so the pill's
          * rounded surface never owns this floating status layer. */}
         {awaitingApproval ? (
           <span
@@ -412,6 +429,14 @@ export function SessionComposer({
             className="absolute -top-2.5 right-6 z-20 rounded-full border border-[var(--vex-line-strong)] bg-[var(--vex-surface-1)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--vex-text-2)]"
           >
             Stopping…
+          </span>
+        ) : submitPending ? (
+          <span
+            data-vex-console-status="working"
+            role="status"
+            className="absolute -top-2.5 right-6 z-20 rounded-full border border-[var(--vex-accent-border-strong)] bg-[var(--vex-surface-1)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--vex-accent-text)]"
+          >
+            Working…
           </span>
         ) : null}
 

--- a/vex-app/src/renderer/features/appShell/SessionComposer.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionComposer.tsx
@@ -25,9 +25,9 @@
  * all live in `.vex-console` (globals.css) — token-only, so both themes
  * recolor from `--vex-accent`. The context strip is gone, so the two
  * transient states it carried survive as a tiny tag FLOATING above the pill:
- * amber "AWAITING SIGNATURE" while a run is parked for approval, muted
- * "Stopping…" while a stop settles, or blue "Working…" while a chat submit
- * remains active between visible stream updates.
+ * amber "AWAITING SIGNATURE" while a run is parked for approval or muted
+ * "Stopping…" while a stop settles. Active work is shown on the agent avatar
+ * in the transcript instead of adding another label above the input.
  *
  * Pure helpers: gating reasons + placeholders in `composer-helpers.ts`.
  * Mission controls (start/continue/recover/stop/edit/renew) are buttons in
@@ -409,11 +409,9 @@ export function SessionComposer({
     <>
       <div className="relative mt-6">
         {/* TRANSIENT SIGNAL TAG — floats above the pill's right side. An
-         * approval pause wins, then a requested stop, then the submit-wide
-         * working state. The latter remains visible between inference streams
-         * and tool calls, when the tape preview can otherwise look idle even
-         * though the turn is still running. Sibling of the form so the pill's
-         * rounded surface never owns this floating status layer. */}
+         * approval pause wins over a requested stop. The active-work signal
+         * lives on the agent avatar in the transcript, so the composer stays
+         * visually quiet while a turn is running. */}
         {awaitingApproval ? (
           <span
             data-vex-console-status="approval"
@@ -429,14 +427,6 @@ export function SessionComposer({
             className="absolute -top-2.5 right-6 z-20 rounded-full border border-[var(--vex-line-strong)] bg-[var(--vex-surface-1)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--vex-text-2)]"
           >
             Stopping…
-          </span>
-        ) : submitPending ? (
-          <span
-            data-vex-console-status="working"
-            role="status"
-            className="absolute -top-2.5 right-6 z-20 rounded-full border border-[var(--vex-accent-border-strong)] bg-[var(--vex-surface-1)] px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.2em] text-[var(--vex-accent-text)]"
-          >
-            Working…
           </span>
         ) : null}
 

--- a/vex-app/src/renderer/features/appShell/SessionTranscript.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionTranscript.tsx
@@ -26,6 +26,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, type JSX } fr
 import type { Result } from "@shared/ipc/result.js";
 import type { MessagePage, SessionMessageDto } from "@shared/schemas/messages.js";
 import { usePendingApprovals } from "../../lib/api/approvals.js";
+import { useIsChatSubmitting } from "../../lib/api/chat.js";
 import {
   flattenTranscriptPages,
   useTranscriptInfinite,
@@ -36,9 +37,12 @@ import { useStreamPreview } from "../../stores/streamStore.js";
 import { StreamingBubble } from "./StreamingBubble.js";
 import { TranscriptMessage } from "./TranscriptMessage.js";
 import {
+  findWorkingAgentEntryKey,
+  transcriptEntryKey as entryKey,
+} from "./agentActivity.js";
+import {
   groupTranscriptRows,
   toTranscriptRows,
-  type TranscriptEntry,
 } from "./transcriptRowModel.js";
 
 const PINNED_THRESHOLD_PX = 48;
@@ -46,19 +50,6 @@ const LOAD_OLDER_THRESHOLD_PX = 64;
 // Same cadence as ApprovalsRegion — both observers share one query, so this
 // adds no IPC load; it only keeps the act-ledger stamps as fresh as the cards.
 const PENDING_APPROVALS_REFETCH_MS = 5_000;
-
-/**
- * React key for a transcript entry. One source DTO id can now appear on up to
- * three entries: a `tool_call` row with prose splits into a standalone
- * assistant-text row PLUS the (prose-less) tool row, and a grouped tool run
- * reuses its first call row's id for the `tool_group` entry. Prefixing the
- * tool / tool_group variants keeps all three keys distinct under one id.
- */
-function entryKey(entry: TranscriptEntry): string {
-  if (entry.variant === "tool_group") return `tg-${entry.id}`;
-  if (entry.variant === "tool") return `t-${entry.id}`;
-  return String(entry.id);
-}
 
 /**
  * Ids that must NOT animate: everything visible at the session's first
@@ -110,6 +101,7 @@ export function SessionTranscript({
 }): JSX.Element {
   const query = useTranscriptInfinite(sessionId);
   const preview = useStreamPreview(sessionId);
+  const chatSubmitting = useIsChatSubmitting(sessionId);
   const scrollRef = useRef<HTMLDivElement>(null);
   const anchorSpacerRef = useRef<HTMLDivElement>(null);
   const pinnedToBottom = useRef(true);
@@ -133,6 +125,7 @@ export function SessionTranscript({
     () => groupTranscriptRows(toTranscriptRows(items)),
     [items],
   );
+  const workingAgentEntryKey = findWorkingAgentEntryKey(rows, chatSubmitting);
 
   // S5 — pending approvals drive two quiet signals: per-act "Awaiting
   // signature" stamps (matched by toolCallId) and the working strip's
@@ -367,7 +360,11 @@ export function SessionTranscript({
               settledIds !== null && !settledIds.has(row.id) && "vex-entry-settle",
             )}
           >
-            <TranscriptMessage row={row} pendingApprovals={pendingApprovals} />
+            <TranscriptMessage
+              row={row}
+              pendingApprovals={pendingApprovals}
+              agentWorking={workingAgentEntryKey === entryKey(row)}
+            />
           </div>
         ))}
         {preview !== null ? (

--- a/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
+++ b/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
@@ -5,10 +5,9 @@
  * Switches on the pure `TranscriptEntry.variant`. The transcript reads as
  * an asymmetric register: USER turns are compact right-aligned cards with a
  * persistent "You · HH:MM" caption; ASSISTANT turns are full-width document
- * flow hung off the Signal Tape spine by a quiet node in a 28px gutter (no
- * bubble, no avatar — the shell is photo-free; accent is rationed to the
- * live/pending node, so a settled node rests in --vex-text-3). Assistant prose
- * renders through
+ * flow hung off the Signal Tape spine by its 18px avatar in a 28px gutter (no
+ * bubble). While the current turn is active, a restrained accent ring rotates
+ * around that avatar; settled turns remain still. Assistant prose renders through
  * `MarkdownContent` (stage 8-2a) — safe React elements, never an HTML
  * string; user/tool/notice rows + the `compaction`/`recall` markers (stage
  * 8-4) render as plain React text nodes. Either way model/tool output cannot
@@ -65,15 +64,28 @@ function TapeClock({ createdAt }: { readonly createdAt: string }): JSX.Element |
  * "Vex" caption carries the name, so the image is aria-hidden. CSP-safe — a
  * same-origin /vex.jpg under the existing `img-src 'self'` directive.
  */
-function AssistantAvatar(): JSX.Element {
+function AssistantAvatar({ working = false }: { readonly working?: boolean }): JSX.Element {
   return (
-    <img
-      src="/vex.jpg"
-      alt=""
-      aria-hidden
-      draggable={false}
-      className="absolute left-0 top-[2px] h-[18px] w-[18px] rounded-full object-cover ring-2 ring-[var(--vex-surface-0)]"
-    />
+    <span
+      data-vex-agent-avatar=""
+      data-vex-agent-avatar-state={working ? "working" : "settled"}
+      className="absolute left-0 top-[2px] h-[18px] w-[18px]"
+    >
+      {working ? (
+        <span
+          data-vex-agent-spinner=""
+          aria-hidden
+          className="absolute -inset-[3px] rounded-full border border-[var(--vex-accent)] border-r-transparent animate-spin [animation-duration:900ms] motion-reduce:animate-none"
+        />
+      ) : null}
+      <img
+        src="/vex.jpg"
+        alt=""
+        aria-hidden
+        draggable={false}
+        className="h-[18px] w-[18px] rounded-full object-cover ring-2 ring-[var(--vex-surface-0)]"
+      />
+    </span>
   );
 }
 
@@ -107,6 +119,7 @@ function AssistantBody({ content }: { readonly content: string }): JSX.Element {
 export function TranscriptMessage({
   row,
   pendingApprovals,
+  agentWorking = false,
 }: {
   readonly row: TranscriptEntry;
   /**
@@ -114,6 +127,8 @@ export function TranscriptMessage({
    * call id matches get the "Awaiting signature" stamp-link to their card.
    */
   readonly pendingApprovals?: ReadonlyMap<string, string>;
+  /** True only for the newest assistant avatar in the currently active turn. */
+  readonly agentWorking?: boolean;
 }): JSX.Element {
   switch (row.variant) {
     case "user":
@@ -131,7 +146,7 @@ export function TranscriptMessage({
     case "assistant":
       return (
         <div data-vex-message-role="assistant" className="relative pl-7">
-          <AssistantAvatar />
+          <AssistantAvatar working={agentWorking} />
           <AssistantCaption createdAt={row.createdAt} />
           <AssistantBody content={row.content} />
         </div>
@@ -143,7 +158,7 @@ export function TranscriptMessage({
           data-vex-stopped=""
           className="relative pl-7"
         >
-          <AssistantAvatar />
+          <AssistantAvatar working={agentWorking} />
           <AssistantCaption createdAt={row.createdAt} />
           <AssistantBody content={row.content} />
           <div className="mt-1.5 flex items-center gap-1 text-[11px] text-[var(--vex-text-3)]">
@@ -174,7 +189,7 @@ export function TranscriptMessage({
           {/* Assistant prose accompanying the tool call (often empty). */}
           {row.content.length > 0 ? (
             <div className="relative pl-7">
-              <AssistantAvatar />
+              <AssistantAvatar working={agentWorking} />
               <AssistantCaption createdAt={row.createdAt} />
               <AssistantBody content={row.content} />
             </div>

--- a/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
+++ b/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
@@ -75,7 +75,7 @@ function AssistantAvatar({ working = false }: { readonly working?: boolean }): J
         <span
           data-vex-agent-spinner=""
           aria-hidden
-          className="absolute -inset-[3px] rounded-full border border-[var(--vex-accent)] border-r-transparent animate-spin [animation-duration:900ms] motion-reduce:animate-none"
+          className="absolute -inset-[3px] rounded-full border border-[var(--vex-accent)] border-r-transparent animate-spin [animation-duration:1200ms] motion-reduce:animate-none"
         />
       ) : null}
       <img

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-console.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-console.test.tsx
@@ -43,7 +43,7 @@ vi.mock("@hugeicons/core-free-icons", () => ({
 }));
 
 const mockSubmitChat = {
-  isPending: false,
+  isPending: false as boolean,
   mutateAsync: vi.fn(),
   stop: vi.fn(),
 };
@@ -92,6 +92,7 @@ function agentRow(over: Partial<SessionListItem> = {}): SessionListItem {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSubmitChat.isPending = false;
   runStatus = null;
   useUiStore.setState({
     pendingFirstMessage: null,
@@ -181,6 +182,22 @@ describe("SessionComposer — Signal Console chrome", () => {
     expect(status?.textContent).toBe("AWAITING SIGNATURE");
     expect(status?.className).toContain("text-[var(--vex-pin)]");
     expect(form?.contains(status)).toBe(false);
+  });
+
+  it("keeps the turn visibly WORKING between stream updates", () => {
+    mockSubmitChat.isPending = true;
+    const { container } = render(
+      <SessionComposer activeSession={agentRow()} activeSessionId={SESSION} />,
+    );
+
+    const status = container.querySelector(
+      '[data-vex-console-status="working"]',
+    );
+    expect(status?.textContent).toBe("Working…");
+    expect(status?.getAttribute("role")).toBe("status");
+    expect(
+      container.querySelector('[data-vex-console-status="stopping"]'),
+    ).toBeNull();
   });
 
   it("has no PROPOSE → ENFORCE → PROVE flow strip on the welcome stage", () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-console.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-console.test.tsx
@@ -184,17 +184,16 @@ describe("SessionComposer — Signal Console chrome", () => {
     expect(form?.contains(status)).toBe(false);
   });
 
-  it("keeps the turn visibly WORKING between stream updates", () => {
+  it("does not add a WORKING label above the composer while a turn is pending", () => {
     mockSubmitChat.isPending = true;
     const { container } = render(
       <SessionComposer activeSession={agentRow()} activeSessionId={SESSION} />,
     );
 
-    const status = container.querySelector(
-      '[data-vex-console-status="working"]',
-    );
-    expect(status?.textContent).toBe("Working…");
-    expect(status?.getAttribute("role")).toBe("status");
+    expect(
+      container.querySelector('[data-vex-console-status="working"]'),
+    ).toBeNull();
+    expect(container.textContent).not.toContain("Working…");
     expect(
       container.querySelector('[data-vex-console-status="stopping"]'),
     ).toBeNull();

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop.test.tsx
@@ -559,7 +559,7 @@ describe("AppShell", () => {
         container.querySelector('[data-vex-tape-state="live"]'),
       ).not.toBeNull(),
     );
-    expect(screen.getByText("Working…")).toBeTruthy();
+    expect(screen.queryByText("Working…")).toBeNull();
     // Pins the fix: a submit-typed Stop would re-run onSubmit (re-sending the
     // draft) instead of only cancelling the turn.
     expect(stopBtn.getAttribute("type")).toBe("button");

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop.test.tsx
@@ -280,6 +280,42 @@ beforeEach(() => {
 });
 
 describe("AppShell", () => {
+  it("surfaces a timed-out turn after tool activity without offering a blind Retry", async () => {
+    const row = makeAgentRow("Timed-out chat");
+    sessionsListMock.mockResolvedValueOnce({ ok: true, data: [row] });
+    sessionsGetMock.mockResolvedValue({ ok: true, data: row });
+    useUiStore.setState({ activeSessionId: row.id });
+    chatSubmitMock.mockReturnValue({
+      promise: Promise.resolve({
+        ok: true,
+        data: {
+          text: null,
+          toolCallsMade: 3,
+          pendingApprovals: [],
+          stopReason: "timeout",
+          missionStatus: null,
+          treatedAsInitialGoal: false,
+        },
+      }),
+      cancel: vi.fn(),
+    });
+
+    renderShell();
+    await screen.findByText("Timed-out chat");
+    const draft = screen.getByLabelText("Session draft") as HTMLTextAreaElement;
+    fireEvent.change(draft, { target: { value: "bridge in one shot" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await screen.findByText(
+      "Vex stopped before completing the task because this turn timed out. Review the transcript before trying again; earlier steps may have completed.",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Retry sending the message" }),
+    ).toBeNull();
+    expect(draft.value).toBe("");
+    expect(chatSubmitMock).toHaveBeenCalledTimes(1);
+  });
+
   it("arms an inline Retry on a retryable provider error and re-sends the same message", async () => {
     const row = makeAgentRow("Retry chat");
     sessionsListMock.mockResolvedValueOnce({ ok: true, data: [row] });
@@ -510,7 +546,7 @@ describe("AppShell", () => {
       cancel,
     });
 
-    renderShell();
+    const { container } = renderShell();
     await screen.findByText("Stoppable chat");
 
     const draft = screen.getByLabelText("Session draft") as HTMLTextAreaElement;
@@ -518,6 +554,12 @@ describe("AppShell", () => {
     fireEvent.click(screen.getByRole("button", { name: "Send message" }));
 
     const stopBtn = await screen.findByRole("button", { name: "Stop generating" });
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-vex-tape-state="live"]'),
+      ).not.toBeNull(),
+    );
+    expect(screen.getByText("Working…")).toBeTruthy();
     // Pins the fix: a submit-typed Stop would re-run onSubmit (re-sending the
     // draft) instead of only cancelling the turn.
     expect(stopBtn.getAttribute("type")).toBe("button");

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionTranscript.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionTranscript.test.tsx
@@ -17,7 +17,10 @@ import type {
   MessageRole,
   SessionMessageDto,
 } from "@shared/schemas/messages.js";
+
 import { SessionTranscript } from "../SessionTranscript.js";
+import { findWorkingAgentEntryKey } from "../agentActivity.js";
+import type { TranscriptEntry } from "../transcriptRowModel.js";
 import { useStreamStore } from "../../../stores/streamStore.js";
 
 const SESSION = "00000000-0000-4000-8000-0000000000aa";
@@ -164,6 +167,44 @@ describe("SessionTranscript", () => {
       cursor: null,
       limit: 50,
     });
+  });
+
+  it("selects only the current turn's newest agent avatar as working", () => {
+    const rows: TranscriptEntry[] = [
+      {
+        id: 1,
+        variant: "assistant" as const,
+        label: null,
+        content: "Earlier reply",
+        createdAt: ISO,
+      },
+      {
+        id: 2,
+        variant: "user" as const,
+        label: null,
+        content: "Send SOL",
+        createdAt: ISO,
+      },
+      {
+        id: 3,
+        variant: "assistant" as const,
+        label: null,
+        content: "Preparing transfer",
+        createdAt: ISO,
+      },
+      {
+        id: 4,
+        variant: "tool" as const,
+        label: "wallet_send_prepare_output",
+        toolKind: "result" as const,
+        content: "prepared",
+        createdAt: ISO,
+      },
+    ];
+
+    expect(findWorkingAgentEntryKey(rows, true)).toBe("3");
+    expect(findWorkingAgentEntryKey(rows, false)).toBeNull();
+    expect(findWorkingAgentEntryKey(rows.slice(0, 2), true)).toBeNull();
   });
 
   it("shows the empty state when there are no messages", async () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/TranscriptMessage.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/TranscriptMessage.test.tsx
@@ -263,3 +263,34 @@ describe("TranscriptMessage assistant_stopped (9-5b)", () => {
     expect(container.querySelector("[data-vex-stopped]")).not.toBeNull();
   });
 });
+
+describe("TranscriptMessage agent activity avatar", () => {
+  it("draws a theme-accent spinner around the active agent avatar", () => {
+    const { container } = render(
+      createElement(TranscriptMessage, {
+        row: row({ variant: "assistant", content: "Preparing the transfer." }),
+        agentWorking: true,
+      }),
+    );
+    const avatar = container.querySelector(
+      '[data-vex-agent-avatar-state="working"]',
+    );
+    const spinner = container.querySelector("[data-vex-agent-spinner]");
+    expect(avatar).not.toBeNull();
+    expect(spinner?.className).toContain("border-[var(--vex-accent)]");
+    expect(spinner?.className).toContain("animate-spin");
+    expect(spinner?.className).toContain("motion-reduce:animate-none");
+  });
+
+  it("keeps settled agent avatars still", () => {
+    const { container } = render(
+      createElement(TranscriptMessage, {
+        row: row({ variant: "assistant", content: "Transfer prepared." }),
+      }),
+    );
+    expect(
+      container.querySelector('[data-vex-agent-avatar-state="settled"]'),
+    ).not.toBeNull();
+    expect(container.querySelector("[data-vex-agent-spinner]")).toBeNull();
+  });
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/TranscriptMessage.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/TranscriptMessage.test.tsx
@@ -279,6 +279,7 @@ describe("TranscriptMessage agent activity avatar", () => {
     expect(avatar).not.toBeNull();
     expect(spinner?.className).toContain("border-[var(--vex-accent)]");
     expect(spinner?.className).toContain("animate-spin");
+    expect(spinner?.className).toContain("[animation-duration:1200ms]");
     expect(spinner?.className).toContain("motion-reduce:animate-none");
   });
 

--- a/vex-app/src/renderer/features/appShell/__tests__/composer-helpers.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/composer-helpers.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { ChatSubmitResult } from "@shared/schemas/chat.js";
+import {
+  submitFailureNotice,
+  submitSuccessText,
+} from "../composer-helpers.js";
+
+function outcome(
+  overrides: Partial<ChatSubmitResult> = {},
+): ChatSubmitResult {
+  return {
+    text: null,
+    toolCallsMade: 0,
+    pendingApprovals: [],
+    stopReason: null,
+    missionStatus: null,
+    treatedAsInitialGoal: false,
+    ...overrides,
+  };
+}
+
+describe("composer outcome copy", () => {
+  it.each([
+    ["iteration_limit", "action limit"],
+    ["timeout", "timed out"],
+    ["system_error", "internal error"],
+  ] as const)("marks %s as an incomplete retryable turn", (stopReason, copy) => {
+    const notice = submitFailureNotice(outcome({ stopReason }));
+    expect(notice?.retryable).toBe(true);
+    expect(notice?.text).toContain(copy);
+  });
+
+  it("blocks blind retry after tool activity and warns that earlier steps may have completed", () => {
+    const notice = submitFailureNotice(
+      outcome({ stopReason: "timeout", toolCallsMade: 2 }),
+    );
+    expect(notice?.retryable).toBe(false);
+    expect(notice?.text).toContain("earlier steps may have completed");
+  });
+
+  it("explains context exhaustion without offering a same-session retry", () => {
+    expect(
+      submitFailureNotice(
+        outcome({ stopReason: "compact_unable_at_critical" }),
+      ),
+    ).toEqual({
+      text: "Vex stopped because this conversation ran out of usable context. Start a new session or try a narrower request.",
+      retryable: false,
+    });
+  });
+
+  it.each([
+    null,
+    "approval_required",
+    "waiting_for_wake",
+    "plan_acceptance_required",
+  ] as const)("leaves %s to its existing transcript or control UI", (stopReason) => {
+    expect(submitFailureNotice(outcome({ stopReason }))).toBeNull();
+  });
+
+  it("preserves the existing stopped and mission-goal success copy", () => {
+    expect(submitSuccessText(outcome({ stopReason: "user_stopped" }))).toBe(
+      "Stopped.",
+    );
+    expect(submitSuccessText(outcome({ treatedAsInitialGoal: true }))).toBe(
+      "Mission goal received.",
+    );
+  });
+});

--- a/vex-app/src/renderer/features/appShell/agentActivity.ts
+++ b/vex-app/src/renderer/features/appShell/agentActivity.ts
@@ -1,0 +1,48 @@
+import type { TranscriptEntry } from "./transcriptRowModel.js";
+
+/**
+ * React key for a transcript entry. One source DTO id can appear on multiple
+ * rendered entries, so tool variants are prefixed to keep keys distinct.
+ */
+export function transcriptEntryKey(entry: TranscriptEntry): string {
+  if (entry.variant === "tool_group") return `tg-${entry.id}`;
+  if (entry.variant === "tool") return `t-${entry.id}`;
+  return String(entry.id);
+}
+
+/** Whether this row owns an assistant avatar in `TranscriptMessage`. */
+function hasAgentAvatar(entry: TranscriptEntry): boolean {
+  return (
+    entry.variant === "assistant" ||
+    entry.variant === "assistant_stopped" ||
+    (entry.variant === "tool" &&
+      entry.toolKind === "call" &&
+      entry.content.length > 0)
+  );
+}
+
+/**
+ * Select the newest assistant avatar after the current turn's user message.
+ * A previous turn must never start spinning while the new turn has not yet
+ * produced assistant prose.
+ */
+export function findWorkingAgentEntryKey(
+  rows: readonly TranscriptEntry[],
+  chatSubmitting: boolean,
+): string | null {
+  if (!chatSubmitting) return null;
+  let latestUserIndex = -1;
+  for (let i = rows.length - 1; i >= 0; i -= 1) {
+    if (rows[i]?.variant === "user") {
+      latestUserIndex = i;
+      break;
+    }
+  }
+  for (let i = rows.length - 1; i > latestUserIndex; i -= 1) {
+    const row = rows[i];
+    if (row !== undefined && hasAgentAvatar(row)) {
+      return transcriptEntryKey(row);
+    }
+  }
+  return null;
+}

--- a/vex-app/src/renderer/features/appShell/composer-helpers.ts
+++ b/vex-app/src/renderer/features/appShell/composer-helpers.ts
@@ -64,6 +64,63 @@ export function submitSuccessText(data: ChatSubmitResult): string | null {
   return null;
 }
 
+/**
+ * A chat submit can resolve successfully at the IPC boundary while the agent
+ * itself stopped before finishing. These runtime guards are not transport
+ * errors, so they arrive in `ChatSubmitResult.stopReason` rather than the
+ * `Result` error channel. Translate only the terminal, operator-actionable
+ * failure reasons here; approval and mission pause states already have their
+ * own dedicated UI.
+ */
+export interface SubmitFailureNotice {
+  readonly text: string;
+  readonly retryable: boolean;
+}
+
+function incompleteTurnNotice(
+  data: ChatSubmitResult,
+  reason: string,
+): SubmitFailureNotice {
+  if (data.toolCallsMade === 0) {
+    return { text: reason, retryable: true };
+  }
+  return {
+    text:
+      `${reason} Review the transcript before trying again; ` +
+      "earlier steps may have completed.",
+    retryable: false,
+  };
+}
+
+export function submitFailureNotice(
+  data: ChatSubmitResult,
+): SubmitFailureNotice | null {
+  switch (data.stopReason) {
+    case "iteration_limit":
+      return incompleteTurnNotice(
+        data,
+        "Vex stopped before completing the task after reaching this turn's action limit.",
+      );
+    case "timeout":
+      return incompleteTurnNotice(
+        data,
+        "Vex stopped before completing the task because this turn timed out.",
+      );
+    case "system_error":
+      return incompleteTurnNotice(
+        data,
+        "Vex stopped before completing the task because of an internal error.",
+      );
+    case "compact_unable_at_critical":
+      return {
+        text: "Vex stopped because this conversation ran out of usable context. Start a new session or try a narrower request.",
+        retryable: false,
+      };
+    default:
+      return null;
+  }
+}
+
 export function placeholderFor(session: SessionListItem | null): string {
   if (session?.mode !== "mission") return "What do you want Vex to do?";
   const goal = session.initialGoal?.trim();

--- a/vex-app/src/renderer/lib/api/chat.ts
+++ b/vex-app/src/renderer/lib/api/chat.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from "react";
 import {
   useMutation,
+  useMutationState,
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
@@ -37,12 +38,33 @@ export type UseSubmitChatResult = UseMutationResult<
   ChatSubmitInput
 > & { readonly stop: () => void };
 
+export const CHAT_SUBMIT_MUTATION_KEY = ["chat", "submit"] as const;
+
+/**
+ * Read the shared mutation cache instead of creating another submit observer.
+ * This keeps shell-level status indicators live for the entire IPC request,
+ * including quiet gaps between provider streams and tool execution.
+ */
+export function useIsChatSubmitting(sessionId: string | null): boolean {
+  const pendingSessionIds = useMutationState({
+    filters: {
+      mutationKey: CHAT_SUBMIT_MUTATION_KEY,
+      status: "pending",
+    },
+    select: (mutation) =>
+      (mutation.state.variables as ChatSubmitInput | undefined)?.sessionId ??
+      null,
+  });
+  return sessionId !== null && pendingSessionIds.includes(sessionId);
+}
+
 export function useSubmitChat(): UseSubmitChatResult {
   const queryClient = useQueryClient();
   const cancelRef = useRef<(() => void) | null>(null);
   const activeSubmitRef = useRef<symbol | null>(null);
 
   const mutation = useMutation({
+    mutationKey: CHAT_SUBMIT_MUTATION_KEY,
     mutationFn: (input: ChatSubmitInput) => {
       const invocation = window.vex.chat.submit(input);
       cancelRef.current = invocation.cancel;


### PR DESCRIPTION
## Problem solved

Agent turns that stopped on a timeout, iteration limit, system error, or exhausted context could return the interface to idle without explaining that the task was incomplete. The desktop already received a structured stop reason from chat.submit, but the composer only surfaced user-requested stops. Quiet gaps between model streams and tool execution could also make an active turn look idle.

## What changed

- Translates incomplete terminal stop reasons into clear, operator-facing feedback.
- Shows active work with a theme-accent spinner around the newest agent avatar in the current turn, including gaps between inference streams and tool calls.
- Removes the separate Working label above the composer so activity stays attached to the agent.
- Keeps settled and previous-turn avatars still, and respects reduced-motion preferences with a static accent ring.
- Keeps the desk-rule header Live until the complete turn settles instead of relying only on stream deltas.
- Offers inline Retry when a retryable turn failed before calling any tools.
- Withholds one-click Retry after tool activity and warns users to review the transcript because earlier actions may already have completed.
- Explains context exhaustion with guidance to start a new session or narrow the request.
- Leaves approvals, scheduled wakes, user pauses, and plan acceptance with their existing dedicated UI.

## User impact

Vex no longer appears to quietly give up on a one-shot task. Users can see when the agent is still working directly on its avatar, when it stopped before completion, why it stopped, and the safest next step. Transaction workflows cannot be blindly replayed after partial tool execution.

## Test coverage

- Timeout, iteration-limit, system-error, and context-exhaustion copy
- Safe retry before tool activity
- Retry suppression and partial-execution warning after tool activity
- Current-turn avatar selection during a quiet pending turn
- Theme-accent spinner, settled-avatar behavior, and reduced-motion fallback
- Desk-rule Live state across the full submit lifecycle
- Existing user-stop and mission-goal feedback
- Existing approval and mission pause ownership

## Validation

- 44 focused composer, transcript, lifecycle, and API checks pass
- Full desktop suite: 2,567 tests pass across 295 files
- Desktop lint, type ratchet, and process-boundary checks pass
- Main, preload, and renderer production builds pass
- Build artifact and CSP checks pass
- React Doctor changed-scope scan: 88/100, no changed-code issues

A screenshot can be attached through the GitHub description editor after manual reproduction so no image assets enter repository history.
