### PR TITLE
fix(uniswap): record trades by economic direction (native-in = buy), not tool name

### DIFF
--- a/src/__tests__/vex-agent/tools/protocols/uniswap-economic-side.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/uniswap-economic-side.test.ts
@@ -1,0 +1,41 @@
+/**
+ * classifyEconomicSide — the recorded trade side must follow the ECONOMIC
+ * direction (which way native flows), not which tool was invoked. A token can
+ * be bought via `uniswap.swap.sell` (native-in) or sold via `uniswap.swap.buy`
+ * (native-out), so the tool's `side` is not a reliable accounting label.
+ */
+
+import { describe, it, expect } from "vitest";
+import { classifyEconomicSide } from "@vex-agent/tools/protocols/uniswap/handlers/swap.js";
+
+describe("classifyEconomicSide", () => {
+  // ── native → token is always a BUY, regardless of the tool invoked ──────────
+
+  it("native → token = buy via the buy-tool", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: true, tokenOutIsNative: false, side: "buy" })).toBe("buy");
+  });
+
+  it("native → token = buy even when routed via the sell-tool (the bug)", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: true, tokenOutIsNative: false, side: "sell" })).toBe("buy");
+  });
+
+  // ── token → native is always a SELL, regardless of the tool invoked ─────────
+
+  it("token → native = sell via the sell-tool", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: true, side: "sell" })).toBe("sell");
+  });
+
+  it("token → native = sell even when routed via the buy-tool", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: true, side: "buy" })).toBe("sell");
+  });
+
+  // ── token ↔ token has no native anchor: fall back to the tool's side ────────
+
+  it("token → token falls back to the tool side (buy)", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: false, side: "buy" })).toBe("buy");
+  });
+
+  it("token → token falls back to the tool side (sell)", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: false, side: "sell" })).toBe("sell");
+  });
+});

--- a/src/vex-agent/tools/protocols/uniswap/handlers/swap.ts
+++ b/src/vex-agent/tools/protocols/uniswap/handlers/swap.ts
@@ -53,6 +53,27 @@ function isNativeInput(input: string): boolean {
 }
 
 /**
+ * Classify the ECONOMIC direction of a swap from the native leg, independent of
+ * which tool (`uniswap.swap.buy` vs `uniswap.swap.sell`) was invoked. A token
+ * can legitimately be bought via the sell-tool (native-in) or sold via the
+ * buy-tool, so the tool name is not a reliable label for accounting.
+ *
+ * Spending native to acquire a token is a BUY; selling a token back to native
+ * is a SELL. Token↔token has no native anchor, so we fall back to the tool's
+ * declared side. This is used ONLY for what is recorded/reported — never for
+ * routing, quoting, or execution.
+ */
+export function classifyEconomicSide(args: {
+  readonly tokenInIsNative: boolean;
+  readonly tokenOutIsNative: boolean;
+  readonly side: "buy" | "sell";
+}): "buy" | "sell" {
+  if (args.tokenInIsNative) return "buy"; // spending native to acquire a token = BUY
+  if (args.tokenOutIsNative) return "sell"; // selling a token back to native = SELL
+  return args.side; // token↔token: fall back to the tool's side
+}
+
+/**
  * Resolve a token leg. Native ("eth"/"native"/sentinel) routes as WETH; a hex
  * address reads metadata on-chain; a bare symbol is rejected (address-only).
  */
