### PR TITLE
fix(polymarket): fail clob.buy/sell when the venue rejects the order

### DIFF
--- a/src/__tests__/vex-agent/tools/polymarket-clob-order-rejection.test.ts
+++ b/src/__tests__/vex-agent/tools/polymarket-clob-order-rejection.test.ts
@@ -1,0 +1,140 @@
+/**
+ * polymarket.clob.buy/sell ToolResult honesty on venue rejection.
+ *
+ * Uses the exact fixture already present in polymarket-handlers.test.ts
+ * ("preserves a non-empty errorMsg in the lean output", success: false,
+ * orderID: "", errorMsg: "order rejected") — that existing test proves the
+ * lean-output SHAPING is correct (errorMsg survives), but it never asserted
+ * `r.success` or `_tradeCapture`. Before the fix, both handlers returned
+ * `success: true` and emitted a phantom `_tradeCapture` with status "open"
+ * for an order the venue never accepted (proven: 4/4 red against the
+ * unmodified handler). Now the venue's `success: false` drives the
+ * ToolResult and the capture pipeline directly.
+ *
+ * Mirrors the polymarket.clob.cancel guard a few lines below in the same
+ * file ("reports success=false when the requested order lands in
+ * not_canceled") — cancel already treated venue rejection as a ToolResult
+ * failure; buy/sell now get the same treatment.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPostOrder = vi.fn();
+const mockGetFeeRate = vi.fn(() => Promise.resolve({ base_fee: 0 }));
+const mockResolveMarket = vi.fn();
+
+vi.mock("@tools/polymarket/clob/client.js", () => ({
+  getPolyClobClient: () => ({
+    postOrder: (...a: unknown[]) => mockPostOrder(...a),
+    getFeeRate: (...a: unknown[]) => mockGetFeeRate(...a),
+  }),
+}));
+vi.mock("@tools/polymarket/gamma/client.js", () => ({
+  getPolyGammaClient: () => ({ resolveMarket: (...a: unknown[]) => mockResolveMarket(...a) }),
+}));
+vi.mock("@tools/polymarket/auth.js", () => ({
+  requirePolyClobCredentials: () => ({ apiKey: "test-api-key", apiSecret: "secret", passphrase: "pass" }),
+}));
+vi.mock("@tools/polymarket/clob/signing.js", () => ({
+  buildClobOrder: () => ({ maker: "0xMAKER", side: "BUY" }),
+  signClobOrder: () => Promise.resolve("0xSIGNATURE"),
+}));
+vi.mock("@vex-agent/tools/internal/wallet/resolve.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vex-agent/tools/internal/wallet/resolve.js")>();
+  return {
+    ...actual,
+    resolveSelectedAddress: () => "0x1111111111111111111111111111111111111111",
+    resolveSigningWallet: () => ({
+      family: "eip155" as const,
+      address: "0x1111111111111111111111111111111111111111",
+      privateKey: "0xabc",
+    }),
+  };
+});
+
+const { POLYMARKET_HANDLERS } = await import("../../../vex-agent/tools/protocols/polymarket/handlers.js");
+
+const SIGNING_CTX = {
+  sessionPermission: "full" as const,
+  approved: true,
+  walletResolution: { source: "session" as const, evm: null, solana: null },
+  walletPolicy: { kind: "none" as const },
+};
+
+const BUY_PARAMS = { conditionId: "0xCOND", outcome: "YES", amount: 10, price: 0.5 };
+const SELL_PARAMS = { conditionId: "0xCOND", outcome: "YES", amount: 8, price: 0.4 };
+
+// The venue's own rejection response — the shape sendOrderResponseSchema
+// actually produces (success: isTrue -> false, errorMsg carries the reason).
+// Not hypothetical: this is the CLOB's real "order not accepted" response.
+const REJECTED = {
+  success: false,
+  orderID: "",
+  status: "live" as const,
+  errorMsg: "not enough balance/allowance",
+};
+
+beforeEach(() => {
+  mockPostOrder.mockReset().mockResolvedValue(REJECTED);
+  mockGetFeeRate.mockReset().mockResolvedValue({ base_fee: 0 });
+  mockResolveMarket.mockReset().mockResolvedValue({
+    clobTokenIds: '["yesTok","noTok"]',
+    negRisk: false,
+    question: "Test market?",
+  });
+});
+
+describe("polymarket.clob.buy — venue rejection must fail the tool result", () => {
+  it("venue said success:false, errorMsg set, no orderID — ToolResult is a failure", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.buy"]!(BUY_PARAMS, SIGNING_CTX);
+    expect(r.success).toBe(false);
+  });
+
+  it("venue said success:false — no _tradeCapture (no phantom open order)", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.buy"]!(BUY_PARAMS, SIGNING_CTX);
+    expect(r.data?._tradeCapture).toBeUndefined();
+  });
+
+  it("venue said success:false — errorMsg/orderID/status still readable in output", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.buy"]!(BUY_PARAMS, SIGNING_CTX);
+    const out = JSON.parse(r.output);
+    expect(out.errorMsg).toBe(REJECTED.errorMsg);
+    expect(out.orderID).toBe("");
+    expect(out.filled).toBe(false);
+  });
+
+  it("regression: a matched order still succeeds and still captures", async () => {
+    mockPostOrder.mockResolvedValue({
+      success: true,
+      orderID: "0xORDER",
+      status: "matched",
+      errorMsg: "",
+    });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.buy"]!(BUY_PARAMS, SIGNING_CTX);
+    expect(r.success).toBe(true);
+    expect(r.data?._tradeCapture).toMatchObject({ status: "executed" });
+  });
+});
+
+describe("polymarket.clob.sell — venue rejection must fail the tool result", () => {
+  it("venue said success:false, errorMsg set, no orderID — ToolResult is a failure", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.sell"]!(SELL_PARAMS, SIGNING_CTX);
+    expect(r.success).toBe(false);
+  });
+
+  it("venue said success:false — no _tradeCapture (no phantom open order)", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.sell"]!(SELL_PARAMS, SIGNING_CTX);
+    expect(r.data?._tradeCapture).toBeUndefined();
+  });
+
+  it("regression: a matched order still succeeds and still captures", async () => {
+    mockPostOrder.mockResolvedValue({
+      success: true,
+      orderID: "0xSELLORDER",
+      status: "matched",
+      errorMsg: "",
+    });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.sell"]!(SELL_PARAMS, SIGNING_CTX);
+    expect(r.success).toBe(true);
+    expect(r.data?._tradeCapture).toMatchObject({ status: "closed" });
+  });
+});

--- a/src/__tests__/vex-agent/tools/polymarket-wallet-scope.test.ts
+++ b/src/__tests__/vex-agent/tools/polymarket-wallet-scope.test.ts
@@ -77,7 +77,7 @@ beforeEach(() => {
   mockResolveSelectedAddress.mockReturnValue(SEL);
   mockGetPrice.mockResolvedValue({ price: 0.5 });
   mockGetFeeRate.mockResolvedValue({ base_fee: 0 });
-  mockPostOrder.mockResolvedValue({ status: "matched", orderID: "oid-1" });
+  mockPostOrder.mockResolvedValue({ success: true, status: "matched", orderID: "oid-1" });
   mockCancelOrder.mockResolvedValue({ canceled: ["oid-1"], not_canceled: {} });
   mockGetTrades.mockResolvedValue({ data: [], next_cursor: "" });
   mockBuildClobOrder.mockReturnValue({ salt: "1", maker: SEL, signer: SEL });

--- a/src/vex-agent/tools/protocols/polymarket/handlers-clob/orders.ts
+++ b/src/vex-agent/tools/protocols/polymarket/handlers-clob/orders.ts
@@ -114,6 +114,20 @@ export const ORDERS_HANDLERS: Record<string, ProtocolHandler> = {
       ...(result.tradeIDs?.length ? { tradeIDs: result.tradeIDs } : {}),
       ...(result.errorMsg ? { errorMsg: result.errorMsg } : {}),
     };
+
+    // The venue rejected the order (bad signature, insufficient balance,
+    // market closed, etc.). Fail the ToolResult and skip _tradeCapture — an
+    // order the CLOB never accepted must not be recorded as a resting/open
+    // order. Same class of bug as relay.bridge (PR #27): venue truth must
+    // drive tool-result truth, not just ride along in the output text.
+    if (!result.success) {
+      return {
+        success: false,
+        output: JSON.stringify(buyOutput, null, 2),
+        data: { ...result, conditionId },
+      };
+    }
+
     return {
       success: true,
       output: JSON.stringify(buyOutput, null, 2),
@@ -212,6 +226,19 @@ export const ORDERS_HANDLERS: Record<string, ProtocolHandler> = {
       ...(result.tradeIDs?.length ? { tradeIDs: result.tradeIDs } : {}),
       ...(result.errorMsg ? { errorMsg: result.errorMsg } : {}),
     };
+
+    // Same rejection guard as clob.buy: the venue rejected the order, so the
+    // ToolResult must fail and no _tradeCapture goes out. Mirrors the repo's
+    // own clob.cancel precedent a few lines below ("reports success=false
+    // when the requested order lands in not_canceled").
+    if (!result.success) {
+      return {
+        success: false,
+        output: JSON.stringify(sellOutput, null, 2),
+        data: { ...result, conditionId },
+      };
+    }
+
     return {
       success: true,
       output: JSON.stringify(sellOutput, null, 2),


### PR DESCRIPTION
## Problem

`polymarket.clob.buy` and `polymarket.clob.sell` always return `success: true`, even when
the venue explicitly rejected the order. The venue's real verdict (`result.success`,
`result.errorMsg`) gets buried inside the JSON output text instead of driving the
ToolResult itself.

Current main — `src/vex-agent/tools/protocols/polymarket/handlers-clob/orders.ts`:

```ts
const buyOutput = {
  ...
  success: result.success,   // the venue's real verdict, buried in the text
  ...
};
return {
  success: true,             // hardcoded regardless
  output: JSON.stringify(buyOutput, null, 2),
  data: { ...result, conditionId, _tradeCapture: {
    status: isMatched ? "executed" : "open",   // a rejected order still gets captured as "open"
    ...
  } },
};
```
Same shape on `clob.sell`.

## Root cause

`postOrder` returns `SendOrderResponse`, whose schema (`sendOrderResponseSchema`) defines
`success` as a real field the CLOB always sends back — not an edge case. A rejection
(bad signature, insufficient balance, market closed, etc.) comes back as
`{ success: false, orderID: "", errorMsg: "<reason>" }`. Neither handler ever checks it.

Worse: `_tradeCapture` is gated only on `order.status === "matched"` (`isMatched`), not on
`result.success`. A rejected order is never matched, so it falls into the `"open"` branch —
captured as a live resting order the venue never actually accepted.

This codebase already has the right pattern next to this bug — `clob.cancel`, a few lines
below in the same file, already treats venue rejection as a ToolResult failure ("reports
success=false when the requested order lands in not_canceled"). Buy/sell just never got the
same treatment.

## Impact

| Who | Effect |
|---|---|
| Agent / model | Tool output says the order worked — no way to tell it was rejected, may retry or plan around a position that doesn't exist |
| Ledger (`proj_activity`) | Success-gated capture pipeline admits the phantom `"open"` order since `success` is always `true` |
| Position tracking | A rejected order shows up as a live resting order with an empty `orderID` |

## Solution

**If the venue rejected the order** (`result.success === false`):
- `success: false` — the tool call itself is reported as failed.
- `errorMsg`, `orderID`, `status` stay readable in the output for diagnostics.
- **No `_tradeCapture`.** Nothing was accepted, so nothing gets recorded as a position.

**If the venue accepted the order** (`result.success === true`, matched or resting):
- Unchanged. Same output shape, same capture behavior as before.

## Testing

- Tests written first against the real rejection shape (`success: false`, `orderID: ""`,
  `errorMsg` set) — 4/4 red against the old handler, confirming the bug. All pass now, plus
  a regression case per handler for the matched-order path.
- Along the way, found a related test gap: `polymarket-wallet-scope.test.ts` mocked
  `postOrder` without ever setting `success` — the old code never checked it, so nobody
  noticed. Fixed the mock to `success: true`, matching what a real matched order returns.
- Full `vex-agent` suite: 336 test files, 4585 tests, all green. `tsc --noEmit` clean.