### PR TITLE
Default New Session dialog to Mission mode when the Mission filter is active

### DIFF
--- a/vex-app/src/renderer/features/appShell/SessionCreator.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionCreator.tsx
@@ -54,6 +54,10 @@ export function SessionCreator({
   onOpenChange,
 }: SessionCreatorProps): JSX.Element {
   const setActiveSessionId = useUiStore((s) => s.setActiveSessionId);
+  // The sidebar's active mode filter (all/agent/mission). When the operator is
+  // already filtered to Mission and opens "New session", default the dialog to
+  // Mission mode so they don't have to flip it by hand.
+  const sessionModeFilter = useUiStore((s) => s.sessionModeFilter);
   const createSessionInitialMessage = useUiStore(
     (s) => s.createSessionInitialMessage,
   );
@@ -82,13 +86,13 @@ export function SessionCreator({
           ? deriveSessionName(createSessionInitialMessage)
           : "",
       );
-      setMode("agent");
+      setMode(sessionModeFilter === "mission" ? "mission" : "agent");
       setPermission("restricted");
       setSelectedEvmWalletId(null);
       setSelectedSolanaWalletId(null);
       setSubmitError(null);
     }
-  }, [open, createSessionInitialMessage]);
+  }, [open, createSessionInitialMessage, sessionModeFilter]);
 
   // Focus the Name input first when the dialog opens — it is the only
   // text field in this modal. Mission goal capture happens in chat.


### PR DESCRIPTION
## What
When the sidebar is filtered to **Mission** (the `all` / `agent` / `mission` filter) and the operator opens **New session**, the dialog now opens pre-selected on **Mission** mode instead of Agent — saving the click of switching it by hand. `all` and `agent` filters keep the existing Agent default.

## Why
If you're browsing your Mission sessions and hit "New session," you almost always want another Mission — the dialog defaulting to Agent forces an extra click every time. Matching the dialog's initial mode to the active filter removes that friction.

## Screenshot
<img width="1147" height="875" alt="image" src="https://github.com/user-attachments/assets/ac6e32dc-efd4-40dd-976b-7c35dd63eaf8" />


## How
`SessionCreator` reads `uiStore.sessionModeFilter` (already the source of truth for the sidebar filter) and seeds the initial `mode` from it inside the existing reset-on-open effect:

```ts
setMode(sessionModeFilter === "mission" ? "mission" : "agent");
```

- Scoped to the reset effect that runs on open, so nothing changes mid-session.
- `sessionModeFilter` added to the effect deps.
- No new state, no API/schema change — one selector + one line.

Single-file change to `SessionCreator.tsx`.