@@ -219,11 +240,19 @@ async function executeUniswapSwap(
   const amountIn = parseUnits(amountInRaw, tokenIn.decimals);
   const slippageBps = num(p, "slippageBps") ?? DEFAULT_SLIPPAGE_BPS;
 
+  // Economic direction for RECORDING/reporting — derived from the native leg,
+  // not the tool name (`side`). `side` still drives routing/execution below.
+  const economicSide = classifyEconomicSide({
+    tokenInIsNative: tokenIn.isNative,
+    tokenOutIsNative: tokenOut.isNative,
+    side,
+  });
+
   const quoted = await computeQuote(deployment, tokenIn, tokenOut, amountIn, slippageBps);
 
   if (p.dryRun === true) {
     return ok({
-      dryRun: true, side, chain: deployment.key,
+      dryRun: true, side: economicSide, chain: deployment.key,
       route: { version: quoted.route.version, path: quoted.route.path, fees: quoted.route.fees ?? null },
       amountOut: formatUnits(quoted.amountOut, tokenOut.decimals),
       minAmountOut: formatUnits(quoted.minAmountOut, tokenOut.decimals),
@@ -300,7 +329,7 @@ async function executeUniswapSwap(
   return {
     success: true,
     output: JSON.stringify({
-      txHash, side, chain: deployment.key,
+      txHash, side: economicSide, chain: deployment.key,
       tokenIn: tokenIn.symbol, tokenOut: tokenOut.symbol,
       amountIn: amountInRaw, amountOut: amountOutHuman,
       route: { version: quoted.route.version, path: quoted.route.path },
@@ -321,11 +350,11 @@ async function executeUniswapSwap(
         outputAmount: amountOutHuman,
         signature: txHash,
         walletAddress: signer.address,
-        tradeSide: side,
-        instrumentKey: `${deployment.key}:${side === "buy" ? tokenOut.address : tokenIn.address}`,
+        tradeSide: economicSide,
+        instrumentKey: `${deployment.key}:${economicSide === "buy" ? tokenOut.address : tokenIn.address}`,
         valuationSource: "none",
-        settlementAssetKey: side === "buy" ? tokenIn.symbol : tokenOut.symbol,
-        meta: { dex: "uniswap", version: quoted.route.version, side },
+        settlementAssetKey: economicSide === "buy" ? tokenIn.symbol : tokenOut.symbol,
+        meta: { dex: "uniswap", version: quoted.route.version, side: economicSide },
       },
     },
   };


### PR DESCRIPTION
## The bug

The Uniswap swap handler records the trade side from **which tool was invoked** rather than the **economic direction** of the swap:

```ts
tradeSide: side,  // side = "buy" | "sell", i.e. uniswap.swap.buy vs uniswap.swap.sell
```

Both `uniswap.swap.buy` and `uniswap.swap.sell` share the same routing and differ only in this label. But a token can legitimately be **bought** by calling `uniswap.swap.sell` with native-in (`nativeWETH → TOKEN`). In that case the fill is recorded as `sell` even though it is economically a **buy**.

### Repro (observed live)

An agent bought a token via the sell-tool with native-in (`ETH → TOKEN`). The captured fill came back with `trade_side = 'sell'` — the opposite of what actually happened economically.

### Impact

Any buy/sell-based accounting reads the wrong direction:
- **cost basis** — a buy recorded as a sell never opens a lot
- **position open/close** — opens look like closes and vice-versa
- **P&L attribution** — realized/unrealized flips sign

This is silent: the swap executes correctly on-chain; only the recorded ledger side is wrong.

## The fix

Derive the economic side from the native leg and use it for the **recorded/reported** fields only. Routing, quoting, execution, balance/allowance, and tool-path decisions are untouched.

```ts
export function classifyEconomicSide(args: {
  readonly tokenInIsNative: boolean;
  readonly tokenOutIsNative: boolean;
  readonly side: "buy" | "sell";
}): "buy" | "sell" {
  if (args.tokenInIsNative) return "buy";   // spending native to acquire a token = BUY
  if (args.tokenOutIsNative) return "sell";  // selling a token back to native = SELL
  return args.side;                          // token↔token: fall back to the tool's side
}
```

`economicSide` is derived once after both legs resolve and applied to: `_tradeCapture.tradeSide`, `instrumentKey`, `settlementAssetKey`, `meta.side`, and the `output.side` of both the dryRun and executed results. The tool `side` still drives all routing/execution logic — this is a pure data-correctness change with **no effect on routing, quoting, or execution**.

## Test

Adds a focused unit test for `classifyEconomicSide` (native→token = buy via either tool, token→native = sell via either tool, token↔token falls back to the tool side).

### Verification
- `pnpm exec vitest run …uniswap-economic-side.test.ts` — 6/6 passing
- `pnpm exec tsc --noEmit` — clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)