### PR TITLE
Release 0.1.3: provider-outcome honesty, docker self-heal, approval handoff, mission time-box + ledger, trusted token labels

### DIFF
--- a/src/__tests__/tools/khalani/khalani-order-status.test.ts
+++ b/src/__tests__/tools/khalani/khalani-order-status.test.ts
@@ -1,0 +1,130 @@
+/**
+ * pollKhalaniOrderToTerminal — bounded order tracking (Khalani Integration Guide).
+ *
+ * Terminal set {filled, refunded, failed}; `refund_pending` is NON-terminal and
+ * must NOT end the poll. Cadence: 5s interval, 24 attempts (~2 min). A transient
+ * getOrderById failure is swallowed and the loop continues. The budget is hard —
+ * a never-terminal order returns its last OBSERVED status.
+ *
+ * Critically, the result DISTINGUISHES three outcomes: `terminal` (observed
+ * terminal), `pending` (observed non-terminal, window closed), and `unavailable`
+ * (NO poll ever succeeded — status API outage). There is NO synthetic default:
+ * an all-failing track must never look like an observed `created` order.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetOrderById = vi.fn();
+vi.mock("@tools/khalani/client.js", () => ({
+  getKhalaniClient: () => ({ getOrderById: (...a: unknown[]) => mockGetOrderById(...a) }),
+}));
+
+const { pollKhalaniOrderToTerminal, KHALANI_TERMINAL_STATUSES } = await import("@tools/khalani/order-status.js");
+
+beforeEach(() => {
+  mockGetOrderById.mockReset();
+});
+
+describe("KHALANI_TERMINAL_STATUSES", () => {
+  it("is exactly {filled, refunded, failed} — refund_pending is NOT terminal", () => {
+    expect([...KHALANI_TERMINAL_STATUSES].sort()).toEqual(["failed", "filled", "refunded"]);
+    expect(KHALANI_TERMINAL_STATUSES.has("refund_pending")).toBe(false);
+  });
+});
+
+describe("pollKhalaniOrderToTerminal — bounded 5s/24 poll", () => {
+  it("returns {kind:'terminal'} on the poll where it flips (filled)", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetOrderById
+        .mockResolvedValueOnce({ status: "deposited" })
+        .mockResolvedValueOnce({ status: "published" })
+        .mockResolvedValueOnce({ status: "filled" });
+
+      const promise = pollKhalaniOrderToTerminal("o1");
+      // Poll 1 at t=5s (deposited), poll 2 at t=10s (published), poll 3 at t=15s (filled).
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(mockGetOrderById).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(await promise).toEqual({ kind: "terminal", status: "filled" });
+      expect(mockGetOrderById).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does NOT terminate on refund_pending — keeps polling, then returns {kind:'pending'} with it", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetOrderById.mockResolvedValue({ status: "refund_pending" });
+      const promise = pollKhalaniOrderToTerminal("o1");
+      // Drive the full 24×5s = 120s budget.
+      await vi.advanceTimersByTimeAsync(120_000);
+      // Observed non-terminal → pending (NOT terminal, NOT unavailable).
+      expect(await promise).toEqual({ kind: "pending", status: "refund_pending" });
+      expect(mockGetOrderById).toHaveBeenCalledTimes(24);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns {kind:'terminal', status:'refunded'} (distinct from refund_pending)", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetOrderById.mockResolvedValueOnce({ status: "refunded" });
+      const promise = pollKhalaniOrderToTerminal("o1");
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(await promise).toEqual({ kind: "terminal", status: "refunded" });
+      expect(mockGetOrderById).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("swallows a transient failure and continues to a later terminal status", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetOrderById
+        .mockRejectedValueOnce(new Error("boom"))
+        .mockResolvedValueOnce({ status: "failed" });
+      const promise = pollKhalaniOrderToTerminal("o1");
+      await vi.advanceTimersByTimeAsync(5_000); // poll 1 throws, swallowed
+      await vi.advanceTimersByTimeAsync(5_000); // poll 2 → failed
+      expect(await promise).toEqual({ kind: "terminal", status: "failed" });
+      expect(mockGetOrderById).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a partial outage still reports the LAST OBSERVED non-terminal status as pending", async () => {
+    vi.useFakeTimers();
+    try {
+      // One real observation ("deposited") then the API goes down for the rest.
+      mockGetOrderById
+        .mockResolvedValueOnce({ status: "deposited" })
+        .mockRejectedValue(new Error("down"));
+      const promise = pollKhalaniOrderToTerminal("o1");
+      await vi.advanceTimersByTimeAsync(120_000);
+      // A status WAS observed once → pending, not unavailable.
+      expect(await promise).toEqual({ kind: "pending", status: "deposited" });
+      expect(mockGetOrderById).toHaveBeenCalledTimes(24);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns {kind:'unavailable'} when NO poll ever succeeds (status API outage, never a synthetic 'created')", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetOrderById.mockRejectedValue(new Error("down"));
+      const promise = pollKhalaniOrderToTerminal("o1");
+      await vi.advanceTimersByTimeAsync(120_000);
+      // NOT a synthetic "created": nothing was ever observed.
+      expect(await promise).toEqual({ kind: "unavailable" });
+      expect(mockGetOrderById).toHaveBeenCalledTimes(24);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/__tests__/tools/relay/execute.test.ts
+++ b/src/__tests__/tools/relay/execute.test.ts
@@ -35,13 +35,23 @@ vi.mock("@tools/khalani/evm-client.js", () => ({
   createDynamicWalletClient: vi.fn(),
 }));
 
-// getRelayClient is used only by the terminal-status poll; quotes without a
-// requestId never poll, so a bare stub suffices.
+// getRelayClient is used only by the terminal-status poll. Quotes without a
+// requestId never poll; the cadence tests below feed a requestId + drive this
+// controllable spy.
+const getIntentStatus = vi.fn();
 vi.mock("@tools/relay/client.js", () => ({
-  getRelayClient: vi.fn(() => ({ getIntentStatus: vi.fn() })),
+  getRelayClient: () => ({ getIntentStatus: (...a: unknown[]) => getIntentStatus(...a) }),
+  // Shared status-path constant the parser matches against.
+  RELAY_INTENT_STATUS_PATH: "/intents/status/v3",
 }));
 
-import { executeRelayBridge } from "@tools/relay/execute.js";
+// Hermetic Relay host for the requestId-derivation test (independent of any
+// local config file) — this is the SAME value the client would poll.
+vi.mock("@config/store.js", () => ({
+  loadConfig: () => ({ services: { relayApiUrl: "https://api.relay.link" } }),
+}));
+
+import { executeRelayBridge, parseRequestIdFromCheckEndpoint } from "@tools/relay/execute.js";
 import type { ChainWallet } from "@tools/wallet/multi-auth.js";
 import type { RelayQuoteResponse } from "@tools/relay/types.js";
 
@@ -56,8 +66,8 @@ const signer = {
   privateKey: `0x${"22".repeat(32)}`,
 } as unknown as ChainWallet;
 
-function step(id: string, chainId: number, to: string, value = "0", data = "0x") {
-  return { id, kind: "transaction", items: [{ data: { to, value, data, chainId } }] };
+function step(id: string, chainId: number, to: string, value = "0", data = "0x", requestId?: string) {
+  return { id, kind: "transaction", requestId, items: [{ data: { to, value, data, chainId } }] };
 }
 
 beforeEach(() => {
@@ -65,6 +75,7 @@ beforeEach(() => {
   waitForTransactionReceipt.mockReset();
   resolveInclusiveEvmChain.mockReset();
   getLocalEvmClients.mockReset();
+  getIntentStatus.mockReset();
 
   waitForTransactionReceipt.mockResolvedValue({ status: "success" });
   resolveInclusiveEvmChain.mockImplementation(async (input: string) => ({
@@ -132,41 +143,105 @@ describe("executeRelayBridge — fail-closed pre-validation (PHASE 1)", () => {
 
 describe("executeRelayBridge — ordered broadcast (PHASE 2)", () => {
   it("(b) valid multi-step quote → every tx broadcast strictly in order", async () => {
-    sendTransaction.mockResolvedValueOnce("0xaaa").mockResolvedValueOnce("0xbbb");
-    const quote = {
-      steps: [
-        step("approve", ORIGIN, APPROVE_TO, "0", "0x"),
-        step("deposit", DESTINATION, DEPOSIT_TO, "1000", "0xabcd"),
-      ],
-    } as unknown as RelayQuoteResponse;
+    vi.useFakeTimers();
+    try {
+      sendTransaction.mockResolvedValueOnce("0xaaa").mockResolvedValueOnce("0xbbb");
+      getIntentStatus.mockResolvedValue({ status: "success" });
+      const quote = {
+        steps: [
+          step("approve", ORIGIN, APPROVE_TO, "0", "0x"),
+          // requestId present → planRelayBridge accepts the quote (a quote with
+          // NO id anywhere fails pre-broadcast, covered separately below).
+          step("deposit", DESTINATION, DEPOSIT_TO, "1000", "0xabcd", "0xreq"),
+        ],
+      } as unknown as RelayQuoteResponse;
 
-    const result = await executeRelayBridge({
-      quote,
-      signer,
-      originChainId: ORIGIN,
-      destinationChainId: DESTINATION,
-    });
+      const promise = executeRelayBridge({
+        quote,
+        signer,
+        originChainId: ORIGIN,
+        destinationChainId: DESTINATION,
+      });
+      await vi.advanceTimersByTimeAsync(0); // flush broadcasts + receipts
+      await vi.advanceTimersByTimeAsync(1_000); // first poll → success
+      const result = await promise;
 
-    expect(sendTransaction).toHaveBeenCalledTimes(2);
-    // Order preserved: approve leg first, deposit leg second.
-    expect(sendTransaction.mock.calls[0]![0].to).toBe(getAddress(APPROVE_TO));
-    expect(sendTransaction.mock.calls[1]![0].to).toBe(getAddress(DEPOSIT_TO));
-    expect(sendTransaction.mock.calls[1]![0].value).toBe(1000n);
-    // Each broadcast waits for its receipt before the next.
-    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(2);
-    expect(result.txHashes).toEqual(["0xaaa", "0xbbb"]);
-    // Per-hop records pair each hash with the chain it broadcast on (origin
-    // approve → ORIGIN, deposit → DESTINATION); txHashes[i] === transactions[i].hash.
-    expect(result.transactions).toEqual([
-      { chainId: ORIGIN, hash: "0xaaa" },
-      { chainId: DESTINATION, hash: "0xbbb" },
-    ]);
-    expect(result.finalStatus).toBe("pending"); // no requestId → no poll
+      expect(sendTransaction).toHaveBeenCalledTimes(2);
+      // Order preserved: approve leg first, deposit leg second.
+      expect(sendTransaction.mock.calls[0]![0].to).toBe(getAddress(APPROVE_TO));
+      expect(sendTransaction.mock.calls[1]![0].to).toBe(getAddress(DEPOSIT_TO));
+      expect(sendTransaction.mock.calls[1]![0].value).toBe(1000n);
+      // Each broadcast waits for its receipt before the next.
+      expect(waitForTransactionReceipt).toHaveBeenCalledTimes(2);
+      expect(result.txHashes).toEqual(["0xaaa", "0xbbb"]);
+      // Per-hop records pair each hash with the chain it broadcast on (origin
+      // approve → ORIGIN, deposit → DESTINATION); txHashes[i] === transactions[i].hash.
+      expect(result.transactions).toEqual([
+        { chainId: ORIGIN, hash: "0xaaa" },
+        { chainId: DESTINATION, hash: "0xbbb" },
+      ]);
+      expect(result.finalStatus).toBe("success");
+      expect(result.statusObserved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("aborts before the next broadcast when a mined step reverted", async () => {
     sendTransaction.mockResolvedValueOnce("0xaaa").mockResolvedValueOnce("0xbbb");
     waitForTransactionReceipt.mockResolvedValueOnce({ status: "reverted" });
+    const quote = {
+      steps: [
+        step("approve", ORIGIN, APPROVE_TO, "0", "0x"),
+        step("deposit", DESTINATION, DEPOSIT_TO, "1000", "0xabcd", "0xreq"),
+      ],
+    } as unknown as RelayQuoteResponse;
+
+    // Step 1's receipt reverts before step 2 broadcasts and before any poll.
+    await expect(
+      executeRelayBridge({ quote, signer, originChainId: ORIGIN, destinationChainId: DESTINATION }),
+    ).rejects.toMatchObject({ code: "RELAY_BRIDGE_FAILED" });
+    expect(sendTransaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("executeRelayBridge — request id resolution (step → check.endpoint → fail closed)", () => {
+  it("derives the request id from item.check.endpoint when the step omits requestId → bridges normally", async () => {
+    vi.useFakeTimers();
+    try {
+      sendTransaction.mockResolvedValue("0xaaa");
+      getIntentStatus.mockResolvedValue({ status: "success" });
+      // No step.requestId — the id lives only on the status check endpoint.
+      const quote = {
+        steps: [
+          {
+            id: "deposit",
+            kind: "transaction",
+            items: [{
+              data: { to: DEPOSIT_TO, value: "1000", data: "0xabcd", chainId: DESTINATION },
+              check: { endpoint: "https://api.relay.link/intents/status/v3?requestId=0xDERIVED", method: "GET" },
+            }],
+          },
+        ],
+      } as unknown as RelayQuoteResponse;
+
+      const promise = executeRelayBridge({ quote, signer, originChainId: ORIGIN, destinationChainId: DESTINATION });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1_000);
+      const result = await promise;
+
+      // The derived id is what gets polled — a legitimate bridge is NOT falsely
+      // failed just because the step omitted requestId.
+      expect(getIntentStatus).toHaveBeenCalledWith("0xDERIVED");
+      expect(result.requestId).toBe("0xDERIVED");
+      expect(result.finalStatus).toBe("success");
+      expect(result.statusObserved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("no request id anywhere (no step.requestId, no check endpoint) → throws BEFORE any broadcast", async () => {
     const quote = {
       steps: [
         step("approve", ORIGIN, APPROVE_TO, "0", "0x"),
@@ -177,6 +252,143 @@ describe("executeRelayBridge — ordered broadcast (PHASE 2)", () => {
     await expect(
       executeRelayBridge({ quote, signer, originChainId: ORIGIN, destinationChainId: DESTINATION }),
     ).rejects.toMatchObject({ code: "RELAY_BRIDGE_FAILED" });
-    expect(sendTransaction).toHaveBeenCalledTimes(1);
+    // Fund safety: an untrackable bridge never moves funds.
+    expect(sendTransaction).not.toHaveBeenCalled();
+  });
+
+  it("a check.endpoint with no parseable requestId is treated as no id → throws pre-broadcast", async () => {
+    const quote = {
+      steps: [
+        {
+          id: "deposit",
+          kind: "transaction",
+          items: [{
+            data: { to: DEPOSIT_TO, value: "1000", data: "0xabcd", chainId: DESTINATION },
+            check: { endpoint: "https://api.relay.link/intents/status/v3", method: "GET" }, // no requestId param
+          }],
+        },
+      ],
+    } as unknown as RelayQuoteResponse;
+
+    await expect(
+      executeRelayBridge({ quote, signer, originChainId: ORIGIN, destinationChainId: DESTINATION }),
+    ).rejects.toMatchObject({ code: "RELAY_BRIDGE_FAILED" });
+    expect(sendTransaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("parseRequestIdFromCheckEndpoint", () => {
+  const BASE = "https://api.relay.link";
+
+  it("extracts requestId from an absolute status URL on the Relay host + exact path", () => {
+    expect(parseRequestIdFromCheckEndpoint("https://api.relay.link/intents/status/v3?requestId=0xABC", BASE)).toBe("0xABC");
+  });
+  it("extracts requestId from a relative status URL (resolved against the Relay host)", () => {
+    expect(parseRequestIdFromCheckEndpoint("/intents/status/v3?requestId=0xDEF&foo=bar", BASE)).toBe("0xDEF");
+  });
+
+  // ── Narrowing: untrusted endpoints must NOT be trusted as a status source ──
+  it("returns null for an absolute URL on the WRONG host (even with the right path + requestId)", () => {
+    expect(parseRequestIdFromCheckEndpoint("https://evil.example.com/intents/status/v3?requestId=0xABC", BASE)).toBeNull();
+  });
+  it("returns null for the right host but the WRONG path", () => {
+    expect(parseRequestIdFromCheckEndpoint("https://api.relay.link/some/other/path?requestId=0xABC", BASE)).toBeNull();
+  });
+  it("returns null for a relative URL with the WRONG path", () => {
+    expect(parseRequestIdFromCheckEndpoint("/intents/status/v2?requestId=0xABC", BASE)).toBeNull();
+  });
+  it("returns null for the right host + path but an EMPTY requestId", () => {
+    expect(parseRequestIdFromCheckEndpoint("https://api.relay.link/intents/status/v3?requestId=", BASE)).toBeNull();
+  });
+  it("returns null when the requestId param is absent", () => {
+    expect(parseRequestIdFromCheckEndpoint("https://api.relay.link/intents/status/v3", BASE)).toBeNull();
+  });
+  it("returns null for a malformed endpoint", () => {
+    expect(parseRequestIdFromCheckEndpoint("::::not a url::::", BASE)).toBeNull();
+  });
+});
+
+// A step with a requestId arms the bounded status poll. `waitForSuccessfulReceipt`
+// calls the (mocked) `waitForTransactionReceipt` once with NO internal timers, so
+// the only fake-timer consumer is pollToTerminal's 1s `delay`.
+function depositStepWithRequestId() {
+  return {
+    steps: [
+      { id: "deposit", kind: "transaction", requestId: "0xreq", items: [{ data: { to: DEPOSIT_TO, value: "1000", data: "0xabcd", chainId: DESTINATION } }] },
+    ],
+  } as unknown as RelayQuoteResponse;
+}
+
+describe("executeRelayBridge — bounded status poll (1s cadence per Relay docs)", () => {
+  it("polls getIntentStatus at a 1s cadence and returns the terminal status", async () => {
+    vi.useFakeTimers();
+    try {
+      sendTransaction.mockResolvedValue("0xaaa");
+      getIntentStatus
+        .mockResolvedValueOnce({ status: "waiting" })
+        .mockResolvedValueOnce({ status: "success" });
+
+      const promise = executeRelayBridge({
+        quote: depositStepWithRequestId(), signer, originChainId: ORIGIN, destinationChainId: DESTINATION,
+      });
+      // Flush the broadcast + receipt microtasks before the first 1s delay.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(getIntentStatus).not.toHaveBeenCalled();
+      // First poll lands at t=1s (non-terminal "waiting").
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(getIntentStatus).toHaveBeenCalledTimes(1);
+      // Second poll lands at t=2s (terminal "success") and resolves the bridge.
+      await vi.advanceTimersByTimeAsync(1_000);
+      const result = await promise;
+      expect(getIntentStatus).toHaveBeenCalledTimes(2);
+      expect(result.finalStatus).toBe("success");
+      expect(result.statusObserved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns the last OBSERVED non-terminal status when the 60s budget is exhausted (never blocks forever)", async () => {
+    vi.useFakeTimers();
+    try {
+      sendTransaction.mockResolvedValue("0xaaa");
+      getIntentStatus.mockResolvedValue({ status: "submitted" }); // never terminal
+
+      const promise = executeRelayBridge({
+        quote: depositStepWithRequestId(), signer, originChainId: ORIGIN, destinationChainId: DESTINATION,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      // Drive the whole 60s budget.
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await promise;
+      expect(result.finalStatus).toBe("submitted");
+      expect(result.statusObserved).toBe(true); // a real status WAS observed
+      // 1s cadence over 60s ≈ ~60 polls — far more than the old 2s→8s backoff
+      // (which stopped near t=54s after ~13 polls, missing late terminal flips).
+      expect(getIntentStatus.mock.calls.length).toBeGreaterThan(50);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports statusObserved:false when EVERY status poll throws (status API unreachable, not benign pending)", async () => {
+    vi.useFakeTimers();
+    try {
+      sendTransaction.mockResolvedValue("0xaaa");
+      getIntentStatus.mockRejectedValue(new Error("status API down"));
+
+      const promise = executeRelayBridge({
+        quote: depositStepWithRequestId(), signer, originChainId: ORIGIN, destinationChainId: DESTINATION,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await promise;
+      // Every poll threw → nothing observed. finalStatus stays the "pending"
+      // seed, but statusObserved is FALSE so the handler can fail closed.
+      expect(result.statusObserved).toBe(false);
+      expect(getIntentStatus.mock.calls.length).toBeGreaterThan(50);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/__tests__/vex-agent/db/migrations-prefix-uniqueness.test.ts
+++ b/src/__tests__/vex-agent/db/migrations-prefix-uniqueness.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Migration numeric-prefix uniqueness — prerequisite guard for WP-J.
+ *
+ * `src/lib/db/migrate-runner.ts`'s `listPendingMigrations` derives each
+ * migration's `version` from `parseInt(file.slice(0, 3), 10)` and records
+ * applied versions in `schema_version` keyed by that integer. Two files
+ * sharing a numeric prefix collide on the SAME version:
+ *   - if pending together in one run, the second INSERT into
+ *     `schema_version` violates the PRIMARY KEY and the run fails; but
+ *   - if the first is applied in an EARLIER run (schema_version already has
+ *     that version), a later-added colliding file is silently excluded by
+ *     `version > currentVersion` and never runs at all.
+ *
+ * This test asserts the invariant holds in the source directory AND in the
+ * vex-app mirror produced by `vex-app/scripts/copy-migrations.mjs` (the
+ * mirror is gitignored/generated, so the script is invoked here rather than
+ * relying on a prior `predev`/`prebuild` run).
+ */
+
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SRC_DIR = resolve(process.cwd(), "src/vex-agent/db/migrations");
+const APP_DIR = resolve(process.cwd(), "vex-app");
+const MIRROR_DIR = resolve(APP_DIR, "resources/migrations");
+
+// Mirrors the exact filter used by `listPendingMigrations` (migrate-runner)
+// and `isMigrationFile` (copy-migrations.mjs) — both must agree with this.
+function isMigrationFile(name: string): boolean {
+  return name.endsWith(".sql") && /^\d{3}_/.test(name);
+}
+
+function migrationPrefixes(dir: string): string[] {
+  return readdirSync(dir)
+    .filter(isMigrationFile)
+    .map((name) => name.slice(0, 3));
+}
+
+function findDuplicates(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const dupes = new Set<string>();
+  for (const v of values) {
+    if (seen.has(v)) dupes.add(v);
+    seen.add(v);
+  }
+  return [...dupes].sort();
+}
+
+describe("migration numeric-prefix uniqueness", () => {
+  it("has no duplicate numeric prefixes in the source migrations directory", () => {
+    const prefixes = migrationPrefixes(SRC_DIR);
+    expect(prefixes.length).toBeGreaterThan(0);
+    expect(findDuplicates(prefixes)).toEqual([]);
+  });
+
+  it("has no duplicate numeric prefixes in the vex-app mirror (copy-migrations.mjs output)", () => {
+    execFileSync("node", ["scripts/copy-migrations.mjs"], {
+      cwd: APP_DIR,
+      stdio: "pipe",
+    });
+    const prefixes = migrationPrefixes(MIRROR_DIR);
+    expect(prefixes.length).toBeGreaterThan(0);
+    expect(findDuplicates(prefixes)).toEqual([]);
+  });
+
+  it("mirror prefixes exactly match source prefixes (copy-script filter parity)", () => {
+    execFileSync("node", ["scripts/copy-migrations.mjs"], {
+      cwd: APP_DIR,
+      stdio: "pipe",
+    });
+    const sourcePrefixes = new Set(migrationPrefixes(SRC_DIR));
+    const mirrorPrefixes = new Set(migrationPrefixes(MIRROR_DIR));
+    expect(mirrorPrefixes).toEqual(sourcePrefixes);
+  });
+});

--- a/src/__tests__/vex-agent/db/repos/mission-results-concurrency.test.ts
+++ b/src/__tests__/vex-agent/db/repos/mission-results-concurrency.test.ts
@@ -1,0 +1,137 @@
+/**
+ * openMissionResult — race-free per-wallet seq_no minting under concurrency.
+ *
+ * `pg_advisory_xact_lock` is a real Postgres guarantee: a transaction that
+ * acquires the lock holds it until COMMIT/ROLLBACK; a second transaction
+ * requesting the SAME lock key blocks until the first releases it. This
+ * test fakes that exact contract (serialize same-key transactions in
+ * acquisition order; different-key transactions run independently) against
+ * an in-memory "table", then drives N concurrent `openMissionResult` calls
+ * for the SAME wallet and asserts every minted seq_no is unique and the set
+ * is exactly {1..N} — the invariant a bare `SELECT COUNT(*)+1` cannot
+ * guarantee (two readers can see the same count before either inserts).
+ *
+ * This proves the repo's lock-then-mint-then-insert sequence is race-free
+ * GIVEN Postgres's own advisory-lock guarantee; it does not replace a
+ * real-Postgres integration test (no local Postgres is available in this
+ * environment — see the builder report for this named gap).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@vex-agent/db/client.js", () => ({
+  query: vi.fn(),
+  queryOne: vi.fn(),
+  execute: vi.fn(),
+  queryOneWith: vi.fn(),
+  executeWith: vi.fn(),
+  withTransaction: vi.fn(),
+}));
+
+const repo = await import("@vex-agent/db/repos/mission-results.js");
+const client = await import("@vex-agent/db/client.js");
+
+interface FakeRow {
+  walletAddress: string;
+  missionRunId: string;
+  seqNo: number;
+}
+
+describe("openMissionResult concurrency", () => {
+  let table: FakeRow[];
+  /** Per-lock-key promise chain — simulates pg_advisory_xact_lock queuing. */
+  let lockChains: Map<string, Promise<void>>;
+
+  beforeEach(() => {
+    table = [];
+    lockChains = new Map();
+
+    vi.mocked(client.withTransaction).mockImplementation(
+      async (fn: (c: unknown) => Promise<unknown>) => {
+        let release: (() => void) | null = null;
+        const fakeClient = {
+          query: async (sql: string, params?: unknown[]) => {
+            if (/pg_advisory_xact_lock/.test(sql)) {
+              const key = params![0] as string;
+              const prior = lockChains.get(key) ?? Promise.resolve();
+              const mine = new Promise<void>((res) => {
+                release = res;
+              });
+              lockChains.set(key, prior.then(() => mine));
+              await prior; // block until the previous holder of THIS key releases
+            }
+            return { rows: [] };
+          },
+        };
+        try {
+          return await fn(fakeClient);
+        } finally {
+          // Lock releases at COMMIT — i.e. once fn (the transaction body)
+          // has resolved, matching pg_advisory_xact_lock's transaction scope.
+          release?.();
+        }
+      },
+    );
+
+    vi.mocked(client.queryOneWith).mockImplementation(
+      async (_c: unknown, _sql: string, params?: unknown[]) => {
+        const wallet = (params![0] as string).toLowerCase();
+        const existing = table.filter((r) => r.walletAddress === wallet);
+        const next = existing.length === 0 ? 1 : Math.max(...existing.map((r) => r.seqNo)) + 1;
+        return { next_seq: String(next) };
+      },
+    );
+
+    vi.mocked(client.executeWith).mockImplementation(
+      async (_c: unknown, _sql: string, params?: unknown[]) => {
+        table.push({
+          walletAddress: (params![4] as string).toLowerCase(),
+          missionRunId: params![2] as string,
+          seqNo: params![6] as number,
+        });
+        return 1;
+      },
+    );
+  });
+
+  it("mints unique, exactly-{1..N} seq_no for N concurrent opens of the SAME wallet", async () => {
+    const N = 8;
+    const inputs = Array.from({ length: N }, (_, i) => ({
+      id: `res-${i}`,
+      missionId: "mission-1",
+      missionRunId: `run-${i}`,
+      sessionId: "session-1",
+      walletAddress: "0xSameWallet",
+      chainId: 4663,
+      goalSnippet: null,
+      bankrollStartEth: 0.01,
+      ethPriceUsdStart: 3000,
+    }));
+
+    await Promise.all(inputs.map((input) => repo.openMissionResult(input)));
+
+    const seqNos = table.map((r) => r.seqNo).sort((a, b) => a - b);
+    expect(seqNos).toEqual(Array.from({ length: N }, (_, i) => i + 1));
+    expect(new Set(seqNos).size).toBe(N); // no duplicate seq_no
+  });
+
+  it("numbers two different wallets independently (no cross-wallet interference)", async () => {
+    const walletA = Array.from({ length: 3 }, (_, i) => ({
+      id: `a-${i}`, missionId: "m", missionRunId: `runA-${i}`, sessionId: "s",
+      walletAddress: "0xWalletA", chainId: 4663, goalSnippet: null,
+      bankrollStartEth: 0.01, ethPriceUsdStart: 3000,
+    }));
+    const walletB = Array.from({ length: 3 }, (_, i) => ({
+      id: `b-${i}`, missionId: "m", missionRunId: `runB-${i}`, sessionId: "s",
+      walletAddress: "0xWalletB", chainId: 4663, goalSnippet: null,
+      bankrollStartEth: 0.01, ethPriceUsdStart: 3000,
+    }));
+
+    await Promise.all([...walletA, ...walletB].map((input) => repo.openMissionResult(input)));
+
+    const seqA = table.filter((r) => r.walletAddress === "0xwalleta").map((r) => r.seqNo).sort();
+    const seqB = table.filter((r) => r.walletAddress === "0xwalletb").map((r) => r.seqNo).sort();
+    expect(seqA).toEqual([1, 2, 3]);
+    expect(seqB).toEqual([1, 2, 3]);
+  });
+});

--- a/src/__tests__/vex-agent/db/repos/mission-results.test.ts
+++ b/src/__tests__/vex-agent/db/repos/mission-results.test.ts
@@ -1,0 +1,157 @@
+/**
+ * mission_results repo — open/close lifecycle + history reads (mocked pool).
+ *
+ * A ledger row is OPENED when a run starts (seq_no minted per wallet, under
+ * a transaction-scoped advisory lock) and CLOSED when the run finalizes.
+ * Pins the SQL shape + params: advisory-lock-then-mint sequencing inside one
+ * transaction, idempotent open, close-by-run_id (incl. stop_reason), and
+ * newest-first per-wallet history reads.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+type QMock = Mock<(sql: string, params?: unknown[]) => Promise<Record<string, unknown>[]>>;
+type EMock = Mock<(sql: string, params?: unknown[]) => Promise<number>>;
+
+let mockQuery: QMock;
+let mockQueryOne: Mock;
+let mockExecute: EMock;
+let mockClientQuery: Mock;
+
+const norm = (s: string) => s.replace(/\s+/g, " ").trim();
+
+vi.mock("@vex-agent/db/client.js", () => ({
+  query: (sql: string, p?: unknown[]) => mockQuery(sql, p),
+  queryOne: (sql: string, p?: unknown[]) => mockQueryOne(sql, p),
+  execute: (sql: string, p?: unknown[]) => mockExecute(sql, p),
+  queryOneWith: vi.fn(async (_client: unknown, sql: string, p?: unknown[]) => {
+    if (/COALESCE\(MAX\(seq_no\)/i.test(sql)) return { next_seq: "1" };
+    return null;
+  }),
+  executeWith: vi.fn(async (_client: unknown, sql: string, p?: unknown[]) => {
+    mockExecute(sql, p);
+    return 1;
+  }),
+  withTransaction: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => {
+    const client = { query: (...a: unknown[]) => mockClientQuery(...a) };
+    return fn(client);
+  }),
+}));
+
+const repo = await import("@vex-agent/db/repos/mission-results.js");
+
+beforeEach(() => {
+  mockQuery = vi.fn(async () => []);
+  mockQueryOne = vi.fn(async () => null);
+  mockExecute = vi.fn(async () => 1);
+  mockClientQuery = vi.fn(async () => ({ rows: [] }));
+});
+
+const OPEN = {
+  id: "res-1",
+  missionId: "mission-1",
+  missionRunId: "run-1",
+  sessionId: "00000000-0000-4000-8000-000000000001",
+  walletAddress: "0xAbC",
+  chainId: 4663,
+  goalSnippet: "grow ETH +8%",
+  bankrollStartEth: 0.012,
+  ethPriceUsdStart: 3000,
+};
+
+describe("openMissionResult", () => {
+  it("acquires a per-wallet advisory lock before minting seq_no", async () => {
+    await repo.openMissionResult(OPEN);
+    expect(mockClientQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockClientQuery.mock.calls[0]!;
+    expect(norm(sql as string)).toContain("pg_advisory_xact_lock(hashtextextended($1, 0))");
+    expect(params).toEqual(["mission_results_seq:0xabc"]);
+  });
+
+  it("inserts with the minted seq_no and idempotent ON CONFLICT", async () => {
+    await repo.openMissionResult(OPEN);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockExecute.mock.calls[0]!;
+    const s = norm(sql);
+    expect(s).toContain("INSERT INTO mission_results");
+    expect(s).toContain("'running'");
+    expect(s).toContain("ON CONFLICT (mission_run_id) DO NOTHING");
+    expect(params).toContain("run-1");
+    expect(params).toContain("0xAbC");
+    expect(params).toContain(1); // seq_no minted from the mocked MAX(seq_no)+1
+  });
+
+  it("mints the next seq_no from the wallet's current MAX(seq_no)", async () => {
+    const { queryOneWith } = await import("@vex-agent/db/client.js");
+    vi.mocked(queryOneWith).mockResolvedValueOnce({ next_seq: "4" } as never);
+
+    await repo.openMissionResult(OPEN);
+    const [, params] = mockExecute.mock.calls[0]!;
+    expect(params).toContain(4);
+  });
+});
+
+describe("closeMissionResult", () => {
+  it("updates the row by run_id with terminal outcome, stop_reason, PnL, and duration", async () => {
+    await repo.closeMissionResult({
+      missionRunId: "run-1",
+      outcome: "completed",
+      stopReason: "goal_reached",
+      bankrollEndEth: 0.013,
+      ethPriceUsdEnd: 3100,
+      pnlEth: 0.001,
+      pnlPct: 8.33,
+      trades: 4,
+      openPositions: [{ token: "NOXA", amount: "10" }],
+    });
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockExecute.mock.calls[0]!;
+    const s = norm(sql);
+    expect(s).toContain("UPDATE mission_results SET");
+    expect(s).toContain("WHERE mission_run_id = $1");
+    expect(s).toContain("ended_at = NOW()");
+    expect(s.toLowerCase()).toContain("duration_s");
+    expect(s).toContain("stop_reason = $3");
+    expect(params).toContain("run-1");
+    expect(params).toContain("completed");
+    expect(params).toContain("goal_reached");
+    // open_positions serialized as jsonb text, not a raw object
+    expect(params!.some((p) => typeof p === "string" && p.includes("NOXA"))).toBe(true);
+  });
+
+  it("persists a null stop_reason as-is (e.g. a run that never resolved a reason)", async () => {
+    await repo.closeMissionResult({
+      missionRunId: "run-1",
+      outcome: "stopped",
+      stopReason: null,
+      bankrollEndEth: null,
+      ethPriceUsdEnd: null,
+      pnlEth: null,
+      pnlPct: null,
+      trades: 0,
+      openPositions: null,
+    });
+    const [, params] = mockExecute.mock.calls[0]!;
+    expect(params).toContain(null);
+  });
+});
+
+describe("history reads", () => {
+  it("listResultsForWallet reads newest-first for the wallet (case-insensitive)", async () => {
+    await repo.listResultsForWallet("0xAbC", 25);
+    const [sql, params] = mockQuery.mock.calls[0]!;
+    const s = norm(sql);
+    expect(s).toContain("FROM mission_results");
+    expect(s).toContain("LOWER(wallet_address) = LOWER($1)");
+    expect(s).toContain("ORDER BY seq_no DESC");
+    expect(params).toEqual(["0xAbC", 25]);
+  });
+
+  it("getResultForRun reads a single row by run_id scoped to its wallet", async () => {
+    await repo.getResultForRun("run-1", "0xAbC");
+    const [sql, params] = mockQueryOne.mock.calls[0]!;
+    expect(norm(sql)).toContain("WHERE mission_run_id = $1");
+    expect(norm(sql)).toContain("LOWER(wallet_address) = LOWER($2)");
+    expect(params).toEqual(["run-1", "0xAbC"]);
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/prepared-action-approval-intent.test.ts
+++ b/src/__tests__/vex-agent/engine/core/prepared-action-approval-intent.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const enqueueWith = vi.fn();
+const createWith = vi.fn();
+const updateStatus = vi.fn();
+
+vi.mock("@vex-agent/db/repos/approvals.js", () => ({ enqueueWith }));
+vi.mock("@vex-agent/db/repos/approval-intents.js", () => ({ createWith }));
+vi.mock("@vex-agent/db/repos/mission-runs.js", () => ({ updateStatus }));
+vi.mock("@vex-agent/db/client.js", () => ({
+  withTransaction: async (fn: (client: object) => Promise<unknown>) => fn({}),
+}));
+
+const { enqueueApprovalIntent } = await import(
+  "../../../../vex-agent/engine/core/turn-loop-tool-batch/approval-stop.js"
+);
+
+const PREPARED_EXPIRY = "2026-07-12T10:10:00.000Z";
+const TRUSTED_PREVIEW = {
+  toolName: "wallet_send_confirm",
+  criticalArgs: {
+    network: "solana",
+    chain: null,
+    to: "3SnLmaqoEczS2ft7RLQ1BRhtsLuAauWnx9K7pDjSRQrp",
+    amount: "32.813008",
+    token: "ANSEM",
+  },
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-12T10:00:00.000Z"));
+  vi.clearAllMocks();
+});
+
+afterEach(() => vi.useRealTimers());
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function baseArgs(overrides: Record<string, unknown> = {}) {
+  return {
+    context: {
+      sessionId: "session-1",
+      sessionPermission: "restricted",
+      missionRunId: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    toolCall: {
+      id: "confirm-call",
+      name: "wallet_send_confirm",
+      arguments: {
+        network: "solana",
+        intentId: "intent-00000000-0000-4000-8000-000000000001",
+        to: "model-spoofed-recipient",
+        amount: "999999",
+      },
+    },
+    result: {
+      success: false,
+      output: "approval required",
+      pendingApproval: true,
+      actionKind: "user_wallet_broadcast",
+    },
+    toolContext: {
+      sessionPermission: "restricted",
+      sessionKind: "agent",
+      missionRunId: null,
+      missionId: null,
+      role: "parent",
+      contextUsageBand: "normal",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    intentActionKind: "user_wallet_broadcast" as const,
+    ...overrides,
+  };
+}
+
+describe("prepared-action approval intent", () => {
+  it("uses the trusted wallet preview and never outlives the prepared intent", async () => {
+    await enqueueApprovalIntent(
+      baseArgs({
+        trustedPreview: TRUSTED_PREVIEW,
+        trustedExpiresAt: PREPARED_EXPIRY,
+      }),
+    );
+
+    expect(createWith).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        previewJson: TRUSTED_PREVIEW,
+        expiresAt: PREPARED_EXPIRY,
+      }),
+    );
+    const stored = createWith.mock.calls[0]![1];
+    expect(JSON.stringify(stored.previewJson)).not.toContain(
+      "model-spoofed-recipient",
+    );
+    expect(JSON.stringify(stored.previewJson)).not.toContain("999999");
+  });
+
+  it("floors the approval TTL at the trusted expiry when it is earlier than the default 1h window", async () => {
+    // System time 10:00:00; trusted expiry 10:10:00 — well inside the 1h
+    // default (11:00:00), so the approval must expire with the intent, not
+    // outlive it.
+    await enqueueApprovalIntent(
+      baseArgs({
+        trustedPreview: TRUSTED_PREVIEW,
+        trustedExpiresAt: PREPARED_EXPIRY,
+      }),
+    );
+    const stored = createWith.mock.calls[0]![1];
+    expect(stored.expiresAt).toBe(PREPARED_EXPIRY);
+  });
+
+  it("falls back to the default 1h TTL when the trusted expiry is LATER than the default window", async () => {
+    await enqueueApprovalIntent(
+      baseArgs({
+        trustedPreview: TRUSTED_PREVIEW,
+        trustedExpiresAt: "2026-07-12T23:00:00.000Z",
+      }),
+    );
+    const stored = createWith.mock.calls[0]![1];
+    expect(stored.expiresAt).toBe(
+      new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    );
+  });
+
+  it("floors the approval TTL at an ALREADY-PAST trusted expiry (fail closed via the existing expiry sweep, never re-extended to the default window)", async () => {
+    // System time 10:00:00; trusted expiry is in the past. The prepared
+    // wallet intent is already expired, so the synthesized approval must be
+    // too — it must never silently gain a fresh 1h window.
+    const pastExpiry = "2026-07-12T09:00:00.000Z";
+    await enqueueApprovalIntent(
+      baseArgs({
+        trustedPreview: TRUSTED_PREVIEW,
+        trustedExpiresAt: pastExpiry,
+      }),
+    );
+    const stored = createWith.mock.calls[0]![1];
+    expect(stored.expiresAt).toBe(pastExpiry);
+  });
+
+  it("falls back to the default 1h TTL when the trusted expiry is malformed", async () => {
+    await enqueueApprovalIntent(
+      baseArgs({
+        trustedPreview: TRUSTED_PREVIEW,
+        trustedExpiresAt: "not-a-date",
+      }),
+    );
+    const stored = createWith.mock.calls[0]![1];
+    expect(stored.expiresAt).toBe(
+      new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    );
+  });
+
+  it("builds the args-derived preview (untrusted-tool default path) when no trusted preview is supplied", async () => {
+    await enqueueApprovalIntent(baseArgs());
+    const stored = createWith.mock.calls[0]![1];
+    // The default (non-handoff) path derives the preview from the tool's own
+    // args via the allow-listed builder — model-visible fields only, still
+    // never the raw untouched args object.
+    expect(stored.previewJson.toolName).toBe("wallet_send_confirm");
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/prepared-action-follow-up.test.ts
+++ b/src/__tests__/vex-agent/engine/core/prepared-action-follow-up.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dispatchTool = vi.fn();
+const persistBatchTranscript = vi.fn().mockResolvedValue(undefined);
+const enqueueApprovalIntent = vi.fn().mockResolvedValue("approval-1");
+
+vi.mock("@vex-agent/tools/dispatcher.js", () => ({
+  dispatchTool: (...args: unknown[]) => dispatchTool(...args),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/execute.js", () => ({
+  buildToolContext: (context: Record<string, unknown>) => ({
+    ...context,
+    approved: false,
+    contextUsageBand: "normal",
+  }),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/approval-stop.js", () => ({
+  assertApprovalActionKind: (result: { actionKind?: string }) => {
+    if (!result.actionKind) throw new Error("missing actionKind");
+    return result.actionKind;
+  },
+  enqueueApprovalIntent: (...args: unknown[]) => enqueueApprovalIntent(...args),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/results.js", () => ({
+  BATCH_ABORTED_BY_COMPACT_OUTPUT: "aborted",
+  persistBatchTranscript: (...args: unknown[]) => persistBatchTranscript(...args),
+  mapBatchOutcome: (args: {
+    batchStopReason: string | null;
+    approvalId: string | null;
+    toolCallsExecuted: number;
+    lastText: string | null;
+  }) => args.batchStopReason === "approval_required"
+    ? {
+        kind: "approval_break",
+        pendingApprovalId: args.approvalId,
+        toolCallsExecuted: args.toolCallsExecuted,
+        lastText: args.lastText,
+      }
+    : {
+        kind: "normal_complete",
+        toolCallsExecuted: args.toolCallsExecuted,
+        lastText: args.lastText,
+      },
+}));
+
+const { processTurnToolBatch } = await import(
+  "../../../../vex-agent/engine/core/turn-loop-tool-batch.js"
+);
+
+const INTENT_ID = "intent-00000000-0000-4000-8000-000000000001";
+const EXPIRES_AT = "2030-01-01T00:00:00.000Z";
+const trustedPreview = {
+  toolName: "wallet_send_confirm",
+  criticalArgs: {
+    network: "solana",
+    chain: null,
+    to: "3SnLmaqoEczS2ft7RLQ1BRhtsLuAauWnx9K7pDjSRQrp",
+    amount: "32.813008",
+    token: "ANSEM",
+  },
+};
+
+function prepareResult(overrides: Record<string, unknown> = {}) {
+  return {
+    success: true,
+    output: "prepared",
+    actionKind: "approval_prepare",
+    preparedActionFollowUp: {
+      toolName: "wallet_send_confirm",
+      args: { network: "solana", intentId: INTENT_ID },
+      expiresAt: EXPIRES_AT,
+      approvalPreview: trustedPreview,
+    },
+    ...overrides,
+  };
+}
+
+function context(permission: "restricted" | "full") {
+  return {
+    sessionId: "session-1",
+    sessionKind: "agent",
+    sessionPermission: permission,
+    missionId: null,
+    missionRunId: null,
+    isSubagent: false,
+    loadedDocuments: new Map(),
+    walletPolicy: { kind: "none" },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+async function run(permission: "restricted" | "full") {
+  return processTurnToolBatch({
+    context: context(permission),
+    turnResult: {
+      content: "Preparing transfer.",
+      toolCalls: [
+        {
+          id: "prepare-call",
+          name: "wallet_send_prepare",
+          arguments: {
+            network: "solana",
+            to: "model-recipient-must-not-feed-preview",
+            amount: "999999",
+          },
+        },
+      ],
+    },
+    liveMessages: [],
+    currentTokenCount: 0,
+    contextLimit: 128_000,
+    lastTextSoFar: null,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enqueueApprovalIntent.mockResolvedValue("approval-1");
+  persistBatchTranscript.mockResolvedValue(undefined);
+});
+
+describe("prepared-action follow-up handoff", () => {
+  it("restricted sessions persist prepare, synthesize confirm, and immediately enqueue its trusted preview", async () => {
+    dispatchTool
+      .mockResolvedValueOnce(prepareResult())
+      .mockResolvedValueOnce({
+        success: false,
+        output: "approval required",
+        pendingApproval: true,
+        actionKind: "user_wallet_broadcast",
+      });
+
+    const outcome = await run("restricted");
+    expect(outcome).toMatchObject({
+      kind: "approval_break",
+      pendingApprovalId: "approval-1",
+      toolCallsExecuted: 2,
+    });
+    expect(dispatchTool).toHaveBeenCalledTimes(2);
+    expect(dispatchTool.mock.calls[1]![0]).toMatchObject({
+      name: "wallet_send_confirm",
+      args: { network: "solana", intentId: INTENT_ID },
+    });
+    expect(enqueueApprovalIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trustedPreview,
+        trustedExpiresAt: EXPIRES_AT,
+        toolCall: expect.objectContaining({ name: "wallet_send_confirm" }),
+      }),
+    );
+    expect(persistBatchTranscript).toHaveBeenCalledTimes(2);
+    expect(persistBatchTranscript.mock.calls[0]![0]).toMatchObject({
+      content: "Preparing transfer.",
+      executedCalls: [expect.objectContaining({ name: "wallet_send_prepare" })],
+      executedResults: [expect.objectContaining({ output: "prepared" })],
+    });
+    // Second persist is the synthetic confirm call — stamped system-originated
+    // so an auditor can never mistake it for model output (see turn.ts
+    // `saveAssistantMessage` provenance stamp + transcript-provenance test).
+    expect(persistBatchTranscript.mock.calls[1]![0]).toMatchObject({
+      content: null,
+      executedCalls: [expect.objectContaining({ name: "wallet_send_confirm" })],
+      executedResults: [],
+      systemOriginated: true,
+    });
+  });
+
+  it("full-permission sessions execute confirm immediately and persist its paired result", async () => {
+    dispatchTool
+      .mockResolvedValueOnce(prepareResult())
+      .mockResolvedValueOnce({ success: true, output: "transfer confirmed" });
+
+    const outcome = await run("full");
+    expect(outcome).toMatchObject({ kind: "normal_complete", toolCallsExecuted: 2 });
+    expect(enqueueApprovalIntent).not.toHaveBeenCalled();
+    expect(persistBatchTranscript.mock.calls[1]![0]).toMatchObject({
+      content: null,
+      executedCalls: [expect.objectContaining({ name: "wallet_send_confirm" })],
+      executedResults: [
+        expect.objectContaining({ output: "transfer confirmed", success: true }),
+      ],
+      systemOriginated: true,
+    });
+  });
+
+  it.each(["restricted", "full"] as const)(
+    "hands off validated EVM transfers in %s sessions",
+    async (permission) => {
+      const evmPreview = {
+        toolName: "wallet_send_confirm",
+        criticalArgs: {
+          network: "eip155",
+          chain: "base",
+          to: "0xfedcba0987654321fedcba0987654321fedcba09",
+          amount: "1.5",
+          token: null,
+        },
+      };
+      dispatchTool
+        .mockResolvedValueOnce(
+          prepareResult({
+            preparedActionFollowUp: {
+              toolName: "wallet_send_confirm",
+              args: { network: "eip155", intentId: INTENT_ID },
+              expiresAt: EXPIRES_AT,
+              approvalPreview: evmPreview,
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          permission === "restricted"
+            ? {
+                success: false,
+                output: "approval required",
+                pendingApproval: true,
+                actionKind: "user_wallet_broadcast",
+              }
+            : { success: true, output: "transfer confirmed" },
+        );
+
+      const outcome = await run(permission);
+      expect(dispatchTool.mock.calls[1]![0]).toMatchObject({
+        name: "wallet_send_confirm",
+        args: { network: "eip155", intentId: INTENT_ID },
+      });
+      if (permission === "restricted") {
+        expect(outcome.kind).toBe("approval_break");
+        expect(enqueueApprovalIntent).toHaveBeenCalledWith(
+          expect.objectContaining({ trustedPreview: evmPreview }),
+        );
+      } else {
+        expect(outcome.kind).toBe("normal_complete");
+        expect(enqueueApprovalIntent).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("rejects unknown mappings without dispatching a second tool", async () => {
+    dispatchTool.mockResolvedValueOnce(
+      prepareResult({
+        preparedActionFollowUp: {
+          ...prepareResult().preparedActionFollowUp,
+          toolName: "swap",
+        },
+      }),
+    );
+
+    const outcome = await run("restricted");
+    expect(outcome).toMatchObject({ kind: "normal_complete", toolCallsExecuted: 1 });
+    expect(dispatchTool).toHaveBeenCalledOnce();
+    expect(persistBatchTranscript.mock.calls[0]![0]).toMatchObject({
+      executedResults: [
+        expect.objectContaining({
+          success: false,
+          output: expect.stringContaining("rejected by the trusted registry"),
+        }),
+      ],
+    });
+  });
+
+  it("rejects recursive chains after one follow-up and never dispatches a third tool", async () => {
+    dispatchTool
+      .mockResolvedValueOnce(prepareResult())
+      .mockResolvedValueOnce(prepareResult());
+
+    const outcome = await run("full");
+    expect(outcome).toMatchObject({ kind: "normal_complete", toolCallsExecuted: 2 });
+    expect(dispatchTool).toHaveBeenCalledTimes(2);
+    expect(persistBatchTranscript.mock.calls[1]![0]).toMatchObject({
+      executedResults: [
+        expect.objectContaining({
+          success: false,
+          output: expect.stringContaining("Recursive"),
+        }),
+      ],
+    });
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/runner/resume-mission-run.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/resume-mission-run.test.ts
@@ -312,6 +312,77 @@ describe("runner", () => {
       expect(result.missionStatus).toBe("running");
     });
 
+    // WP-I1: the hard deadline holds ACROSS resumes — it is recomputed from
+    // the same immutable `missionRunStartedAt` each time, not reset to "now".
+    // (No `contractSnapshotJson` on the run -> frozen duration null -> 60min.)
+    it("threads the hard mission deadline into loopConfig and context on resume", async () => {
+      mockGetRun.mockResolvedValueOnce({
+        id: "run-1", missionId: "mission-1", sessionId: "session-1",
+        status: "running", iterationCount: 5,
+      });
+      mockGetMission.mockResolvedValueOnce({
+        id: "mission-1", rootSessionId: "session-1", status: "running",
+        title: "SOL DCA", goal: "Accumulate", capitalSourceJson: {},
+        allowedWallets: ["sol"], allowedChains: ["sol"], allowedProtocols: ["sol"],
+        riskProfile: "conservative", successCriteriaJson: [], stopConditionsJson: [],
+        constraintsJson: {}, createdAt: "", updatedAt: "", approvedAt: "",
+      });
+      mockHydrate.mockResolvedValueOnce(makeHydratedSession({
+        sessionKind: "mission", missionId: "mission-1", missionRunId: "run-1",
+        missionRunStartedAt: "2026-01-01T00:00:00.000Z",
+      }));
+      mockRunTurnLoop.mockResolvedValueOnce({
+        text: "Resumed", toolCallsMade: 0, pendingApprovals: [], stopReason: null,
+      });
+
+      await resumeMissionRun("run-1");
+
+      const [context, , , , , , , loopConfig] = mockRunTurnLoop.mock.calls[0]!;
+      const expectedMs = Date.parse("2026-01-01T00:00:00.000Z") + 60 * 60_000;
+      expect((loopConfig as { missionDeadlineMs: number }).missionDeadlineMs).toBe(expectedMs);
+      expect((context as { missionDeadline: string }).missionDeadline).toBe(
+        new Date(expectedMs).toISOString(),
+      );
+    });
+
+    // WP-I1 freeze (Codex review Q1): a post-start mutation of the LIVE mission
+    // row's durationMinutes must NOT move the enforced deadline on resume. The
+    // box is re-derived from the run's FROZEN contract snapshot + immutable
+    // started_at, so a wake/resume always yields the ORIGINAL deadline.
+    it("uses the FROZEN snapshot durationMinutes on resume, ignoring a post-start mutation of the live mission row", async () => {
+      mockGetRun.mockResolvedValueOnce({
+        id: "run-1", missionId: "mission-1", sessionId: "session-1",
+        status: "running", iterationCount: 5,
+        // Committed with a 5-minute box.
+        contractSnapshotJson: { frozenMission: { draft: { durationMinutes: 5 } } },
+      });
+      // Live mission row was edited to a 999-minute box AFTER the run started —
+      // must be ignored by the deadline enforcer.
+      mockGetMission.mockResolvedValueOnce({
+        id: "mission-1", rootSessionId: "session-1", status: "running",
+        title: "SOL DCA", goal: "Accumulate", capitalSourceJson: {},
+        allowedWallets: ["sol"], allowedChains: ["sol"], allowedProtocols: ["sol"],
+        riskProfile: "conservative", successCriteriaJson: [], stopConditionsJson: [],
+        constraintsJson: { durationMinutes: 999 }, createdAt: "", updatedAt: "", approvedAt: "",
+      });
+      mockHydrate.mockResolvedValueOnce(makeHydratedSession({
+        sessionKind: "mission", missionId: "mission-1", missionRunId: "run-1",
+        missionRunStartedAt: "2026-01-01T00:00:00.000Z",
+      }));
+      mockRunTurnLoop.mockResolvedValueOnce({
+        text: "Resumed", toolCallsMade: 0, pendingApprovals: [], stopReason: null,
+      });
+
+      await resumeMissionRun("run-1");
+
+      const [context, , , , , , , loopConfig] = mockRunTurnLoop.mock.calls[0]!;
+      const expectedMs = Date.parse("2026-01-01T00:00:00.000Z") + 5 * 60_000; // frozen 5, NOT live 999
+      expect((loopConfig as { missionDeadlineMs: number }).missionDeadlineMs).toBe(expectedMs);
+      expect((context as { missionDeadline: string }).missionDeadline).toBe(
+        new Date(expectedMs).toISOString(),
+      );
+    });
+
     it("pauses the run with evidence when resume throws inside the loop", async () => {
       mockGetRun.mockResolvedValueOnce({
         id: "run-1", missionId: "mission-1", sessionId: "session-1",

--- a/src/__tests__/vex-agent/engine/core/runner/start-mission.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/start-mission.test.ts
@@ -310,6 +310,78 @@ describe("runner", () => {
       expect(result.missionStatus).toBe("running");
     });
 
+    // WP-I1: the hard deadline is computed from the run's immutable
+    // `missionRunStartedAt` (+ FROZEN snapshot duration -> env -> 60min
+    // default) and threaded into both `loopConfig.missionDeadlineMs`
+    // (enforcement) and `context.missionDeadline` (the agent-facing Runtime
+    // Clock). The default commit snapshot has no `durationMinutes` -> 60.
+    it("threads the hard mission deadline into loopConfig and context", async () => {
+      mockGetMission.mockResolvedValueOnce(makeReadyMission());
+      mockHydrate.mockResolvedValueOnce(makeHydratedSession({
+        sessionKind: "mission",
+        missionRunStartedAt: "2026-01-01T00:00:00.000Z",
+      }));
+      mockRunTurnLoop.mockResolvedValueOnce({
+        text: "Starting mission...", toolCallsMade: 0, pendingApprovals: [], stopReason: null,
+      });
+
+      await startMission("mission-1");
+
+      expect(mockRunTurnLoop).toHaveBeenCalled();
+      const [context, , , , , , , loopConfig] = mockRunTurnLoop.mock.calls[0]!;
+      const expectedMs = Date.parse("2026-01-01T00:00:00.000Z") + 60 * 60_000;
+      expect((loopConfig as { missionDeadlineMs: number }).missionDeadlineMs).toBe(expectedMs);
+      expect((context as { missionDeadline: string }).missionDeadline).toBe(
+        new Date(expectedMs).toISOString(),
+      );
+    });
+
+    it("resolves no deadline (fail-open) when the run has no started_at", async () => {
+      mockGetMission.mockResolvedValueOnce(makeReadyMission());
+      mockHydrate.mockResolvedValueOnce(makeHydratedSession({ sessionKind: "mission" }));
+      mockRunTurnLoop.mockResolvedValueOnce({
+        text: "Starting mission...", toolCallsMade: 0, pendingApprovals: [], stopReason: null,
+      });
+
+      await startMission("mission-1");
+
+      const [, , , , , , , loopConfig] = mockRunTurnLoop.mock.calls[0]!;
+      expect((loopConfig as { missionDeadlineMs: number | null }).missionDeadlineMs).toBeNull();
+    });
+
+    // WP-I1 freeze: the box is resolved from the FROZEN contract snapshot's
+    // `durationMinutes`, never the live mission row — so a per-mission box is
+    // pinned at commit time.
+    it("freezes the deadline from the contract snapshot's durationMinutes, not the live mission row", async () => {
+      mockCommitMissionStart.mockImplementationOnce(async (input: { missionId: string; runId: string }) => ({
+        outcome: "committed" as const,
+        // Live row claims a 999-min box; the frozen snapshot says 5 — the
+        // enforcer must use the frozen 5.
+        mission: makeReadyMission({ constraintsJson: { durationMinutes: 999 } }),
+        runId: input.runId,
+        contractSnapshot: {
+          version: 1,
+          capturedAt: "2026-05-22T11:00:00.000Z",
+          missionPromptContext: "# Mission",
+          frozenMission: { draft: { durationMinutes: 5 } },
+        },
+      }));
+      mockGetMission.mockResolvedValueOnce(makeReadyMission({ constraintsJson: { durationMinutes: 999 } }));
+      mockHydrate.mockResolvedValueOnce(makeHydratedSession({
+        sessionKind: "mission",
+        missionRunStartedAt: "2026-01-01T00:00:00.000Z",
+      }));
+      mockRunTurnLoop.mockResolvedValueOnce({
+        text: "Starting mission...", toolCallsMade: 0, pendingApprovals: [], stopReason: null,
+      });
+
+      await startMission("mission-1");
+
+      const [, , , , , , , loopConfig] = mockRunTurnLoop.mock.calls[0]!;
+      const expectedMs = Date.parse("2026-01-01T00:00:00.000Z") + 5 * 60_000;
+      expect((loopConfig as { missionDeadlineMs: number }).missionDeadlineMs).toBe(expectedMs);
+    });
+
     it("marks only goal_reached as completed", async () => {
       mockGetMission.mockResolvedValueOnce(makeReadyMission());
       mockHydrate.mockResolvedValueOnce(makeHydratedSession({ sessionKind: "mission" }));

--- a/src/__tests__/vex-agent/engine/core/transcript-provenance.test.ts
+++ b/src/__tests__/vex-agent/engine/core/transcript-provenance.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Transcript provenance — `saveAssistantMessage`'s `systemOriginated` stamp.
+ *
+ * WP-G requirement: the synthesized `wallet_send_confirm` follow-up call
+ * (`dispatchPreparedActionFollowUp`) must be persisted with a marker an
+ * auditor reading `messages` directly can use to tell it apart from real
+ * model output, even though it shares the `assistant` role + tool_calls
+ * shape the provider transcript format requires. This pins the persistence
+ * boundary itself, one layer below the engine orchestration covered by
+ * `prepared-action-follow-up.test.ts`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const appendMessage = vi.fn().mockResolvedValue({ id: 1 });
+
+vi.mock("@vex-agent/engine/events/index.js", () => ({
+  appendMessage: (...args: unknown[]) => appendMessage(...args),
+  streamDeltaBus: { emit: vi.fn() },
+  toStreamDeltaEvent: vi.fn(),
+}));
+
+const { saveAssistantMessage } = await import(
+  "../../../../vex-agent/engine/core/turn.js"
+);
+
+beforeEach(() => {
+  appendMessage.mockClear();
+});
+
+const SESSION_ID = "session-1";
+
+describe("saveAssistantMessage provenance stamp", () => {
+  it("stamps a genuine model-authored turn as source:assistant, messageType:chat", async () => {
+    await saveAssistantMessage(SESSION_ID, "hello", null);
+    const metadata = appendMessage.mock.calls[0]![2];
+    expect(metadata).toMatchObject({ source: "assistant", messageType: "chat" });
+  });
+
+  it("stamps the synthesized prepared-action follow-up as source:engine with a distinct messageType", async () => {
+    await saveAssistantMessage(
+      SESSION_ID,
+      null,
+      [{ id: "prepared-follow-up-1", name: "wallet_send_confirm", arguments: { network: "solana", intentId: "intent-1" } }],
+      { systemOriginated: true },
+    );
+    const metadata = appendMessage.mock.calls[0]![2];
+    expect(metadata.source).toBe("engine");
+    expect(metadata.source).not.toBe("assistant");
+    expect(metadata.messageType).toBe("prepared_action_follow_up");
+    expect(metadata.messageType).not.toBe("chat");
+  });
+
+  it("keeps the stopped-turn stamp (source:assistant, messageType:chat_stopped) unaffected by the new flag", async () => {
+    await saveAssistantMessage(SESSION_ID, "partial", null, { stopped: true });
+    const metadata = appendMessage.mock.calls[0]![2];
+    expect(metadata).toMatchObject({
+      source: "assistant",
+      messageType: "chat_stopped",
+    });
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/turn-loop/mission-mode.test.ts
+++ b/src/__tests__/vex-agent/engine/core/turn-loop/mission-mode.test.ts
@@ -328,6 +328,49 @@ describe("turn-loop", () => {
       expect(mockIncrementIterations).toHaveBeenCalledWith("run-1");
     });
 
+    // WP-I1: the hard mission deadline is enforced at the turn-loop boundary,
+    // independent of the agent — checked BEFORE any other guard or inference
+    // call each iteration.
+    it("enforces the hard deadline — a past missionDeadlineMs stops with deadline_reached before any turn runs", async () => {
+      const provider = makeProvider([{ content: "should never run" }]);
+
+      const result = await runTurnLoop(
+        makeContext({ sessionKind: "mission", missionRunId: "run-1" }),
+        [], null, 0, provider as any, makeConfig() as any, [],
+        { ...defaultLoopConfig, maxIterations: 5, missionDeadlineMs: Date.now() - 1_000 },
+      );
+
+      expect(result.stopReason).toBe("deadline_reached");
+      // The check is the first thing each iteration — no inference is spent.
+      expect(provider.chatCompletion).not.toHaveBeenCalled();
+    });
+
+    it("does not false-stop when the deadline is still in the future", async () => {
+      const provider = makeProvider([{ content: "Working..." }]);
+
+      const result = await runTurnLoop(
+        makeContext({ sessionKind: "mission", missionRunId: "run-1" }),
+        [], null, 0, provider as any, makeConfig() as any, [],
+        { ...defaultLoopConfig, maxIterations: 1, missionDeadlineMs: Date.now() + 60_000 },
+      );
+
+      expect(result.stopReason).not.toBe("deadline_reached");
+      expect(provider.chatCompletion).toHaveBeenCalled();
+    });
+
+    it("does not stop early when missionDeadlineMs is null/undefined (no box)", async () => {
+      const provider = makeProvider([{ content: "Working..." }]);
+
+      const result = await runTurnLoop(
+        makeContext({ sessionKind: "mission", missionRunId: "run-1" }),
+        [], null, 0, provider as any, makeConfig() as any, [],
+        { ...defaultLoopConfig, maxIterations: 1, missionDeadlineMs: null },
+      );
+
+      expect(result.stopReason).not.toBe("deadline_reached");
+      expect(provider.chatCompletion).toHaveBeenCalled();
+    });
+
     it("merges operator instructions before the next autonomous iteration", async () => {
       const provider = makeProvider([
         { content: "Working..." },

--- a/src/__tests__/vex-agent/engine/mission/bankroll.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/bankroll.test.ts
@@ -1,0 +1,84 @@
+/**
+ * ETH-equivalent bankroll from proj_balances rows. Native ETH + WETH (WETH
+ * matched by the chain's registered contract ADDRESS, never by symbol) make
+ * up the bankroll; every other held token is an OPEN position, reported
+ * separately and excluded from the bankroll figure so an unsold bag never
+ * inflates PnL.
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeEthBankroll } from "../../../../vex-agent/engine/mission/bankroll.js";
+import type { BalanceRow } from "../../../../vex-agent/db/repos/balances/types.js";
+
+const ROBINHOOD_CHAIN_ID = 4663;
+const NATIVE = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+// Real WETH address on Robinhood Chain (tools/evm-chains/registry.ts seedTokens).
+const WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73";
+
+function bal(over: Partial<BalanceRow>): BalanceRow {
+  return {
+    walletFamily: "eip155", walletAddress: "0xW", chainId: ROBINHOOD_CHAIN_ID,
+    tokenAddress: NATIVE, tokenSymbol: "ETH", tokenName: "Ether",
+    balanceRaw: "0", balanceUsd: null, priceUsd: null, decimals: 18, ...over,
+  };
+}
+
+describe("computeEthBankroll", () => {
+  it("sums native ETH + WETH into the bankroll", () => {
+    const r = computeEthBankroll([
+      bal({ tokenAddress: NATIVE, tokenSymbol: "ETH", balanceRaw: "10000000000000000", priceUsd: 3000 }), // 0.01
+      bal({ tokenAddress: WETH, tokenSymbol: "WETH", balanceRaw: "5000000000000000", priceUsd: 3000 }), // 0.005
+    ], ROBINHOOD_CHAIN_ID);
+    expect(r.bankrollEth).toBeCloseTo(0.015, 12);
+    expect(r.ethPriceUsd).toBe(3000);
+    expect(r.openPositions).toHaveLength(0);
+  });
+
+  it("matches WETH by ADDRESS, not by a row's self-reported symbol", () => {
+    // Regression: a token whose SYMBOL happens to be "WETH" but whose
+    // ADDRESS is not the chain's registered WETH contract must be treated
+    // as an open position, not folded into the bankroll (symbol strings are
+    // untrusted / spoofable; the registry address is provenance-checked).
+    const r = computeEthBankroll([
+      bal({ tokenAddress: NATIVE, tokenSymbol: "ETH", balanceRaw: "10000000000000000", priceUsd: 3000 }),
+      bal({ tokenAddress: "0xFakeWethAddress0000000000000000000000", tokenSymbol: "WETH", balanceRaw: "5000000000000000", balanceUsd: 15 }),
+    ], ROBINHOOD_CHAIN_ID);
+    expect(r.bankrollEth).toBeCloseTo(0.01, 12);
+    expect(r.openPositions).toHaveLength(1);
+    expect(r.openPositions[0]).toMatchObject({ symbol: "WETH", address: "0xFakeWethAddress0000000000000000000000" });
+  });
+
+  it("treats other tokens as open positions, excluded from the bankroll", () => {
+    const r = computeEthBankroll([
+      bal({ tokenAddress: NATIVE, tokenSymbol: "ETH", balanceRaw: "10000000000000000", priceUsd: 3000 }),
+      bal({ tokenAddress: "0xNOXA", tokenSymbol: "NOXA", balanceRaw: "2000000000000000000", decimals: 18, balanceUsd: 42 }),
+    ], ROBINHOOD_CHAIN_ID);
+    expect(r.bankrollEth).toBeCloseTo(0.01, 12); // NOXA excluded
+    expect(r.openPositions).toHaveLength(1);
+    expect(r.openPositions[0]).toMatchObject({ symbol: "NOXA", address: "0xNOXA", valueUsd: 42 });
+    expect(r.openPositions[0]!.amount).toBeCloseTo(2, 9);
+  });
+
+  it("ignores zero-balance non-ETH tokens (dust rows)", () => {
+    const r = computeEthBankroll([
+      bal({ tokenAddress: NATIVE, balanceRaw: "10000000000000000", priceUsd: 3000 }),
+      bal({ tokenAddress: "0xDUST", tokenSymbol: "DUST", balanceRaw: "0" }),
+    ], ROBINHOOD_CHAIN_ID);
+    expect(r.openPositions).toHaveLength(0);
+  });
+
+  it("returns a zero bankroll for no rows", () => {
+    const r = computeEthBankroll([], ROBINHOOD_CHAIN_ID);
+    expect(r.bankrollEth).toBe(0);
+    expect(r.ethPriceUsd).toBeNull();
+  });
+
+  it("treats WETH as an open position on a chain with no registered WETH (unknown chain id)", () => {
+    const r = computeEthBankroll([
+      bal({ tokenAddress: NATIVE, balanceRaw: "10000000000000000", priceUsd: 3000, chainId: 999999 }),
+      bal({ tokenAddress: WETH, tokenSymbol: "WETH", balanceRaw: "5000000000000000", balanceUsd: 15, chainId: 999999 }),
+    ], 999999);
+    expect(r.bankrollEth).toBeCloseTo(0.01, 12);
+    expect(r.openPositions).toHaveLength(1);
+  });
+});

--- a/src/__tests__/vex-agent/engine/mission/contract-hash.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/contract-hash.test.ts
@@ -22,6 +22,7 @@ function makeDraft(overrides: Partial<MissionDraft> = {}): MissionDraft {
     successCriteria: ["Accumulated 10 SOL"],
     stopConditions: ["capital_depleted", "deadline_reached"],
     deadline: "2026-04-04",
+    durationMinutes: null,
     ...overrides,
   };
 }

--- a/src/__tests__/vex-agent/engine/mission/mapper.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/mapper.test.ts
@@ -62,6 +62,21 @@ describe("mission mapper", () => {
       expect(draft.startingCapital).toBeNull();
       expect(draft.allowedChains).toBeNull();
       expect(draft.deadline).toBeNull();
+      expect(draft.durationMinutes).toBeNull();
+    });
+
+    it("reads a numeric durationMinutes from constraints", () => {
+      const draft = missionToDraft(makeMission({
+        constraintsJson: { deadline: "2026-04-04", durationMinutes: 30 },
+      }));
+      expect(draft.durationMinutes).toBe(30);
+    });
+
+    it("ignores a non-numeric durationMinutes on legacy/malformed rows", () => {
+      const draft = missionToDraft(makeMission({
+        constraintsJson: { durationMinutes: "30" },
+      }));
+      expect(draft.durationMinutes).toBeNull();
     });
 
     it("ignores legacy constraints_json.stopConditionsAccepted on old rows", () => {
@@ -105,6 +120,11 @@ describe("mission mapper", () => {
     it("converts deadline to constraints_json", () => {
       const row = domainToRow({ deadline: "2026-04-04" });
       expect(row.constraints_json).toEqual({ deadline: "2026-04-04" });
+    });
+
+    it("converts durationMinutes to constraints_json", () => {
+      const row = domainToRow({ deadline: "2026-04-04", durationMinutes: 30 });
+      expect(row.constraints_json).toEqual({ deadline: "2026-04-04", durationMinutes: 30 });
     });
 
     it("does not write a stopConditionsAccepted key", () => {
@@ -172,6 +192,13 @@ describe("mission mapper", () => {
       expect(ctx).toContain("solana");
       expect(ctx).toContain("Accumulated 10 SOL");
       expect(ctx).toContain("2026-04-04");
+    });
+
+    it("includes the time-box when durationMinutes is set", () => {
+      const ctx = draftToPromptContext(makeMission({
+        constraintsJson: { deadline: "2026-04-04", durationMinutes: 30 },
+      }));
+      expect(ctx).toContain("30 min");
     });
 
     it("handles empty mission gracefully", () => {

--- a/src/__tests__/vex-agent/engine/mission/mission-deadline.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/mission-deadline.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Hard mission deadline — computed from the run's immutable started_at + the
+ * FROZEN per-mission duration (default 60 min). Integer-minute contract for
+ * both the per-mission field and the env override.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  hardDeadlineMinutes,
+  resolveDurationMinutes,
+  computeHardDeadlineMs,
+  frozenDurationMinutes,
+  resolveFrozenDeadlineMs,
+} from "../../../../vex-agent/engine/mission/mission-deadline.js";
+
+describe("hardDeadlineMinutes", () => {
+  it("defaults to 60 minutes with no override", () => {
+    expect(hardDeadlineMinutes({})).toBe(60);
+  });
+  it("honors a valid VEX_MISSION_HARD_DEADLINE_MIN override (e.g. a 2-min test box)", () => {
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "2" })).toBe(2);
+  });
+  it("falls back to 60 on a non-numeric or non-positive override", () => {
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "abc" })).toBe(60);
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "0" })).toBe(60);
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "-5" })).toBe(60);
+  });
+  it("clamps absurdly large values to a 24h ceiling", () => {
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "99999" })).toBe(1440);
+  });
+  // Integer-minute contract: the env override is whole minutes only (matches
+  // the per-mission `durationMinutes` field). A fractional value TRUNCATES;
+  // a sub-1-minute value is rejected -> default. No fractional test boxes.
+  it("truncates a fractional override to whole minutes", () => {
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "5.9" })).toBe(5);
+  });
+  it("rejects a sub-1-minute override (no fractional test box) -> default 60", () => {
+    expect(hardDeadlineMinutes({ VEX_MISSION_HARD_DEADLINE_MIN: "0.5" })).toBe(60);
+  });
+});
+
+describe("resolveDurationMinutes (per-mission > env > default)", () => {
+  it("uses the mission's own durationMinutes when set and valid", () => {
+    expect(resolveDurationMinutes(5, {})).toBe(5);
+    expect(resolveDurationMinutes(10, { VEX_MISSION_HARD_DEADLINE_MIN: "60" })).toBe(10);
+  });
+  it("clamps an absurd per-mission value to the 24h ceiling", () => {
+    expect(resolveDurationMinutes(99999, {})).toBe(1440);
+  });
+  it("falls back to the env override when the mission has no duration", () => {
+    expect(resolveDurationMinutes(null, { VEX_MISSION_HARD_DEADLINE_MIN: "2" })).toBe(2);
+    expect(resolveDurationMinutes(undefined, { VEX_MISSION_HARD_DEADLINE_MIN: "2" })).toBe(2);
+  });
+  it("falls back to 60 when neither mission nor env specifies one", () => {
+    expect(resolveDurationMinutes(null, {})).toBe(60);
+    expect(resolveDurationMinutes(0, {})).toBe(60);
+    expect(resolveDurationMinutes(-5, {})).toBe(60);
+  });
+  it("truncates a fractional per-mission value to whole minutes", () => {
+    expect(resolveDurationMinutes(5.9, {})).toBe(5);
+  });
+  it("rejects a sub-1-minute per-mission value -> env/default", () => {
+    expect(resolveDurationMinutes(0.5, {})).toBe(60);
+    expect(resolveDurationMinutes(0.5, { VEX_MISSION_HARD_DEADLINE_MIN: "2" })).toBe(2);
+  });
+});
+
+describe("frozenDurationMinutes (reads the immutable run contract snapshot)", () => {
+  it("reads frozenMission.draft.durationMinutes when present and positive", () => {
+    expect(
+      frozenDurationMinutes({ frozenMission: { draft: { durationMinutes: 5 } } }),
+    ).toBe(5);
+  });
+  it("returns null for any missing/malformed level (fail-open -> env/default)", () => {
+    expect(frozenDurationMinutes(null)).toBeNull();
+    expect(frozenDurationMinutes(undefined)).toBeNull();
+    expect(frozenDurationMinutes(42)).toBeNull();
+    expect(frozenDurationMinutes({})).toBeNull();
+    expect(frozenDurationMinutes({ frozenMission: null })).toBeNull();
+    expect(frozenDurationMinutes({ frozenMission: {} })).toBeNull();
+    expect(frozenDurationMinutes({ frozenMission: { draft: null } })).toBeNull();
+    expect(frozenDurationMinutes({ frozenMission: { draft: {} } })).toBeNull();
+    expect(
+      frozenDurationMinutes({ frozenMission: { draft: { durationMinutes: null } } }),
+    ).toBeNull();
+    expect(
+      frozenDurationMinutes({ frozenMission: { draft: { durationMinutes: 0 } } }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveFrozenDeadlineMs (the single start+resume resolver)", () => {
+  const start = "2026-01-01T00:00:00.000Z";
+  const startMs = Date.parse(start);
+
+  it("uses the frozen per-mission box when the snapshot has one", () => {
+    expect(
+      resolveFrozenDeadlineMs(start, { frozenMission: { draft: { durationMinutes: 5 } } }),
+    ).toBe(startMs + 5 * 60_000);
+  });
+  it("falls back to the 60-min default when the snapshot has no durationMinutes", () => {
+    expect(resolveFrozenDeadlineMs(start, { frozenMission: {} })).toBe(startMs + 60 * 60_000);
+    expect(resolveFrozenDeadlineMs(start, null)).toBe(startMs + 60 * 60_000);
+  });
+  it("is fail-open (null) when started_at is missing or unparseable", () => {
+    expect(resolveFrozenDeadlineMs(null, { frozenMission: { draft: { durationMinutes: 5 } } })).toBeNull();
+    expect(resolveFrozenDeadlineMs(undefined, {})).toBeNull();
+    expect(resolveFrozenDeadlineMs("not-a-date", {})).toBeNull();
+  });
+  it("re-derives the identical deadline on repeated calls (wake/resume stability)", () => {
+    const snap = { frozenMission: { draft: { durationMinutes: 5 } } };
+    expect(resolveFrozenDeadlineMs(start, snap)).toBe(resolveFrozenDeadlineMs(start, snap));
+  });
+});
+
+describe("computeHardDeadlineMs", () => {
+  it("is started_at + duration in epoch ms", () => {
+    const start = "2026-07-12T19:00:00.000Z";
+    const startMs = Date.parse(start);
+    expect(computeHardDeadlineMs(start, 2)).toBe(startMs + 2 * 60_000);
+    expect(computeHardDeadlineMs(start, 60)).toBe(startMs + 60 * 60_000);
+  });
+  it("returns null for an unparseable start (fail-open: no false deadline)", () => {
+    expect(computeHardDeadlineMs("not-a-date", 60)).toBeNull();
+  });
+});

--- a/src/__tests__/vex-agent/engine/mission/mission-metrics.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/mission-metrics.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Per-mission trade count — successful fills recorded in proj_activity,
+ * bounded to the run by its session and time window. (A mission run maps
+ * 1:1 to a session; proj_activity links to a session via
+ * protocol_executions.)
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+let mockQueryOne: Mock;
+
+vi.mock("@vex-agent/db/client.js", () => ({
+  query: vi.fn(),
+  queryOne: (sql: string, p?: unknown[]) => mockQueryOne(sql, p),
+  execute: vi.fn(),
+  queryWith: vi.fn(),
+  queryOneWith: vi.fn(),
+  executeWith: vi.fn(),
+  withTransaction: vi.fn(),
+}));
+
+const { countMissionTrades } = await import(
+  "@vex-agent/engine/mission/mission-metrics.js"
+);
+
+const norm = (s: string) => s.replace(/\s+/g, " ").trim();
+
+beforeEach(() => {
+  mockQueryOne = vi.fn(async () => ({ trades: 4 }));
+});
+
+describe("countMissionTrades", () => {
+  it("counts fills for the session within the run window (joined via protocol_executions)", async () => {
+    const n = await countMissionTrades("sess-1", "2026-07-12T18:00:00Z", "2026-07-12T19:00:00Z");
+    expect(n).toBe(4);
+    const [sql, params] = mockQueryOne.mock.calls[0]!;
+    const s = norm(sql);
+    expect(s).toContain("FROM proj_activity");
+    expect(s).toContain("JOIN protocol_executions");
+    expect(s).toContain("session_id =");
+    expect(s).toContain("created_at BETWEEN");
+    expect(s.toLowerCase()).toContain("count(");
+    expect(params).toEqual(["sess-1", "2026-07-12T18:00:00Z", "2026-07-12T19:00:00Z"]);
+  });
+
+  it("is fail-soft — a query error yields 0, never throws (finalize must not break)", async () => {
+    mockQueryOne = vi.fn(async () => {
+      throw new Error("db down");
+    });
+    await expect(countMissionTrades("s", "a", "b")).resolves.toBe(0);
+  });
+
+  it("returns 0 when the query yields no row", async () => {
+    mockQueryOne = vi.fn(async () => null);
+    await expect(countMissionTrades("s", "a", "b")).resolves.toBe(0);
+  });
+});

--- a/src/__tests__/vex-agent/engine/mission/mission-results-capture.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/mission-results-capture.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Mission results capture — orchestration that opens the ledger row at run
+ * start and closes it at finalize. Deps are injected so this runs with no
+ * DB/network. Pins: wallet/chain resolution from the mission, PNL math, and
+ * fail-soft (a throwing dep never propagates — mission finalization must
+ * not break).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  computePnl,
+  captureMissionStart,
+  captureMissionFinal,
+  type CaptureDeps,
+} from "../../../../vex-agent/engine/mission/mission-results-capture.js";
+
+const MISSION = {
+  id: "mission-1",
+  goal: "grow ETH +8% in 60 min",
+  allowedChains: ["robinhood"],
+  allowedWallets: ["0x9ed25bdedceB28Adf9E3C7fCa34511e78e47C77f"],
+};
+
+function deps(over: Partial<CaptureDeps> = {}): CaptureDeps {
+  return {
+    getMission: vi.fn(async () => MISSION as never),
+    readBankroll: vi.fn(async () => ({ bankrollEth: 0.01, ethPriceUsd: 3000, openPositions: [] })),
+    openResult: vi.fn(async () => {}),
+    closeResult: vi.fn(async () => {}),
+    getResult: vi.fn(async () => null),
+    countTrades: vi.fn(async () => 3),
+    ...over,
+  };
+}
+
+describe("computePnl", () => {
+  it("computes ETH delta and percent vs start", () => {
+    const result = computePnl(0.01, 0.011);
+    expect(result.pnlEth).toBeCloseTo(0.001, 9);
+    expect(result.pnlPct).toBeCloseTo(10, 6);
+  });
+  it("is null when either bankroll is unknown", () => {
+    expect(computePnl(null, 0.01)).toEqual({ pnlEth: null, pnlPct: null });
+    expect(computePnl(0.01, null)).toEqual({ pnlEth: null, pnlPct: null });
+  });
+  it("guards divide-by-zero when start is zero", () => {
+    expect(computePnl(0, 0.01).pnlPct).toBeNull();
+  });
+});
+
+describe("captureMissionStart", () => {
+  it("opens a ledger row with the mission's wallet, resolved chainId, and start bankroll", async () => {
+    const d = deps();
+    await captureMissionStart({ missionId: "mission-1", runId: "run-1", sessionId: "s-1" }, d);
+    expect(d.openResult).toHaveBeenCalledTimes(1);
+    const arg = (d.openResult as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(arg).toMatchObject({
+      missionRunId: "run-1",
+      walletAddress: "0x9ed25bdedceB28Adf9E3C7fCa34511e78e47C77f",
+      chainId: 4663,
+      bankrollStartEth: 0.01,
+      ethPriceUsdStart: 3000,
+    });
+    expect(arg.goalSnippet).toContain("grow ETH");
+  });
+
+  it("no-ops when the mission is missing (nothing to open)", async () => {
+    const d = deps({ getMission: vi.fn(async () => null) });
+    await captureMissionStart({ missionId: "x", runId: "r", sessionId: "s" }, d);
+    expect(d.openResult).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the mission has no resolvable wallet/chain", async () => {
+    const d = deps({
+      getMission: vi.fn(async () => ({ ...MISSION, allowedWallets: [], allowedChains: [] } as never)),
+    });
+    await captureMissionStart({ missionId: "mission-1", runId: "r", sessionId: "s" }, d);
+    expect(d.openResult).not.toHaveBeenCalled();
+  });
+
+  it("is fail-soft — a throwing bankroll read never propagates", async () => {
+    const d = deps({ readBankroll: vi.fn(async () => { throw new Error("db down"); }) });
+    await expect(
+      captureMissionStart({ missionId: "mission-1", runId: "r", sessionId: "s" }, d),
+    ).resolves.toBeUndefined();
+  });
+
+  it("is fail-soft — a throwing getMission never propagates", async () => {
+    const d = deps({ getMission: vi.fn(async () => { throw new Error("db down"); }) });
+    await expect(
+      captureMissionStart({ missionId: "mission-1", runId: "r", sessionId: "s" }, d),
+    ).resolves.toBeUndefined();
+    expect(d.openResult).not.toHaveBeenCalled();
+  });
+});
+
+describe("captureMissionFinal", () => {
+  it("closes with PnL vs the opened start bankroll, the trade count, and the raw stop_reason", async () => {
+    const d = deps({
+      getResult: vi.fn(async () => ({ startedAt: "2026-07-12T18:00:00Z", bankrollStartEth: 0.01 } as never)),
+      readBankroll: vi.fn(async () => ({
+        bankrollEth: 0.011,
+        ethPriceUsd: 3100,
+        openPositions: [{ symbol: "NOXA", address: "0x", amount: 1, valueUsd: 5 }],
+      })),
+    });
+    await captureMissionFinal(
+      { missionId: "mission-1", runId: "run-1", sessionId: "s-1", outcome: "completed", stopReason: "goal_reached" },
+      d,
+    );
+    const arg = (d.closeResult as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(arg).toMatchObject({
+      missionRunId: "run-1",
+      outcome: "completed",
+      stopReason: "goal_reached",
+      bankrollEndEth: 0.011,
+      trades: 3,
+    });
+    expect(arg.pnlEth).toBeCloseTo(0.001, 9);
+    expect(arg.openPositions).toHaveLength(1);
+  });
+
+  it("closes a deadline_reached run with its raw stop_reason (presentation stays out of this module)", async () => {
+    const d = deps({
+      getResult: vi.fn(async () => ({ startedAt: "2026-07-12T18:00:00Z", bankrollStartEth: 0.01 } as never)),
+    });
+    await captureMissionFinal(
+      { missionId: "mission-1", runId: "run-1", sessionId: "s-1", outcome: "failed", stopReason: "deadline_reached" },
+      d,
+    );
+    const arg = (d.closeResult as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(arg.outcome).toBe("failed");
+    expect(arg.stopReason).toBe("deadline_reached");
+  });
+
+  it("no-ops when no ledger row was opened for the run", async () => {
+    const d = deps({ getResult: vi.fn(async () => null) });
+    await captureMissionFinal(
+      { missionId: "m", runId: "r", sessionId: "s", outcome: "failed", stopReason: "system_error" },
+      d,
+    );
+    expect(d.closeResult).not.toHaveBeenCalled();
+  });
+
+  it("is fail-soft — a throwing dependency never propagates", async () => {
+    const d = deps({
+      getResult: vi.fn(async () => { throw new Error("db down"); }),
+    });
+    await expect(
+      captureMissionFinal(
+        { missionId: "m", runId: "r", sessionId: "s", outcome: "failed", stopReason: "system_error" },
+        d,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/vex-agent/engine/mission/patch-parser.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/patch-parser.test.ts
@@ -35,6 +35,11 @@ describe("patch-parser", () => {
       expect(patch!.goal).toBe("Accumulate SOL");
     });
 
+    it("extracts a numeric durationMinutes field", () => {
+      const patch = extractMissionPatch({ durationMinutes: 5 });
+      expect(patch!.durationMinutes).toBe(5);
+    });
+
     it("extracts valid array fields", () => {
       const patch = extractMissionPatch({ allowedChains: ["solana"], successCriteria: ["10 SOL"] });
       expect(patch!.allowedChains).toEqual(["solana"]);
@@ -85,6 +90,39 @@ describe("patch-parser", () => {
       expect(result.title).toBeUndefined();
       expect(result.goal).toBeUndefined();
       expect(result.riskProfile).toBeUndefined();
+    });
+
+    // ── durationMinutes (numeric, NOT string) ──────────────────
+
+    it("keeps a numeric durationMinutes — regression: it must not be dropped as a string field", () => {
+      const result = sanitizePatch({ durationMinutes: 5 });
+      expect(result.durationMinutes).toBe(5);
+    });
+
+    it("truncates a fractional durationMinutes to a whole minute", () => {
+      const result = sanitizePatch({ durationMinutes: 5.9 });
+      expect(result.durationMinutes).toBe(5);
+    });
+
+    it("clamps durationMinutes to the 24h ceiling", () => {
+      const result = sanitizePatch({ durationMinutes: 99999 });
+      expect(result.durationMinutes).toBe(1440);
+    });
+
+    it("rejects a non-positive durationMinutes", () => {
+      expect(sanitizePatch({ durationMinutes: 0 }).durationMinutes).toBeUndefined();
+      expect(sanitizePatch({ durationMinutes: -5 }).durationMinutes).toBeUndefined();
+      expect(sanitizePatch({ durationMinutes: 0.5 }).durationMinutes).toBeUndefined();
+    });
+
+    it("passes null through for durationMinutes", () => {
+      const result = sanitizePatch({ durationMinutes: null });
+      expect(result.durationMinutes).toBeNull();
+    });
+
+    it("rejects a numeric-string durationMinutes (model must send a JSON number)", () => {
+      const result = sanitizePatch({ durationMinutes: "60" });
+      expect(result.durationMinutes).toBeUndefined();
     });
 
     it("sanitizes string arrays", () => {
@@ -147,6 +185,7 @@ describe("patch-parser", () => {
         successCriteria: ["Accumulated 10 SOL"],
         stopConditions: ["capital_depleted", "deadline_reached"],
         deadline: "2026-04-04",
+        durationMinutes: 60,
       });
 
       expect(result.title).toBe("SOL DCA Strategy");
@@ -160,6 +199,7 @@ describe("patch-parser", () => {
       expect(result.successCriteria).toEqual(["Accumulated 10 SOL"]);
       expect(result.stopConditions).toEqual(["capital_depleted", "deadline_reached"]);
       expect(result.deadline).toBe("2026-04-04");
+      expect(result.durationMinutes).toBe(60);
     });
 
     it("drops stopConditionsAccepted from model output", () => {

--- a/src/__tests__/vex-agent/engine/mission/renew.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/renew.test.ts
@@ -12,9 +12,14 @@ const mockGetMissionForUpdate = vi.fn();
 const mockGetActiveRun = vi.fn();
 const mockGetActiveRunBySession = vi.fn();
 const mockCloneMissionAsDraft = vi.fn();
+const mockLockSessionForRenew = vi.fn();
+const mockGetPendingDraftForSession = vi.fn();
 
 vi.mock("@vex-agent/db/repos/missions.js", () => ({
   getMissionForUpdate: (...a: unknown[]) => mockGetMissionForUpdate(...a),
+  lockSessionForRenew: (...a: unknown[]) => mockLockSessionForRenew(...a),
+  getPendingDraftForSession: (...a: unknown[]) =>
+    mockGetPendingDraftForSession(...a),
 }));
 
 vi.mock("@vex-agent/db/repos/mission-runs.js", () => ({
@@ -98,6 +103,8 @@ function makeMission(overrides: Record<string, unknown> = {}) {
 describe("renewMission", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLockSessionForRenew.mockResolvedValue(undefined);
+    mockGetPendingDraftForSession.mockResolvedValue(null);
   });
 
   it("returns previous_mission_not_found when source is missing", async () => {
@@ -191,6 +198,61 @@ describe("renewMission", () => {
     // (client, sourceMissionId, newMissionId, targetSessionId)
     expect(args[1]).toBe("mission-source");
     expect(args[3]).toBe("session-1");
+  });
+
+  it("acquires the session-scoped advisory lock before any precondition check", async () => {
+    mockGetMissionForUpdate.mockResolvedValueOnce(null);
+    await renewMission({
+      sessionId: "session-1",
+      previousMissionId: "mission-source",
+    });
+    expect(mockLockSessionForRenew).toHaveBeenCalledTimes(1);
+    const args = mockLockSessionForRenew.mock.calls[0]!;
+    expect(args[1]).toBe("session-1");
+    // Lock acquisition happened, but the source lookup still ran and failed
+    // first-precondition — proves the lock is taken up front, not gated
+    // behind other checks.
+    expect(mockGetMissionForUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns session_has_pending_draft when the session already holds a draft/ready mission, without cloning", async () => {
+    // WP-D: closes the duplicate-draft-storm race TRANSACTIONALLY (advisory
+    // lock + this check, both inside renewMission's transaction) rather than
+    // relying solely on the renderer/resolver suppressing the button.
+    mockGetMissionForUpdate.mockResolvedValueOnce(makeMission());
+    mockGetActiveRun.mockResolvedValueOnce(null);
+    mockGetActiveRunBySession.mockResolvedValueOnce(null);
+    mockGetPendingDraftForSession.mockResolvedValueOnce({
+      id: "mission-pending-draft",
+      status: "draft",
+    });
+
+    const outcome = await renewMission({
+      sessionId: "session-1",
+      previousMissionId: "mission-source",
+    });
+
+    expect(outcome.outcome).toBe("session_has_pending_draft");
+    if (outcome.outcome === "session_has_pending_draft") {
+      expect(outcome.missionId).toBe("mission-pending-draft");
+    }
+    expect(mockCloneMissionAsDraft).not.toHaveBeenCalled();
+  });
+
+  it("checks for a pending draft using the SAME tx client as the source-mission lock (same transaction)", async () => {
+    mockGetMissionForUpdate.mockResolvedValueOnce(makeMission());
+    mockGetActiveRun.mockResolvedValueOnce(null);
+    mockGetActiveRunBySession.mockResolvedValueOnce(null);
+
+    await renewMission({
+      sessionId: "session-1",
+      previousMissionId: "mission-source",
+    });
+
+    expect(mockGetPendingDraftForSession).toHaveBeenCalledTimes(1);
+    const lockClient = mockLockSessionForRenew.mock.calls[0]![0];
+    const draftCheckClient = mockGetPendingDraftForSession.mock.calls[0]![0];
+    expect(draftCheckClient).toBe(lockClient);
   });
 
   it("does not call the clone helper when any precondition fails", async () => {

--- a/src/__tests__/vex-agent/engine/runtime-clock.test.ts
+++ b/src/__tests__/vex-agent/engine/runtime-clock.test.ts
@@ -46,4 +46,35 @@ describe("runtime-clock", () => {
     expect(snapshot.missionDeadlineState).toBe("overdue by 19m 18s");
     expect(buildRuntimeClockPrompt(snapshot)).toContain("overdue by 19m 18s");
   });
+
+  // WP-I1: the deadline prompt line is NEUTRAL timebox awareness only — the
+  // mission auto-finalizes and open positions are reported as unresolved.
+  // It must never instruct the agent to sell/close/flatten a position; that
+  // is the deferred, approval-gated WP-I2 (prepared-flatten) surface.
+  it("adds a neutral timebox-awareness line when a mission deadline is present", () => {
+    const snapshot = buildRuntimeClockSnapshot({
+      now: new Date("2026-05-03T08:39:18.126Z"),
+      timezone: "UTC",
+      missionDeadline: "2026-05-03T14:10:00.000Z",
+    });
+    const prompt = buildRuntimeClockPrompt(snapshot);
+
+    expect(prompt).toContain("auto-finalizes");
+    expect(prompt).toContain("reported as unresolved");
+    // "not closed automatically" is a NEUTRAL description of what does NOT
+    // happen — it must not be confused with an instruction to act, so this
+    // checks for imperative trade verbs, not the word "close" in isolation.
+    for (const tradeInstruction of ["sell", "flatten", "liquidate", "exit the position", "close the position", "close all positions"]) {
+      expect(prompt.toLowerCase()).not.toContain(tradeInstruction);
+    }
+  });
+
+  it("omits the timebox-awareness line when there is no mission deadline", () => {
+    const snapshot = buildRuntimeClockSnapshot({
+      now: new Date("2026-05-03T08:39:18.126Z"),
+      timezone: "UTC",
+    });
+
+    expect(buildRuntimeClockPrompt(snapshot)).not.toContain("auto-finalizes");
+  });
 });

--- a/src/__tests__/vex-agent/engine/types.test.ts
+++ b/src/__tests__/vex-agent/engine/types.test.ts
@@ -126,10 +126,12 @@ describe("engine types", () => {
         successCriteria: null,
         stopConditions: null,
         deadline: null,
+        durationMinutes: null,
       };
       // Puzzle 04 removed `stopConditionsAccepted` from MissionDraft —
       // acceptance is host-only via `missions.accepted_contract_hash`.
-      expect(Object.keys(draft)).toHaveLength(11);
+      // WP-I1 added `durationMinutes` (hard time-box, minutes).
+      expect(Object.keys(draft)).toHaveLength(12);
     });
 
     it("accepts populated values", () => {
@@ -145,6 +147,7 @@ describe("engine types", () => {
         successCriteria: ["Accumulated 10 SOL"],
         stopConditions: ["capital_depleted", "deadline_reached"],
         deadline: "2026-04-04",
+        durationMinutes: 60,
       };
       expect(draft.title).toBe("SOL DCA Strategy");
       expect(draft.allowedChains).toEqual(["solana"]);
@@ -158,6 +161,10 @@ describe("engine types", () => {
 
     it("does not include deadline (optional)", () => {
       expect(MISSION_DRAFT_REQUIRED_FIELDS).not.toContain("deadline");
+    });
+
+    it("does not include durationMinutes (optional — env/default fallback)", () => {
+      expect(MISSION_DRAFT_REQUIRED_FIELDS).not.toContain("durationMinutes");
     });
 
     it("includes all business-critical fields", () => {

--- a/src/__tests__/vex-agent/tools/internal/mission.test.ts
+++ b/src/__tests__/vex-agent/tools/internal/mission.test.ts
@@ -102,6 +102,38 @@ describe("mission_draft_update tool", () => {
     });
   });
 
+  it("passes a numeric durationMinutes through the setup boundary", async () => {
+    // Regression: durationMinutes is model-set NUMERIC data (a whole-minute
+    // time-box). It must reach applyMissionPatch as a number, not be dropped
+    // by a string-only sanitizer (see patch-parser.ts).
+    mockApplyMissionPatch.mockResolvedValueOnce({
+      missionId: "mission-1",
+      status: "ready",
+      currentDraft: { durationMinutes: 30 },
+      missingFields: [],
+      ready: true,
+    });
+
+    const result = await handleMissionDraftUpdate(
+      { durationMinutes: 30 },
+      { ...baseContext, missionRunId: null },
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockApplyMissionPatch).toHaveBeenCalledWith("mission-1", {
+      durationMinutes: 30,
+    });
+  });
+
+  it("rejects a non-numeric durationMinutes", async () => {
+    const result = await handleMissionDraftUpdate(
+      { durationMinutes: "30 minutes" },
+      { ...baseContext, missionRunId: null },
+    );
+    expect(result.success).toBe(false);
+    expect(mockApplyMissionPatch).not.toHaveBeenCalled();
+  });
+
   it("returns the continue-button hint when a prior run exists", async () => {
     mockApplyMissionPatch.mockResolvedValueOnce({
       missionId: "mission-1",

--- a/src/__tests__/vex-agent/tools/internal/wallet/send/prepare.test.ts
+++ b/src/__tests__/vex-agent/tools/internal/wallet/send/prepare.test.ts
@@ -187,6 +187,18 @@ describe("handleWalletSendPrepare", () => {
         token: null,
       },
     });
+    expect(result.preparedActionFollowUp).toEqual({
+      toolName: "wallet_send_confirm",
+      args: {
+        network: "eip155",
+        intentId: createArgs.intentId,
+      },
+      expiresAt: createArgs.expiresAt,
+      approvalPreview: {
+        toolName: "wallet_send_confirm",
+        criticalArgs: createArgs.previewJson.criticalArgs,
+      },
+    });
   });
 
   it("rejects missing required fields", async () => {
@@ -218,7 +230,7 @@ describe("handleWalletSendPrepare", () => {
   });
 
   it("uses solana wallet address for solana network", async () => {
-    await handleWalletSendPrepare(
+    const result = await handleWalletSendPrepare(
       { network: "solana", to: "SoLAdr11111111111111111111111111111111", amount: "0.5" },
       makeContext(),
     );
@@ -226,5 +238,17 @@ describe("handleWalletSendPrepare", () => {
       "SoLanaAddr1111111111111111111111111111111",
     );
     expect(mockCreate.mock.calls[0][0].chainAlias).toBeNull();
+    expect(result.preparedActionFollowUp).toMatchObject({
+      args: { network: "solana" },
+      approvalPreview: {
+        criticalArgs: {
+          network: "solana",
+          chain: null,
+          to: "SoLAdr11111111111111111111111111111111",
+          amount: "0.5",
+          token: null,
+        },
+      },
+    });
   });
 });

--- a/src/__tests__/vex-agent/tools/khalani-bridge-terminal-status.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-bridge-terminal-status.test.ts
@@ -1,0 +1,196 @@
+/**
+ * khalani.bridge ToolResult honesty on terminal order status.
+ *
+ * Khalani's Integration Guide requires tracking a submitted order to a TERMINAL
+ * state (filled | refunded | failed). The deposit tx mining does NOT mean the
+ * destination leg filled — the handler previously hardcoded capture status
+ * "pending" and `success: true` regardless of the eventual order outcome, so a
+ * failed/refunded bridge still read as a successful tool call and rode a phantom
+ * "pending" capture into the projection pipeline.
+ *
+ * This suite pins the honest mapping (poll result is stubbed — the poll LOOP
+ * itself, incl. the 5s×24 budget, is covered in tools/khalani/order-status.test):
+ *   - filled                 → success:true, capture "executed", no warning msg;
+ *   - failed / refunded       → success:false, NO _tradeCapture, explicit
+ *     funds-returned/failed message; last-seen status stays readable;
+ *   - created/deposited/published (window close) → success:true, capture
+ *     "pending", explicit "NOT confirmed" message + actual last-seen status;
+ *   - refund_pending (window close) → success:true, capture "pending", explicit
+ *     "refund in flight, not yet delivered" message.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
+
+const SEL_EVM = "0x1111111111111111111111111111111111111111";
+
+vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
+  resolveSelectedAddress: () => SEL_EVM,
+  resolveSigningWallet: () => ({ family: "eip155", address: SEL_EVM, privateKey: ("0x" + "ab".repeat(32)) as `0x${string}` }),
+  walletScopeErrorToResult: (err: unknown) => ({ success: false, output: err instanceof Error ? err.message : String(err) }),
+}));
+
+vi.mock("@tools/khalani/chains.js", () => ({
+  getCachedKhalaniChains: vi.fn().mockResolvedValue([]),
+  getChain: vi.fn(() => ({ id: 1, type: "eip155" })),
+  getChainFamily: vi.fn(() => "eip155"),
+  resolveChainId: vi.fn(() => 1),
+}));
+
+vi.mock("@tools/wallet/inventory.js", () => ({
+  walletAddressesEqual: (_fam: string, a: string, b: string) => a === b,
+  familyToInventory: (f: string) => (f === "solana" ? "solana" : "evm"),
+}));
+
+vi.mock("@tools/khalani/request.js", () => ({
+  prepareQuoteRequest: vi.fn(async (input: { fromAddress: string; recipient: string }) => ({
+    chains: [],
+    fromChainId: 1,
+    toChainId: 42,
+    fromFamily: "eip155",
+    toFamily: "eip155",
+    request: { fromAddress: input.fromAddress, recipient: input.recipient },
+  })),
+}));
+
+vi.mock("@tools/khalani/client.js", () => ({
+  getKhalaniClient: () => ({
+    getQuotes: vi.fn(async () => ({
+      quoteId: "q1",
+      routes: [{ routeId: "r1", type: "fast", quote: { amountIn: "1", amountOut: "5", expectedDurationSeconds: 10, quoteExpiresAt: 0, validBefore: 0 } }],
+    })),
+    buildDeposit: vi.fn(async () => ({ kind: "CONTRACT_CALL", approvals: [] })),
+  }),
+}));
+
+vi.mock("@tools/khalani/helpers.js", () => ({ resolveRouteBestIndex: () => 0 }));
+
+vi.mock("@tools/khalani/bridge-executor.js", () => ({
+  executeDepositPlan: vi.fn(async () => ({ orderId: "o1", txHash: "0xhash" })),
+}));
+
+const mockPollOrderToTerminal = vi.fn();
+vi.mock("@tools/khalani/order-status.js", () => ({
+  pollKhalaniOrderToTerminal: (...a: unknown[]) => mockPollOrderToTerminal(...a),
+}));
+
+const { BRIDGE_HANDLERS } = await import("@vex-agent/tools/protocols/khalani/handlers/bridge.js");
+
+const SESSION_CTX: ProtocolExecutionContext = {
+  sessionPermission: "full",
+  approved: true,
+  walletResolution: { source: "session", evm: { id: "w-evm", address: SEL_EVM }, solana: null },
+  walletPolicy: { kind: "none" },
+};
+
+const PARAMS = { fromChain: "ethereum", toChain: "robinhood", fromToken: "USDC", toToken: "USDC", amount: "1000000" };
+
+const TERMINAL = new Set(["filled", "refunded", "failed"]);
+
+/** Map a status string to the poll module's discriminated result for the handler. */
+async function runBridge(finalStatus: string) {
+  const poll = TERMINAL.has(finalStatus)
+    ? { kind: "terminal", status: finalStatus }
+    : { kind: "pending", status: finalStatus };
+  mockPollOrderToTerminal.mockResolvedValue(poll);
+  return BRIDGE_HANDLERS["khalani.bridge"]!(PARAMS, SESSION_CTX);
+}
+
+/** The status-unavailable outcome (every poll threw). */
+async function runBridgeUnavailable() {
+  mockPollOrderToTerminal.mockResolvedValue({ kind: "unavailable" });
+  return BRIDGE_HANDLERS["khalani.bridge"]!(PARAMS, SESSION_CTX);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("khalani.bridge — terminal failure/refund must fail the tool result", () => {
+  for (const finalStatus of ["failed", "refunded"] as const) {
+    it(`finalStatus "${finalStatus}" → success:false, last-seen status preserved in output`, async () => {
+      const result = await runBridge(finalStatus);
+      expect(result.success).toBe(false);
+      const output = JSON.parse(result.output) as Record<string, unknown>;
+      expect(output.success).toBe(false);
+      expect(output.status).toBe(finalStatus);
+      expect(output.orderId).toBe("o1");
+    });
+
+    it(`finalStatus "${finalStatus}" → NO _tradeCapture (failures never reach proj_activity)`, async () => {
+      const result = await runBridge(finalStatus);
+      expect(result.data?._tradeCapture).toBeUndefined();
+      expect(result.data?.orderId).toBe("o1");
+      expect(result.data?.status).toBe(finalStatus);
+    });
+  }
+
+  it('a refund tells the agent funds were returned (no phantom "arrived" balance)', async () => {
+    const result = await runBridge("refunded");
+    const output = JSON.parse(result.output) as Record<string, unknown>;
+    expect(String(output.message)).toMatch(/refund/i);
+    expect(String(output.message)).toMatch(/did NOT arrive/i);
+  });
+
+  it("a failure tells the agent nothing arrived", async () => {
+    const result = await runBridge("failed");
+    const output = JSON.parse(result.output) as Record<string, unknown>;
+    expect(String(output.message)).toMatch(/failed/i);
+    expect(String(output.message)).toMatch(/did NOT arrive/i);
+  });
+});
+
+describe("khalani.bridge — filled is a confirmed delivery (success path)", () => {
+  it('finalStatus "filled" → success:true, capture "executed", no warning message', async () => {
+    const result = await runBridge("filled");
+    expect(result.success).toBe(true);
+    const capture = (result.data as { _tradeCapture?: Record<string, unknown> })._tradeCapture;
+    expect(capture?.status).toBe("executed");
+    const output = JSON.parse(result.output) as Record<string, unknown>;
+    expect(output.status).toBe("filled");
+    expect("message" in output).toBe(false);
+  });
+});
+
+describe("khalani.bridge — non-terminal window close must NOT read as delivery", () => {
+  for (const finalStatus of ["created", "deposited", "published"] as const) {
+    it(`finalStatus "${finalStatus}" → success:true, capture "pending", explicit not-confirmed message + last-seen status`, async () => {
+      const result = await runBridge(finalStatus);
+      expect(result.success).toBe(true);
+      const capture = (result.data as { _tradeCapture?: Record<string, unknown> })._tradeCapture;
+      expect(capture?.status).toBe("pending");
+      const output = JSON.parse(result.output) as Record<string, unknown>;
+      expect(output.status).toBe(finalStatus);
+      expect(String(output.message)).toMatch(/not.*confirm/i);
+      expect(String(output.message)).toContain(finalStatus);
+    });
+  }
+
+  it('finalStatus "refund_pending" → success:true, capture "pending", refund-in-flight-not-delivered message', async () => {
+    const result = await runBridge("refund_pending");
+    expect(result.success).toBe(true);
+    const capture = (result.data as { _tradeCapture?: Record<string, unknown> })._tradeCapture;
+    expect(capture?.status).toBe("pending");
+    const output = JSON.parse(result.output) as Record<string, unknown>;
+    expect(output.status).toBe("refund_pending");
+    expect(String(output.message)).toMatch(/refund/i);
+    expect(String(output.message)).toMatch(/in flight|not yet delivered|did NOT arrive/i);
+  });
+});
+
+describe("khalani.bridge — status unavailable (every poll threw) must NOT read as pending", () => {
+  it("unavailable → success:false, NO _tradeCapture, correlation ids (orderId + deposit txHash) preserved", async () => {
+    const result = await runBridgeUnavailable();
+    expect(result.success).toBe(false);
+    // A total status outage must not enqueue a projection for an unobserved order.
+    expect(result.data?._tradeCapture).toBeUndefined();
+    const output = JSON.parse(result.output) as Record<string, unknown>;
+    expect(output.success).toBe(false);
+    expect(output.status).toBe("unverified");
+    expect(output.orderId).toBe("o1");
+    expect(output.txHash).toBe("0xhash");
+    expect(String(output.message)).toMatch(/could NOT be verified|unreachable|UNCONFIRMED/i);
+    // Correlation ids also on data for the audit log.
+    expect(result.data?.orderId).toBe("o1");
+    expect(result.data?.txHash).toBe("0xhash");
+  });
+});

--- a/src/__tests__/vex-agent/tools/khalani-bridge-wallet-scope.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-bridge-wallet-scope.test.ts
@@ -63,6 +63,12 @@ vi.mock("@tools/khalani/helpers.js", () => ({ resolveRouteBestIndex: () => 0 }))
 const mockExecuteDepositPlan = vi.fn(async () => ({ orderId: "o1", txHash: "0xhash" }));
 vi.mock("@tools/khalani/bridge-executor.js", () => ({ executeDepositPlan: (...a: unknown[]) => mockExecuteDepositPlan(...a) }));
 
+// Terminal-status polling is exercised in khalani-bridge-terminal-status.test.ts.
+// Here it is stubbed to a confirmed fill so the wallet-scope assertions stay fast
+// (no 5s poll delay) and focused on session scoping, not order tracking.
+const mockPollOrderToTerminal = vi.fn(async () => ({ kind: "terminal", status: "filled" }));
+vi.mock("@tools/khalani/order-status.js", () => ({ pollKhalaniOrderToTerminal: (...a: unknown[]) => mockPollOrderToTerminal(...a) }));
+
 const { BRIDGE_HANDLERS } = await import("@vex-agent/tools/protocols/khalani/handlers/bridge.js");
 
 const SESSION_CTX: ProtocolExecutionContext = {
@@ -88,6 +94,7 @@ beforeEach(() => {
   });
   mockBuildDeposit.mockResolvedValue({ kind: "CONTRACT_CALL", approvals: [] });
   mockExecuteDepositPlan.mockResolvedValue({ orderId: "o1", txHash: "0xhash" });
+  mockPollOrderToTerminal.mockResolvedValue({ kind: "terminal", status: "filled" });
 });
 
 describe("khalani.bridge session wallet scope", () => {

--- a/src/__tests__/vex-agent/tools/polymarket-clob-bulk-cancel.test.ts
+++ b/src/__tests__/vex-agent/tools/polymarket-clob-bulk-cancel.test.ts
@@ -1,0 +1,129 @@
+/**
+ * polymarket.clob.cancelOrders / cancelAll / cancelMarket — ToolResult honesty.
+ *
+ * Before this fix, all three bulk-cancel handlers hardcoded `success: true`
+ * regardless of the venue's `not_canceled` map — the exact bug class fixed for
+ * clob.cancel (single) in the "partial-cancel correctness guard" suite, but
+ * left unfixed here. `_tradeCapture`/`_tradeCaptureItems` were also emitted
+ * unconditionally, including a phantom "cancelled" entry with count 0 when
+ * NOTHING was actually cancelled.
+ *
+ * Policy (mirrors clob.cancel's not_canceled check, extended to N ids):
+ *   - total rejection (canceled: [], not_canceled non-empty) → success:false,
+ *     no _tradeCapture / _tradeCaptureItems at all;
+ *   - partial success (some canceled, some not_canceled)     → success:true,
+ *     capture ONLY the ids that actually cancelled (ledger trace preserved,
+ *     mirrors relay.bridge's "pending" precedent of not losing a real trace);
+ *   - "nothing to cancel" (both empty — e.g. cancelAll with no open orders)
+ *     → success:true, no capture (legitimate no-op, not a failure).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockCancelOrders = vi.fn();
+const mockCancelAll = vi.fn();
+const mockCancelMarketOrders = vi.fn();
+
+vi.mock("@tools/polymarket/clob/client.js", () => ({
+  getPolyClobClient: () => ({
+    cancelOrders: (...a: unknown[]) => mockCancelOrders(...a),
+    cancelAll: (...a: unknown[]) => mockCancelAll(...a),
+    cancelMarketOrders: (...a: unknown[]) => mockCancelMarketOrders(...a),
+  }),
+}));
+vi.mock("@vex-agent/tools/internal/wallet/resolve.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vex-agent/tools/internal/wallet/resolve.js")>();
+  return {
+    ...actual,
+    resolveSelectedAddress: () => "0x1111111111111111111111111111111111111111",
+  };
+});
+
+const { POLYMARKET_HANDLERS } = await import("../../../vex-agent/tools/protocols/polymarket/handlers.js");
+
+const SIGNING_CTX = {
+  sessionPermission: "full" as const,
+  approved: true,
+  walletResolution: { source: "session" as const, evm: null, solana: null },
+  walletPolicy: { kind: "none" as const },
+};
+
+beforeEach(() => {
+  mockCancelOrders.mockReset();
+  mockCancelAll.mockReset();
+  mockCancelMarketOrders.mockReset();
+});
+
+describe("polymarket.clob.cancelOrders — bulk correctness guard", () => {
+  it("total rejection (nothing cancelled) — success:false, no capture", async () => {
+    mockCancelOrders.mockResolvedValue({ canceled: [], not_canceled: { a: "order not found", b: "order not found" } });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.cancelOrders"]!({ orderIds: "a,b" }, SIGNING_CTX);
+    expect(r.success).toBe(false);
+    expect(r.data?._tradeCapture).toBeUndefined();
+    expect(r.data?._tradeCaptureItems).toBeUndefined();
+  });
+
+  it("partial success — success:true, capture only the ids that cancelled", async () => {
+    mockCancelOrders.mockResolvedValue({ canceled: ["a"], not_canceled: { b: "order not found" } });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.cancelOrders"]!({ orderIds: "a,b" }, SIGNING_CTX);
+    expect(r.success).toBe(true);
+    expect(r.data?._tradeCapture).toBeDefined();
+    const items = r.data?._tradeCaptureItems as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(1);
+    expect(items[0]?.positionKey).toBe("a");
+    // The rejection reason is still visible in the raw output for diagnostics.
+    const out = JSON.parse(r.output);
+    expect(out.not_canceled.b).toBe("order not found");
+  });
+
+  it("full success — success:true, all ids captured", async () => {
+    mockCancelOrders.mockResolvedValue({ canceled: ["a", "b"], not_canceled: {} });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.cancelOrders"]!({ orderIds: "a,b" }, SIGNING_CTX);
+    expect(r.success).toBe(true);
+    const items = r.data?._tradeCaptureItems as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(2);
+  });
+});
+
+describe("polymarket.clob.cancelAll — bulk correctness guard", () => {
+  it("total rejection — success:false, no capture", async () => {
+    mockCancelAll.mockResolvedValue({ canceled: [], not_canceled: { a: "order not found" } });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.cancelAll"]!({}, SIGNING_CTX);
+    expect(r.success).toBe(false);
+    expect(r.data?._tradeCapture).toBeUndefined();
+  });
+
+  it("nothing to cancel (no open orders) — success:true, no capture (legitimate no-op)", async () => {
+    mockCancelAll.mockResolvedValue({ canceled: [], not_canceled: {} });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.cancelAll"]!({}, SIGNING_CTX);
+    expect(r.success).toBe(true);
+    expect(r.data?._tradeCapture).toBeUndefined();
+    expect(r.data?._tradeCaptureItems).toBeUndefined();
+  });
+
+  it("full success — success:true, captures all cancelled ids", async () => {
+    mockCancelAll.mockResolvedValue({ canceled: ["a", "b"], not_canceled: {} });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.cancelAll"]!({}, SIGNING_CTX);
+    expect(r.success).toBe(true);
+    expect(r.data?._tradeCapture).toMatchObject({ meta: { action: "cancelAll", count: 2 } });
+  });
+});
+
+describe("polymarket.clob.cancelMarket — bulk correctness guard", () => {
+  const PARAMS = { market: "0xCOND", assetId: "tok-1" };
+
+  it("total rejection — success:false, no capture, conditionId still on data", async () => {
+    mockCancelMarketOrders.mockResolvedValue({ canceled: [], not_canceled: { a: "order not found" } });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.cancelMarket"]!(PARAMS, SIGNING_CTX);
+    expect(r.success).toBe(false);
+    expect(r.data?._tradeCapture).toBeUndefined();
+    expect(r.data?.conditionId).toBe("0xCOND");
+  });
+
+  it("partial success — success:true, capture only cancelled ids", async () => {
+    mockCancelMarketOrders.mockResolvedValue({ canceled: ["a"], not_canceled: { b: "order not found" } });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.cancelMarket"]!(PARAMS, SIGNING_CTX);
+    expect(r.success).toBe(true);
+    const items = r.data?._tradeCaptureItems as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(1);
+  });
+});

--- a/src/__tests__/vex-agent/tools/polymarket-clob-order-rejection.test.ts
+++ b/src/__tests__/vex-agent/tools/polymarket-clob-order-rejection.test.ts
@@ -1,0 +1,140 @@
+/**
+ * polymarket.clob.buy/sell ToolResult honesty on venue rejection.
+ *
+ * Uses the exact fixture already present in polymarket-handlers.test.ts
+ * ("preserves a non-empty errorMsg in the lean output", success: false,
+ * orderID: "", errorMsg: "order rejected") — that existing test proves the
+ * lean-output SHAPING is correct (errorMsg survives), but it never asserted
+ * `r.success` or `_tradeCapture`. Before the fix, both handlers returned
+ * `success: true` and emitted a phantom `_tradeCapture` with status "open"
+ * for an order the venue never accepted (proven: 4/4 red against the
+ * unmodified handler). Now the venue's `success: false` drives the
+ * ToolResult and the capture pipeline directly.
+ *
+ * Mirrors the polymarket.clob.cancel guard a few lines below in the same
+ * file ("reports success=false when the requested order lands in
+ * not_canceled") — cancel already treated venue rejection as a ToolResult
+ * failure; buy/sell now get the same treatment.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockPostOrder = vi.fn();
+const mockGetFeeRate = vi.fn(() => Promise.resolve({ base_fee: 0 }));
+const mockResolveMarket = vi.fn();
+
+vi.mock("@tools/polymarket/clob/client.js", () => ({
+  getPolyClobClient: () => ({
+    postOrder: (...a: unknown[]) => mockPostOrder(...a),
+    getFeeRate: (...a: unknown[]) => mockGetFeeRate(...a),
+  }),
+}));
+vi.mock("@tools/polymarket/gamma/client.js", () => ({
+  getPolyGammaClient: () => ({ resolveMarket: (...a: unknown[]) => mockResolveMarket(...a) }),
+}));
+vi.mock("@tools/polymarket/auth.js", () => ({
+  requirePolyClobCredentials: () => ({ apiKey: "test-api-key", apiSecret: "secret", passphrase: "pass" }),
+}));
+vi.mock("@tools/polymarket/clob/signing.js", () => ({
+  buildClobOrder: () => ({ maker: "0xMAKER", side: "BUY" }),
+  signClobOrder: () => Promise.resolve("0xSIGNATURE"),
+}));
+vi.mock("@vex-agent/tools/internal/wallet/resolve.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vex-agent/tools/internal/wallet/resolve.js")>();
+  return {
+    ...actual,
+    resolveSelectedAddress: () => "0x1111111111111111111111111111111111111111",
+    resolveSigningWallet: () => ({
+      family: "eip155" as const,
+      address: "0x1111111111111111111111111111111111111111",
+      privateKey: "0xabc",
+    }),
+  };
+});
+
+const { POLYMARKET_HANDLERS } = await import("../../../vex-agent/tools/protocols/polymarket/handlers.js");
+
+const SIGNING_CTX = {
+  sessionPermission: "full" as const,
+  approved: true,
+  walletResolution: { source: "session" as const, evm: null, solana: null },
+  walletPolicy: { kind: "none" as const },
+};
+
+const BUY_PARAMS = { conditionId: "0xCOND", outcome: "YES", amount: 10, price: 0.5 };
+const SELL_PARAMS = { conditionId: "0xCOND", outcome: "YES", amount: 8, price: 0.4 };
+
+// The venue's own rejection response — the shape sendOrderResponseSchema
+// actually produces (success: isTrue -> false, errorMsg carries the reason).
+// Not hypothetical: this is the CLOB's real "order not accepted" response.
+const REJECTED = {
+  success: false,
+  orderID: "",
+  status: "live" as const,
+  errorMsg: "not enough balance/allowance",
+};
+
+beforeEach(() => {
+  mockPostOrder.mockReset().mockResolvedValue(REJECTED);
+  mockGetFeeRate.mockReset().mockResolvedValue({ base_fee: 0 });
+  mockResolveMarket.mockReset().mockResolvedValue({
+    clobTokenIds: '["yesTok","noTok"]',
+    negRisk: false,
+    question: "Test market?",
+  });
+});
+
+describe("polymarket.clob.buy — venue rejection must fail the tool result", () => {
+  it("venue said success:false, errorMsg set, no orderID — ToolResult is a failure", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.buy"]!(BUY_PARAMS, SIGNING_CTX);
+    expect(r.success).toBe(false);
+  });
+
+  it("venue said success:false — no _tradeCapture (no phantom open order)", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.buy"]!(BUY_PARAMS, SIGNING_CTX);
+    expect(r.data?._tradeCapture).toBeUndefined();
+  });
+
+  it("venue said success:false — errorMsg/orderID/status still readable in output", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.buy"]!(BUY_PARAMS, SIGNING_CTX);
+    const out = JSON.parse(r.output);
+    expect(out.errorMsg).toBe(REJECTED.errorMsg);
+    expect(out.orderID).toBe("");
+    expect(out.filled).toBe(false);
+  });
+
+  it("regression: a matched order still succeeds and still captures", async () => {
+    mockPostOrder.mockResolvedValue({
+      success: true,
+      orderID: "0xORDER",
+      status: "matched",
+      errorMsg: "",
+    });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.buy"]!(BUY_PARAMS, SIGNING_CTX);
+    expect(r.success).toBe(true);
+    expect(r.data?._tradeCapture).toMatchObject({ status: "executed" });
+  });
+});
+
+describe("polymarket.clob.sell — venue rejection must fail the tool result", () => {
+  it("venue said success:false, errorMsg set, no orderID — ToolResult is a failure", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.sell"]!(SELL_PARAMS, SIGNING_CTX);
+    expect(r.success).toBe(false);
+  });
+
+  it("venue said success:false — no _tradeCapture (no phantom open order)", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.sell"]!(SELL_PARAMS, SIGNING_CTX);
+    expect(r.data?._tradeCapture).toBeUndefined();
+  });
+
+  it("regression: a matched order still succeeds and still captures", async () => {
+    mockPostOrder.mockResolvedValue({
+      success: true,
+      orderID: "0xSELLORDER",
+      status: "matched",
+      errorMsg: "",
+    });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.sell"]!(SELL_PARAMS, SIGNING_CTX);
+    expect(r.success).toBe(true);
+    expect(r.data?._tradeCapture).toMatchObject({ status: "closed" });
+  });
+});

--- a/src/__tests__/vex-agent/tools/polymarket-wallet-scope.test.ts
+++ b/src/__tests__/vex-agent/tools/polymarket-wallet-scope.test.ts
@@ -28,7 +28,7 @@ vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
 
 const mockGetPrice = vi.fn().mockResolvedValue({ price: 0.5 });
 const mockGetFeeRate = vi.fn().mockResolvedValue({ base_fee: 0 });
-const mockPostOrder = vi.fn().mockResolvedValue({ status: "matched", orderID: "oid-1" });
+const mockPostOrder = vi.fn().mockResolvedValue({ success: true, status: "matched", orderID: "oid-1" });
 const mockCancelOrder = vi.fn().mockResolvedValue({ canceled: ["oid-1"], not_canceled: {} });
 const mockGetTrades = vi.fn().mockResolvedValue({ data: [], next_cursor: "" });
 vi.mock("@tools/polymarket/clob/client.js", () => ({
@@ -77,7 +77,7 @@ beforeEach(() => {
   mockResolveSelectedAddress.mockReturnValue(SEL);
   mockGetPrice.mockResolvedValue({ price: 0.5 });
   mockGetFeeRate.mockResolvedValue({ base_fee: 0 });
-  mockPostOrder.mockResolvedValue({ status: "matched", orderID: "oid-1" });
+  mockPostOrder.mockResolvedValue({ success: true, status: "matched", orderID: "oid-1" });
   mockCancelOrder.mockResolvedValue({ canceled: ["oid-1"], not_canceled: {} });
   mockGetTrades.mockResolvedValue({ data: [], next_cursor: "" });
   mockBuildClobOrder.mockReturnValue({ salt: "1", maker: SEL, signer: SEL });

--- a/src/__tests__/vex-agent/tools/protocols/uniswap-economic-side.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/uniswap-economic-side.test.ts
@@ -1,0 +1,41 @@
+/**
+ * classifyEconomicSide — the recorded trade side must follow the ECONOMIC
+ * direction (which way native flows), not which tool was invoked. A token can
+ * be bought via `uniswap.swap.sell` (native-in) or sold via `uniswap.swap.buy`
+ * (native-out), so the tool's `side` is not a reliable accounting label.
+ */
+
+import { describe, it, expect } from "vitest";
+import { classifyEconomicSide } from "@vex-agent/tools/protocols/uniswap/handlers/swap.js";
+
+describe("classifyEconomicSide", () => {
+  // ── native → token is always a BUY, regardless of the tool invoked ──────────
+
+  it("native → token = buy via the buy-tool", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: true, tokenOutIsNative: false, side: "buy" })).toBe("buy");
+  });
+
+  it("native → token = buy even when routed via the sell-tool (the bug)", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: true, tokenOutIsNative: false, side: "sell" })).toBe("buy");
+  });
+
+  // ── token → native is always a SELL, regardless of the tool invoked ─────────
+
+  it("token → native = sell via the sell-tool", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: true, side: "sell" })).toBe("sell");
+  });
+
+  it("token → native = sell even when routed via the buy-tool", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: true, side: "buy" })).toBe("sell");
+  });
+
+  // ── token ↔ token has no native anchor: fall back to the tool's side ────────
+
+  it("token → token falls back to the tool side (buy)", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: false, side: "buy" })).toBe("buy");
+  });
+
+  it("token → token falls back to the tool side (sell)", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: false, side: "sell" })).toBe("sell");
+  });
+});

--- a/src/__tests__/vex-agent/tools/registry-prepared-action-follow-ups.test.ts
+++ b/src/__tests__/vex-agent/tools/registry-prepared-action-follow-ups.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { validatePreparedActionFollowUp } from "../../../vex-agent/tools/registry/prepared-action-follow-ups.js";
+
+const INTENT_ID = "intent-00000000-0000-4000-8000-000000000001";
+const EXPIRES_AT = "2030-01-01T00:00:00.000Z";
+
+function candidate() {
+  return {
+    toolName: "wallet_send_confirm",
+    args: { network: "solana", intentId: INTENT_ID },
+    expiresAt: EXPIRES_AT,
+    approvalPreview: {
+      toolName: "wallet_send_confirm",
+      criticalArgs: {
+        network: "solana",
+        chain: null,
+        to: "3SnLmaqoEczS2ft7RLQ1BRhtsLuAauWnx9K7pDjSRQrp",
+        amount: "32.813008",
+        token: "ANSEM",
+      },
+    },
+  };
+}
+
+describe("prepared-action follow-up registry", () => {
+  it("allows and canonicalizes wallet_send_prepare → wallet_send_confirm", () => {
+    const input = candidate();
+    const result = validatePreparedActionFollowUp("wallet_send_prepare", input);
+    expect(result).toEqual({
+      ok: true,
+      followUp: input,
+    });
+  });
+
+  it("rejects unknown source→target pairs", () => {
+    expect(
+      validatePreparedActionFollowUp("token_find", candidate()),
+    ).toEqual({ ok: false, reason: "unknown_mapping" });
+    expect(
+      validatePreparedActionFollowUp("wallet_send_prepare", {
+        ...candidate(),
+        toolName: "swap",
+      }),
+    ).toEqual({ ok: false, reason: "unknown_mapping" });
+  });
+
+  it("rejects a second mapping attempt (maintainer decision: wallet-only, exactly one mapping)", () => {
+    expect(
+      validatePreparedActionFollowUp("kyberswap_prequote", {
+        ...candidate(),
+        toolName: "kyberswap_execute",
+      }),
+    ).toEqual({ ok: false, reason: "unknown_mapping" });
+  });
+
+  it("rejects extra confirm args and spoofed or malformed trusted previews", () => {
+    expect(
+      validatePreparedActionFollowUp("wallet_send_prepare", {
+        ...candidate(),
+        args: { ...candidate().args, to: "model-supplied" },
+      }),
+    ).toEqual({ ok: false, reason: "invalid_contract" });
+    expect(
+      validatePreparedActionFollowUp("wallet_send_prepare", {
+        ...candidate(),
+        approvalPreview: {
+          ...candidate().approvalPreview,
+          criticalArgs: {
+            ...candidate().approvalPreview.criticalArgs,
+            network: "eip155",
+          },
+        },
+      }),
+    ).toEqual({ ok: false, reason: "invalid_contract" });
+  });
+
+  it("rejects a malformed intentId shape", () => {
+    expect(
+      validatePreparedActionFollowUp("wallet_send_prepare", {
+        ...candidate(),
+        args: { network: "solana", intentId: "not-a-uuid" },
+      }),
+    ).toEqual({ ok: false, reason: "invalid_contract" });
+  });
+
+  it("rejects an unparsable expiry", () => {
+    expect(
+      validatePreparedActionFollowUp("wallet_send_prepare", {
+        ...candidate(),
+        expiresAt: "not-a-date",
+      }),
+    ).toEqual({ ok: false, reason: "invalid_contract" });
+  });
+
+  it("rejects an eip155 preview missing a chain and a solana preview carrying one", () => {
+    expect(
+      validatePreparedActionFollowUp("wallet_send_prepare", {
+        toolName: "wallet_send_confirm",
+        args: { network: "eip155", intentId: INTENT_ID },
+        expiresAt: EXPIRES_AT,
+        approvalPreview: {
+          toolName: "wallet_send_confirm",
+          criticalArgs: {
+            network: "eip155",
+            chain: null,
+            to: "0xfedcba0987654321fedcba0987654321fedcba09",
+            amount: "1.5",
+            token: null,
+          },
+        },
+      }),
+    ).toEqual({ ok: false, reason: "invalid_contract" });
+    expect(
+      validatePreparedActionFollowUp("wallet_send_prepare", {
+        ...candidate(),
+        approvalPreview: {
+          ...candidate().approvalPreview,
+          criticalArgs: {
+            ...candidate().approvalPreview.criticalArgs,
+            chain: "base",
+          },
+        },
+      }),
+    ).toEqual({ ok: false, reason: "invalid_contract" });
+  });
+});

--- a/src/__tests__/vex-agent/tools/relay-bridge-capture.test.ts
+++ b/src/__tests__/vex-agent/tools/relay-bridge-capture.test.ts
@@ -110,6 +110,7 @@ beforeEach(() => {
   mockExecuteRelayBridge.mockResolvedValue({
     requestId: "0xreq",
     finalStatus: "success",
+    statusObserved: true,
     txHashes: ["0xhash1"],
     // Per-hop records (origin Base) — the handler maps these to `_explorerRefs`.
     transactions: [{ chainId: 8453, hash: "0xhash1" }],
@@ -200,6 +201,7 @@ describe("relay.bridge explorer refs", () => {
     mockExecuteRelayBridge.mockResolvedValue({
       requestId: "0xreq",
       finalStatus: "success",
+      statusObserved: true,
       txHashes: ["0xorigin", "0xdest"],
       transactions: [
         { chainId: 8453, hash: "0xorigin" },
@@ -218,6 +220,7 @@ describe("relay.bridge explorer refs", () => {
     mockExecuteRelayBridge.mockResolvedValue({
       requestId: "0xreq",
       finalStatus: "success",
+      statusObserved: true,
       txHashes: ["0xorigin", "0xdest"],
       transactions: [
         { chainId: 8453, hash: "0xorigin" },

--- a/src/__tests__/vex-agent/tools/relay-bridge-terminal-status.test.ts
+++ b/src/__tests__/vex-agent/tools/relay-bridge-terminal-status.test.ts
@@ -1,0 +1,205 @@
+/**
+ * relay.bridge ToolResult honesty on terminal Relay statuses.
+ *
+ * `executeRelayBridge` polls the Relay intent to a terminal status and RETURNS
+ * it as a string — `RELAY_TERMINAL_STATUSES` includes "failure" and "refund",
+ * and `pollToTerminal` does not throw on either. The handler previously
+ * returned a hardcoded `success: true` (with a literal `success: true` in the
+ * output JSON next to `status: "failure"`), so a bridge the Relay API reported
+ * as terminally failed or refunded still read as a successful tool call to the
+ * agent, and its capture passed the success-gated projection pipeline
+ * (runtime/capture.ts populates proj_activity ONLY for successful executions;
+ * db/repos/activity.ts documents that a failed action never emits
+ * `_tradeCapture`).
+ *
+ * This suite pins the honest mapping:
+ *   - "failure" / "refund"  → success: false, NO `_tradeCapture`, NO auto-pin;
+ *     structured status/requestId/txHashes preserved in the output, and a
+ *     refund says so (funds returned) so the agent does not invent recovery.
+ *   - "success"             → unchanged (success: true, capture "executed", pin).
+ *   - "pending" (poll window exhausted; the bridge may still complete)
+ *                           → unchanged success/capture/pin semantics, plus an
+ *     explicit message so the model does not read "pending" as completion.
+ *
+ * NOTE: this is the API-status layer, distinct from the per-step on-chain
+ * receipt guard (receipt-guard.ts): every step can mine successfully and the
+ * Relay intent can still terminate as failure/refund.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
+import type { RelayQuoteResponse } from "@tools/relay/types.js";
+
+const SEL_EVM = "0x1111111111111111111111111111111111111111";
+
+const mockGetQuote = vi.fn();
+const mockGetCachedRelayChains = vi.fn();
+vi.mock("@tools/relay/client.js", () => ({
+  getRelayClient: () => ({ getQuote: (...a: unknown[]) => mockGetQuote(...a) }),
+  getCachedRelayChains: (...a: unknown[]) => mockGetCachedRelayChains(...a),
+}));
+
+const mockExecuteRelayBridge = vi.fn();
+vi.mock("@tools/relay/execute.js", () => ({
+  executeRelayBridge: (...a: unknown[]) => mockExecuteRelayBridge(...a),
+}));
+
+vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
+  resolveSelectedAddress: () => SEL_EVM,
+  resolveSigningWallet: () => ({ family: "eip155", address: SEL_EVM, privateKey: ("0x" + "ab".repeat(32)) as `0x${string}` }),
+  walletScopeErrorToResult: (err: unknown) => ({ success: false, output: err instanceof Error ? err.message : String(err) }),
+}));
+
+const mockPinTrackedToken = vi.fn();
+vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
+  pinTrackedToken: (...a: unknown[]) => mockPinTrackedToken(...a),
+}));
+
+const { RELAY_BRIDGE_HANDLERS } = await import("@vex-agent/tools/protocols/relay/handlers/bridge.js");
+
+const SESSION_CTX: ProtocolExecutionContext = {
+  sessionPermission: "full",
+  approved: true,
+  walletResolution: { source: "session", evm: { id: "w-evm", address: SEL_EVM }, solana: null },
+  walletPolicy: { kind: "none" },
+};
+
+const CHAINS = [
+  { id: 8453, name: "base", currency: { symbol: "ETH", decimals: 18 } },
+  { id: 4663, name: "robinhood", currency: { symbol: "ETH", decimals: 18 } },
+];
+
+const STEP = {
+  id: "deposit",
+  kind: "transaction",
+  requestId: "0xreq",
+  items: [{ status: "incomplete", data: { to: "0x2222222222222222222222222222222222222222", value: "1714000000000000", data: "0x", chainId: 8453 } }],
+};
+
+// ERC-20 destination on a LOCAL chain (4663) so the auto-pin path is armed.
+const PARAMS = {
+  fromChain: "base",
+  fromToken: "native",
+  toChain: "robinhood",
+  toToken: "0xc6911796042b15d7Fa4F6CDe69e245DdCd3d9c31",
+  amount: "1714000000000000",
+};
+
+function bridgeResult(finalStatus: string, statusObserved = true) {
+  // `transactions` (per-hop broadcast records) is required by the success/
+  // pending path's `_explorerRefs` mapping (explorer-links feature, landed
+  // after this suite's original PR baseline) — the terminal failure/refund
+  // path returns before that mapping runs, so it does not need this field,
+  // but the mock must supply it for the "success" and "pending" cases.
+  // `statusObserved` defaults true: every case below except the explicit
+  // "unverifiable" test represents a status that WAS actually observed.
+  return { requestId: "0xreq", finalStatus, txHashes: ["0xhash1"], transactions: [{ chainId: 8453, hash: "0xhash1" }], statusObserved };
+}
+
+async function runBridge(finalStatus: string, statusObserved = true) {
+  mockExecuteRelayBridge.mockResolvedValue(bridgeResult(finalStatus, statusObserved));
+  return RELAY_BRIDGE_HANDLERS["relay.bridge"]!(PARAMS, SESSION_CTX);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetCachedRelayChains.mockResolvedValue(CHAINS);
+  mockGetQuote.mockResolvedValue({ steps: [STEP] } as RelayQuoteResponse);
+  mockPinTrackedToken.mockResolvedValue({ inserted: true });
+});
+
+describe("relay.bridge — terminal failure/refund must fail the tool result", () => {
+  for (const finalStatus of ["failure", "refund"] as const) {
+    it(`finalStatus "${finalStatus}" → success: false, status/requestId/txHashes preserved in output`, async () => {
+      const result = await runBridge(finalStatus);
+      expect(result.success).toBe(false);
+      const output = JSON.parse(result.output) as Record<string, unknown>;
+      expect(output.success).toBe(false);
+      expect(output.status).toBe(finalStatus);
+      expect(output.requestId).toBe("0xreq");
+      expect(output.txHashes).toEqual(["0xhash1"]);
+    });
+
+    it(`finalStatus "${finalStatus}" → NO _tradeCapture (failures never reach proj_activity)`, async () => {
+      const result = await runBridge(finalStatus);
+      const data = result.data as Record<string, unknown> | undefined;
+      expect(data?._tradeCapture).toBeUndefined();
+      // Correlation fields survive for diagnostics.
+      expect(data?.requestId).toBe("0xreq");
+      expect(data?.status).toBe(finalStatus);
+    });
+
+    it(`finalStatus "${finalStatus}" → destination token is NOT auto-pinned`, async () => {
+      await runBridge(finalStatus);
+      expect(mockPinTrackedToken).not.toHaveBeenCalled();
+    });
+  }
+
+  it('a refund tells the agent funds were returned (no phantom "arrived" balance)', async () => {
+    const result = await runBridge("refund");
+    const output = JSON.parse(result.output) as Record<string, unknown>;
+    expect(String(output.message)).toMatch(/refund/i);
+  });
+});
+
+describe("relay.bridge — success path is unchanged (regression)", () => {
+  it('finalStatus "success" → success: true, capture "executed", destination pinned', async () => {
+    const result = await runBridge("success");
+    expect(result.success).toBe(true);
+    const capture = (result.data as { _tradeCapture?: Record<string, unknown> })._tradeCapture;
+    expect(capture?.status).toBe("executed");
+    expect(mockPinTrackedToken).toHaveBeenCalledWith({
+      walletAddress: SEL_EVM,
+      chainId: 4663,
+      tokenAddress: "0xc6911796042b15d7Fa4F6CDe69e245DdCd3d9c31",
+      source: "bridge",
+    });
+  });
+});
+
+describe("relay.bridge — pending (poll window exhausted, may still complete)", () => {
+  it('finalStatus "pending" → success/capture/pin semantics preserved, explicit message added', async () => {
+    const result = await runBridge("pending");
+    // Broadcast happened and the bridge may still confirm: keep the tool result
+    // successful so the "pending" capture keeps its ledger trace (the projection
+    // gate drops captures from failed results).
+    expect(result.success).toBe(true);
+    const capture = (result.data as { _tradeCapture?: Record<string, unknown> })._tradeCapture;
+    expect(capture?.status).toBe("pending");
+    expect(mockPinTrackedToken).toHaveBeenCalled();
+    // …but the model must not read "pending" as completion.
+    const output = JSON.parse(result.output) as Record<string, unknown>;
+    expect(String(output.message)).toMatch(/not.*confirm/i);
+  });
+
+  it("surfaces the ACTUAL last-seen non-terminal status in output.status AND the message (not flattened to a generic 'pending')", async () => {
+    // "submitted" is a live, non-terminal Relay status distinct from the
+    // "pending" default — the capture still records "pending" (non-success), but
+    // the raw last-seen value must reach the model verbatim so it can reason
+    // about how far the bridge actually got.
+    const result = await runBridge("submitted");
+    expect(result.success).toBe(true);
+    const output = JSON.parse(result.output) as Record<string, unknown>;
+    expect(output.status).toBe("submitted");
+    expect(String(output.message)).toContain("submitted");
+    const capture = (result.data as { _tradeCapture?: Record<string, unknown> })._tradeCapture;
+    expect(capture?.status).toBe("pending");
+  });
+});
+
+describe("relay.bridge — status unverifiable (every poll threw / no request id)", () => {
+  it("statusObserved:false → success:false, NO _tradeCapture, NO pin, correlation ids preserved", async () => {
+    // finalStatus is the synthetic "pending" seed, but the status was NEVER
+    // observed — the handler must NOT mask that as a benign pending capture.
+    const result = await runBridge("pending", false);
+    expect(result.success).toBe(false);
+    const output = JSON.parse(result.output) as Record<string, unknown>;
+    expect(output.success).toBe(false);
+    expect(output.status).toBe("unverified");
+    expect(output.requestId).toBe("0xreq");
+    expect(output.txHashes).toEqual(["0xhash1"]);
+    expect(String(output.message)).toMatch(/could NOT be verified|unreachable/i);
+    const data = result.data as Record<string, unknown> | undefined;
+    expect(data?._tradeCapture).toBeUndefined();
+    expect(mockPinTrackedToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/khalani/order-status.ts
+++ b/src/tools/khalani/order-status.ts
@@ -1,0 +1,78 @@
+/**
+ * Khalani order status polling.
+ *
+ * Khalani's official Integration Guide REQUIRES tracking a submitted bridge
+ * order to a TERMINAL state — a deposit tx mining does NOT mean the destination
+ * leg filled. `getOrderById` returns the live `OrderStatus`; the terminal set is
+ * {filled, refunded, failed}. `refund_pending` is explicitly NON-terminal with
+ * no documented SLA, so it NEVER ends the poll — the caller surfaces it as an
+ * in-flight (not-yet-delivered) refund when the bounded window closes.
+ *
+ * Cadence mirrors the official reference (5s interval, 24 polls ≈ 2 min) and the
+ * Relay substrate's bounded `pollToTerminal`: we never block a turn forever.
+ */
+
+import { getKhalaniClient } from "./client.js";
+import type { OrderStatus } from "./types.js";
+import { VexError } from "../../errors.js";
+import logger from "../../utils/logger.js";
+
+export const KHALANI_TERMINAL_STATUSES: ReadonlySet<OrderStatus> = new Set<OrderStatus>([
+  "filled",
+  "refunded",
+  "failed",
+]);
+
+/**
+ * The three DISTINCT outcomes of tracking an order — the caller must not conflate
+ * them:
+ *   - `terminal`: a terminal status (filled/refunded/failed) was OBSERVED;
+ *   - `pending`: a non-terminal status was OBSERVED but the bounded window closed
+ *     before it settled (the order is live, may still complete);
+ *   - `unavailable`: NO poll ever succeeded (Khalani status API unreachable for
+ *     the whole window) — delivery is UNKNOWN, NOT benignly pending. Masking this
+ *     as a pending order would enqueue a projection for a status nobody observed.
+ */
+export type KhalaniOrderPoll =
+  | { readonly kind: "terminal"; readonly status: OrderStatus }
+  | { readonly kind: "pending"; readonly status: OrderStatus }
+  | { readonly kind: "unavailable" };
+
+// Official reference: poll every 5s, up to 24 times (~2 min).
+const POLL_INTERVAL_MS = 5_000;
+const POLL_MAX_ATTEMPTS = 24;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll a Khalani order toward a terminal status (bounded). Returns a `terminal`
+ * result once one is observed; otherwise, when the budget is exhausted, `pending`
+ * with the last OBSERVED non-terminal status, or `unavailable` when NO poll ever
+ * succeeded. There is NO synthetic default status — a status is only ever reported
+ * because `getOrderById` actually returned it. Poll failures are swallowed
+ * (logged, bounded reason class only) so one transient error does not abort the
+ * whole track, but a track where EVERY poll fails resolves to `unavailable`.
+ */
+export async function pollKhalaniOrderToTerminal(orderId: string): Promise<KhalaniOrderPoll> {
+  const client = getKhalaniClient();
+  let lastObserved: OrderStatus | null = null;
+  for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS; attempt++) {
+    await delay(POLL_INTERVAL_MS);
+    try {
+      const order = await client.getOrderById(orderId);
+      lastObserved = order.status;
+      if (KHALANI_TERMINAL_STATUSES.has(order.status)) {
+        return { kind: "terminal", status: order.status };
+      }
+    } catch (err) {
+      logger.warn("khalani.bridge.status_poll_failed", {
+        reason: err instanceof VexError ? err.code : "unknown",
+      });
+    }
+  }
+  return lastObserved === null
+    ? { kind: "unavailable" }
+    : { kind: "pending", status: lastObserved };
+}

--- a/src/tools/relay/client.ts
+++ b/src/tools/relay/client.ts
@@ -22,6 +22,13 @@ import {
 const REQUEST_TIMEOUT_MS = 30_000;
 const CHAINS_TTL_MS = 60 * 60 * 1000; // 1h
 
+/**
+ * Canonical Relay intent-status path. Single source of truth: used both to build
+ * the status request AND to validate a quote's step `check.endpoint` before we
+ * trust the requestId it carries (see relay/execute deriveRequestId).
+ */
+export const RELAY_INTENT_STATUS_PATH = "/intents/status/v3";
+
 function mapTransportError(err: unknown): never {
   if (err instanceof VexError && err.code === ErrorCodes.HTTP_TIMEOUT) {
     throw new VexError(ErrorCodes.RELAY_TIMEOUT, err.message, err.hint);
@@ -84,7 +91,7 @@ export class RelayClient {
   }
 
   getIntentStatus(requestId: string): Promise<RelayStatusResponse> {
-    return this.request("/intents/status/v3", (raw) => RelayStatusResponseSchema.parse(raw), {
+    return this.request(RELAY_INTENT_STATUS_PATH, (raw) => RelayStatusResponseSchema.parse(raw), {
       query: { requestId },
     });
   }

--- a/src/tools/relay/execute.ts
+++ b/src/tools/relay/execute.ts
@@ -38,8 +38,9 @@ import {
 import type { ChainWallet } from "@tools/wallet/multi-auth.js";
 import { VexError, ErrorCodes } from "../../errors.js";
 import logger from "../../utils/logger.js";
-import { getRelayClient } from "./client.js";
+import { getRelayClient, RELAY_INTENT_STATUS_PATH } from "./client.js";
 import { RELAY_TERMINAL_STATUSES, type RelayQuoteResponse } from "./types.js";
+import { loadConfig } from "../../config/store.js";
 
 interface EvmClients {
   publicClient: PublicClient<Transport, Chain>;
@@ -66,30 +67,44 @@ function delay(ms: number): Promise<void> {
 
 // Bounded status-poll budget: relay soft-confirms fast, but we never block a turn
 // indefinitely. On timeout we return the last non-terminal status (the capture
-// records it as pending — the intent is still live on Relay).
+// records it as pending — the intent is still live on Relay). Relay's docs
+// recommend polling the status endpoint ~once per second; a constant 1s interval
+// within the 60s budget makes the final poll land right at window close (the old
+// 2s→8s backoff left the last poll near t=54s, missing late terminal flips).
 const POLL_MAX_MS = 60_000;
-const POLL_INITIAL_MS = 2_000;
-const POLL_MAX_INTERVAL_MS = 8_000;
+const POLL_INTERVAL_MS = 1_000;
 
-async function pollToTerminal(requestId: string): Promise<string> {
+/**
+ * Result of the bounded status poll. `observed` is true iff at least one
+ * `getIntentStatus` call actually returned a status — it distinguishes a REAL
+ * last-seen non-terminal status from a poll window where EVERY request threw
+ * (Relay status API unreachable). The caller must not mask the latter as a
+ * benign pending intent.
+ */
+interface RelayPollResult {
+  readonly status: string;
+  readonly observed: boolean;
+}
+
+async function pollToTerminal(requestId: string): Promise<RelayPollResult> {
   const client = getRelayClient();
   const started = Date.now();
-  let interval = POLL_INITIAL_MS;
   let status = "pending";
+  let observed = false;
   while (Date.now() - started < POLL_MAX_MS) {
-    await delay(interval);
+    await delay(POLL_INTERVAL_MS);
     try {
       const res = await client.getIntentStatus(requestId);
       status = res.status;
-      if (RELAY_TERMINAL_STATUSES.has(status)) return status;
+      observed = true;
+      if (RELAY_TERMINAL_STATUSES.has(status)) return { status, observed };
     } catch (err) {
       logger.warn("relay.bridge.status_poll_failed", {
         reason: err instanceof VexError ? err.code : "unknown",
       });
     }
-    interval = Math.min(interval * 2, POLL_MAX_INTERVAL_MS);
   }
-  return status;
+  return { status, observed };
 }
 
 export interface RelayExecuteArgs {
@@ -116,6 +131,14 @@ export interface RelayExecuteResult {
   transactions: RelayTransaction[];
   requestId: string | null;
   finalStatus: string;
+  /**
+   * True iff the intent status was actually OBSERVED (a `getIntentStatus` call
+   * succeeded) OR a terminal state was reached. False when there was no
+   * requestId to track, or every status poll threw — i.e. delivery is UNKNOWN,
+   * not benignly pending. The handler fails closed on `false` rather than
+   * emitting a phantom pending capture.
+   */
+  statusObserved: boolean;
 }
 
 /**
@@ -133,24 +156,84 @@ interface PlannedRelayTx {
 }
 
 /**
+ * The intent request id is the ONLY handle to a bridge's terminal status. Relay
+ * exposes it two ways (per docs.relay.link step-execution): directly on
+ * `step.requestId`, and inside a step item's `check.endpoint` — the status URL
+ * (`/intents/status/v3?requestId=<id>`) the wallet is told to poll. The id can
+ * be present on the check endpoint even when the step omits `requestId`, so we
+ * parse it out as a fallback rather than falsely treating the bridge as
+ * untrackable.
+ *
+ * `check.endpoint` is UNTRUSTED external input, so we accept its `requestId`
+ * ONLY when the endpoint is genuinely the Relay status endpoint: the pathname
+ * must equal the documented status path EXACTLY (`RELAY_INTENT_STATUS_PATH`,
+ * shared with the client so a version bump updates both), and — for absolute
+ * URLs — the host must equal the configured Relay API host (`allowedBaseUrl`,
+ * the SAME value the client polls; never a hardcoded second copy). A relative
+ * endpoint resolves against that host so the exact-path check still applies.
+ * Anything else (wrong host, wrong path, empty/absent id, malformed URL) → null,
+ * which the caller treats as "no id" and fails closed before broadcast.
+ */
+export function parseRequestIdFromCheckEndpoint(endpoint: string, allowedBaseUrl: string): string | null {
+  let base: URL;
+  try {
+    base = new URL(allowedBaseUrl);
+  } catch {
+    return null;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint, base);
+  } catch {
+    return null;
+  }
+  // An endpoint on a different host, or not the exact status path, is NOT a
+  // trustworthy status source — do not associate its requestId with this bridge.
+  if (parsed.host !== base.host) return null;
+  if (parsed.pathname !== RELAY_INTENT_STATUS_PATH) return null;
+  const requestId = parsed.searchParams.get("requestId");
+  return requestId && requestId.length > 0 ? requestId : null;
+}
+
+/**
+ * step.requestId (any step) → parsed from a step item's check.endpoint. The
+ * allowed host is read from the SAME config the client polls, so the endpoint
+ * check can never diverge from where status is actually fetched.
+ */
+function deriveRequestId(quote: RelayQuoteResponse): string | null {
+  for (const step of quote.steps) {
+    if (step.requestId) return step.requestId;
+  }
+  const allowedBaseUrl = loadConfig().services.relayApiUrl;
+  for (const step of quote.steps) {
+    for (const item of step.items) {
+      const endpoint = item.check?.endpoint;
+      const derived = endpoint ? parseRequestIdFromCheckEndpoint(endpoint, allowedBaseUrl) : null;
+      if (derived) return derived;
+    }
+  }
+  return null;
+}
+
+/**
  * PHASE 1 — pre-validate EVERY step of the quote with ZERO broadcasts. Returns
  * the ordered list of transactions to broadcast plus the intent requestId. Any
  * invalid step (unsupported kind, chainId outside {origin, destination}, sender
  * mismatch, malformed calldata) THROWS here, so the caller never broadcasts a
- * partially-valid quote.
+ * partially-valid quote. A quote with NO trackable request id (neither on a step
+ * nor derivable from a check endpoint) ALSO throws here — failing BEFORE any
+ * broadcast is strictly safer than moving funds we could never verify.
  */
 function planRelayBridge(
   quote: RelayQuoteResponse,
   expectedFrom: `0x${string}`,
   originChainId: number,
   destinationChainId: number,
-): { planned: PlannedRelayTx[]; requestId: string | null } {
+): { planned: PlannedRelayTx[]; requestId: string } {
   const allowedChains = new Set([originChainId, destinationChainId]);
   const planned: PlannedRelayTx[] = [];
-  let requestId: string | null = null;
 
   for (const step of quote.steps) {
-    if (step.requestId && !requestId) requestId = step.requestId;
     if (step.kind !== "transaction") {
       throw new VexError(
         ErrorCodes.RELAY_UNSUPPORTED_STEP,
@@ -189,6 +272,19 @@ function planRelayBridge(
       }
       planned.push({ stepId: step.id, chainId: data.chainId, to, data: data.data as Hex, value });
     }
+  }
+
+  // Fail closed BEFORE any broadcast when the intent is untrackable: without a
+  // request id there is no way to ever confirm delivery, so moving funds would
+  // leave an unverifiable bridge. Real Relay quotes always carry the id (step or
+  // check endpoint); this guards a degenerate/idless quote.
+  const requestId = deriveRequestId(quote);
+  if (!requestId) {
+    throw new VexError(
+      ErrorCodes.RELAY_BRIDGE_FAILED,
+      "Relay quote carries no request id (neither on a step nor a check endpoint) — the bridge status could never be verified. Refusing to broadcast an untrackable bridge.",
+      "Re-quote before retrying.",
+    );
   }
 
   return { planned, requestId };
@@ -233,6 +329,17 @@ export async function executeRelayBridge(args: RelayExecuteArgs): Promise<RelayE
     logger.info("relay.bridge.step_broadcast", { stepId: tx.stepId, chainId: tx.chainId });
   }
 
-  const finalStatus = requestId ? await pollToTerminal(requestId) : "pending";
-  return { txHashes: transactions.map((t) => t.hash), transactions, requestId, finalStatus };
+  // requestId is guaranteed non-null here (planRelayBridge fails closed
+  // otherwise). Poll to a terminal state; `observed` distinguishes a real
+  // last-seen status from a window where EVERY status request threw (status API
+  // unreachable) — the handler fails closed on the latter rather than emitting a
+  // phantom pending capture.
+  const poll = await pollToTerminal(requestId);
+  return {
+    txHashes: transactions.map((t) => t.hash),
+    transactions,
+    requestId,
+    finalStatus: poll.status,
+    statusObserved: poll.observed,
+  };
 }

--- a/src/vex-agent/db/migrations/041_mission_results.sql
+++ b/src/vex-agent/db/migrations/041_mission_results.sql
@@ -1,0 +1,57 @@
+-- Mission results ledger. One row per mission RUN, opened when the run
+-- starts and closed at every terminal branch of finalize. Gives every
+-- mission a stable per-wallet number (Mission #N) and a persisted, ETH-
+-- denominated PnL record so performance is comparable across runs.
+--
+-- PnL is denominated in ETH (the bankroll's own unit): bankroll_end_eth
+-- minus bankroll_start_eth, where bankroll = native ETH + WETH matched by
+-- PER-CHAIN ADDRESS (see engine/mission/bankroll.ts) — nets out gas, fees,
+-- and slippage automatically. Token bags still held at close are recorded
+-- in open_positions_json and EXCLUDED from the headline PnL so an unsold
+-- position never distorts it. USD prices are kept only for display
+-- tooltips. `stop_reason` is the raw engine StopReason (e.g.
+-- `deadline_reached`) — presentation (e.g. mapping a reached time-box to a
+-- non-failure outcome) is a pure function in the read layer, never SQL.
+--
+-- seq_no is a per-wallet sequence ("Mission #N") minted under a
+-- transaction-scoped advisory lock (see openMissionResult) so two
+-- concurrent opens for the same wallet can never collide.
+
+CREATE TABLE mission_results (
+  id                    TEXT NOT NULL PRIMARY KEY,
+  mission_id            TEXT NOT NULL REFERENCES missions(id),
+  mission_run_id        TEXT NOT NULL REFERENCES mission_runs(id),
+  session_id            TEXT NOT NULL REFERENCES sessions(id),
+  wallet_address        TEXT NOT NULL,
+  chain_id              BIGINT NOT NULL,
+  seq_no                INTEGER NOT NULL,
+  goal_snippet          TEXT,
+  started_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ended_at              TIMESTAMPTZ,
+  duration_s            INTEGER,
+  bankroll_start_eth    NUMERIC,
+  bankroll_end_eth      NUMERIC,
+  pnl_eth               NUMERIC,
+  pnl_pct                NUMERIC,
+  eth_price_usd_start   NUMERIC,
+  eth_price_usd_end     NUMERIC,
+  trades                INTEGER NOT NULL DEFAULT 0,
+  outcome               TEXT NOT NULL DEFAULT 'running'
+                          CHECK (outcome IN ('running', 'completed', 'cancelled', 'failed', 'stopped')),
+  stop_reason           TEXT,
+  open_positions_json   JSONB,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Exactly one ledger row per run — the open/close lifecycle keys on this
+-- (ON CONFLICT (mission_run_id) DO NOTHING makes a retried open a no-op).
+CREATE UNIQUE INDEX mission_results_run_uidx ON mission_results (mission_run_id);
+
+-- seq_no is unique PER WALLET (case-insensitive) — the numbering invariant
+-- "Mission #N" depends on. Defense in depth alongside the advisory-lock
+-- minting in openMissionResult.
+CREATE UNIQUE INDEX mission_results_wallet_seq_uidx ON mission_results (LOWER(wallet_address), seq_no);
+
+-- Per-wallet history reads, newest first.
+CREATE INDEX mission_results_wallet_history_idx ON mission_results (LOWER(wallet_address), seq_no DESC);

--- a/src/vex-agent/db/repos/mission-results.ts
+++ b/src/vex-agent/db/repos/mission-results.ts
@@ -1,0 +1,243 @@
+/**
+ * Mission results ledger repo — open/close lifecycle + per-wallet history
+ * reads.
+ *
+ * A row is OPENED when a mission run starts (with a per-wallet `seq_no` and
+ * the start bankroll snapshot) and CLOSED when the run finalizes (end
+ * bankroll, PnL, trade count, outcome, raw stop_reason). Open/close key on
+ * `mission_run_id`, so the start and finalize hooks — which run in
+ * different turns — address the same row without holding state in memory.
+ *
+ * `seq_no` is minted under a transaction-scoped Postgres advisory lock keyed
+ * on the wallet address, so two concurrent opens for the SAME wallet can
+ * never mint the same number (a bare `SELECT COUNT(*)+1` here would race).
+ *
+ * PnL is in ETH (bankroll = native ETH + WETH). See migration 041.
+ */
+
+import type pg from "pg";
+import { query, queryOne, queryOneWith, execute, executeWith, withTransaction } from "../client.js";
+import { nullableJsonb } from "../params.js";
+
+export type MissionResultOutcome = "running" | "completed" | "cancelled" | "failed" | "stopped";
+
+export interface MissionResultRow {
+  id: string;
+  missionId: string;
+  missionRunId: string;
+  sessionId: string;
+  walletAddress: string;
+  chainId: number;
+  seqNo: number;
+  goalSnippet: string | null;
+  startedAt: string;
+  endedAt: string | null;
+  durationS: number | null;
+  bankrollStartEth: number | null;
+  bankrollEndEth: number | null;
+  pnlEth: number | null;
+  pnlPct: number | null;
+  ethPriceUsdStart: number | null;
+  ethPriceUsdEnd: number | null;
+  trades: number;
+  outcome: MissionResultOutcome;
+  stopReason: string | null;
+  openPositions: unknown;
+}
+
+export interface OpenMissionResultInput {
+  id: string;
+  missionId: string;
+  missionRunId: string;
+  sessionId: string;
+  walletAddress: string;
+  chainId: number;
+  goalSnippet: string | null;
+  bankrollStartEth: number | null;
+  ethPriceUsdStart: number | null;
+}
+
+export interface CloseMissionResultInput {
+  missionRunId: string;
+  outcome: Exclude<MissionResultOutcome, "running">;
+  stopReason: string | null;
+  bankrollEndEth: number | null;
+  ethPriceUsdEnd: number | null;
+  pnlEth: number | null;
+  pnlPct: number | null;
+  trades: number;
+  openPositions: unknown;
+}
+
+const SELECT_COLUMNS = `
+  id, mission_id, mission_run_id, session_id, wallet_address, chain_id, seq_no,
+  goal_snippet, started_at, ended_at, duration_s,
+  bankroll_start_eth, bankroll_end_eth, pnl_eth, pnl_pct,
+  eth_price_usd_start, eth_price_usd_end,
+  trades, outcome, stop_reason, open_positions_json`;
+
+interface Raw {
+  id: string;
+  mission_id: string;
+  mission_run_id: string;
+  session_id: string;
+  wallet_address: string;
+  chain_id: string | number;
+  seq_no: number;
+  goal_snippet: string | null;
+  started_at: Date | string;
+  ended_at: Date | string | null;
+  duration_s: number | null;
+  bankroll_start_eth: string | null;
+  bankroll_end_eth: string | null;
+  pnl_eth: string | null;
+  pnl_pct: string | null;
+  eth_price_usd_start: string | null;
+  eth_price_usd_end: string | null;
+  trades: number;
+  outcome: MissionResultOutcome;
+  stop_reason: string | null;
+  open_positions_json: unknown;
+}
+
+// pg returns NUMERIC as string to preserve precision; ETH/PnL fit safely in
+// a JS number for display.
+const num = (v: string | number | null): number | null => (v === null ? null : Number(v));
+
+const iso = (v: Date | string): string => (v instanceof Date ? v.toISOString() : String(v));
+
+function toRow(r: Raw): MissionResultRow {
+  return {
+    id: r.id,
+    missionId: r.mission_id,
+    missionRunId: r.mission_run_id,
+    sessionId: r.session_id,
+    walletAddress: r.wallet_address,
+    chainId: Number(r.chain_id),
+    seqNo: r.seq_no,
+    goalSnippet: r.goal_snippet,
+    startedAt: iso(r.started_at),
+    endedAt: r.ended_at === null ? null : iso(r.ended_at),
+    durationS: r.duration_s,
+    bankrollStartEth: num(r.bankroll_start_eth),
+    bankrollEndEth: num(r.bankroll_end_eth),
+    pnlEth: num(r.pnl_eth),
+    pnlPct: num(r.pnl_pct),
+    ethPriceUsdStart: num(r.eth_price_usd_start),
+    ethPriceUsdEnd: num(r.eth_price_usd_end),
+    trades: r.trades,
+    outcome: r.outcome,
+    stopReason: r.stop_reason,
+    openPositions: r.open_positions_json,
+  };
+}
+
+/**
+ * Open the ledger row for a run. `seq_no` is minted as `MAX(seq_no)+1` for
+ * the wallet, under a transaction-scoped advisory lock keyed on the
+ * (lowercased) wallet address — a concurrent open for a DIFFERENT wallet
+ * proceeds independently; a concurrent open for the SAME wallet blocks at
+ * the lock until the first transaction commits, so the two can never mint
+ * the same number. The lock releases automatically at COMMIT/ROLLBACK.
+ *
+ * Idempotent: a duplicate open for the same run is a no-op (the run-id
+ * unique index + `ON CONFLICT`), so a retried start never double-numbers.
+ */
+export async function openMissionResult(input: OpenMissionResultInput): Promise<void> {
+  await withTransaction(async (client: pg.PoolClient) => {
+    await client.query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
+      missionResultsSeqLockKey(input.walletAddress),
+    ]);
+    const next = await queryOneWith<{ next_seq: string }>(
+      client,
+      `SELECT (COALESCE(MAX(seq_no), 0) + 1)::text AS next_seq
+         FROM mission_results
+        WHERE LOWER(wallet_address) = LOWER($1)`,
+      [input.walletAddress],
+    );
+    const seqNo = Number(next?.next_seq ?? "1");
+    const sql = `
+      INSERT INTO mission_results (
+        id, mission_id, mission_run_id, session_id, wallet_address, chain_id,
+        seq_no, goal_snippet, bankroll_start_eth, eth_price_usd_start, outcome
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'running')
+      ON CONFLICT (mission_run_id) DO NOTHING`;
+    await executeWith(client, sql, [
+      input.id,
+      input.missionId,
+      input.missionRunId,
+      input.sessionId,
+      input.walletAddress,
+      input.chainId,
+      seqNo,
+      input.goalSnippet,
+      input.bankrollStartEth,
+      input.ethPriceUsdStart,
+    ]);
+  });
+}
+
+/** Stable advisory-lock key for per-wallet seq_no minting (see openMissionResult). */
+function missionResultsSeqLockKey(walletAddress: string): string {
+  return `mission_results_seq:${walletAddress.toLowerCase()}`;
+}
+
+/** Close the ledger row at finalize. No-op if the row was never opened. */
+export async function closeMissionResult(input: CloseMissionResultInput): Promise<void> {
+  const sql = `
+    UPDATE mission_results SET
+      outcome = $2,
+      stop_reason = $3,
+      ended_at = NOW(),
+      duration_s = EXTRACT(EPOCH FROM (NOW() - started_at))::int,
+      bankroll_end_eth = $4,
+      eth_price_usd_end = $5,
+      pnl_eth = $6,
+      pnl_pct = $7,
+      trades = $8,
+      open_positions_json = $9,
+      updated_at = NOW()
+    WHERE mission_run_id = $1`;
+  await execute(sql, [
+    input.missionRunId,
+    input.outcome,
+    input.stopReason,
+    input.bankrollEndEth,
+    input.ethPriceUsdEnd,
+    input.pnlEth,
+    input.pnlPct,
+    input.trades,
+    nullableJsonb(input.openPositions),
+  ]);
+}
+
+/** Per-wallet mission history, newest first. */
+export async function listResultsForWallet(
+  walletAddress: string,
+  limit = 50,
+): Promise<MissionResultRow[]> {
+  const rows = await query<Raw>(
+    `SELECT ${SELECT_COLUMNS}
+       FROM mission_results
+      WHERE LOWER(wallet_address) = LOWER($1)
+      ORDER BY seq_no DESC
+      LIMIT $2`,
+    [walletAddress, limit],
+  );
+  return rows.map(toRow);
+}
+
+/** The ledger row for a single run and wallet (null if never opened or not owned by that wallet). */
+export async function getResultForRun(
+  missionRunId: string,
+  walletAddress: string,
+): Promise<MissionResultRow | null> {
+  const row = await queryOne<Raw>(
+    `SELECT ${SELECT_COLUMNS}
+       FROM mission_results
+      WHERE mission_run_id = $1
+        AND LOWER(wallet_address) = LOWER($2)`,
+    [missionRunId, walletAddress],
+  );
+  return row ? toRow(row) : null;
+}

--- a/src/vex-agent/db/repos/missions.ts
+++ b/src/vex-agent/db/repos/missions.ts
@@ -248,6 +248,48 @@ export async function getMissionForUpdate(
 }
 
 /**
+ * Session-scoped transactional advisory lock — serializes ALL concurrent
+ * `renewMission` calls for the same session so the pending-draft check in
+ * `getPendingDraftForSession` and the clone insert commit as one atomic
+ * decision (closes the duplicate-draft storm race; a schema unique index
+ * is not viable because production data already contains duplicate drafts
+ * from before this fix). `hashtext` folds the session id into the 32-bit
+ * key `pg_advisory_xact_lock` needs. Xact-scoped: Postgres releases it
+ * automatically at COMMIT/ROLLBACK, so there is no matching unlock call.
+ */
+export async function lockSessionForRenew(
+  client: PoolClient,
+  sessionId: string,
+): Promise<void> {
+  await executeWith(
+    client,
+    "SELECT pg_advisory_xact_lock(hashtext($1))",
+    [sessionId],
+  );
+}
+
+/**
+ * Does the session already hold an un-started (`draft`/`ready`) mission?
+ * Called INSIDE the same locked transaction as `lockSessionForRenew` above
+ * so a second concurrent renew (racing before the first commits) cannot
+ * both pass this check — the root cause of the duplicate-draft storm.
+ */
+export async function getPendingDraftForSession(
+  client: PoolClient,
+  rootSessionId: string,
+): Promise<Mission | null> {
+  const row = await queryOneWith<Record<string, unknown>>(
+    client,
+    `SELECT * FROM missions
+      WHERE root_session_id = $1
+        AND status IN ('draft', 'ready')
+      LIMIT 1`,
+    [rootSessionId],
+  );
+  return row ? mapRow(row) : null;
+}
+
+/**
  * Stamp acceptance metadata on a mission. The caller MUST hold a row
  * lock (via `getMissionForUpdate`) so concurrent `clearAcceptance`
  * / `startMission` see the freshly-committed state.

--- a/src/vex-agent/engine/core/runner/mission-finalize.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize.ts
@@ -20,6 +20,7 @@ import * as missionsRepo from "@vex-agent/db/repos/missions.js";
 import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
 import logger from "@utils/logger.js";
 import { consumeMissionRunAbortIntent } from "./abort.js";
+import { captureMissionFinal } from "../../mission/mission-results-capture.js";
 import {
   isContinuableRuntimeStop,
   scheduleRuntimeContinuation,
@@ -88,6 +89,7 @@ export async function finalizeMissionRunStatus(
       await missionsRepo.clearApprovedAt(missionId);
       await missionsRepo.setStatus(missionId, "draft");
       await emitFinalizeControlState(sessionId, runId);
+      await captureMissionFinal({ missionId, runId, sessionId, outcome: "stopped", stopReason });
       return "draft";
     }
 
@@ -99,6 +101,7 @@ export async function finalizeMissionRunStatus(
     await missionsRepo.setStatus(missionId, status);
     await missionRunsRepo.updateStatus(runId, status, stopReason, stopPayload);
     await emitFinalizeControlState(sessionId, runId);
+    await captureMissionFinal({ missionId, runId, sessionId, outcome: status, stopReason });
     return status;
   }
 
@@ -123,6 +126,7 @@ export async function finalizeMissionRunStatus(
     await missionsRepo.setStatus(missionId, "failed");
     await missionRunsRepo.updateStatus(runId, "failed", stopReason);
     await emitFinalizeControlState(sessionId, runId);
+    await captureMissionFinal({ missionId, runId, sessionId, outcome: "failed", stopReason });
     // Phase 2 BUG-REPORTING emit (puzzle 03): terminal `system_error`
     // is a hard failure surface — record the mission state. Fail-
     // closed so a sink outage cannot mask the terminal flip.

--- a/src/vex-agent/engine/core/runner/mission-run.ts
+++ b/src/vex-agent/engine/core/runner/mission-run.ts
@@ -36,6 +36,8 @@ import {
   type MissionRunContractSnapshot,
   resolveMissionPromptContext,
 } from "../../mission/run-contract.js";
+import { resolveFrozenDeadlineMs } from "../../mission/mission-deadline.js";
+import { captureMissionStart } from "../../mission/mission-results-capture.js";
 import type { PromptStackOptions } from "../../prompts/index.js";
 import { getOpenAITools, type ToolVisibilityBase } from "@vex-agent/tools/registry.js";
 import {
@@ -65,6 +67,11 @@ type Provider = NonNullable<Awaited<ReturnType<typeof resolveProvider>>>;
 type ProviderConfig = NonNullable<
   Awaited<ReturnType<Provider["loadConfig"]>>
 >;
+
+/** Epoch ms -> ISO string for the agent-facing Runtime Clock, or null. */
+function deadlineMsToIso(deadlineMs: number | null | undefined): string | null {
+  return deadlineMs != null ? new Date(deadlineMs).toISOString() : null;
+}
 
 // ── runPreparedMissionStart ─────────────────────────────────────
 
@@ -103,6 +110,13 @@ export async function runPreparedMissionStart(
 ): Promise<TurnResult> {
   const controller = registerMissionRunAbortController(prepared.runId);
   try {
+    // Open the mission results ledger row (per-wallet #N + start bankroll
+    // snapshot). Fail-soft inside — never blocks the run.
+    await captureMissionStart({
+      missionId: prepared.missionId,
+      runId: prepared.runId,
+      sessionId: prepared.sessionId,
+    });
     await addMissionActivationMessage({
       sessionId: prepared.sessionId,
       missionId: prepared.missionId,
@@ -142,6 +156,12 @@ export async function runPreparedMissionStart(
       ...DEFAULT_LOOP_CONFIG,
       contextLimit: prepared.config.contextLimit,
       baseVisibility,
+      // Deadline from FROZEN inputs (run started_at + snapshot durationMinutes),
+      // never the live mission row — see mission-deadline.ts.
+      missionDeadlineMs: resolveFrozenDeadlineMs(
+        hydrated.context.missionRunStartedAt,
+        prepared.contractSnapshot,
+      ),
     };
 
     const result = await runTurnLoop(
@@ -149,6 +169,7 @@ export async function runPreparedMissionStart(
         ...hydrated.context,
         missionRunId: prepared.runId,
         sessionKind: "mission",
+        missionDeadline: deadlineMsToIso(loopConfig.missionDeadlineMs) ?? hydrated.context.missionDeadline ?? null,
       },
       hydrated.messages,
       hydrated.summary,
@@ -261,6 +282,13 @@ export async function resumePreparedMissionRun(
       ...DEFAULT_LOOP_CONFIG,
       contextLimit: prepared.config.contextLimit,
       baseVisibility,
+      // Deadline from FROZEN inputs (run started_at + the SAME snapshot the run
+      // was committed with), so a wake/resume re-derives the identical box —
+      // never the live mission row. See mission-deadline.ts.
+      missionDeadlineMs: resolveFrozenDeadlineMs(
+        hydrated.context.missionRunStartedAt,
+        prepared.run.contractSnapshotJson,
+      ),
     };
 
     const result = await runTurnLoop(
@@ -268,6 +296,7 @@ export async function resumePreparedMissionRun(
         ...hydrated.context,
         missionRunId: prepared.runId,
         sessionKind: "mission",
+        missionDeadline: deadlineMsToIso(loopConfig.missionDeadlineMs) ?? hydrated.context.missionDeadline ?? null,
       },
       hydrated.messages,
       hydrated.summary,

--- a/src/vex-agent/engine/core/turn-loop-tool-batch.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch.ts
@@ -35,8 +35,10 @@
  * Structural split: the outcome contract lives in
  * `./turn-loop-tool-batch/outcome.ts`, the per-call tool-context builder in
  * `./turn-loop-tool-batch/execute.ts`, the approval-enqueue helpers in
- * `./turn-loop-tool-batch/approval-stop.ts`, and the deferred-save +
- * outcome-mapping helpers in `./turn-loop-tool-batch/results.ts`.
+ * `./turn-loop-tool-batch/approval-stop.ts`, the deferred-save +
+ * outcome-mapping helpers in `./turn-loop-tool-batch/results.ts`, and the
+ * trusted prepare→execute handoff in
+ * `./turn-loop-tool-batch/prepared-follow-up.ts`.
  * `processTurnToolBatch` stays here as the orchestrator: it keeps the
  * per-batch mutable state and the dispatch/approval/persistence ordering
  * bit-for-bit.
@@ -59,6 +61,10 @@ import {
   mapBatchOutcome,
   persistBatchTranscript,
 } from "./turn-loop-tool-batch/results.js";
+import {
+  dispatchPreparedActionFollowUp,
+  resolvePreparedActionFollowUp,
+} from "./turn-loop-tool-batch/prepared-follow-up.js";
 
 export type { StopPayload, ToolBatchOutcome } from "./turn-loop-tool-batch/outcome.js";
 
@@ -92,6 +98,11 @@ export async function processTurnToolBatch(args: {
 
   for (let i = 0; i < turnResult.toolCalls.length; i++) {
     const toolCall = turnResult.toolCalls[i];
+    // `i < turnResult.toolCalls.length` guarantees this index is populated;
+    // the guard exists only to satisfy `noUncheckedIndexedAccess` (vex-app's
+    // stricter tsconfig type-checks this file too) and narrows `toolCall` for
+    // every use below.
+    if (toolCall === undefined) continue;
     toolCallsExecuted++;
 
     const toolContext = buildToolContext(context, dispatchBand);
@@ -101,9 +112,20 @@ export async function processTurnToolBatch(args: {
       toolContext,
     );
 
+    // Trusted prepare→execute handoff (wallet_send_prepare → confirm ONLY,
+    // see the registry allow-list): validates the handler-authored contract
+    // and fails closed (never dispatches) on any unknown mapping or
+    // malformed shape. `resultForTranscript` is what actually gets
+    // persisted/returned below — identical to `result` unless the follow-up
+    // was rejected, in which case it carries the rejection message instead.
+    const { resultForTranscript, followUp } = resolvePreparedActionFollowUp(
+      toolCall.name,
+      result,
+    );
+
     // ── Approval break: call was dispatched but has no result in messages ──
     // "awaiting approval" state lives in approval_queue, not in transcript.
-    if (result.pendingApproval) {
+    if (resultForTranscript.pendingApproval) {
       // Puzzle 5 phase 2: approval_intents.action_kind is NOT NULL with a
       // CHECK constraint over the 8 canonical ActionKind variants. The
       // dispatcher's `withActionKindFallback` MUST have stamped a kind
@@ -111,14 +133,14 @@ export async function processTurnToolBatch(args: {
       // registration or in the dispatcher fallback. Fail fast (Codex
       // 2/1B ruling) instead of silently inserting a pseudo-kind or
       // downgrading to a default — neither preserves the policy invariant.
-      const intentActionKind = assertApprovalActionKind(result, toolCall);
+      const intentActionKind = assertApprovalActionKind(resultForTranscript, toolCall);
 
       executedCalls.push(toolCall);
 
       approvalId = await enqueueApprovalIntent({
         context,
         toolCall,
-        result,
+        result: resultForTranscript,
         toolContext,
         intentActionKind,
       });
@@ -131,25 +153,45 @@ export async function processTurnToolBatch(args: {
     executedResults.push({
       toolCallId: toolCall.id,
       toolName: toolCall.name,
-      output: result.output,
-      success: result.success,
+      output: resultForTranscript.output,
+      success: resultForTranscript.success,
       // Derive explorer refs from `result.data` HERE — the transcript drops
       // `data`, so this is the last place the structured capture is available.
-      explorerRefs: deriveExplorerRefs(result.data),
+      explorerRefs: deriveExplorerRefs(resultForTranscript.data),
     });
 
+    // A validated prepared-action follow-up short-circuits the rest of this
+    // batch: persist the prepare call above, then synthesize + dispatch the
+    // trusted confirm call and return its own outcome directly (restricted
+    // sessions enqueue the normal approval flow; full-permission sessions
+    // execute confirm immediately). Remaining calls in THIS batch are never
+    // reached — the model only ever emitted one call when it called prepare.
+    if (followUp !== null) {
+      return dispatchPreparedActionFollowUp({
+        context,
+        toolContext,
+        content: turnResult.content,
+        executedCalls,
+        executedResults,
+        liveMessages,
+        followUp,
+        toolCallsExecuted,
+        lastText: turnResult.content ?? args.lastTextSoFar,
+      });
+    }
+
     // ── Engine signals: result tracked, then stop ──
-    if (result.engineSignal) {
-      const sig = result.engineSignal;
+    if (resultForTranscript.engineSignal) {
+      const sig = resultForTranscript.engineSignal;
       if (sig.type === "stop_mission" || sig.type === "complete_subagent") {
         batchStopReason = sig.reason as StopReason;
-        batchStopOutput = result.output;
+        batchStopOutput = resultForTranscript.output;
         batchStopPayload = { summary: sig.summary, evidence: sig.evidence };
         break;
       }
       if (sig.type === "wait_for_parent") {
         batchStopReason = "waiting_for_parent";
-        batchStopOutput = result.output;
+        batchStopOutput = resultForTranscript.output;
         break;
       }
       if (sig.type === "plan_pause") {
@@ -160,7 +202,7 @@ export async function processTurnToolBatch(args: {
         // (don't wait for an execution attempt — mission text does not break the
         // loop).
         batchStopReason = "plan_acceptance_required";
-        batchStopOutput = result.output;
+        batchStopOutput = resultForTranscript.output;
         batchStopPayload = { summary: sig.summary, evidence: { reason: sig.reason } };
         break;
       }
@@ -170,7 +212,7 @@ export async function processTurnToolBatch(args: {
         // Evidence carries dueAt + reason so PR-7 executor / PR-10 ingress
         // have the hints they need without re-reading the wake row.
         batchStopReason = "waiting_for_wake";
-        batchStopOutput = result.output;
+        batchStopOutput = resultForTranscript.output;
         batchStopPayload = {
           summary: sig.summary,
           evidence: {
@@ -189,6 +231,7 @@ export async function processTurnToolBatch(args: {
         compactCommittedThisBatch = true;
         for (let j = i + 1; j < turnResult.toolCalls.length; j++) {
           const skipped = turnResult.toolCalls[j];
+          if (skipped === undefined) continue;
           executedCalls.push(skipped);
           executedResults.push({
             toolCallId: skipped.id,

--- a/src/vex-agent/engine/core/turn-loop-tool-batch/approval-stop.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch/approval-stop.ts
@@ -19,14 +19,19 @@ import * as approvalIntentsRepo from "@vex-agent/db/repos/approval-intents.js";
 import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
 import { withTransaction } from "@vex-agent/db/client.js";
 import { riskLevelFromActionKind } from "@vex-agent/tools/risk-level.js";
-import { buildIntentPreview, buildPolicySnapshot } from "../approval-intent-preview.js";
+import {
+  buildIntentPreview,
+  buildPolicySnapshot,
+  type IntentPreview,
+} from "../approval-intent-preview.js";
 
 /**
  * Puzzle 5 phase 3 — TTL stamped at enqueue (not at approve). The approve
  * gate (`prepareApprove` snapshot) and the scheduled sweep both rely on a
  * DB-visible `expires_at` so a stale approval gets auto-rejected even
- * without operator action. Single 1h default for all action kinds; phase 7
- * will introduce per-kind TTLs if real workloads need them.
+ * without operator action. One hour is the default; a trusted prepared
+ * action can supply an earlier expiry so its approval never outlives the
+ * underlying wallet intent.
  */
 const APPROVAL_TTL_MS = 60 * 60 * 1000;
 
@@ -66,35 +71,64 @@ export async function enqueueApprovalIntent(args: {
   readonly result: ToolResult;
   readonly toolContext: InternalToolContext;
   readonly intentActionKind: ActionKind;
+  /**
+   * Handler-authored preview for a registry-validated prepared follow-up
+   * (`resolvePreparedActionFollowUp`). When present it REPLACES the
+   * args-derived preview entirely — including any hyperliquid/prequote
+   * enrichment below, which only applies to a direct (non-handoff) dispatch.
+   */
+  readonly trustedPreview?: IntentPreview;
+  /** Optional prepared-action expiry; approval must not outlive it. */
+  readonly trustedExpiresAt?: string;
 }): Promise<string> {
-  const { context, toolCall, result, toolContext, intentActionKind } = args;
+  const {
+    context,
+    toolCall,
+    result,
+    toolContext,
+    intentActionKind,
+    trustedPreview,
+    trustedExpiresAt,
+  } = args;
 
   const approvalId = `approval-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const intentRiskLevel = riskLevelFromActionKind(intentActionKind);
   // Stage 7 R5: carry the gate-matched swap safety verdict (typed, off the
   // ToolResult — NOT raw args) into the preview so restricted-mode approval
   // surfaces `pass` / `unknown` ("UNVERIFIED") before the human approves.
-  const intentPreview = buildIntentPreview(
-    toolCall.name,
-    toolCall.arguments,
-    result.prequote
-      ? {
-          prequoteVerdict: result.prequote.verdict,
-          fotTax: result.prequote.fotTax,
-          // Wave 5 (Pendle): the term-lock maturity rides the same typed channel;
-          // buildIntentPreview renders the fixed lock warning (never from args).
-          termLock: result.prequote.termLock,
-          ...(result.hyperliquid ? { hyperliquid: result.hyperliquid } : {}),
-        }
-      : result.hyperliquid ? { hyperliquid: result.hyperliquid } : undefined,
-  );
+  const intentPreview =
+    trustedPreview ??
+    buildIntentPreview(
+      toolCall.name,
+      toolCall.arguments,
+      result.prequote
+        ? {
+            prequoteVerdict: result.prequote.verdict,
+            fotTax: result.prequote.fotTax,
+            // Wave 5 (Pendle): the term-lock maturity rides the same typed channel;
+            // buildIntentPreview renders the fixed lock warning (never from args).
+            termLock: result.prequote.termLock,
+            ...(result.hyperliquid ? { hyperliquid: result.hyperliquid } : {}),
+          }
+        : result.hyperliquid ? { hyperliquid: result.hyperliquid } : undefined,
+    );
   const intentPolicy = buildPolicySnapshot(toolContext);
   // Phase 3: stamp `expires_at` at enqueue so the approve gate +
   // scheduled sweep have a DB-visible TTL boundary (see APPROVAL_TTL_MS
   // header). `CreateIntentInput.previewJson/policyJson` were widened in
   // phase 3 to accept the structured builder shapes directly — no
-  // `as unknown as Record<string, unknown>` cast needed.
-  const intentExpiresAt = new Date(Date.now() + APPROVAL_TTL_MS).toISOString();
+  // `as unknown as Record<string, unknown>` cast needed. A trusted prepared
+  // action's own expiry floors this so the approval can never outlive the
+  // underlying wallet intent.
+  const defaultExpiresAtMs = Date.now() + APPROVAL_TTL_MS;
+  const trustedExpiresAtMs =
+    trustedExpiresAt === undefined ? Number.POSITIVE_INFINITY : Date.parse(trustedExpiresAt);
+  const intentExpiresAt = new Date(
+    Math.min(
+      defaultExpiresAtMs,
+      Number.isFinite(trustedExpiresAtMs) ? trustedExpiresAtMs : defaultExpiresAtMs,
+    ),
+  ).toISOString();
 
   // Single transaction: queue + intent + mission-status flip. A
   // partial state (queue without intent, or queue+intent without

--- a/src/vex-agent/engine/core/turn-loop-tool-batch/prepared-follow-up.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch/prepared-follow-up.ts
@@ -1,0 +1,170 @@
+/** Trusted, one-hop prepared-action dispatch inside a tool batch. */
+
+import { randomUUID } from "node:crypto";
+import type { Message } from "@vex-agent/db/repos/messages.js";
+import type { ParsedToolCall } from "@vex-agent/inference/types.js";
+import { dispatchTool } from "@vex-agent/tools/dispatcher.js";
+import type { InternalToolContext } from "@vex-agent/tools/internal/types.js";
+import {
+  validatePreparedActionFollowUp,
+  type ValidatedPreparedActionFollowUp,
+} from "@vex-agent/tools/registry/prepared-action-follow-ups.js";
+import type { ToolResult } from "@vex-agent/tools/types.js";
+import { deriveExplorerRefs, type ExplorerRef } from "../explorer-refs.js";
+import type { EngineContext } from "../../types.js";
+import {
+  assertApprovalActionKind,
+  enqueueApprovalIntent,
+} from "./approval-stop.js";
+import type { ToolBatchOutcome } from "./outcome.js";
+import { mapBatchOutcome, persistBatchTranscript } from "./results.js";
+
+export interface PreparedFollowUpResolution {
+  readonly resultForTranscript: ToolResult;
+  readonly followUp: ValidatedPreparedActionFollowUp | null;
+}
+
+/** Validate the handler contract; unknown or malformed mappings fail closed. */
+export function resolvePreparedActionFollowUp(
+  sourceToolName: string,
+  result: ToolResult,
+): PreparedFollowUpResolution {
+  const candidate = result.preparedActionFollowUp;
+  if (candidate === undefined) {
+    return { resultForTranscript: result, followUp: null };
+  }
+  const validation = result.success
+    ? validatePreparedActionFollowUp(sourceToolName, candidate)
+    : null;
+  if (validation === null || !validation.ok) {
+    return {
+      resultForTranscript: {
+        ...result,
+        success: false,
+        output:
+          "Prepared-action follow-up rejected by the trusted registry; no automatic action was dispatched.",
+        preparedActionFollowUp: undefined,
+      },
+      followUp: null,
+    };
+  }
+  return { resultForTranscript: result, followUp: validation.followUp };
+}
+
+/**
+ * Persist prepare, synthesize and dispatch confirm, then either enqueue the
+ * existing approval flow or persist the immediate full-permission result.
+ */
+export async function dispatchPreparedActionFollowUp(args: {
+  readonly context: EngineContext;
+  readonly toolContext: InternalToolContext;
+  readonly content: string | null;
+  readonly executedCalls: ParsedToolCall[];
+  readonly executedResults: Array<{
+    readonly toolCallId: string;
+    readonly toolName: string;
+    readonly output: string;
+    readonly success: boolean;
+    readonly explorerRefs: readonly ExplorerRef[];
+  }>;
+  readonly liveMessages: Message[];
+  readonly followUp: ValidatedPreparedActionFollowUp;
+  readonly toolCallsExecuted: number;
+  readonly lastText: string | null;
+}): Promise<ToolBatchOutcome> {
+  await persistBatchTranscript({
+    sessionId: args.context.sessionId,
+    content: args.content,
+    executedCalls: args.executedCalls,
+    executedResults: args.executedResults,
+    liveMessages: args.liveMessages,
+  });
+
+  const syntheticCall: ParsedToolCall = {
+    id: `prepared-follow-up-${randomUUID()}`,
+    name: args.followUp.toolName,
+    arguments: args.followUp.args,
+  };
+  let result = await dispatchTool(
+    {
+      name: syntheticCall.name,
+      args: syntheticCall.arguments,
+      toolCallId: syntheticCall.id,
+    },
+    args.toolContext,
+  );
+
+  // Only one trusted hop is permitted. Never dispatch recursively.
+  if (result.preparedActionFollowUp !== undefined) {
+    result = {
+      ...result,
+      success: false,
+      pendingApproval: false,
+      output:
+        "Recursive prepared-action follow-up rejected; no additional action was dispatched.",
+      preparedActionFollowUp: undefined,
+    };
+  }
+
+  const toolCallsExecuted = args.toolCallsExecuted + 1;
+  if (result.pendingApproval) {
+    const intentActionKind = assertApprovalActionKind(result, syntheticCall);
+    const approvalId = await enqueueApprovalIntent({
+      context: args.context,
+      toolCall: syntheticCall,
+      result,
+      toolContext: args.toolContext,
+      intentActionKind,
+      trustedPreview: args.followUp.approvalPreview,
+      trustedExpiresAt: args.followUp.expiresAt,
+    });
+    // System-originated: this call was synthesized by the engine from a
+    // validated prepared-action contract, never produced by the model. The
+    // provenance stamp (source:"engine" + a distinct messageType) lives in
+    // `saveAssistantMessage` / `persistBatchTranscript` so an auditor
+    // reading `messages` directly can never mistake it for model output.
+    await persistBatchTranscript({
+      sessionId: args.context.sessionId,
+      content: null,
+      executedCalls: [syntheticCall],
+      executedResults: [],
+      liveMessages: args.liveMessages,
+      systemOriginated: true,
+    });
+    return mapBatchOutcome({
+      batchStopReason: "approval_required",
+      batchStopOutput: null,
+      batchStopPayload: undefined,
+      compactCommittedThisBatch: false,
+      approvalId,
+      toolCallsExecuted,
+      lastText: args.lastText,
+    });
+  }
+
+  await persistBatchTranscript({
+    sessionId: args.context.sessionId,
+    content: null,
+    executedCalls: [syntheticCall],
+    executedResults: [
+      {
+        toolCallId: syntheticCall.id,
+        toolName: syntheticCall.name,
+        output: result.output,
+        success: result.success,
+        explorerRefs: deriveExplorerRefs(result.data),
+      },
+    ],
+    liveMessages: args.liveMessages,
+    systemOriginated: true,
+  });
+  return mapBatchOutcome({
+    batchStopReason: null,
+    batchStopOutput: null,
+    batchStopPayload: undefined,
+    compactCommittedThisBatch: false,
+    approvalId: null,
+    toolCallsExecuted,
+    lastText: args.lastText,
+  });
+}

--- a/src/vex-agent/engine/core/turn-loop-tool-batch/results.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch/results.ts
@@ -42,11 +42,20 @@ export async function persistBatchTranscript(args: {
   readonly executedResults: ExecutedResult[];
   /** MUTATED: pushed with assistant message + tool result messages. */
   readonly liveMessages: Message[];
+  /**
+   * True ONLY for the synthetic prepared-action follow-up call the engine
+   * dispatches itself (never model output — see
+   * `dispatchPreparedActionFollowUp`). Stamps transcript provenance so the
+   * assistant-role row is never mistaken for real model output.
+   */
+  readonly systemOriginated?: boolean;
 }): Promise<void> {
   const { sessionId, content, executedCalls, executedResults, liveMessages } = args;
 
   // ── DEFERRED SAVE: assistant message with canonical calls only ──
-  await saveAssistantMessage(sessionId, content, executedCalls);
+  await saveAssistantMessage(sessionId, content, executedCalls, {
+    systemOriginated: args.systemOriginated,
+  });
 
   liveMessages.push({
     role: "assistant",

--- a/src/vex-agent/engine/core/turn-loop.ts
+++ b/src/vex-agent/engine/core/turn-loop.ts
@@ -28,6 +28,7 @@ import type { EngineContext, StopReason } from "../types.js";
 import type { InferenceProvider, InferenceConfig, ToolDefinition } from "@vex-agent/inference/types.js";
 import type { Message } from "@vex-agent/db/repos/messages.js";
 import type { PromptStackOptions } from "../prompts/index.js";
+import logger from "@utils/logger.js";
 import { executeTurn, saveAssistantMessage } from "./turn.js";
 import type { TurnLoopConfig, TurnLoopResult } from "./turn-loop/state.js";
 export type { TurnLoopConfig, TurnLoopResult } from "./turn-loop/state.js";
@@ -129,6 +130,24 @@ export async function runTurnLoop(
   }
 
   for (let iteration = 0; iteration < loopConfig.maxIterations; iteration++) {
+    // Hard mission deadline — the agent-independent time-box. Checked FIRST
+    // each iteration, before any other guard or inference call, so an
+    // expired run stops with `deadline_reached` no matter what the agent is
+    // doing. finalizeMissionRunStatus maps it to the existing terminal
+    // status taxonomy (no new status) via the standard business-stop path.
+    if (
+      loopConfig.missionDeadlineMs != null &&
+      Date.now() >= loopConfig.missionDeadlineMs
+    ) {
+      logger.info("engine.mission.deadline_enforced", {
+        missionRunId: context.missionRunId ?? null,
+        deadlineMs: loopConfig.missionDeadlineMs,
+        iteration,
+      });
+      stopReason = "deadline_reached";
+      break;
+    }
+
     // Iteration entry: abort → observe-control → runtime-stop, in that order.
     // Helper returns the outcome; caller emits + sets stopReason + breaks.
     const entry = await runIterationEntryGuards({

--- a/src/vex-agent/engine/core/turn-loop/state.ts
+++ b/src/vex-agent/engine/core/turn-loop/state.ts
@@ -21,6 +21,15 @@ export interface TurnLoopConfig {
    * `ToolVisibilityContext` that drives BOTH the tools array and the Tool Map.
    */
   baseVisibility?: ToolVisibilityBase;
+  /**
+   * Hard mission time-box as an absolute epoch (ms). When set, the turn loop
+   * stops with `deadline_reached` the moment `Date.now() >= missionDeadlineMs`,
+   * independent of the agent — checked first each iteration, before another
+   * inference call is spent. Computed from the run's immutable `started_at` +
+   * the configured duration (see `engine/mission/mission-deadline.ts`).
+   * Null/undefined = no box.
+   */
+  missionDeadlineMs?: number | null;
 }
 
 export interface TurnLoopResult {

--- a/src/vex-agent/engine/core/turn.ts
+++ b/src/vex-agent/engine/core/turn.ts
@@ -253,7 +253,7 @@ export async function saveAssistantMessage(
   sessionId: string,
   content: string | null,
   toolCalls: ParsedToolCall[] | null,
-  opts?: { readonly stopped?: boolean },
+  opts?: { readonly stopped?: boolean; readonly systemOriginated?: boolean },
 ): Promise<void> {
   const hasContent = content !== null && content !== undefined;
   const hasToolCalls = toolCalls !== null && toolCalls !== undefined && toolCalls.length > 0;
@@ -261,11 +261,24 @@ export async function saveAssistantMessage(
   if (!hasContent && !hasToolCalls) return;
 
   const metadata: MessageMetadata = {
-    source: "assistant",
+    // `role` stays "assistant" even for a system-synthesized call (below) —
+    // the provider transcript format requires an assistant-role turn to
+    // carry `tool_calls`. Provenance instead lives here: a genuinely
+    // model-authored turn always stamps `source: "assistant"`; a call the
+    // engine synthesized itself (never model output — see
+    // `dispatchPreparedActionFollowUp`) stamps `source: "engine"` with a
+    // distinct `messageType` so an auditor reading `messages` directly can
+    // never mistake one for the other, regardless of the shared `role`.
+    source: opts?.systemOriginated === true ? "engine" : "assistant",
     // 9-5a: a chat turn stopped mid-stream persists its partial text as
     // `chat_stopped`, so the ephemeral streamed preview is replaced by a
     // durable row. Renderer mapping/badge for this type lands in 9-5b.
-    messageType: opts?.stopped === true ? "chat_stopped" : "chat",
+    messageType:
+      opts?.stopped === true
+        ? "chat_stopped"
+        : opts?.systemOriginated === true
+          ? "prepared_action_follow_up"
+          : "chat",
     visibility: "user",
   };
 

--- a/src/vex-agent/engine/mission/bankroll.ts
+++ b/src/vex-agent/engine/mission/bankroll.ts
@@ -1,0 +1,114 @@
+/**
+ * ETH-equivalent bankroll read for the mission results ledger.
+ *
+ * The bankroll is native ETH + WETH (they are 1:1 and price rides on
+ * wrapped native). WETH is matched by the chain's registered contract
+ * ADDRESS (`tools/evm-chains/registry.ts` seed tokens), never by symbol —
+ * a fake/spoofed token whose reported symbol happens to be "WETH" must
+ * never inflate the bankroll or hide as an open position.
+ *
+ * Every other held token is an OPEN position: reported separately and
+ * EXCLUDED from the bankroll so an unsold bag never distorts a mission's
+ * PnL. Reads the `proj_balances` projection (no on-chain RPC) and is
+ * fail-soft — a read error yields null so mission finalization is never
+ * blocked by bankroll accounting.
+ */
+
+import { formatUnits } from "viem";
+import { getBalances } from "../../db/repos/balances/read.js";
+import type { BalanceRow } from "../../db/repos/balances/types.js";
+import { NATIVE_TOKEN_ADDRESS } from "../../../tools/kyberswap/constants.js";
+import { getLocalChain } from "../../../tools/evm-chains/registry.js";
+import logger from "@utils/logger.js";
+
+export interface OpenPosition {
+  symbol: string | null;
+  address: string;
+  amount: number;
+  valueUsd: number | null;
+}
+
+export interface EthBankroll {
+  /** Native ETH + WETH, in ETH. */
+  bankrollEth: number;
+  /** ETH/USD from the native/WETH row (display tooltip only); null if unpriced. */
+  ethPriceUsd: number | null;
+  /** Non-ETH tokens still held, excluded from the bankroll. */
+  openPositions: OpenPosition[];
+}
+
+function toAmount(raw: string, decimals: number | null): number {
+  try {
+    return Number(formatUnits(BigInt(raw), decimals ?? 18));
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * The chain's registered WETH contract address (lowercased), or null when
+ * the chain isn't in the local registry or has no WETH seed token. Matching
+ * by ADDRESS — not the row's self-reported `tokenSymbol` — is the point:
+ * a balance row can claim any symbol string, but the contract address at a
+ * given chain id is the registry's own provenance-checked data.
+ */
+function resolveWethAddress(chainId: number): string | null {
+  const chain = getLocalChain(chainId);
+  const weth = chain?.seedTokens.find((t) => t.label === "WETH");
+  return weth ? weth.address.toLowerCase() : null;
+}
+
+/** Pure: fold proj_balances rows for one chain into an ETH bankroll + open-position list. */
+export function computeEthBankroll(rows: readonly BalanceRow[], chainId: number): EthBankroll {
+  const wethAddress = resolveWethAddress(chainId);
+  let bankrollEth = 0;
+  let ethPriceUsd: number | null = null;
+  const openPositions: OpenPosition[] = [];
+
+  for (const r of rows) {
+    const tokenAddress = r.tokenAddress.toLowerCase();
+    const isNative = tokenAddress === NATIVE_TOKEN_ADDRESS.toLowerCase();
+    const isWeth = wethAddress !== null && tokenAddress === wethAddress;
+    const amount = toAmount(r.balanceRaw, r.decimals);
+
+    if (isNative || isWeth) {
+      bankrollEth += amount;
+      if (ethPriceUsd === null && r.priceUsd !== null) ethPriceUsd = r.priceUsd;
+    } else if (amount > 0) {
+      openPositions.push({
+        symbol: r.tokenSymbol,
+        address: r.tokenAddress,
+        amount,
+        valueUsd: r.balanceUsd,
+      });
+    }
+  }
+
+  return { bankrollEth, ethPriceUsd, openPositions };
+}
+
+export interface BankrollDeps {
+  getBalances: typeof getBalances;
+}
+
+/**
+ * Read the wallet's ETH bankroll on a chain from `proj_balances`. Fail-soft:
+ * returns null on any read error (caller records a null snapshot rather
+ * than failing the run). Never logs the wallet address.
+ */
+export async function readEthBankroll(
+  walletAddress: string,
+  chainId: number,
+  deps: BankrollDeps = { getBalances },
+): Promise<EthBankroll | null> {
+  try {
+    const rows = await deps.getBalances(walletAddress, chainId);
+    return computeEthBankroll(rows, chainId);
+  } catch (err) {
+    logger.warn("mission.results.bankroll_read_failed", {
+      chainId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/src/vex-agent/engine/mission/mapper.ts
+++ b/src/vex-agent/engine/mission/mapper.ts
@@ -28,6 +28,8 @@ export function missionToDraft(m: Mission): MissionDraft {
     successCriteria: m.successCriteriaJson.length > 0 ? m.successCriteriaJson : null,
     stopConditions: m.stopConditionsJson.length > 0 ? m.stopConditionsJson : null,
     deadline: constraints?.deadline as string ?? null,
+    durationMinutes:
+      typeof constraints?.durationMinutes === "number" ? constraints.durationMinutes : null,
     hyperliquidRisk: risk.success ? risk.data : null,
   };
 }
@@ -57,9 +59,16 @@ export function domainToRow(draft: Partial<MissionDraft>): MissionDraftRow {
   // `stopConditionsAccepted` — acceptance lives on
   // `missions.accepted_contract_hash` (mig 023) and is written by the
   // host-only acceptance path, never by the model/draft update flow.
-  if (draft.deadline !== undefined || draft.hyperliquidRisk !== undefined) {
+  if (
+    draft.deadline !== undefined ||
+    draft.durationMinutes !== undefined ||
+    draft.hyperliquidRisk !== undefined
+  ) {
     row.constraints_json = {
       ...(draft.deadline !== undefined ? { deadline: draft.deadline } : {}),
+      ...(draft.durationMinutes !== undefined
+        ? { durationMinutes: draft.durationMinutes }
+        : {}),
       ...(draft.hyperliquidRisk !== undefined ? { hyperliquidRisk: draft.hyperliquidRisk } : {}),
     };
   }
@@ -122,6 +131,7 @@ export function draftToPromptContext(m: Mission): string {
     for (const s of draft.stopConditions) lines.push(`- ${s}`);
   }
   if (draft.deadline) lines.push(`**Deadline:** ${draft.deadline}`);
+  if (draft.durationMinutes) lines.push(`**Time-box:** ${draft.durationMinutes} min (run auto-finalizes at start + this)`);
   if (draft.hyperliquidRisk) {
     lines.push(`**Hyperliquid risk:** ${draft.hyperliquidRisk.leverageCap}x leverage cap, ${draft.hyperliquidRisk.perOrderNotionalPct}% per order, ${draft.hyperliquidRisk.totalNotionalPct}% total`);
   }

--- a/src/vex-agent/engine/mission/mission-deadline.ts
+++ b/src/vex-agent/engine/mission/mission-deadline.ts
@@ -1,0 +1,129 @@
+/**
+ * Hard mission deadline — the agent-independent time-box.
+ *
+ * Missions run for a fixed duration (default 60 min) and then auto-finalize.
+ * The hard boundary is computed purely from FROZEN, run-immutable inputs:
+ *   - the run's `started_at` (immutable once the run row exists), and
+ *   - the per-mission `durationMinutes` read from the FROZEN run contract
+ *     snapshot (`frozenMission.draft.durationMinutes`, see
+ *     `frozenDurationMinutes`), NOT from the live mission row.
+ * Reading the frozen value is what keeps the box pinned across wakes/resumes:
+ * the live mission row can be edited (or moved back to draft after a failed
+ * run and re-edited before recovery), so a post-start mutation must never be
+ * able to move the enforced deadline mid-run. This mirrors how
+ * `resolveWalletPolicy` reads `allowedWallets` and `snapshotAutoRetryEnabled`
+ * reads its opt-in — both from the same frozen snapshot.
+ *
+ * Enforcement lives at the turn-loop boundary (see turn-loop.ts): once
+ * `now >= deadline`, the loop stops with `deadline_reached` before spending
+ * another inference call, regardless of what the agent is doing.
+ *
+ * DURATION CONTRACT — integer minutes only. Both the per-mission
+ * `durationMinutes` field (sanitized in `patch-parser.ts`) and the
+ * `VEX_MISSION_HARD_DEADLINE_MIN` env override are normalized to a WHOLE
+ * minute in `[1, 1440]`: a fractional value TRUNCATES toward zero (5.9 -> 5)
+ * and a sub-1-minute value (0.5) is rejected -> the next fallback applies.
+ * The env override exists to run short (e.g. 2-minute) test boxes without
+ * waiting an hour; the repo's own usages are all whole minutes, so a
+ * fractional test box is intentionally NOT supported (it would diverge from
+ * the per-mission field's contract).
+ *
+ * This module has NO trading surface — it only computes when a run must
+ * finalize. What happens to open positions at that point is a presentation /
+ * ledger concern (see mission-results work), never a trade instruction here.
+ */
+
+const DEFAULT_MINUTES = 60;
+const MAX_MINUTES = 1440; // 24h ceiling — a guard against a fat-fingered override or draft value
+const MIN_MINUTES = 1; // whole-minute floor — a sub-1-minute box is rejected, not truncated to 0
+
+/**
+ * Normalize a raw minute count to a whole minute in `[MIN_MINUTES, MAX_MINUTES]`,
+ * or `null` when it is not a usable box (non-finite, or truncates below 1).
+ * The single source of the integer-minute contract shared by the per-mission
+ * field and the env override.
+ */
+function clampWholeMinutes(value: number): number | null {
+  if (!Number.isFinite(value)) return null;
+  const whole = Math.trunc(value);
+  if (whole < MIN_MINUTES) return null;
+  return Math.min(whole, MAX_MINUTES);
+}
+
+/** Resolve the hard-deadline duration in minutes (default 60, env-overridable). */
+export function hardDeadlineMinutes(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env.VEX_MISSION_HARD_DEADLINE_MIN;
+  if (raw === undefined || raw === "") return DEFAULT_MINUTES;
+  return clampWholeMinutes(Number(raw)) ?? DEFAULT_MINUTES;
+}
+
+/**
+ * Resolve the box duration for a specific mission: the mission's own
+ * `durationMinutes` (a structured contract field the agent sets — "5-minute
+ * box" -> 5, "one hour" -> 60) when present and valid, else the env
+ * override, else the 60-minute default. Fractional/​sub-minute values follow
+ * the integer-minute contract (see `clampWholeMinutes`).
+ */
+export function resolveDurationMinutes(
+  missionMinutes?: number | null,
+  env: Record<string, string | undefined> = process.env,
+): number {
+  if (typeof missionMinutes === "number") {
+    const clamped = clampWholeMinutes(missionMinutes);
+    if (clamped !== null) return clamped;
+  }
+  return hardDeadlineMinutes(env);
+}
+
+/**
+ * Read the per-mission `durationMinutes` from a FROZEN run contract snapshot
+ * (`frozenMission.draft.durationMinutes`) — the same immutable source
+ * `resolveWalletPolicy` reads `allowedWallets` from. The live mission row is
+ * intentionally NOT consulted so a post-start mutation can never move the
+ * enforced deadline. FAIL-OPEN to `null` (-> env -> 60) on any
+ * missing/malformed level or a non-positive value.
+ */
+export function frozenDurationMinutes(snapshot: unknown): number | null {
+  if (snapshot === null || typeof snapshot !== "object") return null;
+  const frozen = (snapshot as Record<string, unknown>).frozenMission;
+  if (frozen === null || typeof frozen !== "object") return null;
+  const draft = (frozen as Record<string, unknown>).draft;
+  if (draft === null || typeof draft !== "object") return null;
+  const raw = (draft as Record<string, unknown>).durationMinutes;
+  return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : null;
+}
+
+/**
+ * The absolute hard-deadline epoch (ms) for a run: `started_at + duration`.
+ * Returns null when `started_at` is unparseable — fail-open, so a bad
+ * timestamp never manufactures a spurious deadline that kills a run early.
+ */
+export function computeHardDeadlineMs(
+  startedAtIso: string,
+  durationMin: number = hardDeadlineMinutes(),
+): number | null {
+  const startMs = Date.parse(startedAtIso);
+  if (Number.isNaN(startMs)) return null;
+  return startMs + durationMin * 60_000;
+}
+
+/**
+ * Resolve the frozen hard-deadline epoch (ms) for a run from its IMMUTABLE
+ * inputs: the run's `started_at` + the `durationMinutes` frozen in the run
+ * contract snapshot (-> env override -> 60-min default). Returns null when
+ * `started_at` is missing/unparseable (fail-open: no false early stop). This
+ * is the single resolver both the start and the resume paths use, so the box
+ * is identical across the run's whole life.
+ */
+export function resolveFrozenDeadlineMs(
+  startedAtIso: string | null | undefined,
+  contractSnapshot: unknown,
+): number | null {
+  if (!startedAtIso) return null;
+  return computeHardDeadlineMs(
+    startedAtIso,
+    resolveDurationMinutes(frozenDurationMinutes(contractSnapshot)),
+  );
+}

--- a/src/vex-agent/engine/mission/mission-metrics.ts
+++ b/src/vex-agent/engine/mission/mission-metrics.ts
@@ -1,0 +1,40 @@
+/**
+ * Per-mission trade metrics for the results ledger.
+ *
+ * `proj_activity` holds one row per successful fill; it links to a session
+ * via `protocol_executions.id`. A mission run maps 1:1 to a session, so
+ * bounding by (session_id, created_at within the run window) attributes
+ * fills to the run. Fail-soft: a read error yields 0 so mission
+ * finalization is never blocked by metrics.
+ *
+ * v1 computes the trade COUNT only. Per-trade win/loss/rotation
+ * attribution is a documented follow-up (see mission-results-capture.ts);
+ * mission-level win-rate is derived in the UI from PnL sign, which needs no
+ * per-trade pairing.
+ */
+
+import { queryOne } from "../../db/client.js";
+import logger from "@utils/logger.js";
+
+export async function countMissionTrades(
+  sessionId: string,
+  startedAt: string,
+  endedAt: string,
+): Promise<number> {
+  try {
+    const row = await queryOne<{ trades: number }>(
+      `SELECT COUNT(*)::int AS trades
+         FROM proj_activity a
+         JOIN protocol_executions e ON a.execution_id = e.id
+        WHERE e.session_id = $1
+          AND a.created_at BETWEEN $2 AND $3`,
+      [sessionId, startedAt, endedAt],
+    );
+    return row?.trades ?? 0;
+  } catch (err) {
+    logger.warn("mission.results.count_trades_failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return 0;
+  }
+}

--- a/src/vex-agent/engine/mission/mission-results-capture.ts
+++ b/src/vex-agent/engine/mission/mission-results-capture.ts
@@ -1,0 +1,156 @@
+/**
+ * Mission results capture — opens the ledger row when a run starts and
+ * closes it when the run finalizes. Both are FAIL-SOFT: any error is
+ * logged and swallowed so bankroll accounting can never break a mission's
+ * lifecycle. Deps are injected for tests; production wires the real
+ * repos/helpers.
+ *
+ * Start and finalize run in different turns, so nothing is held in memory —
+ * the row is keyed on `mission_run_id` and re-addressed at close.
+ *
+ * Naming: this produces a "mission result (ETH)" — an honest, ETH-
+ * denominated PnL record. Never call it "performance" here or in any
+ * consumer (agent behavior is directional and carries risk; a single
+ * numeric ledger is not a guarantee of future results).
+ *
+ * Never logs a wallet address — only ids (mission/run/session) and error
+ * messages.
+ */
+
+import { randomUUID } from "node:crypto";
+import { getMission, type Mission } from "../../db/repos/missions.js";
+import { resolveLocalChainId } from "../../../tools/evm-chains/registry.js";
+import { readEthBankroll } from "./bankroll.js";
+import { countMissionTrades } from "./mission-metrics.js";
+import {
+  openMissionResult,
+  closeMissionResult,
+  getResultForRun,
+  type MissionResultOutcome,
+} from "../../db/repos/mission-results.js";
+import logger from "@utils/logger.js";
+
+const GOAL_SNIPPET_MAX = 240;
+
+export interface CaptureDeps {
+  getMission: typeof getMission;
+  readBankroll: typeof readEthBankroll;
+  openResult: typeof openMissionResult;
+  closeResult: typeof closeMissionResult;
+  getResult: typeof getResultForRun;
+  countTrades: typeof countMissionTrades;
+}
+
+// Built lazily (inside each function's try) rather than at module load: some
+// runner tests partially-mock the repo modules, and a top-level object
+// literal would touch those bindings at import time. Resolving inside the
+// try keeps the access under the fail-soft guard.
+function productionDeps(): CaptureDeps {
+  return {
+    getMission,
+    readBankroll: readEthBankroll,
+    openResult: openMissionResult,
+    closeResult: closeMissionResult,
+    getResult: getResultForRun,
+    countTrades: countMissionTrades,
+  };
+}
+
+/** Pure PnL: ETH delta + percent vs start. Null when either side is unknown. */
+export function computePnl(
+  startEth: number | null,
+  endEth: number | null,
+): { pnlEth: number | null; pnlPct: number | null } {
+  if (startEth === null || endEth === null) return { pnlEth: null, pnlPct: null };
+  const pnlEth = endEth - startEth;
+  const pnlPct = startEth > 0 ? (pnlEth / startEth) * 100 : null;
+  return { pnlEth, pnlPct };
+}
+
+/** The mission's primary wallet + resolved local chain id, or null if either is absent/unresolvable. */
+function resolveWalletChain(
+  mission: Pick<Mission, "allowedWallets" | "allowedChains">,
+): { wallet: string; chainId: number } | null {
+  const wallet = mission.allowedWallets[0];
+  const chainKey = mission.allowedChains[0];
+  if (!wallet || !chainKey) return null;
+  const chainId = resolveLocalChainId(chainKey);
+  if (chainId === undefined) return null;
+  return { wallet, chainId };
+}
+
+/** Open the ledger row at run start (fail-soft). */
+export async function captureMissionStart(
+  args: { missionId: string; runId: string; sessionId: string },
+  injected?: CaptureDeps,
+): Promise<void> {
+  try {
+    const deps = injected ?? productionDeps();
+    const mission = await deps.getMission(args.missionId);
+    if (!mission) return;
+    const wc = resolveWalletChain(mission);
+    if (!wc) return;
+    const bankroll = await deps.readBankroll(wc.wallet, wc.chainId);
+    await deps.openResult({
+      id: `mres-${randomUUID()}`,
+      missionId: args.missionId,
+      missionRunId: args.runId,
+      sessionId: args.sessionId,
+      walletAddress: wc.wallet,
+      chainId: wc.chainId,
+      goalSnippet: mission.goal?.slice(0, GOAL_SNIPPET_MAX) ?? null,
+      bankrollStartEth: bankroll?.bankrollEth ?? null,
+      ethPriceUsdStart: bankroll?.ethPriceUsd ?? null,
+    });
+  } catch (err) {
+    logger.warn("mission.results.capture_start_failed", {
+      runId: args.runId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/** Close the ledger row at finalize with PnL + trade count (fail-soft). */
+export async function captureMissionFinal(
+  args: {
+    missionId: string;
+    runId: string;
+    sessionId: string;
+    outcome: Exclude<MissionResultOutcome, "running">;
+    stopReason: string | null;
+  },
+  injected?: CaptureDeps,
+): Promise<void> {
+  try {
+    const deps = injected ?? productionDeps();
+    const mission = await deps.getMission(args.missionId);
+    const wc = mission ? resolveWalletChain(mission) : null;
+    if (!wc) return;
+    const existing = await deps.getResult(args.runId, wc.wallet);
+    if (!existing) return; // never opened or not owned by this mission wallet -> nothing to close
+    const bankroll = await deps.readBankroll(wc.wallet, wc.chainId);
+    const endEth = bankroll?.bankrollEth ?? null;
+    const { pnlEth, pnlPct } = computePnl(existing.bankrollStartEth, endEth);
+    const trades = await deps.countTrades(
+      args.sessionId,
+      existing.startedAt,
+      new Date().toISOString(),
+    );
+    await deps.closeResult({
+      missionRunId: args.runId,
+      outcome: args.outcome,
+      stopReason: args.stopReason,
+      bankrollEndEth: endEth,
+      ethPriceUsdEnd: bankroll?.ethPriceUsd ?? null,
+      pnlEth,
+      pnlPct,
+      trades,
+      openPositions: bankroll?.openPositions ?? null,
+    });
+  } catch (err) {
+    logger.warn("mission.results.capture_final_failed", {
+      runId: args.runId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/vex-agent/engine/mission/patch-parser.ts
+++ b/src/vex-agent/engine/mission/patch-parser.ts
@@ -28,9 +28,19 @@ const ALLOWED_ARRAY_KEYS = new Set<keyof MissionDraft>([
   "successCriteria", "stopConditions",
 ]);
 
+/**
+ * `durationMinutes` is model-set NUMERIC data (a whole-minute time-box), not
+ * a string — it must not go through `ALLOWED_STRING_KEYS`/`sanitizeString`,
+ * which rejects any non-string typeof and would silently drop every numeric
+ * value (the run then falls back to the 60-minute default with no signal to
+ * the model or the operator).
+ */
+const ALLOWED_NUMBER_KEYS = new Set<keyof MissionDraft>(["durationMinutes"]);
+
 const ALL_ALLOWED_KEYS = new Set<string>([
   ...ALLOWED_STRING_KEYS,
   ...ALLOWED_ARRAY_KEYS,
+  ...ALLOWED_NUMBER_KEYS,
   "hyperliquidRisk",
 ]);
 
@@ -40,6 +50,8 @@ const MAX_STRING_LENGTH = 2000;
 const MAX_ARRAY_ITEMS = 50;
 /** Max string length per array item. */
 const MAX_ARRAY_ITEM_LENGTH = 500;
+/** Ceiling for `durationMinutes` — mirrors the 24h hard-deadline clamp. */
+const MAX_DURATION_MINUTES = 1440;
 
 // ── Extract ─────────────────────────────────────────────────────
 
@@ -87,6 +99,11 @@ export function sanitizePatch(patch: MissionPatch): Partial<MissionDraft> {
       if (sanitized !== undefined) {
         (result as Record<string, unknown>)[key] = sanitized;
       }
+    } else if (ALLOWED_NUMBER_KEYS.has(key as keyof MissionDraft)) {
+      const sanitized = sanitizeDurationMinutes(value);
+      if (sanitized !== undefined) {
+        (result as Record<string, unknown>)[key] = sanitized;
+      }
     } else if (key === "hyperliquidRisk") {
       const parsed = value === null
         ? { success: true as const, data: null }
@@ -106,6 +123,22 @@ function sanitizeString(value: unknown): string | null | undefined {
   const trimmed = value.trim();
   if (trimmed.length === 0) return null;
   return trimmed.slice(0, MAX_STRING_LENGTH);
+}
+
+/**
+ * Sanitize the mission's `durationMinutes` time-box: a positive whole-number
+ * minute count, clamped to `MAX_DURATION_MINUTES`. Rejects the wrong type
+ * (including numeric strings — the model must send a JSON number) and
+ * non-positive/non-finite values so a bad value falls through to the
+ * env/60-minute default instead of persisting garbage.
+ */
+function sanitizeDurationMinutes(value: unknown): number | null | undefined {
+  if (value === null) return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  if (value <= 0) return undefined;
+  const wholeMinutes = Math.trunc(value);
+  if (wholeMinutes < 1) return undefined;
+  return Math.min(wholeMinutes, MAX_DURATION_MINUTES);
 }
 
 // ── Model output parser ─────────────────────────────────────────

--- a/src/vex-agent/engine/mission/renew.ts
+++ b/src/vex-agent/engine/mission/renew.ts
@@ -45,6 +45,8 @@ import { withTransaction } from "../../db/client.js";
 import {
   type Mission,
   getMissionForUpdate,
+  getPendingDraftForSession,
+  lockSessionForRenew,
 } from "../../db/repos/missions.js";
 import * as missionRunsRepo from "../../db/repos/mission-runs.js";
 import { cloneMissionAsDraft } from "./renew-internals.js";
@@ -81,6 +83,16 @@ export type RenewMissionOutcome =
     readonly outcome: "session_has_active_run";
     readonly missionRunId: string;
     readonly runStatus: string;
+  }
+  | {
+    /**
+     * The session already holds an un-started (`draft`/`ready`) mission.
+     * Renewal clones a finished mission into a fresh draft; without this
+     * check, two renews racing before the first commits could both clone
+     * one (the duplicate-draft storm — see `lockSessionForRenew`).
+     */
+    readonly outcome: "session_has_pending_draft";
+    readonly missionId: string;
   };
 
 /** Clone an accepted + terminal mission into a fresh draft row. */
@@ -88,6 +100,13 @@ export async function renewMission(
   input: RenewMissionInput,
 ): Promise<RenewMissionOutcome> {
   return withTransaction(async (client): Promise<RenewMissionOutcome> => {
+    // 0. Session-scoped advisory lock, acquired FIRST so it serializes the
+    //    ENTIRE decision below (not just the source-mission row) against
+    //    any other concurrent renew for this session — including one
+    //    targeting a DIFFERENT previousMissionId. Xact-scoped; Postgres
+    //    releases it automatically at COMMIT/ROLLBACK.
+    await lockSessionForRenew(client, input.sessionId);
+
     // 1. Row-locked read of the source mission.
     const source: Mission | null = await getMissionForUpdate(
       client,
@@ -158,7 +177,25 @@ export async function renewMission(
       };
     }
 
-    // 6. Clone via dedicated repo helper. The clone:
+    // 6. Refuse if the session already holds a pending (un-started) draft
+    //    or ready mission. Runs INSIDE the session-locked transaction
+    //    (step 0), so a second concurrent renew racing before the first
+    //    commits cannot ALSO pass this check — closes the duplicate-draft
+    //    storm at its root. Not a schema unique index: production data
+    //    already contains duplicate drafts from before this fix, so an
+    //    index would fail to apply.
+    const pendingDraft = await getPendingDraftForSession(
+      client,
+      input.sessionId,
+    );
+    if (pendingDraft !== null) {
+      return {
+        outcome: "session_has_pending_draft",
+        missionId: pendingDraft.id,
+      };
+    }
+
+    // 7. Clone via dedicated repo helper. The clone:
     //      - copies every contract field
     //      - resets status to 'draft', acceptance + approved_at to NULL
     //      - stamps renewed_from_mission_id = source.id

--- a/src/vex-agent/engine/prompts/mission-setup.ts
+++ b/src/vex-agent/engine/prompts/mission-setup.ts
@@ -59,6 +59,7 @@ export function buildMissionSetupPrompt(
   lines.push("- **successCriteria** — how to know the mission succeeded");
   lines.push("- **stopConditions** — proposed/user-owned non-success stop conditions. Final acceptance happens via the host Accept contract step (mission.acceptContract), not by chat agreement. Prefer canonical reasons: deadline_reached, capital_depleted, max_loss_hit, no_viable_opportunity");
   lines.push("- **deadline** (optional) — time limit for the mission");
+  lines.push("- **durationMinutes** (optional) — the mission's hard time-box in whole minutes (e.g. 5, 60), set from the goal's stated duration. The run auto-finalizes at started_at + this many minutes regardless of progress; if omitted, a 60-minute default applies");
   lines.push("");
   lines.push("## Stop Condition Semantics");
   lines.push("- goal_reached is not a stopCondition; it is success and is covered by successCriteria");

--- a/src/vex-agent/engine/runtime-clock.ts
+++ b/src/vex-agent/engine/runtime-clock.ts
@@ -98,6 +98,9 @@ export function buildRuntimeClockPrompt(snapshot: RuntimeClockSnapshot): string 
   lines.push("- You do not observe time while deferred; a wake means the executor resumed you after real time passed.");
   lines.push("- To wait when `loop_defer` is available in your current mode, call `loop_defer(after_ms, reason)` for relative waits or `loop_defer(wake_at, reason)` for an exact ISO time.");
   lines.push("- Before using deadline_reached or scheduling another wake, compare live state against this Runtime Clock.");
+  if (snapshot.missionDeadline) {
+    lines.push("- The mission auto-finalizes when this deadline passes. Any positions still open at that point are reported as unresolved, not closed automatically.");
+  }
 
   return lines.join("\n");
 }

--- a/src/vex-agent/engine/types.ts
+++ b/src/vex-agent/engine/types.ts
@@ -203,6 +203,13 @@ export interface MissionDraft {
   stopConditions: string[] | null;
   /** Optional — mission may have no deadline. */
   deadline: string | null;
+  /**
+   * Optional hard time-box in whole minutes. The turn-loop deadline
+   * enforcer stops the run at `started_at + this` (see
+   * `engine/mission/mission-deadline.ts`). Absent -> env override -> 60min
+   * default. Distinct from `deadline` (free-text, informational only).
+   */
+  durationMinutes: number | null;
   /** Optional, host-accepted Hyperliquid envelope for an autonomous mission. */
   hyperliquidRisk?: import("../../lib/hyperliquid-policy.js").HyperliquidMissionRisk | null;
 }

--- a/src/vex-agent/engine/types.ts
+++ b/src/vex-agent/engine/types.ts
@@ -183,7 +183,16 @@ export type MessageType =
   | "checkpoint"
   | "wake_due"
   | "subagent_relay"
-  | "tool_result";
+  | "tool_result"
+  /**
+   * A trusted prepare→execute handoff the engine synthesized itself (never
+   * model output — see `dispatchPreparedActionFollowUp`). Paired with
+   * `source: "engine"` on the same assistant-role row so an auditor reading
+   * `messages` directly can never mistake it for a real model-authored
+   * tool_call, even though the row keeps `role: "assistant"` for the
+   * provider transcript format.
+   */
+  | "prepared_action_follow_up";
 
 export type MessageVisibility = "user" | "internal";
 

--- a/src/vex-agent/tools/internal/mission.ts
+++ b/src/vex-agent/tools/internal/mission.ts
@@ -42,6 +42,7 @@ const MissionDraftUpdateArgs = z
     successCriteria: z.array(z.string().trim().min(1).max(MAX_ARRAY_ITEM_LENGTH)).max(MAX_ARRAY_ITEMS).nullable().optional(),
     stopConditions: z.array(z.string().trim().min(1).max(MAX_ARRAY_ITEM_LENGTH)).max(MAX_ARRAY_ITEMS).nullable().optional(),
     deadline: z.string().trim().min(1).max(MAX_STRING_LENGTH).nullable().optional(),
+    durationMinutes: z.number().int().positive().max(1440).nullable().optional(),
     hyperliquidRisk: hyperliquidMissionRiskSchema.nullable().optional(),
   })
   .strict()

--- a/src/vex-agent/tools/internal/wallet/send/prepare.ts
+++ b/src/vex-agent/tools/internal/wallet/send/prepare.ts
@@ -64,7 +64,7 @@ export async function handleWalletSendPrepare(
     idempotencyKey: intentId,
   });
 
-  return ok({
+  const result = ok({
     intentId,
     network,
     chain: chain ?? undefined,
@@ -73,6 +73,22 @@ export async function handleWalletSendPrepare(
     token: token ?? "native",
     status: "prepared",
     expiresAt,
-    message: "Use wallet_send_confirm to broadcast this transfer.",
+    // Confirm is now auto-dispatched by the turn loop's trusted follow-up
+    // handoff (see `preparedActionFollowUp` below) — this line is
+    // transcript/model-facing copy only and no longer prescribes a
+    // follow-up action the agent itself must take.
+    message: "Transfer prepared; Vex will confirm it automatically.",
   });
+  return {
+    ...result,
+    preparedActionFollowUp: {
+      toolName: "wallet_send_confirm",
+      args: { network, intentId },
+      expiresAt,
+      approvalPreview: {
+        toolName: "wallet_send_confirm",
+        criticalArgs: { ...previewJson.criticalArgs },
+      },
+    },
+  };
 }

--- a/src/vex-agent/tools/protocols/khalani/handlers/bridge.ts
+++ b/src/vex-agent/tools/protocols/khalani/handlers/bridge.ts
@@ -12,6 +12,7 @@ import {
 import { resolveRouteBestIndex } from "@tools/khalani/helpers.js";
 import { prepareQuoteRequest } from "@tools/khalani/request.js";
 import { executeDepositPlan } from "@tools/khalani/bridge-executor.js";
+import { pollKhalaniOrderToTerminal } from "@tools/khalani/order-status.js";
 import type { DepositMethod, QuoteRoute } from "@tools/khalani/types.js";
 import type { ChainWallet } from "@tools/wallet/multi-auth.js";
 import { familyToInventory, walletAddressesEqual } from "@tools/wallet/inventory.js";
@@ -184,8 +185,13 @@ export const BRIDGE_HANDLERS: Record<string, ProtocolHandler> = {
       signer,
     });
 
-    // 9. Return result with trade capture data
-    const bridgeResult = {
+    // 9. Track the submitted order to a TERMINAL state (Khalani Integration
+    // Guide). The deposit tx mining does NOT mean the destination leg filled —
+    // the fill can still fail or refund. Bounded (5s × 24 ≈ 2 min) so a turn
+    // never blocks forever; mirrors relay.bridge's terminal-status handling.
+    const poll = await pollKhalaniOrderToTerminal(result.orderId);
+
+    const bridgeBase = {
       orderId: result.orderId,
       txHash: result.txHash,
       fromChain: fromChainId,
@@ -198,16 +204,82 @@ export const BRIDGE_HANDLERS: Record<string, ProtocolHandler> = {
       etaSeconds: selectedRoute.quote.expectedDurationSeconds,
     };
 
+    // Status could NOT be verified: EVERY getOrderById poll failed (Khalani status
+    // API unreachable for the whole window). Do NOT mask a total verification
+    // outage as a benign pending order — that would enqueue a projection for a
+    // status nobody observed. Fail closed, NO _tradeCapture, and surface the
+    // orderId + deposit tx hash so the user can verify the order manually.
+    if (poll.kind === "unavailable") {
+      logger.warn("khalani.bridge.status_unverifiable", {
+        fromChain: fromChainId,
+        toChain: toChainId,
+        orderId: result.orderId,
+      });
+      const message = `Khalani order status could NOT be verified — the Khalani status API was unreachable for the entire tracking window. The deposit was broadcast but delivery is UNCONFIRMED. Do NOT re-bridge; verify the order manually via orderId=${result.orderId} (deposit txHash=${result.txHash}).`;
+      return {
+        success: false,
+        output: JSON.stringify({ success: false, ...bridgeBase, status: "unverified", message }, null, 2),
+        data: { ...bridgeBase, status: "unverified" },
+      };
+    }
+
+    const finalStatus = poll.status;
+    const bridgeResult = { ...bridgeBase, status: finalStatus };
+
+    // Terminal failure/refund: the destination amount did NOT arrive. Fail the
+    // tool result and emit NO _tradeCapture — nothing arrived to record. Mirrors
+    // relay.bridge (PR #27): venue truth drives tool-result truth.
+    if (finalStatus === "failed" || finalStatus === "refunded") {
+      logger.warn("khalani.bridge.terminal_failure", {
+        fromChain: fromChainId,
+        toChain: toChainId,
+        finalStatus,
+        orderId: result.orderId,
+      });
+      const message = finalStatus === "refunded"
+        ? "Khalani reported this bridge as refunded: the destination amount did NOT arrive; funds were returned toward the refund address. Verify balances before any follow-up."
+        : "Khalani reported this bridge as failed: the destination amount did NOT arrive. Verify balances via the order id before retrying.";
+      return {
+        success: false,
+        output: JSON.stringify({ success: false, ...bridgeResult, message }, null, 2),
+        data: { ...bridgeResult },
+      };
+    }
+
+    logger.info("khalani.bridge.completed", {
+      fromChain: fromChainId,
+      toChain: toChainId,
+      finalStatus,
+      orderId: result.orderId,
+    });
+
+    // filled → confirmed delivery. Any NON-terminal status here means the bounded
+    // poll window closed while the order was still live (created/deposited/
+    // published/refund_pending) — keep the pending capture (the order is live and
+    // may still complete) BUT the output must never read as delivery. A
+    // refund_pending is called out explicitly: a refund is in flight, NOT yet
+    // delivered, and the destination amount did NOT arrive.
+    const captureStatus = finalStatus === "filled" ? "executed" : "pending";
+    const pendingMessage = finalStatus === "filled"
+      ? undefined
+      : finalStatus === "refund_pending"
+        ? 'Khalani has NOT confirmed this bridge — the last status was "refund_pending": a refund is IN FLIGHT but not yet delivered, and the destination amount did NOT arrive. Do NOT re-bridge; track the order id.'
+        : `Khalani has NOT confirmed this bridge yet — the last status after the poll window was "${finalStatus}". It may still complete; track the order id before any retry. Do NOT re-bridge.`;
+
     return {
       success: true,
-      output: JSON.stringify({ success: true, ...bridgeResult }, null, 2),
+      output: JSON.stringify({
+        success: true,
+        ...bridgeResult,
+        ...(pendingMessage ? { message: pendingMessage } : {}),
+      }, null, 2),
       data: {
         ...bridgeResult,
         // Trade capture hint — runtime uses this to auto-store
         _tradeCapture: {
           type: "bridge",
           chain: String(fromChainId),
-          status: "pending",
+          status: captureStatus,
           inputToken: fromToken,
           inputTokenAddress: fromToken,
           inputAmount: amount,
@@ -221,6 +293,7 @@ export const BRIDGE_HANDLERS: Record<string, ProtocolHandler> = {
             destChain: String(toChainId),
             routeId: selectedRoute.routeId,
             orderId: result.orderId,
+            finalStatus,
           },
         },
       },

--- a/src/vex-agent/tools/protocols/kyberswap/handlers/swap.ts
+++ b/src/vex-agent/tools/protocols/kyberswap/handlers/swap.ts
@@ -137,6 +137,29 @@ const VEX_INTEGRATOR_FEE_ROUTE_PARAMS = {
   feeReceiver: KYBERSWAP_FEE_RECEIVER,
 } as const;
 
+/**
+ * Classify the ECONOMIC direction of a swap from the native leg, independent of
+ * which tool (`kyberswap.swap.buy` vs `kyberswap.swap.sell`) was invoked. A
+ * token can legitimately be bought via the sell-tool (native-in) or sold via
+ * the buy-tool, so the tool name alone is not a reliable accounting label.
+ *
+ * Spending native to acquire a token is a BUY; selling a token back to native
+ * is a SELL. Token↔token has no native anchor, so we fall back to the tool's
+ * declared side. Used ONLY for what is recorded/reported — never for routing,
+ * quoting, or execution. Mirrors uniswap's `classifyEconomicSide` (same bug
+ * class, same fix shape; kept local per protocol per the repo's "3+ = extract"
+ * convention — two occurrences do not yet warrant a shared helper).
+ */
+export function classifyEconomicSide(args: {
+  readonly tokenInIsNative: boolean;
+  readonly tokenOutIsNative: boolean;
+  readonly side: "buy" | "sell";
+}): "buy" | "sell" {
+  if (args.tokenInIsNative) return "buy";
+  if (args.tokenOutIsNative) return "sell";
+  return args.side;
+}
+
 // ── Shared swap execution (sell + buy use same routing, differ in trade_side) ──
 
 async function executeKyberSwap(p: Record<string, unknown>, side: "buy" | "sell", context: ProtocolExecutionContext): Promise<ToolResult> {
@@ -188,8 +211,16 @@ async function executeKyberSwap(p: Record<string, unknown>, side: "buy" | "sell"
   const { routeSummary, routerAddress } = routeResp.data;
   verifyRouterAddress(routerAddress, META_AGGREGATION_ROUTER_V2);
 
+  // Economic direction for RECORDING/reporting — derived from the native leg,
+  // not the tool name (`side`). `side` still drives routing/execution below.
+  const economicSide = classifyEconomicSide({
+    tokenInIsNative: tokenIn.isNative,
+    tokenOutIsNative: tokenOut.isNative,
+    side,
+  });
+
   if (p.dryRun === true) {
-    return ok({ dryRun: true, side, chain: slug, routeSummary: formatRouteSummary(routeSummary), routerAddress });
+    return ok({ dryRun: true, side: economicSide, chain: slug, routeSummary: formatRouteSummary(routeSummary), routerAddress });
   }
 
   // Per-session signing wallet (puzzle 5 phase 5D-protocols) — resolved AFTER the
@@ -244,21 +275,21 @@ async function executeKyberSwap(p: Record<string, unknown>, side: "buy" | "sell"
 
   return {
     success: true,
-    output: JSON.stringify({ txHash, side, chain: slug, tokenIn: tokenIn.symbol, tokenOut: tokenOut.symbol, amountIn: buildResp.data.amountIn, amountOut: buildResp.data.amountOut, amountInUsd: buildResp.data.amountInUsd, amountOutUsd: buildResp.data.amountOutUsd }, null, 2),
+    output: JSON.stringify({ txHash, side: economicSide, chain: slug, tokenIn: tokenIn.symbol, tokenOut: tokenOut.symbol, amountIn: buildResp.data.amountIn, amountOut: buildResp.data.amountOut, amountInUsd: buildResp.data.amountInUsd, amountOutUsd: buildResp.data.amountOutUsd }, null, 2),
     data: { txHash, _tradeCapture: {
       type: "swap", chain: slug, status: "executed",
       inputToken: tokenIn.symbol, outputToken: tokenOut.symbol,
       inputTokenAddress: tokenIn.address, outputTokenAddress: tokenOut.address,
       inputAmount: buildResp.data.amountIn, outputAmount: buildResp.data.amountOut,
-      signature: txHash, walletAddress: signer.address, tradeSide: side,
-      instrumentKey: `${slug}:${side === "buy" ? tokenOut.address : tokenIn.address}`,
+      signature: txHash, walletAddress: signer.address, tradeSide: economicSide,
+      instrumentKey: `${slug}:${economicSide === "buy" ? tokenOut.address : tokenIn.address}`,
       inputValueUsd: buildResp.data.amountInUsd, outputValueUsd: buildResp.data.amountOutUsd,
       feeValueUsd: buildResp.data.gasUsd, valuationSource: "kyberswap_exact",
       benchmarkAssetKey: benchmarkAssetKey ?? undefined,
-      settlementAssetKey: side === "buy" ? tokenIn.symbol : tokenOut.symbol,
+      settlementAssetKey: economicSide === "buy" ? tokenIn.symbol : tokenOut.symbol,
       inputValueNative: inputIsNative ? formatUnits(amountIn, tokenIn.decimals) : undefined,
       outputValueNative: outputIsNative ? formatUnits(BigInt(buildResp.data.amountOut), tokenOut.decimals) : undefined,
-      meta: { dex: "kyberswap", side },
+      meta: { dex: "kyberswap", side: economicSide },
     } },
   };
 }

--- a/src/vex-agent/tools/protocols/polymarket/handlers-clob/orders.ts
+++ b/src/vex-agent/tools/protocols/polymarket/handlers-clob/orders.ts
@@ -114,6 +114,20 @@ export const ORDERS_HANDLERS: Record<string, ProtocolHandler> = {
       ...(result.tradeIDs?.length ? { tradeIDs: result.tradeIDs } : {}),
       ...(result.errorMsg ? { errorMsg: result.errorMsg } : {}),
     };
+
+    // The venue rejected the order (bad signature, insufficient balance,
+    // market closed, etc.). Fail the ToolResult and skip _tradeCapture — an
+    // order the CLOB never accepted must not be recorded as a resting/open
+    // order. Same class of bug as relay.bridge: venue truth must drive
+    // tool-result truth, not just ride along in the output text.
+    if (!result.success) {
+      return {
+        success: false,
+        output: JSON.stringify(buyOutput, null, 2),
+        data: { ...result, conditionId },
+      };
+    }
+
     return {
       success: true,
       output: JSON.stringify(buyOutput, null, 2),
@@ -212,6 +226,19 @@ export const ORDERS_HANDLERS: Record<string, ProtocolHandler> = {
       ...(result.tradeIDs?.length ? { tradeIDs: result.tradeIDs } : {}),
       ...(result.errorMsg ? { errorMsg: result.errorMsg } : {}),
     };
+
+    // Same rejection guard as clob.buy: the venue rejected the order, so the
+    // ToolResult must fail and no _tradeCapture goes out. Mirrors the repo's
+    // own clob.cancel precedent a few lines below ("reports success=false
+    // when the requested order lands in not_canceled").
+    if (!result.success) {
+      return {
+        success: false,
+        output: JSON.stringify(sellOutput, null, 2),
+        data: { ...result, conditionId },
+      };
+    }
+
     return {
       success: true,
       output: JSON.stringify(sellOutput, null, 2),
@@ -267,11 +294,28 @@ export const ORDERS_HANDLERS: Record<string, ProtocolHandler> = {
       return walletScopeErrorToResult(err);
     }
     const result = await getPolyClobClient().cancelOrders({ address }, ids);
+    // Same not_canceled correctness guard as clob.cancel, extended to N ids:
+    // the venue can return 200 while rejecting every requested cancellation.
+    // A total rejection (nothing cancelled, venue reported reasons) is a real
+    // failure — no _tradeCapture. A partial success keeps the ledger trace for
+    // the ids that DID cancel (captureItems only ever covers result.canceled).
+    if (result.canceled.length === 0 && Object.keys(result.not_canceled).length > 0) {
+      return { success: false, output: JSON.stringify(result, null, 2), data: { ...result } };
+    }
     const captureItems = result.canceled.map(oid => ({
       type: "order" as const, chain: "polygon" as const, status: "cancelled" as const,
       walletAddress: address, positionKey: oid, meta: { action: "cancel" },
     }));
-    return { success: true, output: JSON.stringify(result, null, 2), data: { ...result, _tradeCapture: { type: "order", chain: "polygon", status: "cancelled", walletAddress: address, meta: { action: "cancelOrders", count: result.canceled.length } }, _tradeCaptureItems: captureItems } };
+    return {
+      success: true,
+      output: JSON.stringify(result, null, 2),
+      data: {
+        ...result,
+        ...(result.canceled.length > 0
+          ? { _tradeCapture: { type: "order", chain: "polygon", status: "cancelled", walletAddress: address, meta: { action: "cancelOrders", count: result.canceled.length } }, _tradeCaptureItems: captureItems }
+          : {}),
+      },
+    };
   },
 
   "polymarket.clob.cancelAll": async (_p, ctx) => {
@@ -282,11 +326,27 @@ export const ORDERS_HANDLERS: Record<string, ProtocolHandler> = {
       return walletScopeErrorToResult(err);
     }
     const result = await getPolyClobClient().cancelAll({ address });
+    // Same not_canceled correctness guard as cancelOrders. "Nothing to cancel"
+    // (both canceled and not_canceled empty — no open orders) is a legitimate
+    // no-op success, not a failure; a total rejection (venue reported reasons,
+    // nothing cancelled) is.
+    if (result.canceled.length === 0 && Object.keys(result.not_canceled).length > 0) {
+      return { success: false, output: JSON.stringify(result, null, 2), data: { ...result } };
+    }
     const captureItems = result.canceled.map(oid => ({
       type: "order" as const, chain: "polygon" as const, status: "cancelled" as const,
       walletAddress: address, positionKey: oid, meta: { action: "cancel" },
     }));
-    return { success: true, output: JSON.stringify(result, null, 2), data: { ...result, _tradeCapture: { type: "order", chain: "polygon", status: "cancelled", walletAddress: address, meta: { action: "cancelAll", count: result.canceled.length } }, _tradeCaptureItems: captureItems.length > 0 ? captureItems : undefined } };
+    return {
+      success: true,
+      output: JSON.stringify(result, null, 2),
+      data: {
+        ...result,
+        ...(captureItems.length > 0
+          ? { _tradeCapture: { type: "order", chain: "polygon", status: "cancelled", walletAddress: address, meta: { action: "cancelAll", count: result.canceled.length } }, _tradeCaptureItems: captureItems }
+          : {}),
+      },
+    };
   },
 
   "polymarket.clob.cancelMarket": async (p, ctx) => {
@@ -299,11 +359,25 @@ export const ORDERS_HANDLERS: Record<string, ProtocolHandler> = {
       return walletScopeErrorToResult(err);
     }
     const result = await getPolyClobClient().cancelMarketOrders({ address }, market, assetId);
+    // Same not_canceled correctness guard as cancelOrders/cancelAll.
+    if (result.canceled.length === 0 && Object.keys(result.not_canceled).length > 0) {
+      return { success: false, output: JSON.stringify(result, null, 2), data: { ...result, conditionId: market } };
+    }
     const captureItems = result.canceled.map(oid => ({
       type: "order" as const, chain: "polygon" as const, status: "cancelled" as const,
       walletAddress: address, positionKey: oid, meta: { action: "cancelMarket", conditionId: market, assetId },
     }));
-    return { success: true, output: JSON.stringify(result, null, 2), data: { ...result, conditionId: market, _tradeCapture: { type: "order", chain: "polygon", status: "cancelled", walletAddress: address, meta: { action: "cancelMarket", conditionId: market, assetId } }, _tradeCaptureItems: captureItems.length > 0 ? captureItems : undefined } };
+    return {
+      success: true,
+      output: JSON.stringify(result, null, 2),
+      data: {
+        ...result,
+        conditionId: market,
+        ...(captureItems.length > 0
+          ? { _tradeCapture: { type: "order", chain: "polygon", status: "cancelled", walletAddress: address, meta: { action: "cancelMarket", conditionId: market, assetId } }, _tradeCaptureItems: captureItems }
+          : {}),
+      },
+    };
   },
 
   "polymarket.clob.orders": async (p, ctx) => {

--- a/src/vex-agent/tools/protocols/relay/handlers/bridge.ts
+++ b/src/vex-agent/tools/protocols/relay/handlers/bridge.ts
@@ -212,12 +212,70 @@ async function relayBridge(
     destinationChainId: legs.destinationChainId,
   });
 
-  const captureStatus =
-    result.finalStatus === "success"
-      ? "executed"
-      : result.finalStatus === "failure" || result.finalStatus === "refund"
-        ? "failed"
-        : "pending";
+  // "failure"/"refund" are TERMINAL Relay intent statuses (`pollToTerminal`
+  // returns them without throwing): every step may have mined successfully and
+  // the bridge still did not deliver. The tool result must say so — the
+  // capture pipeline projects proj_activity only from successful results, and
+  // the model plans off `success`. No capture, no pin: nothing arrived.
+  if (result.finalStatus === "failure" || result.finalStatus === "refund") {
+    logger.warn("relay.bridge.terminal_failure", {
+      originChainId: legs.originChainId,
+      destinationChainId: legs.destinationChainId,
+      finalStatus: result.finalStatus,
+    });
+    const message = result.finalStatus === "refund"
+      ? "Relay reported this bridge as refunded: the destination amount did NOT arrive; funds were returned toward the origin/refund address. Verify balances before any follow-up."
+      : "Relay reported this bridge as failed: the destination amount did NOT arrive. Verify balances via the request id before retrying.";
+    return {
+      success: false,
+      output: JSON.stringify({
+        success: false,
+        requestId: result.requestId,
+        status: result.finalStatus,
+        txHashes: result.txHashes,
+        fromChain: legs.originChainId,
+        toChain: legs.destinationChainId,
+        message,
+      }, null, 2),
+      data: {
+        requestId: result.requestId,
+        status: result.finalStatus,
+        txHashes: result.txHashes,
+      },
+    };
+  }
+
+  // Status was never OBSERVED: every status poll threw (Relay status API
+  // unreachable for the whole window). Delivery is UNKNOWN — do NOT mask a total
+  // verification failure as a benign pending capture. Fail closed, NO capture, NO
+  // pin, and surface the broadcast correlation ids so the user can check manually.
+  // (An untrackable quote with no request id at all fails EARLIER, pre-broadcast,
+  // in executeRelayBridge — it never reaches here.)
+  if (!result.statusObserved) {
+    logger.warn("relay.bridge.status_unverifiable", {
+      originChainId: legs.originChainId,
+      destinationChainId: legs.destinationChainId,
+    });
+    return {
+      success: false,
+      output: JSON.stringify({
+        success: false,
+        requestId: result.requestId,
+        status: "unverified",
+        txHashes: result.txHashes,
+        fromChain: legs.originChainId,
+        toChain: legs.destinationChainId,
+        message: "Relay bridge status could NOT be verified — the status API was unreachable for the entire poll window. The transactions were broadcast but delivery is UNCONFIRMED. Do NOT re-bridge; verify balances via the request id / tx hashes before any follow-up.",
+      }, null, 2),
+      data: {
+        requestId: result.requestId,
+        status: "unverified",
+        txHashes: result.txHashes,
+      },
+    };
+  }
+
+  const captureStatus = result.finalStatus === "success" ? "executed" : "pending";
 
   // Display legs (symbols + human-readable amounts) for the capture; the raw
   // currency addresses stay in inputTokenAddress/outputTokenAddress.
@@ -227,6 +285,8 @@ async function relayBridge(
   // Auto-pin (fail-soft): an ERC-20 bridged ONTO a local chain joins the
   // tracked_tokens set (seed ∪ pins) so balance scans and the portfolio see
   // it. Native needs no pin. A DB bookmark — never fails the bridge result.
+  // Pending pins too: the bridge may still complete and the scan must not
+  // miss the token when it lands.
   if (getLocalChain(legs.destinationChainId) && legs.destinationCurrency !== RELAY_NATIVE_CURRENCY && isAddress(legs.destinationCurrency)) {
     try {
       await pinTrackedToken({
@@ -258,6 +318,14 @@ async function relayBridge(
       txHashes: result.txHashes,
       fromChain: legs.originChainId,
       toChain: legs.destinationChainId,
+      // "pending" = the status poll window closed before a terminal status:
+      // broadcast happened and the bridge may still complete, but it is NOT
+      // confirmed — spell that out so it is never read as completion, and
+      // surface the ACTUAL last-seen status (waiting/depositing/submitted have
+      // materially different meanings) instead of flattening it away.
+      ...(result.finalStatus !== "success"
+        ? { message: `Relay has NOT confirmed this bridge yet — the last status seen after the poll window was "${result.finalStatus}". It may still complete; check the request id before any retry. Do NOT re-bridge.` }
+        : {}),
     }, null, 2),
     data: {
       requestId: result.requestId,

--- a/src/vex-agent/tools/protocols/uniswap/handlers/swap.ts
+++ b/src/vex-agent/tools/protocols/uniswap/handlers/swap.ts
@@ -53,6 +53,27 @@ function isNativeInput(input: string): boolean {
 }
 
 /**
+ * Classify the ECONOMIC direction of a swap from the native leg, independent of
+ * which tool (`uniswap.swap.buy` vs `uniswap.swap.sell`) was invoked. A token
+ * can legitimately be bought via the sell-tool (native-in) or sold via the
+ * buy-tool, so the tool name is not a reliable label for accounting.
+ *
+ * Spending native to acquire a token is a BUY; selling a token back to native
+ * is a SELL. Token↔token has no native anchor, so we fall back to the tool's
+ * declared side. This is used ONLY for what is recorded/reported — never for
+ * routing, quoting, or execution.
+ */
+export function classifyEconomicSide(args: {
+  readonly tokenInIsNative: boolean;
+  readonly tokenOutIsNative: boolean;
+  readonly side: "buy" | "sell";
+}): "buy" | "sell" {
+  if (args.tokenInIsNative) return "buy"; // spending native to acquire a token = BUY
+  if (args.tokenOutIsNative) return "sell"; // selling a token back to native = SELL
+  return args.side; // token↔token: fall back to the tool's side
+}
+
+/**
  * Resolve a token leg. Native ("eth"/"native"/sentinel) routes as WETH; a hex
  * address reads metadata on-chain; a bare symbol is rejected (address-only).
  */
@@ -219,11 +240,19 @@ async function executeUniswapSwap(
   const amountIn = parseUnits(amountInRaw, tokenIn.decimals);
   const slippageBps = num(p, "slippageBps") ?? DEFAULT_SLIPPAGE_BPS;
 
+  // Economic direction for RECORDING/reporting — derived from the native leg,
+  // not the tool name (`side`). `side` still drives routing/execution below.
+  const economicSide = classifyEconomicSide({
+    tokenInIsNative: tokenIn.isNative,
+    tokenOutIsNative: tokenOut.isNative,
+    side,
+  });
+
   const quoted = await computeQuote(deployment, tokenIn, tokenOut, amountIn, slippageBps);
 
   if (p.dryRun === true) {
     return ok({
-      dryRun: true, side, chain: deployment.key,
+      dryRun: true, side: economicSide, chain: deployment.key,
       route: { version: quoted.route.version, path: quoted.route.path, fees: quoted.route.fees ?? null },
       amountOut: formatUnits(quoted.amountOut, tokenOut.decimals),
       minAmountOut: formatUnits(quoted.minAmountOut, tokenOut.decimals),
@@ -300,7 +329,7 @@ async function executeUniswapSwap(
   return {
     success: true,
     output: JSON.stringify({
-      txHash, side, chain: deployment.key,
+      txHash, side: economicSide, chain: deployment.key,
       tokenIn: tokenIn.symbol, tokenOut: tokenOut.symbol,
       amountIn: amountInRaw, amountOut: amountOutHuman,
       route: { version: quoted.route.version, path: quoted.route.path },
@@ -321,11 +350,11 @@ async function executeUniswapSwap(
         outputAmount: amountOutHuman,
         signature: txHash,
         walletAddress: signer.address,
-        tradeSide: side,
-        instrumentKey: `${deployment.key}:${side === "buy" ? tokenOut.address : tokenIn.address}`,
+        tradeSide: economicSide,
+        instrumentKey: `${deployment.key}:${economicSide === "buy" ? tokenOut.address : tokenIn.address}`,
         valuationSource: "none",
-        settlementAssetKey: side === "buy" ? tokenIn.symbol : tokenOut.symbol,
-        meta: { dex: "uniswap", version: quoted.route.version, side },
+        settlementAssetKey: economicSide === "buy" ? tokenIn.symbol : tokenOut.symbol,
+        meta: { dex: "uniswap", version: quoted.route.version, side: economicSide },
       },
     },
   };

--- a/src/vex-agent/tools/registry/mission.ts
+++ b/src/vex-agent/tools/registry/mission.ts
@@ -21,6 +21,7 @@ export const MISSION_TOOLS: readonly ToolDef[] = [
       successCriteria: { type: "array", items: { type: "string" }, description: "Concrete success criteria" },
       stopConditions: { type: "array", items: { type: "string" }, description: "Proposed non-success stop conditions for the contract. The user owns this list — propose, refine with the user, and save updates here. Final acceptance happens via the host Accept contract step, not in chat" },
       deadline: { type: "string", description: "Optional deadline, preferably ISO8601 or an absolute date/time with timezone" },
+      durationMinutes: { type: "number", description: "The mission's time-box in whole minutes (e.g. 5, 60). The run auto-finalizes at started_at + this many minutes, regardless of progress. Set this from the goal's stated duration; if omitted, a 60-minute default applies." },
     }, additionalProperties: false },
   },
   {

--- a/src/vex-agent/tools/registry/prepared-action-follow-ups.ts
+++ b/src/vex-agent/tools/registry/prepared-action-follow-ups.ts
@@ -1,0 +1,116 @@
+/** Explicit allow-list for trusted prepare → execute handoffs. */
+
+import type {
+  ApprovalPreviewScalar,
+  PreparedActionFollowUp,
+} from "../types.js";
+
+export interface ValidatedPreparedActionFollowUp {
+  readonly toolName: "wallet_send_confirm";
+  readonly args: {
+    readonly network: "eip155" | "solana";
+    readonly intentId: string;
+  };
+  readonly expiresAt: string;
+  readonly approvalPreview: {
+    readonly toolName: "wallet_send_confirm";
+    readonly criticalArgs: Record<string, ApprovalPreviewScalar>;
+  };
+}
+
+export type PreparedActionFollowUpValidation =
+  | { readonly ok: true; readonly followUp: ValidatedPreparedActionFollowUp }
+  | { readonly ok: false; readonly reason: "unknown_mapping" | "invalid_contract" };
+
+const INTENT_ID_RE = /^intent-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PREVIEW_KEYS = ["network", "chain", "to", "amount", "token"] as const;
+
+function isScalar(value: unknown): value is ApprovalPreviewScalar {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+/**
+ * Validate and canonicalize a handler-authored follow-up. Unknown pairs fail
+ * closed. For wallet sends, only network + intentId cross into confirm args;
+ * the richer preview is validated independently and never rebuilt from args.
+ *
+ * Maintainer decision (2026-07): wallet-only. Exactly one mapping —
+ * wallet_send_prepare → wallet_send_confirm. Do not add a second mapping
+ * without an explicit product decision; every other source/target pair fails
+ * closed as "unknown_mapping".
+ */
+export function validatePreparedActionFollowUp(
+  sourceToolName: string,
+  candidate: PreparedActionFollowUp,
+): PreparedActionFollowUpValidation {
+  if (
+    sourceToolName !== "wallet_send_prepare" ||
+    candidate.toolName !== "wallet_send_confirm"
+  ) {
+    return { ok: false, reason: "unknown_mapping" };
+  }
+
+  const argKeys = Object.keys(candidate.args).sort();
+  if (argKeys.join(",") !== "intentId,network") {
+    return { ok: false, reason: "invalid_contract" };
+  }
+  const network = candidate.args.network;
+  const intentId = candidate.args.intentId;
+  if (
+    (network !== "eip155" && network !== "solana") ||
+    typeof intentId !== "string" ||
+    !INTENT_ID_RE.test(intentId)
+  ) {
+    return { ok: false, reason: "invalid_contract" };
+  }
+
+  const preview = candidate.approvalPreview;
+  if (preview.toolName !== "wallet_send_confirm") {
+    return { ok: false, reason: "invalid_contract" };
+  }
+  if (!Number.isFinite(Date.parse(candidate.expiresAt))) {
+    return { ok: false, reason: "invalid_contract" };
+  }
+  const criticalArgs: Record<string, ApprovalPreviewScalar> = {};
+  for (const key of PREVIEW_KEYS) {
+    const value = preview.criticalArgs[key];
+    if (!isScalar(value)) return { ok: false, reason: "invalid_contract" };
+    criticalArgs[key] = value;
+  }
+  if (
+    criticalArgs.network !== network ||
+    typeof criticalArgs.to !== "string" ||
+    criticalArgs.to.length === 0 ||
+    typeof criticalArgs.amount !== "string" ||
+    criticalArgs.amount.length === 0 ||
+    !(criticalArgs.chain === null || typeof criticalArgs.chain === "string") ||
+    !(criticalArgs.token === null || typeof criticalArgs.token === "string")
+  ) {
+    return { ok: false, reason: "invalid_contract" };
+  }
+  if (
+    (network === "eip155" &&
+      !(typeof criticalArgs.chain === "string" && criticalArgs.chain.length > 0)) ||
+    (network === "solana" && criticalArgs.chain !== null)
+  ) {
+    return { ok: false, reason: "invalid_contract" };
+  }
+
+  return {
+    ok: true,
+    followUp: {
+      toolName: "wallet_send_confirm",
+      args: { network, intentId },
+      expiresAt: candidate.expiresAt,
+      approvalPreview: {
+        toolName: "wallet_send_confirm",
+        criticalArgs,
+      },
+    },
+  };
+}

--- a/src/vex-agent/tools/types.ts
+++ b/src/vex-agent/tools/types.ts
@@ -240,6 +240,27 @@ export interface ToolResult {
     readonly estLiquidationPx?: string;
     readonly destinationClass?: string;
   };
+  /**
+   * Trusted one-step handoff from a successful non-mutating prepare tool to
+   * its mutating execution tool. The turn loop validates the source→target
+   * pair and canonicalizes the args through the registry before dispatch.
+   * This is handler-authored data; it is never populated from model output.
+   */
+  preparedActionFollowUp?: PreparedActionFollowUp;
+}
+
+export type ApprovalPreviewScalar = string | number | boolean | null;
+
+export interface PreparedActionFollowUp {
+  readonly toolName: string;
+  readonly args: Record<string, unknown>;
+  /** Earliest expiry of the prepared action, carried into approval TTL. */
+  readonly expiresAt: string;
+  /** Trusted, renderer-safe preview sourced from validated prepared state. */
+  readonly approvalPreview: {
+    readonly toolName: string;
+    readonly criticalArgs: Record<string, ApprovalPreviewScalar>;
+  };
 }
 
 /**

--- a/vex-app/src/main/compose/__tests__/lifecycle-recreate.test.ts
+++ b/vex-app/src/main/compose/__tests__/lifecycle-recreate.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for the WP-B self-heal wiring (issue #26): both stale-bind-mount
+ * failure branches in `composeUp` must attempt ONE non-destructive recreate
+ * (`recreateProjectNonDestructively`) before giving up —
+ *   (a) the primary post-setup dead-end (destructive wipe refused), and
+ *   (b) the reused-stack convergence branch's `up -d` failure.
+ * The destructive `clearStaleSecretCache` path (pre-setup only) stays
+ * untouched; these tests pin that its behavior/callers are unaffected.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RenderDeps } from "../render.js";
+
+const STALE_STDERR =
+  'error mounting "docker-desktop-bind-mounts/Ubuntu/deadbeef" to rootfs: no such file or directory';
+
+const mocks = vi.hoisted(() => ({
+  renderCompose: vi.fn(),
+  inspectEndpoint: vi.fn(),
+  checkComposeFloor: vi.fn(),
+  ensureDaemon: vi.fn(),
+  isPortFree: vi.fn(),
+  isOurProjectActive: vi.fn(),
+  findPrevious: vi.fn(),
+  waitForHealth: vi.fn(),
+  waitForEmbeddingsRuntimeReady: vi.fn(),
+  clearStaleSecretCache: vi.fn(),
+  composePull: vi.fn(),
+  composeUpDetached: vi.fn(),
+  recreateProjectNonDestructively: vi.fn(),
+}));
+
+vi.mock("../render.js", () => ({ renderCompose: mocks.renderCompose }));
+vi.mock("../preflight.js", () => ({
+  inspectDockerEndpointPolicy: mocks.inspectEndpoint,
+  checkComposeFloor: mocks.checkComposeFloor,
+  ensureDockerDaemonReady: mocks.ensureDaemon,
+  isPortFree: mocks.isPortFree,
+}));
+vi.mock("../health.js", () => ({
+  HEALTH_TIMEOUT_MS: 1,
+  isOurProjectActive: mocks.isOurProjectActive,
+  waitForHealth: mocks.waitForHealth,
+}));
+vi.mock("../orphan-stacks.js", () => ({
+  findPreviousInstallContainersHoldingPorts: mocks.findPrevious,
+}));
+vi.mock("../embeddings-health.js", () => ({
+  waitForEmbeddingsRuntimeReady: mocks.waitForEmbeddingsRuntimeReady,
+}));
+vi.mock("../stale-secret-recovery.js", () => ({
+  clearStaleSecretCache: mocks.clearStaleSecretCache,
+  STALE_BIND_MOUNT_RE: /no such file or directory/,
+}));
+vi.mock("../up.js", () => ({
+  PULL_TIMEOUT_MS: 1,
+  UP_TIMEOUT_MS: 1,
+  composePull: mocks.composePull,
+  composeUpDetached: mocks.composeUpDetached,
+}));
+vi.mock("../recreate.js", () => ({
+  recreateProjectNonDestructively: mocks.recreateProjectNonDestructively,
+}));
+
+import { composeUp } from "../lifecycle.js";
+
+const deps: RenderDeps = {
+  userDataDir: "/tmp/user-data",
+  resourcesDir: "/tmp/resources",
+  secretAdapter: {
+    write: async (targetPath) => ({ composePath: targetPath }),
+    read: async () => null,
+    cleanup: async () => {},
+    bootCleanup: async () => {},
+  },
+  randomAdapter: {
+    uuid: () => "11111111-2222-4333-8444-555555555555",
+    randomBytes: (size) => new Uint8Array(size),
+  },
+  cryptoAdapter: { base64url: () => "test" },
+};
+
+function spawnResult(partial: Partial<{
+  code: number | null;
+  stderr: string;
+  timedOut: boolean;
+}> = {}) {
+  return {
+    code: 0,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    aborted: false,
+    timedOut: false,
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.inspectEndpoint.mockResolvedValue({ accepted: true });
+  mocks.checkComposeFloor.mockResolvedValue(null);
+  mocks.ensureDaemon.mockResolvedValue({ kind: "ready" });
+  mocks.renderCompose.mockResolvedValue({
+    outPath: "/tmp/compose/docker-compose.yml",
+    installId: "11111111-2222-4333-8444-555555555555",
+    embedPort: 27134,
+    pgPasswordComposePath: "/tmp/secrets/pg_password",
+  });
+  mocks.isPortFree.mockResolvedValue(true);
+  mocks.composePull.mockResolvedValue(spawnResult());
+  mocks.waitForHealth.mockResolvedValue(true);
+  mocks.waitForEmbeddingsRuntimeReady.mockResolvedValue({
+    kind: "ready",
+    observedDim: 384,
+  });
+});
+
+describe("composeUp — post-setup stale bind-mount branch (primary up path)", () => {
+  beforeEach(() => {
+    mocks.composeUpDetached.mockResolvedValueOnce(
+      spawnResult({ code: 1, stderr: STALE_STDERR }),
+    );
+    mocks.clearStaleSecretCache.mockResolvedValue({ wiped: false });
+  });
+
+  it("attempts exactly ONE non-destructive recreate, and recovers on success", async () => {
+    mocks.recreateProjectNonDestructively.mockResolvedValueOnce({
+      downResult: spawnResult(),
+      upResult: spawnResult({ code: 0 }),
+    });
+
+    const result = await composeUp(deps);
+
+    expect(mocks.recreateProjectNonDestructively).toHaveBeenCalledTimes(1);
+    // Destructive wipe was refused (setup complete) — never re-renders /
+    // regenerates the secret on this path.
+    expect(mocks.renderCompose).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBe("running");
+  });
+
+  it("passes project scoping through to the recreate helper (installId + composeDir)", async () => {
+    mocks.recreateProjectNonDestructively.mockResolvedValueOnce({
+      downResult: spawnResult(),
+      upResult: spawnResult({ code: 0 }),
+    });
+
+    await composeUp(deps);
+
+    const call = mocks.recreateProjectNonDestructively.mock.calls[0]![0] as {
+      installId: string;
+      composeDir: string;
+    };
+    expect(call.installId).toBe("11111111-2222-4333-8444-555555555555");
+    expect(call.composeDir).toBe("/tmp/compose");
+  });
+
+  it("surfaces a failure WITHOUT the 'contact support to recover your keys' phishing-style phrasing when recreate also fails", async () => {
+    mocks.recreateProjectNonDestructively.mockResolvedValueOnce({
+      downResult: spawnResult(),
+      upResult: spawnResult({ code: 1, stderr: STALE_STDERR }),
+    });
+
+    const result = await composeUp(deps);
+
+    expect(mocks.recreateProjectNonDestructively).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBe("failed");
+    expect(result.message).not.toMatch(/contact support.*recover your keys/i);
+    expect(result.message).toMatch(/never ask/i);
+    expect(result.message).toMatch(/seed phrase|private key/i);
+  });
+
+  it("does not touch the destructive wipe path beyond the existing pre-gate call", async () => {
+    mocks.recreateProjectNonDestructively.mockResolvedValueOnce({
+      downResult: spawnResult(),
+      upResult: spawnResult({ code: 0 }),
+    });
+
+    await composeUp(deps);
+
+    // clearStaleSecretCache is still called once (the existing gate check);
+    // the non-destructive recreate must not trigger any ADDITIONAL
+    // destructive-wipe call.
+    expect(mocks.clearStaleSecretCache).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("composeUp — reused-stack convergence branch (port-busy path)", () => {
+  beforeEach(() => {
+    mocks.isPortFree
+      .mockResolvedValueOnce(false) // pg port busy
+      .mockResolvedValueOnce(true); // embed port free
+    mocks.isOurProjectActive.mockResolvedValue(true);
+  });
+
+  it("applies the stale-signature match BEFORE falling through to health probes, with exactly one recreate attempt", async () => {
+    mocks.composeUpDetached.mockResolvedValueOnce(
+      spawnResult({ code: 1, stderr: STALE_STDERR }),
+    );
+    mocks.recreateProjectNonDestructively.mockResolvedValueOnce({
+      downResult: spawnResult(),
+      upResult: spawnResult({ code: 0 }),
+    });
+
+    const result = await composeUp(deps, { pgPort: 27432 });
+
+    expect(mocks.recreateProjectNonDestructively).toHaveBeenCalledTimes(1);
+    // Health probes still run afterward regardless of recreate's outcome.
+    expect(mocks.waitForHealth).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBe("reused");
+  });
+
+  it("falls through to health probes without recreating when the reuse-up failure is NOT the stale-mount signature", async () => {
+    mocks.composeUpDetached.mockResolvedValueOnce(
+      spawnResult({ code: 1, stderr: "some other transient failure" }),
+    );
+
+    await composeUp(deps, { pgPort: 27432 });
+
+    expect(mocks.recreateProjectNonDestructively).not.toHaveBeenCalled();
+    expect(mocks.waitForHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it("still falls through to health probes when the recreate retry itself fails", async () => {
+    mocks.composeUpDetached.mockResolvedValueOnce(
+      spawnResult({ code: 1, stderr: STALE_STDERR }),
+    );
+    mocks.recreateProjectNonDestructively.mockResolvedValueOnce({
+      downResult: spawnResult(),
+      upResult: spawnResult({ code: 1, stderr: STALE_STDERR }),
+    });
+    mocks.waitForHealth.mockResolvedValueOnce(false);
+
+    const result = await composeUp(deps, { pgPort: 27432 });
+
+    expect(mocks.recreateProjectNonDestructively).toHaveBeenCalledTimes(1);
+    expect(mocks.waitForHealth).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBe("unhealthy");
+  });
+});

--- a/vex-app/src/main/compose/__tests__/recreate.test.ts
+++ b/vex-app/src/main/compose/__tests__/recreate.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for `recreateProjectNonDestructively` (issue #26) — the
+ * non-destructive `compose down --remove-orphans` (no `--volumes`) + ONE
+ * `up -d` retry helper used to recover from Docker Desktop's stale
+ * bind-mount cache without the destructive wipe in stale-secret-recovery.ts.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SpawnRunnerResult } from "../../docker/spawn-runner.js";
+
+const runSpawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../docker/spawn-runner.js", () => ({ runSpawn: runSpawnMock }));
+
+import { recreateProjectNonDestructively } from "../recreate.js";
+
+const INSTALL_ID = "11111111-2222-4333-8444-555555555555";
+const COMPOSE_DIR = "/tmp/vex-compose/11111111-2222-4333-8444-555555555555";
+
+function spawnResult(partial: Partial<SpawnRunnerResult> = {}): SpawnRunnerResult {
+  return {
+    code: 0,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    aborted: false,
+    timedOut: false,
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runSpawnMock.mockResolvedValue(spawnResult());
+});
+
+describe("recreateProjectNonDestructively", () => {
+  it("runs a project-scoped `down --remove-orphans` then exactly ONE `up -d` retry", async () => {
+    const result = await recreateProjectNonDestructively({
+      composeDir: COMPOSE_DIR,
+      installId: INSTALL_ID,
+    });
+
+    expect(runSpawnMock).toHaveBeenCalledTimes(2);
+
+    const [downCmd, downArgs, downOpts] = runSpawnMock.mock.calls[0]!;
+    expect(downCmd).toBe("docker");
+    expect(downArgs).toEqual([
+      "compose",
+      "-p",
+      `vex-${INSTALL_ID}`,
+      "down",
+      "--remove-orphans",
+    ]);
+    expect((downOpts as { cwd?: string }).cwd).toBe(COMPOSE_DIR);
+
+    const [upCmd, upArgs, upOpts] = runSpawnMock.mock.calls[1]!;
+    expect(upCmd).toBe("docker");
+    expect(upArgs).toEqual(["compose", "up", "-d"]);
+    // Same composeDir as the down call — no re-render, secret untouched.
+    expect((upOpts as { cwd?: string }).cwd).toBe(COMPOSE_DIR);
+
+    expect(result.downResult.code).toBe(0);
+    expect(result.upResult.code).toBe(0);
+  });
+
+  it("never passes `--volumes` on the down call", async () => {
+    await recreateProjectNonDestructively({
+      composeDir: COMPOSE_DIR,
+      installId: INSTALL_ID,
+    });
+    const downArgs = runSpawnMock.mock.calls[0]![1] as string[];
+    expect(downArgs).not.toContain("--volumes");
+  });
+
+  it("scopes the down call to this install's project only (`-p vex-<installId>`)", async () => {
+    await recreateProjectNonDestructively({
+      composeDir: COMPOSE_DIR,
+      installId: INSTALL_ID,
+    });
+    const downArgs = runSpawnMock.mock.calls[0]![1] as string[];
+    expect(downArgs).toContain("-p");
+    expect(downArgs[downArgs.indexOf("-p") + 1]).toBe(`vex-${INSTALL_ID}`);
+  });
+
+  it("does not run either command when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await recreateProjectNonDestructively({
+      composeDir: COMPOSE_DIR,
+      installId: INSTALL_ID,
+      signal: controller.signal,
+    });
+
+    expect(runSpawnMock).not.toHaveBeenCalled();
+    expect(result.downResult.aborted).toBe(true);
+    expect(result.upResult.aborted).toBe(true);
+  });
+
+  it("skips the `up -d` retry when cancellation lands between down and up (down already ran safely)", async () => {
+    const controller = new AbortController();
+    runSpawnMock.mockImplementationOnce(async () => {
+      // Cancellation arrives while `down` is in flight — `down` itself
+      // still completes (no `--volumes`, so it is safe either way), but
+      // the retry must not fire afterward.
+      controller.abort();
+      return spawnResult();
+    });
+
+    const result = await recreateProjectNonDestructively({
+      composeDir: COMPOSE_DIR,
+      installId: INSTALL_ID,
+      signal: controller.signal,
+    });
+
+    expect(runSpawnMock).toHaveBeenCalledTimes(1); // only `down` ran
+    expect(result.downResult.code).toBe(0);
+    expect(result.upResult.aborted).toBe(true);
+  });
+
+  it("propagates the up -d failure result when the retry itself fails", async () => {
+    runSpawnMock
+      .mockResolvedValueOnce(spawnResult()) // down
+      .mockResolvedValueOnce(spawnResult({ code: 1, stderr: "still stale" })); // up retry
+
+    const result = await recreateProjectNonDestructively({
+      composeDir: COMPOSE_DIR,
+      installId: INSTALL_ID,
+    });
+
+    expect(result.upResult.code).toBe(1);
+    expect(result.upResult.stderr).toContain("still stale");
+  });
+});

--- a/vex-app/src/main/compose/lifecycle.ts
+++ b/vex-app/src/main/compose/lifecycle.ts
@@ -47,6 +47,7 @@ import {
   composePull,
   composeUpDetached,
 } from "./up.js";
+import { recreateProjectNonDestructively } from "./recreate.js";
 import {
   COMPOSE_FILE_MISSING_RE,
   composeStop,
@@ -221,10 +222,36 @@ export async function composeUp(
       // wrong. A hard `compose up` failure (e.g. init script still
       // failing post-fix) surfaces via the embeddings probe message.
       if (reuseUp.code !== 0 && !reuseUp.timedOut) {
-        onLogLine?.(
-          "stderr",
-          `[reuse] compose up exited ${reuseUp.code ?? "?"}; falling through to health probes`
-        );
+        if (STALE_BIND_MOUNT_RE.test(reuseUp.stderr)) {
+          // Same stale Docker Desktop bind-mount cache symptom as the
+          // primary up path below — the signature match MUST be applied
+          // here too, BEFORE falling through to health probes, or the
+          // non-destructive recreate helper is unreachable on this branch
+          // (issue #26). One recreate attempt; if it still fails we fall
+          // through exactly like the generic failure below and let the
+          // health probes report the specific service that's unhealthy.
+          onLogLine?.(
+            "stdout",
+            "[reuse] Detected stale Docker Desktop bind-mount cache; attempting non-destructive recreate…"
+          );
+          const recreate = await recreateProjectNonDestructively({
+            composeDir,
+            installId: rendered.installId,
+            ...(signal !== undefined ? { signal } : {}),
+            ...(onLogLine !== undefined ? { onLogLine } : {}),
+          });
+          if (recreate.upResult.code !== 0 && !recreate.upResult.timedOut) {
+            onLogLine?.(
+              "stderr",
+              `[reuse] recreate retry exited ${recreate.upResult.code ?? "?"}; falling through to health probes`
+            );
+          }
+        } else {
+          onLogLine?.(
+            "stderr",
+            `[reuse] compose up exited ${reuseUp.code ?? "?"}; falling through to health probes`
+          );
+        }
       }
 
       const dbHealthy = await waitForHealth({
@@ -382,34 +409,56 @@ export async function composeUp(
       signal
     );
     if (!cleared.wiped) {
-      // Setup gate refused — return failure WITHOUT destructive
-      // instructions (codex round 3 RED #2). Telling the user to
-      // delete `local-infra/secrets/` would regenerate the Postgres
-      // password while the existing volume still holds the OLD
-      // password — `password authentication failed for user "vex"`
-      // locks them out of their own data. Recovery here is
-      // support-guided.
-      return {
-        kind: "failed",
-        composeOutPath: rendered.outPath,
+      // Setup gate refused the destructive wipe (codex round 3 RED #2) —
+      // try the NON-destructive recreate first (issue #26): project-scoped
+      // `compose down --remove-orphans` (no `--volumes`, secret file
+      // untouched) + ONE `up -d` retry. Recreating the containers rebuilds
+      // Docker Desktop's bind-mount cache for the unchanged secret, which
+      // clears the stale-hash symptom without touching user data.
+      onLogLine?.(
+        "stdout",
+        "[recovery] Destructive wipe refused (setup complete); attempting non-destructive recreate…"
+      );
+      const recreate = await recreateProjectNonDestructively({
+        composeDir,
         installId: rendered.installId,
-        message:
-          "Docker Desktop has a stale bind-mount cache pointing at this install's Postgres password secret, and your setup is already complete. Vex will NOT auto-wipe your data. Try fully quitting Docker Desktop and restarting it, then retry — if the issue persists, contact support before any further action so we can guide you through a recovery that preserves your wallet keys and long-term memory.",
-        pgPort,
-        embedPort: rendered.embedPort,
-        pgPasswordPath: rendered.pgPasswordComposePath,
-        embeddingsReadiness: null,
-        previousInstallHoldingPorts: false,
-        conflictPorts: [],
-      };
+        ...(signal !== undefined ? { signal } : {}),
+        ...(onLogLine !== undefined ? { onLogLine } : {}),
+      });
+      if (recreate.upResult.code === 0 && !recreate.upResult.timedOut) {
+        // Recovered — continue below with the SAME rendered/composeDir
+        // (the secret never changed, so no re-render is needed) and let
+        // the existing timedOut/code checks + health probes take over.
+        upResult = recreate.upResult;
+      } else {
+        // Non-destructive recreate ALSO failed — surface failure without
+        // destructive instructions and without the "contact support to
+        // recover your keys" phrasing (issue #26 secondary UX note: that
+        // reads like a phishing script). A safe automatic recovery was
+        // already attempted; support-guided recovery is the last resort.
+        return {
+          kind: "failed",
+          composeOutPath: rendered.outPath,
+          installId: rendered.installId,
+          message:
+            "Docker Desktop has a stale bind-mount cache pointing at this install's Postgres password secret. Vex automatically attempted a safe recovery (recreating the containers without touching your data or password), but it did not resolve the issue. Try fully quitting Docker Desktop and restarting it, then retry. If the issue persists, contact support — support will never ask you for your seed phrase or private key.",
+          pgPort,
+          embedPort: rendered.embedPort,
+          pgPasswordPath: rendered.pgPasswordComposePath,
+          embeddingsReadiness: null,
+          previousInstallHoldingPorts: false,
+          conflictPorts: [],
+        };
+      }
+    } else {
+      renderedAfterRecovery = await renderCompose(deps, renderOptions);
+      composeDirAfterRecovery = path.dirname(renderedAfterRecovery.outPath);
+      upResult = await composeUpDetached({
+        composeDir: composeDirAfterRecovery,
+        ...(signal !== undefined ? { signal } : {}),
+        ...(onLogLine !== undefined ? { onLogLine } : {}),
+      });
     }
-    renderedAfterRecovery = await renderCompose(deps, renderOptions);
-    composeDirAfterRecovery = path.dirname(renderedAfterRecovery.outPath);
-    upResult = await composeUpDetached({
-      composeDir: composeDirAfterRecovery,
-      ...(signal !== undefined ? { signal } : {}),
-      ...(onLogLine !== undefined ? { onLogLine } : {}),
-    });
   }
 
   if (upResult.timedOut) {

--- a/vex-app/src/main/compose/recreate.ts
+++ b/vex-app/src/main/compose/recreate.ts
@@ -1,0 +1,91 @@
+/**
+ * Non-destructive project recreation — issue #26. After a Docker Desktop
+ * restart the daemon can reference a wiped bind-mount cache hash, so
+ * `up -d` fails with "no such file or directory" (`STALE_BIND_MOUNT_RE` in
+ * `stale-secret-recovery.ts`). That module's wipe (`down --volumes` +
+ * regenerated password + reset install state) is destructive and gated to
+ * PRE-SETUP only. This module is the POST-SETUP-safe alternative: recreating
+ * the containers forces Docker Desktop to rebuild the bind-mount cache for
+ * the UNCHANGED secret file, so `pg_authid` still matches and nothing is
+ * lost — never pass `--volumes` here, and never touch the secret file.
+ */
+
+import { runSpawn, type SpawnRunnerResult } from "../docker/spawn-runner.js";
+import { composeArgs, projectName } from "./project.js";
+import { composeUpDetached, type ComposeSpawnContext } from "./up.js";
+
+/** `compose down --remove-orphans` (no `--volumes`) budget. */
+export const RECREATE_DOWN_TIMEOUT_MS = 30_000;
+
+export interface RecreateProjectContext extends ComposeSpawnContext {
+  readonly installId: string;
+}
+
+export interface RecreateProjectResult {
+  readonly downResult: SpawnRunnerResult;
+  readonly upResult: SpawnRunnerResult;
+}
+
+function skippedResult(): SpawnRunnerResult {
+  return {
+    code: null,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    aborted: true,
+    timedOut: false,
+  };
+}
+
+/**
+ * `docker compose -p <project> down --remove-orphans` (containers + network
+ * only — no `--volumes`, so the Postgres volume and the secret file mounted
+ * at `/run/secrets/pg_password` are untouched) followed by exactly ONE
+ * `up -d` retry. Recreating the containers rebuilds Docker Desktop's
+ * bind-mount cache for the same, unchanged secret; since the password never
+ * changes, the existing volume's `pg_authid` still matches and no data is
+ * lost.
+ *
+ * Cancellation: if `signal` is already aborted, NEITHER command runs (both
+ * results come back as synthetic aborted results). If it aborts after
+ * `down` completes, `up` is skipped — `down` never touched user data, so a
+ * partial cancellation here is always safe.
+ */
+export async function recreateProjectNonDestructively(
+  ctx: RecreateProjectContext
+): Promise<RecreateProjectResult> {
+  const { composeDir, installId, signal, onLogLine } = ctx;
+  // Read the abort flag through a function so TS does not narrow
+  // `signal.aborted` from the first guard and then treat the post-`await`
+  // re-check as unreachable — at runtime the flag CAN flip to true while
+  // `down` runs (control-flow narrowing does not survive the await).
+  const isAborted = (): boolean => signal?.aborted === true;
+
+  if (isAborted()) {
+    const skipped = skippedResult();
+    return { downResult: skipped, upResult: skipped };
+  }
+
+  const downResult = await runSpawn(
+    "docker",
+    composeArgs(["-p", projectName(installId), "down", "--remove-orphans"]),
+    {
+      cwd: composeDir,
+      timeoutMs: RECREATE_DOWN_TIMEOUT_MS,
+      ...(signal !== undefined ? { signal } : {}),
+      onStdoutLine: (line) => onLogLine?.("stdout", `[recreate] ${line}`),
+      onStderrLine: (line) => onLogLine?.("stderr", `[recreate] ${line}`),
+    }
+  );
+
+  if (isAborted()) {
+    return { downResult, upResult: skippedResult() };
+  }
+
+  const upResult = await composeUpDetached({
+    composeDir,
+    ...(signal !== undefined ? { signal } : {}),
+    ...(onLogLine !== undefined ? { onLogLine } : {}),
+  });
+  return { downResult, upResult };
+}

--- a/vex-app/src/main/database/__tests__/mission-runs-db.test.ts
+++ b/vex-app/src/main/database/__tests__/mission-runs-db.test.ts
@@ -39,7 +39,9 @@ vi.mock("../db-config.js", () => ({
 
 vi.mock("../../logger/index.js", () => ({ log: mocks.log }));
 
-const { getActiveRunForSession } = await import("../mission-runs-db.js");
+const { getActiveRunForSession, getLatestRunForSession } = await import(
+  "../mission-runs-db.js"
+);
 
 const SESSION = "00000000-0000-4000-8000-00000000eeee";
 
@@ -154,5 +156,52 @@ describe("mission-runs-db mapper", () => {
     if (result.ok) return;
     expect(result.error.code).toBe("internal.unexpected");
     expect(result.error.domain).toBe("runtime");
+  });
+});
+
+describe("getLatestRunForSession — lease-active mapping (WP-C)", () => {
+  // `vi.mocked` re-types the hoisted `QueryFn`-cast mock so the vitest Mock
+  // API (`mockResolvedValueOnce`) is visible without re-triggering the
+  // file's pre-existing `QueryFn`-cast type-baseline pattern.
+  const q = vi.mocked(mocks.query);
+
+  it("returns null when the session never had a run", async () => {
+    q.mockResolvedValueOnce({ rows: [] });
+    const result = await getLatestRunForSession(SESSION);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toBeNull();
+  });
+
+  it("maps lease_active=true through for a running row with a live lease", async () => {
+    q.mockResolvedValueOnce({
+      rows: [{ id: "run-1", status: "running", lease_active: true }],
+    });
+    const result = await getLatestRunForSession(SESSION);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toEqual({
+      missionRunId: "run-1",
+      status: "running",
+      leaseActive: true,
+    });
+  });
+
+  it("maps a NULL lease join (no runner_leases row) to leaseActive=false", async () => {
+    q.mockResolvedValueOnce({
+      rows: [{ id: "run-1", status: "running", lease_active: null }],
+    });
+    const result = await getLatestRunForSession(SESSION);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data?.leaseActive).toBe(false);
+  });
+
+  it("rejects an unrecognized status defensively", async () => {
+    q.mockResolvedValueOnce({
+      rows: [{ id: "run-1", status: "not_a_real_status", lease_active: false }],
+    });
+    const result = await getLatestRunForSession(SESSION);
+    expect(result.ok).toBe(false);
   });
 });

--- a/vex-app/src/main/database/__tests__/missions-db.renewable-source.test.ts
+++ b/vex-app/src/main/database/__tests__/missions-db.renewable-source.test.ts
@@ -135,6 +135,28 @@ describe("getRenewableSourceForSession", () => {
     );
   });
 
+  it("suppresses the source while the session still has an un-started draft/ready mission (no double-renew)", async () => {
+    // Root cause of the duplicate-draft storm: once `mission.renew` clones a
+    // fresh draft, the OLD terminal accepted mission still satisfies every
+    // renewable predicate above — so without this guard the resolver keeps
+    // reporting it as renewable, the Renew button lingers, and each extra
+    // click clones ANOTHER duplicate draft. A finished mission is only
+    // renewable when there is nothing pending to act on: suppress it whenever
+    // the session already holds a draft/ready mission (which `getDraft`
+    // surfaces instead). Makes `getDraft` and `getRenewableSource` mutually
+    // exclusive at the source, not just in each renderer consumer.
+    //
+    // `vi.mocked` re-types the hoisted `QueryFn`-cast mock so the vitest Mock
+    // API is visible without re-triggering the file's pre-existing
+    // `QueryFn`-cast type-baseline pattern.
+    const q = vi.mocked(mocks.query);
+    q.mockResolvedValueOnce({ rows: [] });
+    await getRenewableSourceForSession(SESSION);
+    const sql = normaliseSql(q.mock.calls[0]?.[0] ?? "");
+    expect(sql).toContain("NOT EXISTS");
+    expect(sql).toContain("d.status IN ('draft', 'ready')");
+  });
+
   it("orders results by latest run's end-or-start time (newest first)", async () => {
     // Tie-break still flips to mission updated_at when run timestamps
     // collide. The outer SQL must preserve "newest finished first" so

--- a/vex-app/src/main/database/__tests__/moves-db.test.ts
+++ b/vex-app/src/main/database/__tests__/moves-db.test.ts
@@ -24,7 +24,11 @@
  *  - the tolerant mapper passes through a row with `trade_side = null`,
  *    `capture_status = 'filled'`, and `value_usd = null`;
  *  - a failed session-scope read propagates (fail closed);
- *  - the SELECT projects ONLY bounded columns (never params/result/trade_capture).
+ *  - the SELECT projects ONLY bounded columns: never params/result or raw
+ *    JSONB; token symbols are type-checked, length-bounded scalar
+ *    extractions from the exact capture item, then re-validated in JS by the
+ *    shared ASCII-allowlist sanitizer (trims whitespace, drops control
+ *    characters/bidi controls/zero-width characters/Unicode confusables).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -182,14 +186,21 @@ describe("moves-db getMovesForSession — scoping + binding", () => {
     expect(bound).not.toContain(WALLET_A.toLowerCase());
   });
 
-  it("projects ONLY bounded columns (never params/result/trade_capture)", async () => {
+  it("projects ONLY bounded columns and bounded capture-item symbol scalars", async () => {
     mocks.getSessionWalletScope.mockResolvedValue(scopeOk(WALLET_A, null));
     mocks.query.mockResolvedValueOnce({ rows: [] });
     await getMovesForSession(SESSION);
     const sql = String(mocks.query.mock.calls[0]?.[0] ?? "");
     expect(sql).not.toContain("params");
     expect(sql).not.toContain("result");
-    expect(sql).not.toContain("trade_capture");
+    expect(sql).not.toContain("SELECT ci.trade_capture");
+    expect(sql).toContain("jsonb_typeof(ci.trade_capture->'inputToken')");
+    expect(sql).toContain("LEFT(ci.trade_capture->>'inputToken', 64)");
+    expect(sql).toContain("jsonb_typeof(ci.trade_capture->'outputToken')");
+    expect(sql).toContain("LEFT(ci.trade_capture->>'outputToken', 64)");
+    expect(sql).toContain("LEFT JOIN protocol_capture_items ci");
+    expect(sql).toContain("ci.id = a.capture_item_id");
+    expect(sql).toContain("ci.execution_id = a.execution_id");
     expect(sql).toContain("LIMIT 50");
   });
 });
@@ -207,7 +218,7 @@ describe("moves-db getMovesForSession — strict per-session attribution (JOIN)"
 
     const sql = String(mocks.query.mock.calls[0]?.[0] ?? "");
     expect(sql).toContain("JOIN protocol_executions");
-    expect(sql).not.toContain("LEFT JOIN");
+    expect(sql).not.toContain("LEFT JOIN protocol_executions");
     expect(sql).toContain("a.execution_id");
   });
 
@@ -252,8 +263,10 @@ describe("moves-db getMovesForSession — strict per-session attribution (JOIN)"
           product_type: "spot",
           venue: "uniswap",
           input_token: "USDC",
+          input_token_symbol: "USDC",
           input_amount: "50",
           output_token: "ETH",
+          output_token_symbol: "ETH",
           output_amount: "0.02",
           value_usd: "50",
           capture_status: "executed",
@@ -276,6 +289,8 @@ describe("moves-db getMovesForSession — strict per-session attribution (JOIN)"
     expect(result.data[0]?.walletAddress).toBe(WALLET_A);
     expect(result.data[0]?.productType).toBe("spot");
     expect(result.data[0]?.venue).toBe("uniswap");
+    expect(result.data[0]?.inputTokenSymbol).toBe("USDC");
+    expect(result.data[0]?.outputTokenSymbol).toBe("ETH");
   });
 
   it("selects product_type and namespace-as-venue for the chip derivation", async () => {
@@ -297,6 +312,71 @@ describe("moves-db getMovesForSession — strict per-session attribution (JOIN)"
 });
 
 describe("moves-db getMovesForSession — tolerant mapping", () => {
+  it("trims valid capture symbols and drops symbols containing control characters", async () => {
+    mocks.getSessionWalletScope.mockResolvedValue(scopeOk(WALLET_A, null));
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 6,
+          trade_side: "buy",
+          product_type: "spot",
+          venue: "jupiter",
+          input_token: SOL_ADDR,
+          input_token_symbol: "  SOL  ",
+          input_amount: "100",
+          output_token: "7jk8UbH339rCgnohpBvqiss4a7bXWmicMPCUCFmDrmYK",
+          output_token_symbol: "BAD\nSYMBOL",
+          output_amount: "1",
+          value_usd: null,
+          capture_status: "executed",
+          instrument_key: null,
+          chain: "solana",
+          tx_ref: null,
+          created_at: "2026-05-21T10:00:00.000Z",
+        },
+      ],
+    });
+
+    const result = await getMovesForSession(SESSION);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data[0]?.inputTokenSymbol).toBe("SOL");
+    expect(result.data[0]?.outputTokenSymbol).toBeNull();
+  });
+
+  it("drops a captured symbol containing Unicode confusables (e.g. a fake SOL claim)", async () => {
+    mocks.getSessionWalletScope.mockResolvedValue(scopeOk(WALLET_A, null));
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 10,
+          trade_side: "buy",
+          product_type: "spot",
+          venue: "jupiter",
+          input_token: "ScamMint111111111111111111111111111111111",
+          // Cyrillic Es (U+0405) standing in for Latin S — never surfaces as "SOL".
+          input_token_symbol: "ЅOL",
+          input_amount: "1",
+          output_token: SOL_ADDR,
+          output_token_symbol: "SOL",
+          output_amount: "1",
+          value_usd: null,
+          capture_status: "executed",
+          instrument_key: null,
+          chain: "solana",
+          tx_ref: null,
+          created_at: "2026-05-21T10:00:00.000Z",
+        },
+      ],
+    });
+
+    const result = await getMovesForSession(SESSION);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data[0]?.inputTokenSymbol).toBeNull();
+    expect(result.data[0]?.outputTokenSymbol).toBe("SOL");
+  });
+
   it("maps a tolerant row (trade_side=null, capture_status='filled', value_usd=null)", async () => {
     mocks.getSessionWalletScope.mockResolvedValue(scopeOk(WALLET_A, null));
     mocks.query.mockResolvedValueOnce({
@@ -307,8 +387,10 @@ describe("moves-db getMovesForSession — tolerant mapping", () => {
           product_type: null,
           venue: null,
           input_token: "USDC",
+          input_token_symbol: null,
           input_amount: "100",
           output_token: "SOL",
+          output_token_symbol: null,
           output_amount: "1.2",
           value_usd: null,
           capture_status: "filled",
@@ -331,8 +413,10 @@ describe("moves-db getMovesForSession — tolerant mapping", () => {
         productType: null,
         venue: null,
         inputToken: "USDC",
+        inputTokenSymbol: null,
         inputAmount: "100",
         outputToken: "SOL",
+        outputTokenSymbol: null,
         outputAmount: "1.2",
         valueUsd: null,
         captureStatus: "filled",
@@ -355,8 +439,10 @@ describe("moves-db getMovesForSession — tolerant mapping", () => {
           product_type: "bridge",
           venue: "relay",
           input_token: "ETH",
+          input_token_symbol: "ETH",
           input_amount: "0.001714",
           output_token: "ETH",
+          output_token_symbol: "ETH",
           output_amount: "0.001693",
           value_usd: null,
           capture_status: "executed",
@@ -375,6 +461,7 @@ describe("moves-db getMovesForSession — tolerant mapping", () => {
     expect(row?.productType).toBe("bridge");
     expect(row?.venue).toBe("relay");
     expect(row?.inputToken).toBe("ETH");
+    expect(row?.inputTokenSymbol).toBe("ETH");
     expect(row?.inputAmount).toBe("0.001714");
     expect(row?.outputAmount).toBe("0.001693");
   });

--- a/vex-app/src/main/database/mission-runs-db.ts
+++ b/vex-app/src/main/database/mission-runs-db.ts
@@ -153,19 +153,35 @@ function toIntOrNull(value: number | string | null): number | null {
  * Unlike `getActiveRunForSession` (active/paused only), this lets the
  * `mission.retry` dispatcher distinguish a terminal run (→ blocked_terminal)
  * from a session that never had a run (→ no_active_run). `null` = no run ever.
+ *
+ * `leaseActive` (same `runner_leases` join as `getActiveRunForSession`) lets
+ * the retry dispatcher tell a genuinely `running` run apart from one whose
+ * lease expired/released while status stayed `running` — WITHOUT that, a
+ * dead lease reported `already_running` and stranded the operator with no
+ * way to recover it (issue #12's bug class).
  */
 export async function getLatestRunForSession(
   sessionId: string,
 ): Promise<
-  Result<{ missionRunId: string; status: MissionRunStatus } | null, VexError>
+  Result<
+    { missionRunId: string; status: MissionRunStatus; leaseActive: boolean } | null,
+    VexError
+  >
 > {
   return withClient(async (client) => {
     try {
-      const result = await client.query<{ id: string; status: string }>(
-        `SELECT id, status
-           FROM mission_runs
-          WHERE session_id = $1
-          ORDER BY started_at DESC
+      const result = await client.query<{
+        id: string;
+        status: string;
+        lease_active: boolean | null;
+      }>(
+        `SELECT m.id, m.status,
+                CASE WHEN l.session_id IS NOT NULL AND l.expires_at >= NOW()
+                     THEN TRUE ELSE FALSE END AS lease_active
+           FROM mission_runs m
+           LEFT JOIN runner_leases l ON l.session_id = m.session_id
+          WHERE m.session_id = $1
+          ORDER BY m.started_at DESC
           LIMIT 1`,
         [sessionId],
       );
@@ -177,7 +193,11 @@ export async function getLatestRunForSession(
           `getLatestRunForSession: unrecognized run status "${row.status}"`,
         );
       }
-      return ok({ missionRunId: row.id, status: parsed.data });
+      return ok({
+        missionRunId: row.id,
+        status: parsed.data,
+        leaseActive: Boolean(row.lease_active),
+      });
     } catch (cause) {
       return dbError("getLatestRunForSession query failed", cause);
     }

--- a/vex-app/src/main/database/missions-db.ts
+++ b/vex-app/src/main/database/missions-db.ts
@@ -188,6 +188,14 @@ export async function getDraftForSession(
  * with a newer active run on top does NOT qualify — only the truly
  * finished missions surface.
  *
+ * Pending-draft exclusion: a source is ALSO suppressed while the session
+ * still holds a `draft`/`ready` mission. Renewal clones a finished mission
+ * into a fresh draft, but the source keeps satisfying every predicate above,
+ * so without this the Renew control lingered and repeat clicks cloned
+ * duplicate drafts. While a draft is pending, `getDraftForSession` surfaces
+ * it instead — the two resolvers are mutually exclusive, so a renderer that
+ * shows one never simultaneously shows the other.
+ *
  * Returns `null` when no eligible mission exists; the renderer maps
  * that to the friendly "No completed mission to renew" notice without
  * round-tripping through the engine's `previous_mission_not_found`
@@ -214,6 +222,20 @@ export async function getRenewableSourceForSession(
             AND m.accepted_contract_by IS NOT NULL
             AND m.contract_hash_version IS NOT NULL
             AND latest.status IN ('completed', 'failed', 'stopped', 'cancelled')
+            -- Suppress the source once a fresh draft already exists for the
+            -- session. Otherwise the OLD terminal accepted mission keeps
+            -- satisfying every predicate above even after mission.renew
+            -- clones a draft from it, so the Renew control lingers and each
+            -- extra click clones ANOTHER duplicate draft. A finished mission
+            -- is renewable only when nothing is pending: while a draft/ready
+            -- mission exists, getDraftForSession surfaces it instead. Keeps
+            -- the two resolvers mutually exclusive at the source.
+            AND NOT EXISTS (
+              SELECT 1
+                FROM missions d
+               WHERE d.root_session_id = m.root_session_id
+                 AND d.status IN ('draft', 'ready')
+            )
           ORDER BY COALESCE(latest.ended_at, latest.started_at) DESC,
                    m.updated_at DESC
           LIMIT 1`,

--- a/vex-app/src/main/database/moves-db.ts
+++ b/vex-app/src/main/database/moves-db.ts
@@ -39,11 +39,20 @@
  *  - join key is the raw ADDRESS string — DO NOT lowercase (the engine stores
  *    raw checksum/base58 addresses).
  *  - The SELECT projects ONLY bounded, renderer-safe columns. It NEVER selects
- *    `params`, `result`, `trade_capture`, `meta`, or the raw `external_refs`
- *    JSONB. The single sanctioned extraction from `external_refs` is the
- *    on-chain tx reference scalar (`->>'txHash'` for EVM, `->>'signature'`
- *    for Solana) — public on-chain data powering the renderer's
- *    block-explorer deep links; never the whole blob.
+ *    `params`, `result`, `meta`, or any raw JSONB blob. The sanctioned scalar
+ *    extractions are: the on-chain tx reference from `external_refs`
+ *    (`->>'txHash'` for EVM, `->>'signature'` for Solana — public on-chain
+ *    data powering the renderer's block-explorer deep links), and the
+ *    input/output token display symbols from the activity row's EXACT
+ *    capture item (`protocol_capture_items`, joined on `capture_item_id` AND
+ *    `execution_id`). Symbol extraction is string-type checked and
+ *    SQL-bounded to `MOVE_TOKEN_SYMBOL_MAX` chars, then re-validated in JS by
+ *    the shared `sanitizeTokenSymbol` (ASCII allowlist — rejects control
+ *    characters, bidi controls, zero-width characters, and Unicode
+ *    confusables in one pass). Captured symbols are UNTRUSTED display data —
+ *    the renderer must never let them override `input_token`/`output_token`
+ *    identity or claim a brand icon without independent corroboration.
+ *    Neither raw `trade_capture` nor raw `external_refs` crosses IPC.
  *  - `wallet_address` IS projected (`walletAddress`) so the renderer can build
  *    an account block-explorer link for rows without a tx ref (HyperCore). This
  *    is the session's OWN wallet, already server-side scoped by the wallet
@@ -57,8 +66,10 @@ import { Client, type ClientConfig } from "pg";
 import { err, ok, type Result, type VexError } from "@shared/ipc/result.js";
 import {
   MOVES_MAX,
+  MOVE_TOKEN_SYMBOL_MAX,
   type MovesDto,
 } from "@shared/schemas/portfolio-moves.js";
+import { sanitizeTokenSymbol } from "@shared/token-symbol-sanitizer.js";
 import { getSessionWalletScope } from "./sessions-db.js";
 import { buildPoolConfig } from "./db-config.js";
 import { log } from "../logger/index.js";
@@ -137,8 +148,10 @@ interface MoveRow {
   readonly product_type: string | null;
   readonly venue: string | null;
   readonly input_token: string | null;
+  readonly input_token_symbol: string | null;
   readonly input_amount: string | null;
   readonly output_token: string | null;
+  readonly output_token_symbol: string | null;
   readonly output_amount: string | null;
   readonly value_usd: number | string | null;
   readonly capture_status: string | null;
@@ -220,14 +233,34 @@ export async function getMovesForSession(
       // The wallet_address filter is KEPT as defense-in-depth (never omitted).
       // Columns are qualified with the `a` alias because proj_activity and
       // protocol_executions share `id`, `created_at`, and `external_refs`.
+      // The LEFT JOIN to protocol_capture_items resolves the EXACT capture
+      // item for this activity row (batch captures produce N items per
+      // execution) — both `capture_item_id` AND `execution_id` must match,
+      // so a row can never pick up a sibling execution's capture item. The
+      // symbol CASE expressions extract ONLY string-typed, length-bounded
+      // scalars from `trade_capture`; the raw JSONB itself never leaves SQL.
       const result = await client.query<MoveRow>(
         `SELECT a.id,
                 a.trade_side,
                 a.product_type,
                 a.namespace AS venue,
                 a.input_token,
+                CASE
+                  WHEN jsonb_typeof(ci.trade_capture->'inputToken') = 'string'
+                   AND char_length(ci.trade_capture->>'inputToken')
+                       BETWEEN 1 AND ${MOVE_TOKEN_SYMBOL_MAX}
+                  THEN LEFT(ci.trade_capture->>'inputToken', ${MOVE_TOKEN_SYMBOL_MAX})
+                  ELSE NULL
+                END AS input_token_symbol,
                 a.input_amount,
                 a.output_token,
+                CASE
+                  WHEN jsonb_typeof(ci.trade_capture->'outputToken') = 'string'
+                   AND char_length(ci.trade_capture->>'outputToken')
+                       BETWEEN 1 AND ${MOVE_TOKEN_SYMBOL_MAX}
+                  THEN LEFT(ci.trade_capture->>'outputToken', ${MOVE_TOKEN_SYMBOL_MAX})
+                  ELSE NULL
+                END AS output_token_symbol,
                 a.output_amount,
                 a.value_usd,
                 a.capture_status,
@@ -239,6 +272,9 @@ export async function getMovesForSession(
                 a.created_at
            FROM proj_activity a
            JOIN protocol_executions e ON e.id = a.execution_id
+           LEFT JOIN protocol_capture_items ci
+             ON ci.id = a.capture_item_id
+            AND ci.execution_id = a.execution_id
           WHERE a.wallet_address = ANY($1::text[])
             AND e.session_id = $2
           ORDER BY a.created_at DESC, a.id DESC
@@ -252,8 +288,10 @@ export async function getMovesForSession(
         productType: row.product_type,
         venue: row.venue,
         inputToken: row.input_token,
+        inputTokenSymbol: sanitizeTokenSymbol(row.input_token_symbol),
         inputAmount: row.input_amount,
         outputToken: row.output_token,
+        outputTokenSymbol: sanitizeTokenSymbol(row.output_token_symbol),
         outputAmount: row.output_amount,
         valueUsd: toNumberOrNull(row.value_usd),
         captureStatus: row.capture_status,

--- a/vex-app/src/main/ipc/__tests__/mission/results.test.ts
+++ b/vex-app/src/main/ipc/__tests__/mission/results.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Mission results ledger handler tests (WP-J) — `listResults` (PER-WALLET)
+ * and `getResultForRun`. Both are read-only projections of the engine's
+ * `mission_results` ledger; no wallet-address logging anywhere in this path.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IpcMainInvokeEvent } from "electron";
+import { CH } from "@shared/ipc/channels.js";
+import {
+  createTestWebContents,
+  createTrustedSender,
+} from "../test-sender.js";
+
+const mockListResultsForWallet = vi.fn();
+const mockGetResultForRun = vi.fn();
+const mockEnsureEngineDbUrl = vi.fn();
+
+vi.mock("electron", () => {
+  const handlers = new Map<string, (e: IpcMainInvokeEvent, p: unknown) => unknown>();
+  return {
+    ipcMain: {
+      handle: vi.fn(
+        (
+          channel: string,
+          fn: (e: IpcMainInvokeEvent, p: unknown) => unknown,
+        ) => handlers.set(channel, fn),
+      ),
+      removeHandler: vi.fn((ch: string) => handlers.delete(ch)),
+    },
+    __handlers: handlers,
+  };
+});
+
+vi.mock("@vex-agent/db/repos/mission-results.js", () => ({
+  listResultsForWallet: (...a: unknown[]) => mockListResultsForWallet(...a),
+  getResultForRun: (...a: unknown[]) => mockGetResultForRun(...a),
+}));
+
+vi.mock("../../runtime/_ensure-engine-db-url.js", () => ({
+  ensureEngineDbUrl: (...a: unknown[]) => mockEnsureEngineDbUrl(...a),
+}));
+
+vi.mock("../../../logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { registerMissionHandlers } = await import("../../mission.js");
+const electronMock = (await import("electron")) as unknown as {
+  __handlers: Map<string, (e: IpcMainInvokeEvent, p: unknown) => unknown>;
+};
+
+const trustedSender = createTrustedSender({ sender: createTestWebContents() });
+
+async function call(channel: string, payload: unknown) {
+  const handler = electronMock.__handlers.get(channel);
+  if (!handler) throw new Error(`No handler for ${channel}`);
+  return (await handler(
+    trustedSender as unknown as IpcMainInvokeEvent,
+    {
+      requestId: "11111111-1111-4111-8111-111111111111",
+      payload,
+    },
+  )) as { ok: boolean; data?: unknown; error?: { code: string } };
+}
+
+const LEDGER_ROW = {
+  missionRunId: "run-1",
+  missionId: "mission-1",
+  sessionId: "session-1",
+  walletAddress: "0xAbC",
+  chainId: 4663,
+  seqNo: 1,
+  goalSnippet: "grow ETH",
+  startedAt: "2026-07-12T18:00:00.000Z",
+  endedAt: "2026-07-12T19:00:00.000Z",
+  durationS: 3600,
+  bankrollStartEth: 0.01,
+  bankrollEndEth: 0.011,
+  pnlEth: 0.001,
+  pnlPct: 10,
+  ethPriceUsdStart: 3000,
+  ethPriceUsdEnd: 3100,
+  trades: 2,
+  outcome: "completed" as const,
+  stopReason: "goal_reached",
+  openPositions: [{ symbol: "NOXA" }],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnsureEngineDbUrl.mockResolvedValue({ ok: true, data: undefined });
+  electronMock.__handlers.clear();
+  registerMissionHandlers();
+});
+
+describe("mission.listResults", () => {
+  it("reads history for the given wallet only (PER-WALLET, never all wallets)", async () => {
+    mockListResultsForWallet.mockResolvedValueOnce([LEDGER_ROW]);
+    const result = await call(CH.mission.listResults, { walletAddress: "0xAbC" });
+
+    expect(result.ok).toBe(true);
+    expect(mockListResultsForWallet).toHaveBeenCalledWith("0xAbC", 50);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(1);
+    expect(data[0]).toMatchObject({
+      missionRunId: "run-1",
+      seqNo: 1,
+      outcome: "completed",
+      stopReason: "goal_reached",
+      openPositionsCount: 1,
+    });
+    // The DTO never echoes the wallet address or raw open-position payload.
+    expect(data[0]).not.toHaveProperty("walletAddress");
+    expect(data[0]).not.toHaveProperty("openPositions");
+  });
+
+  it("honors an explicit limit", async () => {
+    mockListResultsForWallet.mockResolvedValueOnce([]);
+    await call(CH.mission.listResults, { walletAddress: "0xAbC", limit: 10 });
+    expect(mockListResultsForWallet).toHaveBeenCalledWith("0xAbC", 10);
+  });
+
+  it("maps a db-unavailable ensureEngineDbUrl failure straight through", async () => {
+    mockEnsureEngineDbUrl.mockResolvedValueOnce({
+      ok: false,
+      error: { code: "internal.unexpected", domain: "runtime", message: "db down", retryable: true, userActionable: true, redacted: true, correlationId: "x" },
+    });
+    const result = await call(CH.mission.listResults, { walletAddress: "0xAbC" });
+    expect(result.ok).toBe(false);
+    expect(mockListResultsForWallet).not.toHaveBeenCalled();
+  });
+
+  it("maps a repo throw to a controlFailedError, never a crash", async () => {
+    mockListResultsForWallet.mockRejectedValueOnce(new Error("db exploded"));
+    const result = await call(CH.mission.listResults, { walletAddress: "0xAbC" });
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("internal.unexpected");
+  });
+});
+
+describe("mission.getResultForRun", () => {
+  it("returns the mapped DTO for a known run", async () => {
+    mockGetResultForRun.mockResolvedValueOnce(LEDGER_ROW);
+    const result = await call(CH.mission.getResultForRun, { missionRunId: "run-1", walletAddress: "0xAbC" });
+    expect(result.ok).toBe(true);
+    expect(mockGetResultForRun).toHaveBeenCalledWith("run-1", "0xAbC");
+    expect(result.data).toMatchObject({ missionRunId: "run-1", outcome: "completed" });
+  });
+
+  it("returns null when the run was never opened", async () => {
+    mockGetResultForRun.mockResolvedValueOnce(null);
+    const result = await call(CH.mission.getResultForRun, { missionRunId: "run-x", walletAddress: "0xAbC" });
+    expect(result.ok).toBe(true);
+    expect(result.data).toBeNull();
+  });
+});

--- a/vex-app/src/main/ipc/__tests__/mission/retry.test.ts
+++ b/vex-app/src/main/ipc/__tests__/mission/retry.test.ts
@@ -127,13 +127,48 @@ describe("mission.retry", () => {
     expect(mockClaim).not.toHaveBeenCalled();
   });
 
-  it("returns already_running for a running run", async () => {
+  it("returns already_running for a running run with a LIVE lease", async () => {
     mockGetLatestRunForSession.mockResolvedValueOnce({
       ok: true,
-      data: { missionRunId: "run-1", status: "running" },
+      data: { missionRunId: "run-1", status: "running", leaseActive: true },
     });
     const r = await call({ sessionId: SESSION });
     expect(r.data).toEqual({ outcome: "already_running", runId: "run-1" });
+    expect(mockClaim).not.toHaveBeenCalled();
+  });
+
+  it("attempts to RECLAIM (fromStatuses=['running']) instead of already_running when the lease is DEAD", async () => {
+    // Regression: status='running' alone does not mean a runner is
+    // observing the session (issue #12's bug class, ported to retry too).
+    mockGetLatestRunForSession.mockResolvedValueOnce({
+      ok: true,
+      data: { missionRunId: "run-dead", status: "running", leaseActive: false },
+    });
+    mockEnqueueRequest.mockResolvedValueOnce({ id: "audit-dead" });
+    mockClaim.mockResolvedValueOnce({
+      outcome: "claimed",
+      lease: { ownerId: "owner-y" },
+      previousStatus: "running",
+      wakeCancelledCount: 0,
+    });
+    mockCreateLeaseHandle.mockReturnValueOnce({});
+    mockResumeMissionRun.mockResolvedValueOnce({ text: "ok" });
+    mockRelease.mockResolvedValue(undefined);
+
+    const r = await call({ sessionId: SESSION });
+    expect(r.data).toEqual({ outcome: "resumed", runId: "run-dead" });
+    expect(mockClaim).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromStatuses: ["running"],
+        missionRunId: "run-dead",
+      }),
+    );
+    // A running row never has an error_retry wake pending — the
+    // paused_error-only wake cancellation must not fire here.
+    expect(mockCancelForSession).not.toHaveBeenCalled();
+    await vi.waitFor(() =>
+      expect(mockResumeMissionRun).toHaveBeenCalledWith("run-dead"),
+    );
   });
 
   it("returns blocked_approval for a paused_approval run", async () => {

--- a/vex-app/src/main/ipc/__tests__/mission/stop.test.ts
+++ b/vex-app/src/main/ipc/__tests__/mission/stop.test.ts
@@ -85,10 +85,10 @@ async function call(payload: unknown) {
   })) as { ok: boolean; data?: { outcome: string }; error?: { code: string } };
 }
 
-function activeState(status: string) {
+function activeState(status: string, leaseActive = true) {
   return {
     ok: true,
-    data: { hasActiveRun: true, missionRunId: "run-1", status },
+    data: { hasActiveRun: true, missionRunId: "run-1", status, leaseActive },
   };
 }
 
@@ -101,8 +101,10 @@ beforeEach(() => {
 });
 
 describe("mission.stop (runStopDispatch)", () => {
-  it("enqueues a graceful stop for a running run (queued, no abort)", async () => {
-    mockGetActiveRunForSession.mockResolvedValueOnce(activeState("running"));
+  it("enqueues a graceful stop for a running run with a LIVE lease (queued, no abort)", async () => {
+    mockGetActiveRunForSession.mockResolvedValueOnce(
+      activeState("running", true),
+    );
     mockEnqueueRequest.mockResolvedValueOnce({
       id: "22222222-2222-4222-8222-222222222222",
     });
@@ -110,6 +112,25 @@ describe("mission.stop (runStopDispatch)", () => {
     expect(r.data?.outcome).toBe("queued");
     expect(mockEnqueueRequest).toHaveBeenCalledTimes(1);
     expect(mockAbortActiveMissionForSession).not.toHaveBeenCalled();
+  });
+
+  it("aborts a running run whose lease is NOT active — no live runner would observe a queued stop", async () => {
+    // Regression: a run can be status='running' with leaseActive=false
+    // (parked between autonomous mission slices, or an expired/released
+    // lease). Enqueue-only strands the stop forever, leaving the session
+    // un-stoppable/un-deletable (issue #12).
+    mockGetActiveRunForSession.mockResolvedValueOnce(
+      activeState("running", false),
+    );
+    mockAbortActiveMissionForSession.mockResolvedValueOnce({
+      aborted: true,
+      finalStatus: "cancelled",
+      rejectedApprovals: 0,
+    });
+    const r = await call({ sessionId: SESSION });
+    expect(r.data).toEqual({ outcome: "stopped" });
+    expect(mockAbortActiveMissionForSession).toHaveBeenCalledWith(SESSION);
+    expect(mockEnqueueRequest).not.toHaveBeenCalled();
   });
 
   it("aborts a paused_error run directly (stopped, no enqueue)", async () => {

--- a/vex-app/src/main/ipc/__tests__/runtime-resume-dispatch-lease.test.ts
+++ b/vex-app/src/main/ipc/__tests__/runtime-resume-dispatch-lease.test.ts
@@ -1,0 +1,151 @@
+/**
+ * runResumeDispatch — dead-lease reclaim (WP-C, issue #12's bug class).
+ *
+ * `status === 'running'` alone does NOT mean a runner is observing the
+ * session: the lease can be expired/released. A LIVE lease still reports
+ * `already_running` (unchanged); a DEAD lease now falls through to the same
+ * claim/resume path as `paused_user` / `paused_wake` instead of lying that
+ * the run is already going.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetActiveRun = vi.fn();
+const mockEnsureDbUrl = vi.fn();
+const mockEmitControlState = vi.fn();
+const mockEnqueueRequest = vi.fn();
+const mockMarkObserved = vi.fn();
+const mockMarkCleared = vi.fn();
+const mockMarkFailed = vi.fn();
+const mockClaim = vi.fn();
+const mockCreateLeaseHandle = vi.fn();
+const mockResumeMissionRun = vi.fn();
+const mockRelease = vi.fn();
+
+vi.mock("../../database/mission-runs-db.js", () => ({
+  getActiveRunForSession: (...a: unknown[]) => mockGetActiveRun(...a),
+}));
+vi.mock("../runtime/_ensure-engine-db-url.js", () => ({
+  ensureEngineDbUrl: (...a: unknown[]) => mockEnsureDbUrl(...a),
+}));
+vi.mock("../runtime/_emit-control-state.js", () => ({
+  emitControlStateAfterChange: (...a: unknown[]) => mockEmitControlState(...a),
+}));
+vi.mock("../runtime/_errors.js", () => ({
+  controlFailedError: () => ({ code: "control_failed", redacted: true }),
+}));
+vi.mock("../../logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@vex-agent/db/repos/runtime-control-requests.js", () => ({
+  enqueueRequest: (...a: unknown[]) => mockEnqueueRequest(...a),
+  markObserved: (...a: unknown[]) => mockMarkObserved(...a),
+  markCleared: (...a: unknown[]) => mockMarkCleared(...a),
+  markFailed: (...a: unknown[]) => mockMarkFailed(...a),
+}));
+vi.mock("@vex-agent/engine/runtime/lease-and-status.js", () => ({
+  claimRunLeaseAndFlipToRunning: (...a: unknown[]) => mockClaim(...a),
+}));
+vi.mock("@vex-agent/engine/runtime/lease-handle.js", () => ({
+  createLeaseHandle: (...a: unknown[]) => mockCreateLeaseHandle(...a),
+}));
+vi.mock("@vex-agent/engine/index.js", () => ({
+  resumeMissionRun: (...a: unknown[]) => mockResumeMissionRun(...a),
+}));
+vi.mock("@vex-agent/engine/runtime/release-and-emit.js", () => ({
+  releaseLeaseAndEmitControlState: (...a: unknown[]) => mockRelease(...a),
+}));
+
+const { runResumeDispatch } = await import(
+  "../_shared/runtime-resume-dispatch.js"
+);
+
+const CTX = { requestId: "req-1", channelLabel: "test" };
+const SESSION = "s1";
+
+function activeState(status: string, leaseActive: boolean) {
+  return {
+    ok: true,
+    data: {
+      hasActiveRun: true,
+      missionRunId: "run-1",
+      status,
+      leaseActive,
+      stopReason: null,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnsureDbUrl.mockResolvedValue({ ok: true, data: undefined });
+  mockEmitControlState.mockResolvedValue(undefined);
+});
+
+describe("runResumeDispatch — running status + lease liveness", () => {
+  it("reports already_running for a running run with a LIVE lease (unchanged)", async () => {
+    mockGetActiveRun.mockResolvedValue(activeState("running", true));
+
+    const result = await runResumeDispatch({ sessionId: SESSION }, CTX);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.data.outcome).toBe("already_running");
+    expect(mockClaim).not.toHaveBeenCalled();
+  });
+
+  it("attempts to RECLAIM (fromStatuses=['running']) instead of already_running when the lease is DEAD", async () => {
+    mockGetActiveRun.mockResolvedValue(activeState("running", false));
+    mockEnqueueRequest.mockResolvedValue({ id: "audit-1" });
+    mockClaim.mockResolvedValue({
+      outcome: "claimed",
+      lease: { ownerId: "owner-x" },
+      previousStatus: "running",
+      wakeCancelledCount: 0,
+    });
+    mockCreateLeaseHandle.mockReturnValue({});
+    mockResumeMissionRun.mockResolvedValue({ text: "ok" });
+    mockRelease.mockResolvedValue(undefined);
+
+    const result = await runResumeDispatch({ sessionId: SESSION }, CTX);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.data.outcome).toBe("resumed");
+    expect(mockClaim).toHaveBeenCalledWith(
+      expect.objectContaining({ fromStatuses: ["running"], missionRunId: "run-1" }),
+    );
+    await vi.waitFor(() =>
+      expect(mockResumeMissionRun).toHaveBeenCalledWith("run-1"),
+    );
+  });
+
+  it("returns lease_busy — does not lie — when a live runner reclaims the dead lease first (race)", async () => {
+    mockGetActiveRun.mockResolvedValue(activeState("running", false));
+    mockEnqueueRequest.mockResolvedValue({ id: "audit-1" });
+    mockClaim.mockResolvedValue({
+      outcome: "lease_busy",
+      currentLease: { expiresAt: new Date(Date.now() + 30_000) },
+    });
+
+    const result = await runResumeDispatch({ sessionId: SESSION }, CTX);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.data.outcome).toBe("lease_busy");
+    expect(mockResumeMissionRun).not.toHaveBeenCalled();
+  });
+
+  it("returns blocked_error status_changed when the run's status changed between the read and the claim (race)", async () => {
+    mockGetActiveRun.mockResolvedValue(activeState("running", false));
+    mockEnqueueRequest.mockResolvedValue({ id: "audit-1" });
+    mockClaim.mockResolvedValue({ outcome: "status_mismatch", currentStatus: "completed" });
+
+    const result = await runResumeDispatch({ sessionId: SESSION }, CTX);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.data.outcome).toBe("blocked_error");
+    expect(mockResumeMissionRun).not.toHaveBeenCalled();
+  });
+});

--- a/vex-app/src/main/ipc/__tests__/runtime/request-pause.test.ts
+++ b/vex-app/src/main/ipc/__tests__/runtime/request-pause.test.ts
@@ -1,0 +1,210 @@
+/**
+ * runtime.requestPause tests — the dead-lease `already_parked` fix.
+ *
+ * A `running` run with a LIVE lease is paused gracefully (enqueue
+ * `pause_after_step`, observed by the runner at its next iteration
+ * boundary). A `running` run whose lease is NOT active has no runner to
+ * observe that request, so it is refused up front with `already_parked`
+ * instead of being enqueued and stranded forever (same bug class as
+ * issue #12's stop dead-end).
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IpcMainInvokeEvent } from "electron";
+import { CH } from "@shared/ipc/channels.js";
+import {
+  createTestWebContents,
+  createTrustedSender,
+} from "../test-sender.js";
+
+const mockGetActiveRunForSession = vi.fn();
+const mockEnsureEngineDbUrl = vi.fn();
+const mockEmitControlStateAfterChange = vi.fn();
+const mockEnqueueRequest = vi.fn();
+const mockGetPendingForSession = vi.fn();
+
+vi.mock("electron", () => {
+  const handlers = new Map<
+    string,
+    (e: IpcMainInvokeEvent, p: unknown) => unknown
+  >();
+  return {
+    ipcMain: {
+      handle: vi.fn(
+        (channel: string, fn: (e: IpcMainInvokeEvent, p: unknown) => unknown) =>
+          handlers.set(channel, fn),
+      ),
+      removeHandler: vi.fn((ch: string) => handlers.delete(ch)),
+    },
+    __handlers: handlers,
+  };
+});
+
+vi.mock("../../../database/mission-runs-db.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../../database/mission-runs-db.js")
+    >();
+  return {
+    ...actual,
+    getActiveRunForSession: (...a: unknown[]) =>
+      mockGetActiveRunForSession(...a),
+  };
+});
+vi.mock("../../runtime/_ensure-engine-db-url.js", () => ({
+  ensureEngineDbUrl: (...a: unknown[]) => mockEnsureEngineDbUrl(...a),
+}));
+vi.mock("../../runtime/_emit-control-state.js", () => ({
+  emitControlStateAfterChange: (...a: unknown[]) =>
+    mockEmitControlStateAfterChange(...a),
+}));
+vi.mock("../../../logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@vex-agent/db/repos/runtime-control-requests.js", () => ({
+  enqueueRequest: (...a: unknown[]) => mockEnqueueRequest(...a),
+  getPendingForSession: (...a: unknown[]) => mockGetPendingForSession(...a),
+}));
+
+const { registerRuntimeRequestPauseHandler } = await import(
+  "../../runtime/request-pause.js"
+);
+const electronMock = (await import("electron")) as unknown as {
+  __handlers: Map<string, (e: IpcMainInvokeEvent, p: unknown) => unknown>;
+};
+
+const SESSION = "00000000-0000-4000-8000-00000000bbbb";
+const trustedSender = createTrustedSender({ sender: createTestWebContents() });
+
+async function call(payload: unknown) {
+  const handler = electronMock.__handlers.get(CH.runtime.requestPause);
+  if (!handler) throw new Error("No handler for runtime.requestPause");
+  return (await handler(trustedSender as unknown as IpcMainInvokeEvent, {
+    requestId: "11111111-1111-4111-8111-111111111111",
+    payload,
+  })) as { ok: boolean; data?: { outcome: string }; error?: { code: string } };
+}
+
+function activeState(status: string, leaseActive: boolean) {
+  return {
+    ok: true,
+    data: { hasActiveRun: true, missionRunId: "run-1", status, leaseActive },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnsureEngineDbUrl.mockResolvedValue({ ok: true, data: undefined });
+  mockEmitControlStateAfterChange.mockResolvedValue(undefined);
+  mockGetPendingForSession.mockResolvedValue([]);
+  electronMock.__handlers.clear();
+  registerRuntimeRequestPauseHandler();
+});
+
+describe("runtime.requestPause", () => {
+  it("enqueues a graceful pause for a running run with a LIVE lease", async () => {
+    mockGetActiveRunForSession.mockResolvedValueOnce(
+      activeState("running", true),
+    );
+    mockEnqueueRequest.mockResolvedValueOnce({
+      id: "22222222-2222-4222-8222-222222222222",
+    });
+    const r = await call({ sessionId: SESSION });
+    expect(r.data?.outcome).toBe("queued");
+    expect(mockEnqueueRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns already_parked for a running run whose lease is NOT active — never enqueues", async () => {
+    mockGetActiveRunForSession.mockResolvedValueOnce(
+      activeState("running", false),
+    );
+    const r = await call({ sessionId: SESSION });
+    expect(r.data).toEqual({ outcome: "already_parked" });
+    expect(mockEnqueueRequest).not.toHaveBeenCalled();
+    expect(mockGetPendingForSession).not.toHaveBeenCalled();
+  });
+
+  it("still returns already_paused for a genuinely paused run (unaffected by the lease check)", async () => {
+    mockGetActiveRunForSession.mockResolvedValueOnce(
+      activeState("paused_user", false),
+    );
+    const r = await call({ sessionId: SESSION });
+    expect(r.data).toEqual({ outcome: "already_paused", status: "paused_user" });
+    expect(mockEnqueueRequest).not.toHaveBeenCalled();
+  });
+
+  it("returns no_active_run when there is no active run", async () => {
+    mockGetActiveRunForSession.mockResolvedValueOnce({
+      ok: true,
+      data: { hasActiveRun: false, missionRunId: null, status: null },
+    });
+    const r = await call({ sessionId: SESSION });
+    expect(r.data).toEqual({ outcome: "no_active_run" });
+    expect(mockEnqueueRequest).not.toHaveBeenCalled();
+  });
+
+  // Read-to-action lease race: the lease state can flip between the
+  // classifier's single `getActiveRunForSession` read and the point where the
+  // handler would take its action (enqueue on the live path). The handler must
+  // stay safe under BOTH interleavings. The graceful path calls
+  // `getPendingForSession` AFTER classification and BEFORE `enqueueRequest`, so
+  // that read is the concrete injection point for a mid-flight lease change.
+  describe("read-to-action lease race", () => {
+    it("classifier sees a DEAD lease that a runner re-acquires mid-flight → declines with already_parked, never enqueues an unobservable request", async () => {
+      // Interleaving dead→live: the classifier read is the SOLE decision
+      // authority. It sees a dead lease and returns already_parked before ever
+      // reaching the action path (getPendingForSession → enqueueRequest), so a
+      // live runner re-acquiring the lease the instant afterward cannot turn
+      // this into a stranded pause_after_step. The action path never running is
+      // exactly what proves the reacquire is irrelevant to this call's outcome.
+      mockGetActiveRunForSession.mockResolvedValueOnce(
+        activeState("running", false),
+      );
+
+      const r = await call({ sessionId: SESSION });
+
+      expect(r.data).toEqual({ outcome: "already_parked" });
+      // Dead path short-circuits before the action path — nothing stranded.
+      expect(mockGetPendingForSession).not.toHaveBeenCalled();
+      expect(mockEnqueueRequest).not.toHaveBeenCalled();
+    });
+
+    it("classifier sees a LIVE lease that is reassigned to another live runner mid-flight → still enqueues pause_after_step, which the live runner observes", async () => {
+      // Interleaving live→(re-acquired) live: the classifier reads a live lease
+      // and commits to the graceful enqueue path. Model the lease being handed
+      // to a DIFFERENT live runner BETWEEN the classifier read and the enqueue
+      // (side effect inside the intervening getPendingForSession read). Per the
+      // stop-fix safety pattern, enqueuing here is safe precisely because a
+      // live runner is (still/again) observing, so the pause_after_step is
+      // applied at the next iteration boundary rather than stranded. Assert the
+      // enqueue actually happened with the correct kind so the request is
+      // observable, not silently dropped.
+      let leaseReassignedMidFlight = false;
+      mockGetActiveRunForSession.mockResolvedValueOnce(
+        activeState("running", true),
+      );
+      mockGetPendingForSession.mockImplementationOnce(async () => {
+        leaseReassignedMidFlight = true; // lease handed to another live runner
+        return [];
+      });
+      mockEnqueueRequest.mockResolvedValueOnce({
+        id: "44444444-4444-4444-8444-444444444444",
+      });
+
+      const r = await call({ sessionId: SESSION });
+
+      expect(leaseReassignedMidFlight).toBe(true);
+      expect(r.data?.outcome).toBe("queued");
+      expect(mockEnqueueRequest).toHaveBeenCalledTimes(1);
+      expect(mockEnqueueRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "pause_after_step",
+          missionRunId: "run-1",
+        }),
+      );
+      // The single classifier read is the decision authority — the handler
+      // does not issue a second lease read that could disagree mid-decision.
+      expect(mockGetActiveRunForSession).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/vex-app/src/main/ipc/_shared/__tests__/lease-state.test.ts
+++ b/vex-app/src/main/ipc/_shared/__tests__/lease-state.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { classifyRunLeaseState } from "../lease-state.js";
+
+describe("classifyRunLeaseState", () => {
+  it("returns 'live' for running + an active lease", () => {
+    expect(classifyRunLeaseState("running", true)).toBe("live");
+  });
+
+  it("returns 'dead' for running + no active lease", () => {
+    expect(classifyRunLeaseState("running", false)).toBe("dead");
+  });
+
+  it("returns 'not_running' for any non-running status regardless of lease state", () => {
+    expect(classifyRunLeaseState("paused_user", true)).toBe("not_running");
+    expect(classifyRunLeaseState("paused_error", false)).toBe("not_running");
+    expect(classifyRunLeaseState("completed", true)).toBe("not_running");
+    expect(classifyRunLeaseState(null, true)).toBe("not_running");
+  });
+});

--- a/vex-app/src/main/ipc/_shared/lease-state.ts
+++ b/vex-app/src/main/ipc/_shared/lease-state.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared classification for "is a live runner actually observing this
+ * session's run right now?"
+ *
+ * `mission_runs.status === 'running'` alone does NOT imply a live runner —
+ * the lease can be expired or released while status is still `running`
+ * (parked between autonomous mission slices, or the process that held it
+ * exited without finalizing). Every control operation (stop, pause, resume,
+ * retry) needs this same distinction and previously re-derived it ad hoc —
+ * `runtime-stop-dispatch.ts` checked it, but `request-pause.ts`,
+ * `runtime-resume-dispatch.ts`, and `runtime-retry-dispatch.ts` did not,
+ * which is exactly the bug class issue #12 reported (a `running` status
+ * with a dead lease strands the operation because no runner ever observes
+ * it). This module owns ONLY the classification; each dispatcher decides
+ * its own response to a dead lease.
+ */
+
+export type RunLeaseState =
+  /** `status === 'running'` and a live lease is held — a runner is observing. */
+  | "live"
+  /** `status === 'running'` but the lease is expired/absent — no runner is observing. */
+  | "dead"
+  /** `status !== 'running'` — lease liveness is not the relevant question. */
+  | "not_running";
+
+export function classifyRunLeaseState(
+  status: string | null,
+  leaseActive: boolean,
+): RunLeaseState {
+  if (status !== "running") return "not_running";
+  return leaseActive ? "live" : "dead";
+}

--- a/vex-app/src/main/ipc/_shared/runtime-resume-dispatch.ts
+++ b/vex-app/src/main/ipc/_shared/runtime-resume-dispatch.ts
@@ -10,6 +10,13 @@
  * The dispatcher returns a discriminated union compatible with both
  * `runtimeRequestResumeResultSchema` and `missionContinueResultSchema`
  * (the two are deliberately identical).
+ *
+ * A `running` status alone does NOT mean a runner is observing the
+ * session — the lease can be expired/released (parked between autonomous
+ * mission slices). Reporting `already_running` in that case is a lie that
+ * strands the operator with no way to reclaim the run; instead a dead
+ * lease falls through to the same claim/resume path as `paused_user` /
+ * `paused_wake` (issue #12's bug class, ported here per WP-C).
  */
 
 import { randomUUID } from "node:crypto";
@@ -19,6 +26,7 @@ import { log } from "../../logger/index.js";
 import { controlFailedError } from "../runtime/_errors.js";
 import { ensureEngineDbUrl } from "../runtime/_ensure-engine-db-url.js";
 import { emitControlStateAfterChange } from "../runtime/_emit-control-state.js";
+import { classifyRunLeaseState } from "./lease-state.js";
 
 export interface ResumeFlowInput {
   readonly sessionId: string;
@@ -62,7 +70,18 @@ export async function runResumeDispatch(
     const status = state.data.status;
     const runId = state.data.missionRunId;
     if (status === "running") {
-      return ok({ outcome: "already_running", runId });
+      if (classifyRunLeaseState(status, state.data.leaseActive) === "live") {
+        return ok({ outcome: "already_running", runId });
+      }
+      // Dead lease: `status === 'running'` alone does NOT mean a runner is
+      // observing this session (parked between autonomous slices, or the
+      // process that held the lease exited without finalizing). Reporting
+      // `already_running` here would be a lie — nothing is actually
+      // running. Fall through to the SAME claim/resume path used for
+      // paused_user/paused_wake below: `claimRunLeaseAndFlipToRunning`
+      // re-validates the lease is expired/absent under a row lock before
+      // reclaiming it, so this is race-safe against a runner that reacquires
+      // the lease between this read and the claim.
     }
     if (status === "paused_approval") {
       return ok({
@@ -99,8 +118,12 @@ export async function runResumeDispatch(
         return ok({ outcome: "blocked_error", reason: "plan_acceptance_required" });
       }
     }
-    // paused_user, paused_wake, or an ACCEPTED paused_plan_acceptance —
-    // claim + flip + dispatch.
+    // paused_user, paused_wake, an ACCEPTED paused_plan_acceptance, or a
+    // `running` status with a DEAD lease (no runner actually observing) —
+    // claim + flip + dispatch. `fromStatuses: [status]` covers the
+    // running-with-dead-lease case too: `claimRunLeaseAndFlipToRunning`
+    // flips running -> running (a no-op status transition) while
+    // atomically reclaiming a fresh lease under a row lock.
     const { enqueueRequest, markObserved, markCleared, markFailed } =
       await import("@vex-agent/db/repos/runtime-control-requests.js");
     const auditRequest = await enqueueRequest({

--- a/vex-app/src/main/ipc/_shared/runtime-retry-dispatch.ts
+++ b/vex-app/src/main/ipc/_shared/runtime-retry-dispatch.ts
@@ -3,14 +3,21 @@
  *
  * Deliberately distinct from `runResumeDispatch`: that dispatcher owns
  * paused_user / paused_wake and refuses paused_error. This one claims +
- * resumes ONLY a `paused_error` run, and classifies every other state
- * explicitly so the dispatcher is total. Fire-and-forget like the resume
- * path: it claims the lease + flips status, kicks off `resumeMissionRun`
- * asynchronously, and returns a Result immediately.
+ * resumes ONLY a `paused_error` run (or a `running` run with a DEAD lease —
+ * see below), and classifies every other state explicitly so the dispatcher
+ * is total. Fire-and-forget like the resume path: it claims the lease +
+ * flips status, kicks off `resumeMissionRun` asynchronously, and returns a
+ * Result immediately.
  *
  * Duplicates ~60% of `runResumeDispatch` by intent (codex review): a shared
  * claim + fire-and-forget helper is only worth extracting once the stop-fix
  * slice proves the shape is stable.
+ *
+ * `status === 'running'` alone does NOT mean a runner is observing the
+ * session — the lease can be expired/released. `getLatestRunForSession` now
+ * loads lease state (it did not before) so this dispatcher can tell the two
+ * apart, same as `runResumeDispatch` and `runtime-stop-dispatch.ts` (issue
+ * #12's bug class, ported here per WP-C).
  */
 
 import { randomUUID } from "node:crypto";
@@ -21,6 +28,7 @@ import { log } from "../../logger/index.js";
 import { controlFailedError } from "../runtime/_errors.js";
 import { ensureEngineDbUrl } from "../runtime/_ensure-engine-db-url.js";
 import { emitControlStateAfterChange } from "../runtime/_emit-control-state.js";
+import { classifyRunLeaseState } from "./lease-state.js";
 
 export interface RetryFlowInput {
   readonly sessionId: string;
@@ -59,7 +67,16 @@ export async function runRetryDispatch(
     const runId = latest.data.missionRunId;
     const status = latest.data.status;
     if (status === "running") {
-      return ok({ outcome: "already_running", runId });
+      if (classifyRunLeaseState(status, latest.data.leaseActive) === "live") {
+        return ok({ outcome: "already_running", runId });
+      }
+      // Dead lease: no runner is actually observing this session. Fall
+      // through to the SAME claim/reclaim path as paused_error below —
+      // `claimRunLeaseAndFlipToRunning` re-validates the lease is
+      // expired/absent under a row lock before reclaiming it, so this is
+      // race-safe. SKIP the paused_error-specific auto-retry-wake
+      // cancellation just below: a `running` row never has an
+      // error_retry wake pending.
     }
     if (status === "paused_approval") {
       return ok({ outcome: "blocked_approval", pendingApprovalId: runId });
@@ -77,16 +94,19 @@ export async function runRetryDispatch(
       return ok({ outcome: "not_recoverable", status });
     }
 
-    // status === "paused_error" — claim + flip + fire-and-forget resume.
-    // Phase 4d: a human Recover supersedes any scheduled auto-retry — cancel
-    // the pending error_retry wake so it can't fire later. A wake already
-    // CONSUMED by the executor can't be cancelled; there, claimRunForAutoRetry's
-    // atomic re-check (status/unsafe/attempt) is the authority and will skip.
-    const { cancelForSession } = await import(
-      "@vex-agent/db/repos/loop-wake.js"
-    );
-    await cancelForSession(input.sessionId, "superseded_by_manual_recover");
+    if (status === "paused_error") {
+      // Phase 4d: a human Recover supersedes any scheduled auto-retry — cancel
+      // the pending error_retry wake so it can't fire later. A wake already
+      // CONSUMED by the executor can't be cancelled; there, claimRunForAutoRetry's
+      // atomic re-check (status/unsafe/attempt) is the authority and will skip.
+      const { cancelForSession } = await import(
+        "@vex-agent/db/repos/loop-wake.js"
+      );
+      await cancelForSession(input.sessionId, "superseded_by_manual_recover");
+    }
 
+    // status === "paused_error", or "running" with a DEAD lease — claim +
+    // flip + fire-and-forget resume.
     const { enqueueRequest, markObserved, markCleared, markFailed } =
       await import("@vex-agent/db/repos/runtime-control-requests.js");
     const auditRequest = await enqueueRequest({
@@ -102,7 +122,10 @@ export async function runRetryDispatch(
     const claim = await claimRunLeaseAndFlipToRunning({
       sessionId: input.sessionId,
       missionRunId: runId,
-      fromStatuses: ["paused_error"],
+      // `[status]` — either `["paused_error"]` (the normal Recover path) or
+      // `["running"]` (the dead-lease reclaim path above). Never both: only
+      // one of the two branches above reaches here for a given call.
+      fromStatuses: [status],
       ownerId: `${RETRY_OWNER_PREFIX}${randomUUID()}`,
       processKind: "electron_main",
       ttlMs: LEASE_TTL_MS,

--- a/vex-app/src/main/ipc/_shared/runtime-stop-dispatch.ts
+++ b/vex-app/src/main/ipc/_shared/runtime-stop-dispatch.ts
@@ -5,13 +5,17 @@
  * Returns the discriminated union compatible with both
  * `runtimeRequestStopResultSchema` and `missionStopResultSchema`.
  *
- * A `running` run is stopped GRACEFULLY: the handler enqueues a
- * `stop_terminal` audit row that the live runner observes at its next
- * iteration boundary (codex puzzle-03: IPC must not apply to a live loop
- * directly). A PAUSED run (approval/wake/error/user) has NO runner to observe
+ * A `running` run with a LIVE lease is stopped GRACEFULLY: the handler
+ * enqueues a `stop_terminal` audit row that the live runner observes at its
+ * next iteration boundary (codex puzzle-03: IPC must not apply to a live
+ * loop directly). Everything else — a PAUSED run (approval/wake/error/user)
+ * OR a `running` run whose lease is NOT active (parked between autonomous
+ * slices, or the process that held it exited) — has NO runner to observe
  * that request, so it is aborted directly via `abortActiveMissionForSession`
  * (the engine finalizes it to `cancelled` and rejects pending approvals +
- * cancels wakes).
+ * cancels wakes). `status === 'running'` alone does NOT imply a live
+ * runner — see `classifyRunLeaseState`; without this check a dead-lease
+ * `running` run strands the stop request forever (issue #12).
  */
 
 import { ok, err, type Result } from "@shared/ipc/result.js";
@@ -21,6 +25,7 @@ import { log } from "../../logger/index.js";
 import { controlFailedError } from "../runtime/_errors.js";
 import { ensureEngineDbUrl } from "../runtime/_ensure-engine-db-url.js";
 import { emitControlStateAfterChange } from "../runtime/_emit-control-state.js";
+import { classifyRunLeaseState } from "./lease-state.js";
 
 export interface StopFlowInput {
   readonly sessionId: string;
@@ -62,9 +67,10 @@ export async function runStopDispatch(
     ) {
       return ok({ outcome: "already_terminal", status });
     }
-    if (status === "running") {
-      // Graceful path: the live runner observes this queued stop_terminal
-      // request at its next iteration boundary and finalizes the run.
+    if (classifyRunLeaseState(status, state.data.leaseActive) === "live") {
+      // Graceful path — ONLY when a live runner (active lease) is present:
+      // it observes this queued stop_terminal request at its next iteration
+      // boundary and finalizes the run.
       const { enqueueRequest } = await import(
         "@vex-agent/db/repos/runtime-control-requests.js"
       );
@@ -78,9 +84,12 @@ export async function runStopDispatch(
       await emitControlStateAfterChange(input.sessionId, ctx.requestId);
       return ok({ outcome: "queued", requestId: request.id });
     }
-    // Paused (approval/wake/error/user): no runner is observing, so a queued
-    // stop would never be applied. Abort directly — the engine finalizes the
-    // run to `cancelled` and rejects pending approvals + cancels wakes.
+    // No live runner is observing — either a paused run (approval/wake/
+    // error/user) OR a `running` run whose lease is not active (out-of-
+    // process / parked). A queued stop would never be applied, so abort
+    // directly: the engine finalizes the run to `cancelled` and rejects
+    // pending approvals + cancels wakes (`abortMissionRun` already handles
+    // out-of-process running).
     const { abortActiveMissionForSession } = await import(
       "@vex-agent/engine/index.js"
     );

--- a/vex-app/src/main/ipc/mission.ts
+++ b/vex-app/src/main/ipc/mission.ts
@@ -18,6 +18,8 @@
  *   - recover.ts           (prepareMissionRecover + fire-and-forget)
  *   - stop.ts              (shared stop dispatcher)
  *   - update-draft.ts      (fail-closed, lands with the form in phase 7+)
+ *   - list-results.ts       (WP-J: per-wallet mission results ledger read)
+ *   - get-result-for-run.ts (WP-J: single-run ledger read)
  */
 
 export { registerMissionHandlers } from "./mission/index.js";

--- a/vex-app/src/main/ipc/mission/_result-dto.ts
+++ b/vex-app/src/main/ipc/mission/_result-dto.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared row -> DTO mapper for `mission.listResults` /
+ * `mission.getResultForRun` — both read the same `mission_results` ledger
+ * row shape and must project it identically for the renderer.
+ */
+
+import type { MissionResultRow } from "@vex-agent/db/repos/mission-results.js";
+import type { MissionResultDto } from "@shared/schemas/mission.js";
+
+export function toMissionResultDto(row: MissionResultRow): MissionResultDto {
+  return {
+    missionRunId: row.missionRunId,
+    seqNo: row.seqNo,
+    goalSnippet: row.goalSnippet,
+    startedAt: row.startedAt,
+    endedAt: row.endedAt,
+    durationS: row.durationS,
+    bankrollStartEth: row.bankrollStartEth,
+    bankrollEndEth: row.bankrollEndEth,
+    pnlEth: row.pnlEth,
+    pnlPct: row.pnlPct,
+    ethPriceUsdEnd: row.ethPriceUsdEnd,
+    trades: row.trades,
+    outcome: row.outcome,
+    stopReason: row.stopReason,
+    openPositionsCount: Array.isArray(row.openPositions) ? row.openPositions.length : 0,
+  };
+}

--- a/vex-app/src/main/ipc/mission/get-result-for-run.ts
+++ b/vex-app/src/main/ipc/mission/get-result-for-run.ts
@@ -1,0 +1,50 @@
+/**
+ * `mission.getResultForRun` — read-only ledger row for a single mission run
+ * (e.g. the post-mission summary card shown right after a run finalizes).
+ * It is scoped to the requested wallet, just like mission history.
+ * Reads the `mission_results` ledger (written by the engine's capture
+ * hooks); returns null if the run was never opened (never started, or
+ * accounting failed-soft before an open committed).
+ */
+
+import { CH } from "@shared/ipc/channels.js";
+import { ok, err, type Result } from "@shared/ipc/result.js";
+import {
+  missionGetResultForRunInputSchema,
+  missionGetResultForRunResultSchema,
+  type MissionGetResultForRunResult,
+} from "@shared/schemas/mission.js";
+import { log } from "../../logger/index.js";
+import { registerHandler } from "../register-handler.js";
+import { controlFailedError } from "../runtime/_errors.js";
+import { ensureEngineDbUrl } from "../runtime/_ensure-engine-db-url.js";
+import { toMissionResultDto } from "./_result-dto.js";
+
+export function registerMissionGetResultForRunHandler(): () => void {
+  return registerHandler({
+    channel: CH.mission.getResultForRun,
+    domain: "mission",
+    inputSchema: missionGetResultForRunInputSchema,
+    outputSchema: missionGetResultForRunResultSchema,
+    handle: async (input, ctx): Promise<Result<MissionGetResultForRunResult>> => {
+      const dbUrlOutcome = await ensureEngineDbUrl(ctx.requestId);
+      if (!dbUrlOutcome.ok) return dbUrlOutcome;
+      try {
+        const { getResultForRun } = await import(
+          "@vex-agent/db/repos/mission-results.js"
+        );
+        const row = await getResultForRun(input.missionRunId, input.walletAddress);
+        log.info(
+          `[ipc:vex:mission:getResultForRun] ok found=${row !== null} correlationId=${ctx.requestId}`,
+        );
+        return ok(row === null ? null : toMissionResultDto(row));
+      } catch (cause) {
+        log.warn(
+          `[ipc:vex:mission:getResultForRun] failed correlationId=${ctx.requestId}`,
+          cause,
+        );
+        return err(controlFailedError(ctx.requestId));
+      }
+    },
+  });
+}

--- a/vex-app/src/main/ipc/mission/index.ts
+++ b/vex-app/src/main/ipc/mission/index.ts
@@ -15,6 +15,8 @@ import { registerMissionEditHandler } from "./edit.js";
 import { registerMissionGetDiffHandler } from "./get-diff.js";
 import { registerMissionGetDraftHandler } from "./get-draft.js";
 import { registerMissionGetRenewableSourceHandler } from "./get-renewable-source.js";
+import { registerMissionGetResultForRunHandler } from "./get-result-for-run.js";
+import { registerMissionListResultsHandler } from "./list-results.js";
 import { registerMissionRecoverHandler } from "./recover.js";
 import { registerMissionRenewHandler } from "./renew.js";
 import { registerMissionRetryHandler } from "./retry.js";
@@ -38,5 +40,7 @@ export function registerMissionHandlers(): ReadonlyArray<() => void> {
     registerMissionStopHandler(),
     registerMissionGetRenewableSourceHandler(),
     registerMissionSetAutoRetryHandler(),
+    registerMissionListResultsHandler(),
+    registerMissionGetResultForRunHandler(),
   ];
 }

--- a/vex-app/src/main/ipc/mission/list-results.ts
+++ b/vex-app/src/main/ipc/mission/list-results.ts
@@ -1,0 +1,56 @@
+/**
+ * `mission.listResults` — read-only, PER-WALLET mission history for the
+ * Mission History view. Reads the `mission_results` ledger (written by the
+ * engine's capture hooks — see `engine/mission/mission-results-capture.ts`),
+ * newest first.
+ *
+ * There is intentionally no "list every wallet" read — the caller always
+ * supplies the wallet address it wants history for.
+ */
+
+import { CH } from "@shared/ipc/channels.js";
+import { ok, err, type Result } from "@shared/ipc/result.js";
+import {
+  missionListResultsInputSchema,
+  missionListResultsResultSchema,
+  DEFAULT_MISSION_RESULTS_LIMIT,
+  type MissionListResultsResult,
+} from "@shared/schemas/mission.js";
+import { log } from "../../logger/index.js";
+import { registerHandler } from "../register-handler.js";
+import { controlFailedError } from "../runtime/_errors.js";
+import { ensureEngineDbUrl } from "../runtime/_ensure-engine-db-url.js";
+import { toMissionResultDto } from "./_result-dto.js";
+
+export function registerMissionListResultsHandler(): () => void {
+  return registerHandler({
+    channel: CH.mission.listResults,
+    domain: "mission",
+    inputSchema: missionListResultsInputSchema,
+    outputSchema: missionListResultsResultSchema,
+    handle: async (input, ctx): Promise<Result<MissionListResultsResult>> => {
+      const dbUrlOutcome = await ensureEngineDbUrl(ctx.requestId);
+      if (!dbUrlOutcome.ok) return dbUrlOutcome;
+      try {
+        const { listResultsForWallet } = await import(
+          "@vex-agent/db/repos/mission-results.js"
+        );
+        const rows = await listResultsForWallet(
+          input.walletAddress,
+          input.limit ?? DEFAULT_MISSION_RESULTS_LIMIT,
+        );
+        const dtos = rows.map(toMissionResultDto);
+        log.info(
+          `[ipc:vex:mission:listResults] ok count=${dtos.length} correlationId=${ctx.requestId}`,
+        );
+        return ok(dtos);
+      } catch (cause) {
+        log.warn(
+          `[ipc:vex:mission:listResults] failed correlationId=${ctx.requestId}`,
+          cause,
+        );
+        return err(controlFailedError(ctx.requestId));
+      }
+    },
+  });
+}

--- a/vex-app/src/main/ipc/runtime/request-pause.ts
+++ b/vex-app/src/main/ipc/runtime/request-pause.ts
@@ -8,6 +8,14 @@
  * #1). The runner observes pending pause requests at its
  * iteration-boundary checkpoint in `turn-loop.ts` and applies the
  * transition there.
+ *
+ * `status === 'running'` alone does NOT imply a live runner — the lease
+ * can be expired/released (parked between autonomous mission slices). In
+ * that case a `pause_after_step` request would be enqueued but never
+ * observed (same bug class as issue #12's stop dead-end), so it is
+ * refused up front with `already_parked` instead — the run is already
+ * effectively idle; the caller should use Resume/Retry to reclaim it or
+ * Stop to end it.
  */
 
 import { CH } from "@shared/ipc/channels.js";
@@ -23,6 +31,7 @@ import { registerHandler } from "../register-handler.js";
 import { controlFailedError } from "./_errors.js";
 import { ensureEngineDbUrl } from "./_ensure-engine-db-url.js";
 import { emitControlStateAfterChange } from "./_emit-control-state.js";
+import { classifyRunLeaseState } from "../_shared/lease-state.js";
 
 export function registerRuntimeRequestPauseHandler(): () => void {
   return registerHandler({
@@ -59,7 +68,13 @@ export function registerRuntimeRequestPauseHandler(): () => void {
           // resumes next) will be the one to honor a fresh request.
           return ok({ outcome: "already_paused", status });
         }
-        // Running — enqueue the request and return.
+        if (classifyRunLeaseState(status, state.data.leaseActive) === "dead") {
+          // Dead lease: no runner would ever observe an enqueued pause
+          // request. Refuse rather than enqueue an unobservable request
+          // that sits pending forever.
+          return ok({ outcome: "already_parked" });
+        }
+        // Running with a live lease — enqueue the request and return.
         const { enqueueRequest, getPendingForSession } = await import(
           "@vex-agent/db/repos/runtime-control-requests.js"
         );

--- a/vex-app/src/preload/agent/mission.ts
+++ b/vex-app/src/preload/agent/mission.ts
@@ -16,6 +16,8 @@ import {
   missionGetDiffInputSchema,
   missionGetDraftInputSchema,
   missionGetRenewableSourceInputSchema,
+  missionGetResultForRunInputSchema,
+  missionListResultsInputSchema,
   missionRecoverInputSchema,
   missionRenewInputSchema,
   missionEditInputSchema,
@@ -31,6 +33,8 @@ import type {
   MissionGetDiffInput,
   MissionGetDraftInput,
   MissionGetRenewableSourceInput,
+  MissionGetResultForRunInput,
+  MissionListResultsInput,
   MissionRecoverInput,
   MissionRenewInput,
   MissionEditInput,
@@ -133,6 +137,20 @@ export const mission = {
       CH.mission.setAutoRetry,
       input,
       missionSetAutoRetryInputSchema,
+    );
+  },
+  listResults(input: MissionListResultsInput) {
+    return invokeWithSchema(
+      CH.mission.listResults,
+      input,
+      missionListResultsInputSchema,
+    );
+  },
+  getResultForRun(input: MissionGetResultForRunInput) {
+    return invokeWithSchema(
+      CH.mission.getResultForRun,
+      input,
+      missionGetResultForRunInputSchema,
     );
   },
 } satisfies MissionBridge;

--- a/vex-app/src/renderer/components/common/TokenIcon.tsx
+++ b/vex-app/src/renderer/components/common/TokenIcon.tsx
@@ -44,6 +44,18 @@ const ICON_BY_SYMBOL: Readonly<Record<string, BrandIcon>> = {
   op: Optimism,
 };
 
+/**
+ * Lower-cased symbols that resolve to a real brand mark above. Callers that
+ * accept an UNTRUSTED display symbol (e.g. a captured/provider-supplied
+ * token symbol that can self-declare arbitrary metadata) use this set to
+ * decide whether a symbol claim needs independent verification before it is
+ * allowed to borrow a brand's identity — see
+ * `vex-app/src/shared/token-symbol-sanitizer.ts`.
+ */
+export const BRAND_ICON_SYMBOLS: ReadonlySet<string> = new Set(
+  Object.keys(ICON_BY_SYMBOL),
+);
+
 export function TokenIcon({
   symbol,
   size = 13,

--- a/vex-app/src/renderer/features/appShell/AppShell.tsx
+++ b/vex-app/src/renderer/features/appShell/AppShell.tsx
@@ -45,6 +45,7 @@ import { SessionPanel } from "./SessionPanel.js";
 import { SessionsLibrary } from "./SessionsLibrary.js";
 import { SessionsList } from "./SessionsList.js";
 import { MemoryPanel } from "./MemoryPanel.js";
+import { MissionHistory } from "./MissionHistory.js";
 import { GlobalApprovals } from "./GlobalApprovals.js";
 import { SignalSky } from "./SignalSky.js";
 import { HypervexingWorkspace } from "./workspace/HypervexingWorkspace.js";
@@ -198,6 +199,8 @@ function NormalShell({
             <SessionsLibrary />
           ) : appShellView === "memory" ? (
             <MemoryPanel />
+          ) : appShellView === "missionHistory" ? (
+            <MissionHistory />
           ) : (
             <SessionPanel />
           )}

--- a/vex-app/src/renderer/features/appShell/DeskRuleTapeState.tsx
+++ b/vex-app/src/renderer/features/appShell/DeskRuleTapeState.tsx
@@ -5,9 +5,9 @@
  * the head of the tape.
  *
  * State precedence mirrors the streaming strip's circuit-break: a pending
- * approval FREEZES the run, so AWAITING wins over LIVE; otherwise LIVE while the
- * engine streams; then a non-streaming mission run reads PAUSED (paused_*) or
- * RUNNING (so a started, quiet run no longer looks idle); IDLE at rest. Blue is
+ * approval FREEZES the run, so AWAITING wins over LIVE; otherwise LIVE while a
+ * chat submit remains active (including quiet gaps between engine streams);
+ * then a mission run reads PAUSED (paused_*) or RUNNING; IDLE at rest. Blue is
  * rationed to the non-idle states.
  *
  * Landing hero-status treatment: the dot carries the `.vex-pulse-dot` ring
@@ -23,6 +23,7 @@
 
 import type { JSX } from "react";
 import { usePendingApprovals } from "../../lib/api/approvals.js";
+import { useIsChatSubmitting } from "../../lib/api/chat.js";
 import { useRuntimeState } from "../../lib/api/runtime.js";
 import { useStreamPreview } from "../../stores/streamStore.js";
 import { useUiStore } from "../../stores/uiStore.js";
@@ -32,6 +33,7 @@ export function DeskRuleTapeState(): JSX.Element | null {
   const activeSessionId = useUiStore((s) => s.activeSessionId);
   const appShellView = useUiStore((s) => s.appShellView);
   const preview = useStreamPreview(activeSessionId);
+  const chatSubmitting = useIsChatSubmitting(activeSessionId);
   const pending = usePendingApprovals(activeSessionId);
   const runtime = useRuntimeState(activeSessionId);
 
@@ -40,14 +42,15 @@ export function DeskRuleTapeState(): JSX.Element | null {
   const pendingData = pending.data;
   const hasPending =
     pendingData !== undefined && pendingData.ok && pendingData.data.length > 0;
-  const streaming = preview !== null && preview.phase === "streaming";
+  const live =
+    chatSubmitting || (preview !== null && preview.phase === "streaming");
   const run = runtime.data !== undefined && runtime.data.ok ? runtime.data.data : null;
   const hasActiveRun = run?.hasActiveRun === true;
   const paused = hasActiveRun && (run?.status?.startsWith("paused") ?? false);
 
   const state = hasPending
     ? "awaiting"
-    : streaming
+    : live
       ? "live"
       : paused
         ? "paused"

--- a/vex-app/src/renderer/features/appShell/MissionControls.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionControls.tsx
@@ -139,6 +139,8 @@ function renewNoticeFor(r: Result<MissionRenewResult>): string | null {
       return `The source mission isn't finished yet (status ${r.data.runStatus}). Wait for it to finish first.`;
     case "session_has_active_run":
       return `A mission run is already active (status ${r.data.runStatus}). Stop it before renewing.`;
+    case "session_has_pending_draft":
+      return "A draft mission already exists for this session — accept or discard it before renewing again.";
     default:
       return assertNever(r.data);
   }
@@ -300,7 +302,14 @@ export function MissionControls({
   // into a fresh draft (the new contract must still be accepted before it runs,
   // so this is non-destructive and needs no confirm step).
   const renewSource = readRenewable(renewableQuery.data);
-  if (renewSource !== null) {
+  // `draft === null` guard mirrors MissionRail's load-bearing guard:
+  // `getRenewableSourceForSession` keeps returning the OLD terminal accepted
+  // mission even after `mission.renew` (or `edit`) inserts a fresh draft. Without
+  // this guard the Renew button LINGERS once a fresh draft exists — so a renew
+  // looks like it "does nothing", and each extra click clones ANOTHER duplicate
+  // draft. Gating on `draft === null` lets the fresh draft fall through to the
+  // acceptance-pending UI below (accept it, then Start).
+  if (renewSource !== null && draft === null) {
     const previousMissionId = renewSource.missionId;
     return (
       <div data-vex-area="mission-controls" className="mt-3">

--- a/vex-app/src/renderer/features/appShell/MissionHistory.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionHistory.tsx
@@ -1,0 +1,239 @@
+/**
+ * Mission History — a read-only AppShell sub-view (mission-results-ledger,
+ * WP-J). Per-wallet ledger of finalized mission runs: a summary register
+ * (total missions, win rate, cumulative ETH PnL) then one row per mission,
+ * newest first. Mirrors the MemoryPanel shell grammar (h-12 register header
+ * + back key, hairline-separated ledger, `--vex-*` ink) so it reads as one
+ * surface with the rest of the desk.
+ *
+ * The ledger is EVM/ETH-specific (bankroll = native ETH + WETH), so this
+ * reads the PRIMARY EVM wallet from the inventory — never every wallet.
+ *
+ * All arithmetic + formatting lives in `missionHistoryModel.ts`; this file
+ * is presentation over derived values. Naming: "mission result (ETH)" —
+ * never "performance".
+ */
+
+import type { JSX } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
+import type { Result } from "@shared/ipc/result.js";
+import type { MissionListResultsResult, MissionResultDto } from "@shared/schemas/mission.js";
+import { useUiStore } from "../../stores/uiStore.js";
+import { useMissionResults } from "../../lib/api/mission.js";
+import { useAvailableWallets } from "../../lib/api/wallet-inventory.js";
+import { formatPercentDelta, formatUsd } from "../../lib/format.js";
+import { cn } from "../../lib/utils.js";
+import { Empty, ErrorState, Loading } from "./MemoryPanelShared.js";
+import { OutcomeBadge } from "./OutcomeBadge.js";
+import {
+  EM_DASH,
+  computeWinRate,
+  formatDurationS,
+  formatEth,
+  missionDisplayOutcome,
+  pnlUsd,
+  sumPnlEth,
+} from "./missionHistoryModel.js";
+
+export function MissionHistory(): JSX.Element {
+  const setAppShellView = useUiStore((s) => s.setAppShellView);
+  const walletsQuery = useAvailableWallets();
+  const primaryWallet =
+    walletsQuery.data && walletsQuery.data.ok ? (walletsQuery.data.data.evm[0] ?? null) : null;
+  const resultsQuery = useMissionResults(primaryWallet?.address ?? null);
+
+  return (
+    <div
+      data-vex-screen="missionHistory"
+      className="flex h-full min-h-0 flex-col text-foreground"
+    >
+      {/* Register header — same h-12 datum + quiet back key as the Memory
+       * panel; the affordance is an icon, never a chrome pill. */}
+      <header className="flex h-12 shrink-0 items-center gap-3 border-b border-[var(--vex-line)] px-6">
+        <button
+          type="button"
+          onClick={() => setAppShellView("session")}
+          aria-label="Back to chat"
+          className="flex h-8 w-8 items-center justify-center rounded-[6px] text-[var(--vex-text-2)] transition-colors hover:bg-white/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)]"
+        >
+          <HugeiconsIcon icon={ArrowLeft01Icon} size={17} aria-hidden />
+        </button>
+        <h1 className="font-mono text-[13px] font-medium uppercase tracking-[0.3em] text-foreground">
+          Missions
+        </h1>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+        <div className="mx-auto flex w-full max-w-[760px] flex-col gap-6">
+          {primaryWallet === null ? (
+            <Empty label="No wallet available — add a wallet to see mission history." />
+          ) : (
+            <Body query={resultsQuery} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Query-state fork: pending -> loading, thrown/transport error OR an
+ * `ok:false` Result envelope -> error, empty array -> friendly empty state,
+ * else the ledger.
+ */
+function Body({
+  query,
+}: {
+  readonly query: UseQueryResult<Result<MissionListResultsResult>>;
+}): JSX.Element {
+  if (query.isPending) return <Loading label="Loading missions…" />;
+  if (query.isError) return <ErrorState message={query.error.message} />;
+  const res = query.data;
+  if (!res.ok) return <ErrorState message={res.error.message} />;
+  if (res.data.length === 0) {
+    return <Empty label="No missions yet — finish a mission to see it here." />;
+  }
+  return <Ledger results={res.data} />;
+}
+
+function Ledger({ results }: { readonly results: readonly MissionResultDto[] }): JSX.Element {
+  const winRate = computeWinRate(results);
+  const cumulative = sumPnlEth(results);
+
+  return (
+    <>
+      <SummaryHeader total={results.length} winRate={winRate} cumulativeEth={cumulative} />
+      <ResultsTable results={results} />
+    </>
+  );
+}
+
+function SummaryHeader({
+  total,
+  winRate,
+  cumulativeEth,
+}: {
+  readonly total: number;
+  readonly winRate: number | null;
+  readonly cumulativeEth: number;
+}): JSX.Element {
+  return (
+    <section className="flex flex-wrap items-end gap-x-10 gap-y-4 border-b border-[var(--vex-line)] pb-6">
+      <Stat label="Missions" value={String(total)} />
+      <Stat label="Win rate" value={winRate === null ? EM_DASH : `${winRate.toFixed(0)}%`} />
+      <Stat
+        label="Cumulative PnL"
+        value={`${formatEth(cumulativeEth, { signed: true })} ETH`}
+        tone={pnlTone(cumulativeEth)}
+      />
+    </section>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly tone?: string;
+}): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--vex-text-3)]">
+        {label}
+      </span>
+      <span className={cn("font-mono text-lg tabular-nums", tone ?? "text-foreground")}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function ResultsTable({
+  results,
+}: {
+  readonly results: readonly MissionResultDto[];
+}): JSX.Element {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-left text-xs">
+        <thead>
+          <tr className="border-b border-[var(--vex-line)] font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--vex-text-3)]">
+            <Th>#</Th>
+            <Th>Goal</Th>
+            <Th>Outcome</Th>
+            <Th align="right">Duration</Th>
+            <Th align="right">Trades</Th>
+            <Th align="right">PnL (ETH)</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {results.map((r) => (
+            <ResultRow key={r.missionRunId} result={r} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ResultRow({ result }: { readonly result: MissionResultDto }): JSX.Element {
+  const usd = pnlUsd(result.pnlEth, result.ethPriceUsdEnd);
+  const pnlTitle = usd === null ? undefined : `${formatUsd(usd)} at close`;
+
+  return (
+    <tr className="border-b border-[var(--vex-line)] last:border-b-0 hover:bg-white/[0.02]">
+      <td className="py-2.5 pr-3 font-mono tabular-nums text-[var(--vex-text-2)]">
+        #{result.seqNo}
+      </td>
+      <td className="max-w-[220px] truncate py-2.5 pr-3 text-foreground">
+        <span title={result.goalSnippet ?? undefined}>{result.goalSnippet ?? EM_DASH}</span>
+      </td>
+      <td className="py-2.5 pr-3">
+        <OutcomeBadge outcome={missionDisplayOutcome(result)} />
+      </td>
+      <td className="py-2.5 pr-3 text-right font-mono tabular-nums text-[var(--vex-text-2)]">
+        {formatDurationS(result.durationS)}
+      </td>
+      <td className="py-2.5 pr-3 text-right font-mono tabular-nums text-[var(--vex-text-2)]">
+        {result.trades}
+      </td>
+      <td className="py-2.5 text-right">
+        <span title={pnlTitle} className={cn("font-mono tabular-nums", pnlTone(result.pnlEth))}>
+          {formatEth(result.pnlEth, { signed: true })}
+        </span>
+        {result.pnlPct !== null ? (
+          <span className="ml-2 font-mono text-[10px] tabular-nums text-[var(--vex-text-3)]">
+            {formatPercentDelta(result.pnlPct)}
+          </span>
+        ) : null}
+      </td>
+    </tr>
+  );
+}
+
+function Th({
+  children,
+  align,
+}: {
+  readonly children: string;
+  readonly align?: "right";
+}): JSX.Element {
+  return (
+    <th className={cn("py-2 pr-3 font-normal", align === "right" ? "text-right" : "text-left")}>
+      {children}
+    </th>
+  );
+}
+
+/** Sign -> PnL colour class: positive success, negative destructive, flat/unknown muted. */
+function pnlTone(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "text-[var(--vex-text-3)]";
+  if (value > 0) return "text-[var(--color-success)]";
+  if (value < 0) return "text-destructive";
+  return "text-[var(--vex-text-2)]";
+}

--- a/vex-app/src/renderer/features/appShell/MissionsButton.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionsButton.tsx
@@ -1,0 +1,40 @@
+/**
+ * Sidebar footer key — opens the Mission History ledger sub-view
+ * (mission-results-ledger, WP-J). Mirrors `MemoryButton`: a quiet
+ * full-width registry row carrying its own border-t hairline so the footer
+ * stack stays separated.
+ */
+
+import { useCallback, type JSX } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { AnalyticsUpIcon } from "@hugeicons/core-free-icons";
+import { Button } from "../../components/ui/button.js";
+import { cn } from "../../lib/utils.js";
+import { useUiStore } from "../../stores/uiStore.js";
+
+interface MissionsButtonProps {
+  readonly compact?: boolean;
+}
+
+export function MissionsButton({ compact = false }: MissionsButtonProps): JSX.Element {
+  const setAppShellView = useUiStore((s) => s.setAppShellView);
+  const onClick = useCallback((): void => {
+    setAppShellView("missionHistory");
+  }, [setAppShellView]);
+
+  return (
+    <Button
+      variant="ghost"
+      size={compact ? "icon" : "sm"}
+      onClick={onClick}
+      aria-label="Open mission history"
+      className={cn(
+        "h-9 w-full rounded-none border-0 border-t border-[var(--vex-line)] bg-transparent text-[10px] tracking-[0.18em] text-[var(--vex-text-2)] hover:bg-white/[0.035] hover:text-foreground",
+        compact ? "justify-center px-0" : "justify-start gap-2 px-4",
+      )}
+    >
+      <HugeiconsIcon icon={AnalyticsUpIcon} size={15} aria-hidden />
+      {compact ? null : <span>Missions</span>}
+    </Button>
+  );
+}

--- a/vex-app/src/renderer/features/appShell/OutcomeBadge.tsx
+++ b/vex-app/src/renderer/features/appShell/OutcomeBadge.tsx
@@ -1,0 +1,50 @@
+/**
+ * OutcomeBadge — the ONE shared small colour-toned stamp for a mission's
+ * outcome (WP-J: replaces a duplicated inline badge — every surface that
+ * shows a mission outcome renders it through this single component).
+ *
+ * Takes the DISPLAY outcome (`missionHistoryModel.ts` `missionDisplayOutcome`),
+ * never the raw ledger `outcome` — a deadline-reached run reads as the
+ * neutral "time-boxed", not "failed".
+ */
+
+import type { JSX } from "react";
+import { cn } from "../../lib/utils.js";
+import type { MissionDisplayOutcome } from "./missionHistoryModel.js";
+
+const LABEL: Record<MissionDisplayOutcome, string> = {
+  completed: "completed",
+  timeBoxed: "time-boxed",
+  cancelled: "cancelled",
+  failed: "failed",
+  stopped: "stopped",
+  running: "running",
+};
+
+const TONE: Record<MissionDisplayOutcome, string> = {
+  completed:
+    "border-[color-mix(in_oklab,var(--color-success)_40%,transparent)] text-[var(--color-success)]",
+  // Neutral/medium-level — a reached time-box is not a failure.
+  timeBoxed: "border-[var(--vex-accent-border)] text-[var(--vex-accent-text)]",
+  failed: "border-destructive/40 text-destructive",
+  running: "border-[var(--vex-accent-border)] text-[var(--vex-accent-text)]",
+  cancelled: "border-[var(--vex-line)] text-[var(--vex-text-2)]",
+  stopped: "border-[var(--vex-line)] text-[var(--vex-text-2)]",
+};
+
+export interface OutcomeBadgeProps {
+  readonly outcome: MissionDisplayOutcome;
+}
+
+export function OutcomeBadge({ outcome }: OutcomeBadgeProps): JSX.Element {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-[3px] border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em]",
+        TONE[outcome],
+      )}
+    >
+      {LABEL[outcome]}
+    </span>
+  );
+}

--- a/vex-app/src/renderer/features/appShell/SessionComposer.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionComposer.tsx
@@ -25,8 +25,9 @@
  * all live in `.vex-console` (globals.css) — token-only, so both themes
  * recolor from `--vex-accent`. The context strip is gone, so the two
  * transient states it carried survive as a tiny tag FLOATING above the pill:
- * amber "AWAITING SIGNATURE" while a run is parked for approval, muted
- * "Stopping…" while a stop settles (they cannot co-occur).
+ * amber "AWAITING SIGNATURE" while a run is parked for approval or muted
+ * "Stopping…" while a stop settles. Active work is shown on the agent avatar
+ * in the transcript instead of adding another label above the input.
  *
  * Pure helpers: gating reasons + placeholders in `composer-helpers.ts`.
  * Mission controls (start/continue/recover/stop/edit/renew) are buttons in
@@ -64,6 +65,7 @@ import {
   gatedReason,
   placeholderFor,
   readRunStatus,
+  submitFailureNotice,
   submitSuccessText,
 } from "./composer-helpers.js";
 import { ComposerQuickActions } from "./ComposerQuickActions.js";
@@ -241,6 +243,21 @@ export function SessionComposer({
           }
           return;
         }
+        const failure = submitFailureNotice(outcome.data);
+        if (failure !== null) {
+          const armRetry =
+            failure.retryable &&
+            activeSession?.id === targetSessionId &&
+            activeSession.mode === "agent";
+          setNotice({
+            tone: "error",
+            text: failure.text,
+            ...(armRetry && {
+              retry: { sessionId: targetSessionId, message },
+            }),
+          });
+          return;
+        }
         const successText = submitSuccessText(outcome.data);
         if (successText !== null) setNotice({ tone: "info", text: successText });
       } finally {
@@ -398,12 +415,10 @@ export function SessionComposer({
   return (
     <>
       <div className="relative mt-6">
-        {/* TRANSIENT SIGNAL TAG — floats above the pill's right side, carrying
-         * the two states the retired context strip held (they cannot co-occur:
-         * an approval pause freezes free-text submit, so nothing is in flight).
-         * amber "AWAITING SIGNATURE" while parked for a signature; muted
-         * "Stopping…" while a stop settles. Sibling of the form so the pill's
-         * rounded surface never owns this floating status layer. */}
+        {/* TRANSIENT SIGNAL TAG — floats above the pill's right side. An
+         * approval pause wins over a requested stop. The active-work signal
+         * lives on the agent avatar in the transcript, so the composer stays
+         * visually quiet while a turn is running. */}
         {awaitingApproval ? (
           <span
             data-vex-console-status="approval"

--- a/vex-app/src/renderer/features/appShell/SessionTranscript.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionTranscript.tsx
@@ -26,6 +26,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, type JSX } fr
 import type { Result } from "@shared/ipc/result.js";
 import type { MessagePage, SessionMessageDto } from "@shared/schemas/messages.js";
 import { usePendingApprovals } from "../../lib/api/approvals.js";
+import { useIsChatSubmitting } from "../../lib/api/chat.js";
 import {
   flattenTranscriptPages,
   useTranscriptInfinite,
@@ -36,9 +37,12 @@ import { useStreamPreview } from "../../stores/streamStore.js";
 import { StreamingBubble } from "./StreamingBubble.js";
 import { TranscriptMessage } from "./TranscriptMessage.js";
 import {
+  findWorkingAgentEntryKey,
+  transcriptEntryKey as entryKey,
+} from "./agentActivity.js";
+import {
   groupTranscriptRows,
   toTranscriptRows,
-  type TranscriptEntry,
 } from "./transcriptRowModel.js";
 
 const PINNED_THRESHOLD_PX = 48;
@@ -46,19 +50,6 @@ const LOAD_OLDER_THRESHOLD_PX = 64;
 // Same cadence as ApprovalsRegion — both observers share one query, so this
 // adds no IPC load; it only keeps the act-ledger stamps as fresh as the cards.
 const PENDING_APPROVALS_REFETCH_MS = 5_000;
-
-/**
- * React key for a transcript entry. One source DTO id can now appear on up to
- * three entries: a `tool_call` row with prose splits into a standalone
- * assistant-text row PLUS the (prose-less) tool row, and a grouped tool run
- * reuses its first call row's id for the `tool_group` entry. Prefixing the
- * tool / tool_group variants keeps all three keys distinct under one id.
- */
-function entryKey(entry: TranscriptEntry): string {
-  if (entry.variant === "tool_group") return `tg-${entry.id}`;
-  if (entry.variant === "tool") return `t-${entry.id}`;
-  return String(entry.id);
-}
 
 /**
  * Ids that must NOT animate: everything visible at the session's first
@@ -110,6 +101,7 @@ export function SessionTranscript({
 }): JSX.Element {
   const query = useTranscriptInfinite(sessionId);
   const preview = useStreamPreview(sessionId);
+  const chatSubmitting = useIsChatSubmitting(sessionId);
   const scrollRef = useRef<HTMLDivElement>(null);
   const anchorSpacerRef = useRef<HTMLDivElement>(null);
   const pinnedToBottom = useRef(true);
@@ -133,6 +125,7 @@ export function SessionTranscript({
     () => groupTranscriptRows(toTranscriptRows(items)),
     [items],
   );
+  const workingAgentEntryKey = findWorkingAgentEntryKey(rows, chatSubmitting);
 
   // S5 — pending approvals drive two quiet signals: per-act "Awaiting
   // signature" stamps (matched by toolCallId) and the working strip's
@@ -383,7 +376,11 @@ export function SessionTranscript({
               settledIds !== null && !settledIds.has(row.id) && "vex-entry-settle",
             )}
           >
-            <TranscriptMessage row={row} pendingApprovals={pendingApprovals} />
+            <TranscriptMessage
+              row={row}
+              pendingApprovals={pendingApprovals}
+              agentWorking={workingAgentEntryKey === entryKey(row)}
+            />
           </div>
         ))}
         {preview !== null ? (

--- a/vex-app/src/renderer/features/appShell/SessionsList.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionsList.tsx
@@ -20,6 +20,7 @@ import {
 import { useUiStore } from "../../stores/uiStore.js";
 import { SessionDeleteDialog } from "./SessionDeleteDialog.js";
 import { MemoryButton } from "./MemoryButton.js";
+import { MissionsButton } from "./MissionsButton.js";
 import { RuntimeLedger } from "./RuntimeLedger.js";
 import { SettingsButton } from "./SettingsButton.js";
 import { SidebarHomeSigil } from "./SidebarHomeSigil.js";
@@ -378,6 +379,7 @@ export function SessionsList({ onCreate }: SessionsListProps): JSX.Element {
         )}
       >
         <MemoryButton compact={!sidebarOpen} />
+        <MissionsButton compact={!sidebarOpen} />
         <SettingsButton compact={!sidebarOpen} />
         {/* Report issue intentionally hidden for now; ReportIssueButton/Dialog retained for re-enable. */}
         <RuntimeLedger sidebarOpen={sidebarOpen} />

--- a/vex-app/src/renderer/features/appShell/ToolLedger/ToolActRow.tsx
+++ b/vex-app/src/renderer/features/appShell/ToolLedger/ToolActRow.tsx
@@ -1,10 +1,10 @@
 /**
  * THE ACT LEDGER — one registered act (S5): a tool call plus its merged
- * output. The transcript shows REGISTERED FACTS: the DTO carries no per-call
- * status or duration, so the row is quiet — name + Args (+ Output when a
- * result paired in the same run). The only stamp the data supports is
- * "Awaiting signature": a pending approval whose `toolCallId` matches this
- * act (rendered as a sibling link, see `ApprovalLinkStamp`).
+ * output. The transcript shows REGISTERED FACTS: most rows stay quiet — name
+ * + Args (+ Output when a result paired in the same run). Two deterministic
+ * stamps are supported: "Awaiting signature" from the approval queue, and
+ * "Confirmed" when a `wallet_send_confirm` result carries the tool's strict
+ * `{ status: "confirmed", txHash }` output contract.
  *
  * Collapsed by default (today's disclosure contract). The expanded body is a
  * recessed well; args/output are sanitized strings rendered as TEXT (`<pre>`
@@ -15,13 +15,53 @@
 
 import { useId, useState, type JSX } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import {
+  ArrowRight01Icon,
+  CheckmarkCircle01Icon,
+} from "@hugeicons/core-free-icons";
 import { cn } from "../../../lib/utils.js";
 import type { ToolCallActView } from "../transcriptRowModel.js";
 import type { HyperliquidDisplayBlock } from "@shared/schemas/hyperliquid.js";
 import { ApprovalLinkStamp } from "./ApprovalLinkStamp.js";
 import { ExplorerRefLinks } from "./ExplorerRefLinks.js";
 import { toolGlyph } from "./toolGlyph.js";
+
+/**
+ * Recognise only the successful wallet-confirm output contract. Tool output
+ * is still treated as untrusted text: malformed JSON, lookalike tools, a
+ * missing hash, or any non-confirmed status all fail closed to no stamp.
+ */
+function isConfirmedWalletTransfer(act: ToolCallActView): boolean {
+  if (act.toolName !== "wallet_send_confirm" || act.output === null) return false;
+  try {
+    const parsed: unknown = JSON.parse(act.output);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return false;
+    }
+    const record = parsed as Record<string, unknown>;
+    return (
+      record["status"] === "confirmed" &&
+      typeof record["txHash"] === "string" &&
+      record["txHash"].length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+function ConfirmedStamp(): JSX.Element {
+  return (
+    <span
+      role="status"
+      aria-label="Transaction confirmed"
+      data-vex-transaction-status="confirmed"
+      className="inline-flex shrink-0 items-center gap-1 rounded-[3px] border border-[color-mix(in_oklab,var(--color-success)_40%,transparent)] px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--color-success)]"
+    >
+      <HugeiconsIcon icon={CheckmarkCircle01Icon} size={12} aria-hidden />
+      Confirmed
+    </span>
+  );
+}
 
 /** Section label inside the expanded well — mono microtype (10px floor). */
 function SectionHeading({
@@ -99,6 +139,7 @@ export function ToolActRow({
   const [open, setOpen] = useState(false);
   const bodyId = useId();
   const hyperliquidDisplay = act.toolDisplayBlock ?? null;
+  const confirmed = isConfirmedWalletTransfer(act);
   return (
     <div
       // Semantic contract: every visible tool row keeps the role attr.
@@ -165,7 +206,9 @@ export function ToolActRow({
             never nest inside a button (invalid HTML). Rendered only when a
             paired result deposited resolvable refs; inert otherwise. */}
         <ExplorerRefLinks refs={act.explorerRefs} />
-        {pendingApprovalId !== null ? (
+        {confirmed ? (
+          <ConfirmedStamp />
+        ) : pendingApprovalId !== null ? (
           <ApprovalLinkStamp approvalId={pendingApprovalId} />
         ) : null}
       </div>

--- a/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
+++ b/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
@@ -5,10 +5,9 @@
  * Switches on the pure `TranscriptEntry.variant`. The transcript reads as
  * an asymmetric register: USER turns are compact right-aligned cards with a
  * persistent "You · HH:MM" caption; ASSISTANT turns are full-width document
- * flow hung off the Signal Tape spine by a quiet node in a 28px gutter (no
- * bubble, no avatar — the shell is photo-free; accent is rationed to the
- * live/pending node, so a settled node rests in --vex-text-3). Assistant prose
- * renders through
+ * flow hung off the Signal Tape spine by its 18px avatar in a 28px gutter (no
+ * bubble). While the current turn is active, a restrained accent ring rotates
+ * around that avatar; settled turns remain still. Assistant prose renders through
  * `MarkdownContent` (stage 8-2a) — safe React elements, never an HTML
  * string; user/tool/notice rows + the `compaction`/`recall` markers (stage
  * 8-4) render as plain React text nodes. Either way model/tool output cannot
@@ -66,15 +65,28 @@ function TapeClock({ createdAt }: { readonly createdAt: string }): JSX.Element |
  * "Vex" caption carries the name, so the image is aria-hidden. CSP-safe — a
  * same-origin /vex.jpg under the existing `img-src 'self'` directive.
  */
-function AssistantAvatar(): JSX.Element {
+function AssistantAvatar({ working = false }: { readonly working?: boolean }): JSX.Element {
   return (
-    <img
-      src="/vex.jpg"
-      alt=""
-      aria-hidden
-      draggable={false}
-      className="absolute left-0 top-[2px] h-[18px] w-[18px] rounded-full object-cover ring-2 ring-[var(--vex-surface-0)]"
-    />
+    <span
+      data-vex-agent-avatar=""
+      data-vex-agent-avatar-state={working ? "working" : "settled"}
+      className="absolute left-0 top-[2px] h-[18px] w-[18px]"
+    >
+      {working ? (
+        <span
+          data-vex-agent-spinner=""
+          aria-hidden
+          className="absolute -inset-[3px] rounded-full border border-[var(--vex-accent)] border-r-transparent animate-spin [animation-duration:1200ms] motion-reduce:animate-none"
+        />
+      ) : null}
+      <img
+        src="/vex.jpg"
+        alt=""
+        aria-hidden
+        draggable={false}
+        className="h-[18px] w-[18px] rounded-full object-cover ring-2 ring-[var(--vex-surface-0)]"
+      />
+    </span>
   );
 }
 
@@ -108,6 +120,7 @@ function AssistantBody({ content }: { readonly content: string }): JSX.Element {
 export function TranscriptMessage({
   row,
   pendingApprovals,
+  agentWorking = false,
 }: {
   readonly row: TranscriptEntry;
   /**
@@ -115,6 +128,8 @@ export function TranscriptMessage({
    * call id matches get the "Awaiting signature" stamp-link to their card.
    */
   readonly pendingApprovals?: ReadonlyMap<string, string>;
+  /** True only for the newest assistant avatar in the currently active turn. */
+  readonly agentWorking?: boolean;
 }): JSX.Element {
   switch (row.variant) {
     case "user":
@@ -132,7 +147,7 @@ export function TranscriptMessage({
     case "assistant":
       return (
         <div data-vex-message-role="assistant" className="relative pl-7">
-          <AssistantAvatar />
+          <AssistantAvatar working={agentWorking} />
           <AssistantCaption createdAt={row.createdAt} />
           <AssistantBody content={row.content} />
         </div>
@@ -144,7 +159,7 @@ export function TranscriptMessage({
           data-vex-stopped=""
           className="relative pl-7"
         >
-          <AssistantAvatar />
+          <AssistantAvatar working={agentWorking} />
           <AssistantCaption createdAt={row.createdAt} />
           <AssistantBody content={row.content} />
           <div className="mt-1.5 flex items-center gap-1 text-[11px] text-[var(--vex-text-3)]">
@@ -179,7 +194,7 @@ export function TranscriptMessage({
           {/* Assistant prose accompanying the tool call (often empty). */}
           {row.content.length > 0 ? (
             <div className="relative pl-7">
-              <AssistantAvatar />
+              <AssistantAvatar working={agentWorking} />
               <AssistantCaption createdAt={row.createdAt} />
               <AssistantBody content={row.content} />
             </div>

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-console.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-console.test.tsx
@@ -43,7 +43,7 @@ vi.mock("@hugeicons/core-free-icons", () => ({
 }));
 
 const mockSubmitChat = {
-  isPending: false,
+  isPending: false as boolean,
   mutateAsync: vi.fn(),
   stop: vi.fn(),
 };
@@ -92,6 +92,7 @@ function agentRow(over: Partial<SessionListItem> = {}): SessionListItem {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSubmitChat.isPending = false;
   runStatus = null;
   useUiStore.setState({
     pendingFirstMessage: null,
@@ -181,6 +182,21 @@ describe("SessionComposer — Signal Console chrome", () => {
     expect(status?.textContent).toBe("AWAITING SIGNATURE");
     expect(status?.className).toContain("text-[var(--vex-pin)]");
     expect(form?.contains(status)).toBe(false);
+  });
+
+  it("does not add a WORKING label above the composer while a turn is pending", () => {
+    mockSubmitChat.isPending = true;
+    const { container } = render(
+      <SessionComposer activeSession={agentRow()} activeSessionId={SESSION} />,
+    );
+
+    expect(
+      container.querySelector('[data-vex-console-status="working"]'),
+    ).toBeNull();
+    expect(container.textContent).not.toContain("Working…");
+    expect(
+      container.querySelector('[data-vex-console-status="stopping"]'),
+    ).toBeNull();
   });
 
   it("has no PROPOSE → ENFORCE → PROVE flow strip on the welcome stage", () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@hugeicons/react", () => ({
 
 vi.mock("@hugeicons/core-free-icons", () => ({
   Add01Icon: "Add01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   AiChat01Icon: "AiChat01Icon",
   // S5 act ledger — ToolLedger/toolGlyph.ts imports these four.
   AiWebBrowsingIcon: "AiWebBrowsingIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop.test.tsx
@@ -293,6 +293,42 @@ beforeEach(() => {
 });
 
 describe("AppShell", () => {
+  it("surfaces a timed-out turn after tool activity without offering a blind Retry", async () => {
+    const row = makeAgentRow("Timed-out chat");
+    sessionsListMock.mockResolvedValueOnce({ ok: true, data: [row] });
+    sessionsGetMock.mockResolvedValue({ ok: true, data: row });
+    useUiStore.setState({ activeSessionId: row.id });
+    chatSubmitMock.mockReturnValue({
+      promise: Promise.resolve({
+        ok: true,
+        data: {
+          text: null,
+          toolCallsMade: 3,
+          pendingApprovals: [],
+          stopReason: "timeout",
+          missionStatus: null,
+          treatedAsInitialGoal: false,
+        },
+      }),
+      cancel: vi.fn(),
+    });
+
+    renderShell();
+    await screen.findByText("Timed-out chat");
+    const draft = screen.getByLabelText("Session draft") as HTMLTextAreaElement;
+    fireEvent.change(draft, { target: { value: "bridge in one shot" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await screen.findByText(
+      "Vex stopped before completing the task because this turn timed out. Review the transcript before trying again; earlier steps may have completed.",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Retry sending the message" }),
+    ).toBeNull();
+    expect(draft.value).toBe("");
+    expect(chatSubmitMock).toHaveBeenCalledTimes(1);
+  });
+
   it("arms an inline Retry on a retryable provider error and re-sends the same message", async () => {
     const row = makeAgentRow("Retry chat");
     sessionsListMock.mockResolvedValueOnce({ ok: true, data: [row] });
@@ -523,7 +559,7 @@ describe("AppShell", () => {
       cancel,
     });
 
-    renderShell();
+    const { container } = renderShell();
     await screen.findByText("Stoppable chat");
 
     const draft = screen.getByLabelText("Session draft") as HTMLTextAreaElement;
@@ -531,6 +567,12 @@ describe("AppShell", () => {
     fireEvent.click(screen.getByRole("button", { name: "Send message" }));
 
     const stopBtn = await screen.findByRole("button", { name: "Stop generating" });
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-vex-tape-state="live"]'),
+      ).not.toBeNull(),
+    );
+    expect(screen.queryByText("Working…")).toBeNull();
     // Pins the fix: a submit-typed Stop would re-run onSubmit (re-sending the
     // draft) instead of only cancelling the turn.
     expect(stopBtn.getAttribute("type")).toBe("button");

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-send.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-send.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@hugeicons/react", () => ({
 
 vi.mock("@hugeicons/core-free-icons", () => ({
   Add01Icon: "Add01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   AiChat01Icon: "AiChat01Icon",
   // S5 act ledger — ToolLedger/toolGlyph.ts imports these four.
   AiWebBrowsingIcon: "AiWebBrowsingIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/pin.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/pin.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@hugeicons/react", () => ({
 
 vi.mock("@hugeicons/core-free-icons", () => ({
   Add01Icon: "Add01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   AiChat01Icon: "AiChat01Icon",
   // S5 act ledger — ToolLedger/toolGlyph.ts imports these four.
   AiWebBrowsingIcon: "AiWebBrowsingIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/remove-library.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/remove-library.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@hugeicons/react", () => ({
 
 vi.mock("@hugeicons/core-free-icons", () => ({
   Add01Icon: "Add01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   AiChat01Icon: "AiChat01Icon",
   // S5 act ledger — ToolLedger/toolGlyph.ts imports these four.
   AiWebBrowsingIcon: "AiWebBrowsingIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/shell-sidebar.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/shell-sidebar.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@hugeicons/react", () => ({
 
 vi.mock("@hugeicons/core-free-icons", () => ({
   Add01Icon: "Add01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   AiChat01Icon: "AiChat01Icon",
   // S5 act ledger — ToolLedger/toolGlyph.ts imports these four.
   AiWebBrowsingIcon: "AiWebBrowsingIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/welcome-create.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/welcome-create.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@hugeicons/react", () => ({
 
 vi.mock("@hugeicons/core-free-icons", () => ({
   Add01Icon: "Add01Icon",
+  AnalyticsUpIcon: "AnalyticsUpIcon",
   AiChat01Icon: "AiChat01Icon",
   // S5 act ledger — ToolLedger/toolGlyph.ts imports these four.
   AiWebBrowsingIcon: "AiWebBrowsingIcon",

--- a/vex-app/src/renderer/features/appShell/__tests__/GlobalWalletAddresses.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/GlobalWalletAddresses.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * GlobalWalletAddresses — carries the session-mode sidebar's wallet
+ * identity presentation (DepositAddresses) onto the welcome/empty state
+ * (WP-L). Data source: `useAvailableWallets` (the existing config-backed
+ * inventory hook — NO new IPC). Renders nothing while loading/erroring or
+ * when the inventory is empty (a convenience row, not a panel state).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const mockUseAvailableWallets = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../lib/api/wallet-inventory.js", () => ({
+  useAvailableWallets: mockUseAvailableWallets,
+}));
+
+const { GlobalWalletAddresses } = await import(
+  "../book/GlobalWalletAddresses.js"
+);
+
+const EVM_1 = { id: "evm-1", family: "evm" as const, address: "0xAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaa", label: "" };
+const EVM_2 = { id: "evm-2", family: "evm" as const, address: "0xBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbb", label: "Trading" };
+const SOL_1 = { id: "sol-1", family: "solana" as const, address: "9jk8UbH339rCgnohpBvqiss4a7bXWmicMPCUCFmDrmYK", label: "" };
+
+function mockWallets(evm: (typeof EVM_1)[], solana: (typeof SOL_1)[]): void {
+  mockUseAvailableWallets.mockReturnValue({
+    data: { ok: true, data: { evm, solana } },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GlobalWalletAddresses", () => {
+  it("renders nothing when the inventory has no wallets", () => {
+    mockWallets([], []);
+    const { container } = render(<GlobalWalletAddresses />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing while the query has not resolved a result yet", () => {
+    mockUseAvailableWallets.mockReturnValue({ data: undefined });
+    const { container } = render(<GlobalWalletAddresses />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing on a failed query result", () => {
+    mockUseAvailableWallets.mockReturnValue({
+      data: { ok: false, error: { code: "INTERNAL", message: "boom" } },
+    });
+    const { container } = render(<GlobalWalletAddresses />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows the primary EVM and Solana wallets by default with no 'more wallets' group", () => {
+    mockWallets([EVM_1], [SOL_1]);
+    render(<GlobalWalletAddresses />);
+    expect(screen.getByText("EVM")).not.toBeNull();
+    expect(screen.getByText("SOL")).not.toBeNull();
+    expect(screen.queryByText(/more wallet/)).toBeNull();
+  });
+
+  it("lists additional configured wallets below the primaries, with their label", () => {
+    mockWallets([EVM_1, EVM_2], [SOL_1]);
+    render(<GlobalWalletAddresses />);
+    expect(screen.getByText("1 more wallet")).not.toBeNull();
+    expect(screen.getByText("Trading")).not.toBeNull();
+  });
+
+  it("pluralizes the remaining-wallets count", () => {
+    const evm3 = { id: "evm-3", family: "evm" as const, address: "0xCCCCccccCCCCccccCCCCccccCCCCccccCCCCcccc", label: "" };
+    mockWallets([EVM_1, EVM_2, evm3], [SOL_1]);
+    render(<GlobalWalletAddresses />);
+    expect(screen.getByText("2 more wallets")).not.toBeNull();
+  });
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
@@ -315,6 +315,21 @@ describe("MissionControls", () => {
     expect(screen.queryByRole("button", { name: "Renew mission" })).toBeNull();
   });
 
+  it("hides Renew once a fresh draft exists (post-renew) — no duplicate-draft loop", async () => {
+    // After mission.renew, a fresh status='draft' mission exists, but
+    // getRenewableSource STILL returns the old terminal accepted mission. Renew
+    // must NOT linger — else it looks like it "did nothing" and each extra click
+    // clones another duplicate draft. The fresh draft's acceptance UI wins.
+    getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+    getDraftMock.mockResolvedValue(ok({ missionId: MISSION, status: "draft" }));
+    getDiffMock.mockResolvedValue(diffAccepted(false));
+    getRenewableMock.mockResolvedValue(ok({ missionId: "m-done" }));
+    renderControls();
+
+    await screen.findByText(/Mission contract not accepted/i);
+    expect(screen.queryByRole("button", { name: "Renew mission" })).toBeNull();
+  });
+
   it("surfaces a renew refusal (not_terminal_yet → notice)", async () => {
     getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
     getDraftMock.mockResolvedValue(ok(null));
@@ -332,6 +347,23 @@ describe("MissionControls", () => {
     const renewBtn = await screen.findByRole("button", { name: "Renew mission" });
     fireEvent.click(renewBtn);
     await screen.findByText(/isn't finished yet/i);
+  });
+
+  it("surfaces a renew refusal (session_has_pending_draft → notice, WP-D transactional close)", async () => {
+    getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+    getDraftMock.mockResolvedValue(ok(null));
+    getRenewableMock.mockResolvedValue(ok({ missionId: "m-done" }));
+    renewMock.mockResolvedValue(
+      ok({
+        outcome: "session_has_pending_draft",
+        missionId: "m-pending-draft",
+      }),
+    );
+    renderControls();
+
+    const renewBtn = await screen.findByRole("button", { name: "Renew mission" });
+    fireEvent.click(renewBtn);
+    await screen.findByText(/draft mission already exists/i);
   });
 
   it("no active run, no startable draft, no renew source → renders nothing", async () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/MovesBlock.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MovesBlock.test.tsx
@@ -2,11 +2,25 @@
  * MOVES ledger — pins the token-display grammar that replaced raw base58
  * mint rows (the rejected "buy So1111…" feed):
  *
- *   - well-known mints resolve to tickers (native SOL mint → SOL) with the
- *     full mint preserved on the tooltip,
+ *   - well-known mints (by ADDRESS in KNOWN_MINTS) resolve to tickers (native
+ *     SOL mint → SOL) with the full mint preserved on the tooltip and the
+ *     app's offline brand mark shown beside the label — a known mint address
+ *     is the ONLY thing that authorizes a brand LOGO, and it wins over ANY
+ *     captured symbol claim,
+ *   - a sanitized captured symbol (from the activity's exact capture item)
+ *     is shown ONLY when it is NOT a brand-marked ticker — a brand claim
+ *     (e.g. capture metadata declaring "SOL"/"eTh" for a scam mint) is
+ *     dropped outright, in ANY casing, with no corroboration exception (the
+ *     raw token field is provider-populated too, so it cannot vouch for it),
+ *   - a captured symbol carrying Unicode confusables, bidi controls, or
+ *     zero-width characters is rejected by the shared sanitizer before it
+ *     ever reaches display or the icon lookup,
  *   - address-like strings (long alnum base58/hex) truncate via the canonical
  *     `truncateAddress` shape (`7jk8Ub…rmYK`), full mint on the tooltip,
- *   - short token strings render as uppercase symbols,
+ *   - short raw token strings render as uppercased PLAIN TEXT (a legacy
+ *     `ETH`/`SOL` leg stays readable), but a brand-matching raw string is
+ *     WITHHELD from the icon (text, never a borrowed logo) while a non-brand
+ *     raw string keeps the neutral monogram,
  *   - stamps give `productType` priority: bridge → BRIDGE·VENUE (plain BRIDGE
  *     without a venue), send/transfer → TRANSFER; otherwise the tolerant
  *     `tradeSide` derives: buy → BUY, sell → SELL, null (neutral Solana
@@ -50,8 +64,10 @@ function move(overrides: Partial<MoveItem> & { readonly id: string }): MoveItem 
     productType: null,
     venue: null,
     inputToken: null,
+    inputTokenSymbol: null,
     inputAmount: null,
     outputToken: null,
+    outputTokenSymbol: null,
     outputAmount: null,
     valueUsd: null,
     captureStatus: "executed",
@@ -87,14 +103,130 @@ describe("MovesBlock ledger display", () => {
     ]);
     render(<MovesBlock sessionId={SESSION} />);
 
-    // Known mint → ticker, full mint kept on the tooltip.
+    // Known mint → ticker, full mint kept on the tooltip (title now sits on
+    // the icon+text wrapper, not the bare text node).
     const sol = screen.getByText("SOL");
-    expect(sol.getAttribute("title")).toBe(SOL_MINT);
+    expect(sol.parentElement?.getAttribute("title")).toBe(SOL_MINT);
     // Address-like → truncateAddress shape, full mint on the tooltip.
     const truncated = screen.getByText("7jk8Ub…rmYK");
-    expect(truncated.getAttribute("title")).toBe(LONG_MINT);
+    expect(truncated.parentElement?.getAttribute("title")).toBe(LONG_MINT);
     // The raw base58 run never prints in full.
     expect(screen.queryByText(LONG_MINT)).toBeNull();
+  });
+
+  it("prefers a sanitized captured symbol over a raw address, keeping the full mint on the tooltip", () => {
+    mockMoves([
+      move({
+        id: "1",
+        tradeSide: "buy",
+        inputToken: SOL_MINT,
+        inputTokenSymbol: "SOL",
+        outputToken: LONG_MINT,
+        outputTokenSymbol: "ansem",
+      }),
+    ]);
+    render(<MovesBlock sessionId={SESSION} />);
+
+    // SOL_MINT is a KNOWN_MINTS address, so the address wins outright (same
+    // ticker either way here) and the captured symbol is irrelevant to it.
+    expect(screen.getByText("SOL").parentElement?.getAttribute("title")).toBe(
+      SOL_MINT,
+    );
+    // LONG_MINT is NOT a known mint — the captured, non-brand symbol "ansem"
+    // is trusted and replaces the truncated-address fallback.
+    expect(screen.getByText("ANSEM").parentElement?.getAttribute("title")).toBe(
+      LONG_MINT,
+    );
+    expect(screen.queryByText("7jk8Ub…rmYK")).toBeNull();
+    // Unknown symbols use the app's offline monogram instead of a brand mark.
+    expect(screen.getByText("a").getAttribute("aria-hidden")).not.toBeNull();
+  });
+
+  it("never lets an unverified captured symbol borrow a brand's name or logo (spoofed 'SOL'/'USDC' claims)", () => {
+    const SCAM_MINT = "ScamMint1111111111111111111111111111111111";
+    mockMoves([
+      // ASCII "SOL" claimed for a mint that is NOT the real SOL address.
+      move({
+        id: "1",
+        inputToken: SCAM_MINT,
+        inputTokenSymbol: "SOL",
+        outputToken: null,
+      }),
+      // Confusable Unicode "USDC" (Cyrillic De for Latin D) claimed for an
+      // unrelated address — the shared sanitizer rejects it outright.
+      move({
+        id: "2",
+        inputToken: SCAM_MINT,
+        inputTokenSymbol: "US\u0414C",
+        outputToken: null,
+      }),
+    ]);
+    render(<MovesBlock sessionId={SESSION} />);
+
+    // Neither row ever prints the claimed brand ticker...
+    expect(screen.queryByText("SOL")).toBeNull();
+    expect(screen.queryByText("USDC")).toBeNull();
+    expect(screen.queryByText("US\u0414C")).toBeNull();
+    // ...both fall back to the truncated scam-mint address instead.
+    expect(screen.getAllByText("ScamMi…1111")).toHaveLength(2);
+  });
+
+  it("drops a captured brand claim regardless of casing (address-backed legs isolate the captured path)", () => {
+    const SCAM_A = "ScamMintAAAA1111111111111111111111111111111";
+    const SCAM_B = "ScamMintBBBB2222222222222222222222222222222";
+    mockMoves([
+      move({
+        id: "1",
+        productType: "bridge",
+        venue: "relay",
+        // Raw tokens are addresses here, so the ONLY brand candidate is the
+        // captured symbol — its case-variant brand claim must be dropped.
+        inputToken: SCAM_A,
+        inputTokenSymbol: "eTh",
+        outputToken: SCAM_B,
+        outputTokenSymbol: "sOl",
+      }),
+    ]);
+    render(<MovesBlock sessionId={SESSION} />);
+    // A captured brand claim never renders its ticker, in ANY casing, and can
+    // never reach TokenIcon's case-insensitive brand lookup.
+    expect(screen.queryByText("ETH")).toBeNull();
+    expect(screen.queryByText("SOL")).toBeNull();
+    // The legs fall back to the truncated scam-mint addresses instead.
+    expect(screen.getByText("ScamMi…1111")).not.toBeNull();
+    expect(screen.getByText("ScamMi…2222")).not.toBeNull();
+  });
+
+  it("renders a brand-matching RAW token as plain text WITHOUT the brand logo (rule 3 no-logo clause)", () => {
+    // `inputToken` is the provider-populated activity field, NOT a known-mint
+    // address — so "ETH" stays readable as text but must not borrow the
+    // Ethereum brand mark (no known mint proves the identity).
+    mockMoves([move({ id: "1", inputToken: "ETH", outputToken: null })]);
+    render(<MovesBlock sessionId={SESSION} />);
+
+    const eth = screen.getByText("ETH");
+    const leg = eth.parentElement;
+    expect(leg).not.toBeNull();
+    // No brand SVG mark...
+    expect(leg?.querySelector("svg")).toBeNull();
+    // ...and NO icon at all (a withheld brand claim renders no monogram either).
+    expect(leg?.querySelector("span[aria-hidden]")).toBeNull();
+    // Only the text node lives in the leg wrapper.
+    expect(leg?.childElementCount).toBe(1);
+  });
+
+  it("renders a non-brand RAW token with the neutral monogram (not a brand mark)", () => {
+    mockMoves([move({ id: "1", inputToken: "wif", outputToken: null })]);
+    render(<MovesBlock sessionId={SESSION} />);
+
+    const wif = screen.getByText("WIF");
+    const leg = wif.parentElement;
+    expect(leg).not.toBeNull();
+    // Non-brand symbols get NO brand SVG...
+    expect(leg?.querySelector("svg")).toBeNull();
+    // ...but DO keep the app's neutral first-glyph monogram (decorative).
+    const monogram = leg?.querySelector("span[aria-hidden]");
+    expect(monogram?.textContent).toBe("w");
   });
 
   it("renders short strings as uppercase symbols and null legs as ?", () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/PositionBlock.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/PositionBlock.test.tsx
@@ -14,7 +14,10 @@
  *   - totals stay untouched — they reflect the full portfolio.
  *
  * `usePortfolio` is mocked — this suite owns the block's display rules,
- * not the query wiring.
+ * not the query wiring. `useAvailableWallets` (consumed by the GLOBAL-scope
+ * `GlobalWalletAddresses`, WP-L) is mocked to an empty inventory so this
+ * suite's assertions stay about the token/total display rules; the panel's
+ * own behavior is pinned separately in `GlobalWalletAddresses.test.tsx`.
  */
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -27,6 +30,7 @@ import type {
 
 const mockUsePortfolio = vi.hoisted(() => vi.fn());
 const mockUseSessionWallets = vi.hoisted(() => vi.fn());
+const mockUseAvailableWallets = vi.hoisted(() => vi.fn());
 
 vi.mock("../../../lib/api/portfolio.js", () => ({
   usePortfolio: mockUsePortfolio,
@@ -34,6 +38,10 @@ vi.mock("../../../lib/api/portfolio.js", () => ({
 
 vi.mock("../../../lib/api/session-wallets.js", () => ({
   useSessionWallets: mockUseSessionWallets,
+}));
+
+vi.mock("../../../lib/api/wallet-inventory.js", () => ({
+  useAvailableWallets: mockUseAvailableWallets,
 }));
 
 const { PositionBlock } = await import("../book/PositionBlock.js");
@@ -115,6 +123,12 @@ beforeEach(() => {
     isLoading: true,
     isError: false,
     data: undefined,
+  });
+  // GLOBAL scope renders GlobalWalletAddresses (WP-L); default to an empty
+  // inventory so this suite's assertions stay about the token/total rules —
+  // GlobalWalletAddresses' own rendering is pinned in its dedicated suite.
+  mockUseAvailableWallets.mockReturnValue({
+    data: { ok: true, data: { evm: [], solana: [] } },
   });
 });
 

--- a/vex-app/src/renderer/features/appShell/__tests__/PositionChains.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/PositionChains.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * PositionChains — pins the token-symbol trust boundary for the POSITION
+ * chain switcher's per-chain top holdings (WP-H: the same protection
+ * MovesBlock applies to captured symbols, applied here to the portfolio's
+ * provider-supplied `token.symbol`, which carries NO mitigation upstream).
+ *
+ * `token.symbol` is UNTRUSTED: any on-chain token can self-declare arbitrary
+ * metadata, including a symbol that impersonates a well-known ticker or
+ * embeds deceptive Unicode (confusables, bidi controls, zero-width
+ * characters). Every symbol must pass through the shared
+ * `sanitizeTokenSymbol` allowlist before it becomes display text or reaches
+ * `TokenIcon`'s symbol-keyed brand-mark lookup — a rejected symbol renders
+ * the existing "—" placeholder and the neutral monogram, never a brand name
+ * or logo.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { PositionChainDto } from "@shared/schemas/portfolio.js";
+import { PositionChains } from "../book/PositionChains.js";
+
+const ETHEREUM_CHAIN_ID = 1;
+
+function chain(
+  chainId: number,
+  family: "evm" | "solana",
+  totalUsd: number,
+  tokens: PositionChainDto["tokens"],
+): PositionChainDto {
+  return { chainId, family, totalUsd, tokens };
+}
+
+describe("PositionChains token-symbol trust boundary", () => {
+  it("renders a legitimate ASCII symbol as display text and brand icon input", () => {
+    render(
+      <PositionChains
+        chains={[
+          chain(ETHEREUM_CHAIN_ID, "evm", 100, [
+            { symbol: "USDC", balanceUsd: 100, amount: 100 },
+          ]),
+        ]}
+        hasEvmWallet
+        hasSolanaWallet={false}
+      />,
+    );
+    expect(screen.getByText("USDC")).not.toBeNull();
+  });
+
+  it("drops a Unicode-confusable symbol impersonating a brand ticker (fullwidth/Cyrillic lookalikes)", () => {
+    render(
+      <PositionChains
+        chains={[
+          chain(ETHEREUM_CHAIN_ID, "evm", 100, [
+            // Cyrillic Es (U+0405) standing in for Latin S in "SOL".
+            { symbol: "\u0405OL", balanceUsd: 100, amount: 1 },
+          ]),
+        ]}
+        hasEvmWallet
+        hasSolanaWallet={false}
+      />,
+    );
+    // Never renders the spoofed label...
+    expect(screen.queryByText("\u0405OL")).toBeNull();
+    expect(screen.queryByText("SOL")).toBeNull();
+    // ...and falls back to the existing unresolved-symbol placeholder.
+    expect(screen.getByText("—")).not.toBeNull();
+  });
+
+  it("drops a symbol carrying zero-width/bidi-control spoofing characters", () => {
+    render(
+      <PositionChains
+        chains={[
+          chain(ETHEREUM_CHAIN_ID, "evm", 50, [
+            // Zero-width space spliced into "ETH".
+            { symbol: "E\u200bTH", balanceUsd: 50, amount: 1 },
+          ]),
+        ]}
+        hasEvmWallet
+        hasSolanaWallet={false}
+      />,
+    );
+    expect(screen.queryByText("ETH")).toBeNull();
+    expect(screen.getByText("—")).not.toBeNull();
+  });
+
+  it("drops a symbol containing control characters", () => {
+    render(
+      <PositionChains
+        chains={[
+          chain(ETHEREUM_CHAIN_ID, "evm", 50, [
+            { symbol: "BAD\nSYMBOL", balanceUsd: 50, amount: 1 },
+          ]),
+        ]}
+        hasEvmWallet
+        hasSolanaWallet={false}
+      />,
+    );
+    expect(screen.queryByText(/SYMBOL/)).toBeNull();
+    expect(screen.getByText("—")).not.toBeNull();
+  });
+
+  it("never renders duplicate/unsanitized rows for a null symbol", () => {
+    const { container } = render(
+      <PositionChains
+        chains={[
+          chain(ETHEREUM_CHAIN_ID, "evm", 10, [
+            { symbol: null, balanceUsd: 10, amount: 1 },
+          ]),
+        ]}
+        hasEvmWallet
+        hasSolanaWallet={false}
+      />,
+    );
+    expect(container.querySelectorAll("li")).toHaveLength(1);
+    expect(screen.getByText("—")).not.toBeNull();
+  });
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionTranscript.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionTranscript.test.tsx
@@ -17,7 +17,10 @@ import type {
   MessageRole,
   SessionMessageDto,
 } from "@shared/schemas/messages.js";
+
 import { SessionTranscript } from "../SessionTranscript.js";
+import { findWorkingAgentEntryKey } from "../agentActivity.js";
+import type { TranscriptEntry } from "../transcriptRowModel.js";
 import { useStreamStore } from "../../../stores/streamStore.js";
 
 const SESSION = "00000000-0000-4000-8000-0000000000aa";
@@ -165,6 +168,44 @@ describe("SessionTranscript", () => {
       cursor: null,
       limit: 50,
     });
+  });
+
+  it("selects only the current turn's newest agent avatar as working", () => {
+    const rows: TranscriptEntry[] = [
+      {
+        id: 1,
+        variant: "assistant" as const,
+        label: null,
+        content: "Earlier reply",
+        createdAt: ISO,
+      },
+      {
+        id: 2,
+        variant: "user" as const,
+        label: null,
+        content: "Send SOL",
+        createdAt: ISO,
+      },
+      {
+        id: 3,
+        variant: "assistant" as const,
+        label: null,
+        content: "Preparing transfer",
+        createdAt: ISO,
+      },
+      {
+        id: 4,
+        variant: "tool" as const,
+        label: "wallet_send_prepare_output",
+        toolKind: "result" as const,
+        content: "prepared",
+        createdAt: ISO,
+      },
+    ];
+
+    expect(findWorkingAgentEntryKey(rows, true)).toBe("3");
+    expect(findWorkingAgentEntryKey(rows, false)).toBeNull();
+    expect(findWorkingAgentEntryKey(rows.slice(0, 2), true)).toBeNull();
   });
 
   it("shows the empty state when there are no messages", async () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/ToolLedger.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/ToolLedger.test.tsx
@@ -116,6 +116,90 @@ describe("ToolActRow", () => {
   it("renders no stamp at rest (the persisted ledger row is quiet)", () => {
     render(createElement(ToolActRow, { act: act() }));
     expect(screen.queryByText(/awaiting signature/i)).toBeNull();
+    expect(screen.queryByRole("status", { name: /transaction confirmed/i })).toBeNull();
+  });
+
+  it("marks a confirmed wallet transfer with a visible check state", () => {
+    const { container } = render(
+      createElement(ToolActRow, {
+        act: act({
+          toolName: "wallet_send_confirm",
+          output: JSON.stringify({
+            txHash: "solana-signature",
+            chain: "solana",
+            status: "confirmed",
+          }),
+        }),
+      }),
+    );
+
+    expect(
+      screen.getByRole("status", { name: "Transaction confirmed" }),
+    ).not.toBeNull();
+    expect(screen.getByText("Confirmed")).not.toBeNull();
+    expect(
+      container.querySelector('[data-vex-transaction-status="confirmed"]'),
+    ).not.toBeNull();
+  });
+
+  it("does not infer confirmation from malformed, failed, or unrelated output", () => {
+    const cases = [
+      act({ toolName: "wallet_send_confirm", output: "not json" }),
+      act({
+        toolName: "wallet_send_confirm",
+        output: JSON.stringify({ txHash: "hash", status: "failed" }),
+      }),
+      act({
+        toolName: "wallet_send_confirm",
+        output: JSON.stringify({ status: "confirmed" }),
+      }),
+      act({
+        toolName: "wallet_balances",
+        output: JSON.stringify({ txHash: "hash", status: "confirmed" }),
+      }),
+    ];
+
+    for (const candidate of cases) {
+      const view = render(createElement(ToolActRow, { act: candidate }));
+      expect(
+        screen.queryByRole("status", { name: /transaction confirmed/i }),
+      ).toBeNull();
+      view.unmount();
+    }
+  });
+
+  it("shows the Confirmed stamp alongside the Hyperliquid frame and explorer links without hiding either", () => {
+    // WP-G port fix: current main already renders a Hyperliquid protocol
+    // frame + ExplorerRefLinks in this exact row region (Hyperliquid wave,
+    // merged after the reference PR was authored) — the Confirmed stamp
+    // must integrate with both, not clobber them.
+    const { container } = render(
+      createElement(ToolActRow, {
+        act: act({
+          toolName: "wallet_send_confirm",
+          output: JSON.stringify({
+            txHash: "0xabc",
+            chain: "base",
+            status: "confirmed",
+          }),
+          explorerRefs: [{ chain: "base", txRef: "0xabc" }],
+          toolDisplayBlock: {
+            namespace: "hyperliquid",
+            kind: "order_receipt",
+            coin: "BTC",
+            side: "long",
+            status: "accepted",
+            protectionState: "PROTECTED",
+          },
+        }),
+      }),
+    );
+
+    expect(container.querySelector('[data-hyperliquid-card="true"]')).not.toBeNull();
+    expect(
+      container.querySelector('[data-vex-transaction-status="confirmed"]'),
+    ).not.toBeNull();
+    expect(container.querySelector("a[href]")).not.toBeNull();
   });
 
   it("renders the Hyperliquid frame only from a typed display block", () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/TranscriptMessage.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/TranscriptMessage.test.tsx
@@ -263,3 +263,35 @@ describe("TranscriptMessage assistant_stopped (9-5b)", () => {
     expect(container.querySelector("[data-vex-stopped]")).not.toBeNull();
   });
 });
+
+describe("TranscriptMessage agent activity avatar", () => {
+  it("draws a theme-accent spinner around the active agent avatar", () => {
+    const { container } = render(
+      createElement(TranscriptMessage, {
+        row: row({ variant: "assistant", content: "Preparing the transfer." }),
+        agentWorking: true,
+      }),
+    );
+    const avatar = container.querySelector(
+      '[data-vex-agent-avatar-state="working"]',
+    );
+    const spinner = container.querySelector("[data-vex-agent-spinner]");
+    expect(avatar).not.toBeNull();
+    expect(spinner?.className).toContain("border-[var(--vex-accent)]");
+    expect(spinner?.className).toContain("animate-spin");
+    expect(spinner?.className).toContain("[animation-duration:1200ms]");
+    expect(spinner?.className).toContain("motion-reduce:animate-none");
+  });
+
+  it("keeps settled agent avatars still", () => {
+    const { container } = render(
+      createElement(TranscriptMessage, {
+        row: row({ variant: "assistant", content: "Transfer prepared." }),
+      }),
+    );
+    expect(
+      container.querySelector('[data-vex-agent-avatar-state="settled"]'),
+    ).not.toBeNull();
+    expect(container.querySelector("[data-vex-agent-spinner]")).toBeNull();
+  });
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/composer-helpers.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/composer-helpers.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { ChatSubmitResult } from "@shared/schemas/chat.js";
+import {
+  submitFailureNotice,
+  submitSuccessText,
+} from "../composer-helpers.js";
+
+function outcome(
+  overrides: Partial<ChatSubmitResult> = {},
+): ChatSubmitResult {
+  return {
+    text: null,
+    toolCallsMade: 0,
+    pendingApprovals: [],
+    stopReason: null,
+    missionStatus: null,
+    treatedAsInitialGoal: false,
+    ...overrides,
+  };
+}
+
+describe("composer outcome copy", () => {
+  it.each([
+    ["iteration_limit", "action limit"],
+    ["timeout", "timed out"],
+    ["system_error", "internal error"],
+  ] as const)("marks %s as an incomplete retryable turn", (stopReason, copy) => {
+    const notice = submitFailureNotice(outcome({ stopReason }));
+    expect(notice?.retryable).toBe(true);
+    expect(notice?.text).toContain(copy);
+  });
+
+  it("blocks blind retry after tool activity and warns that earlier steps may have completed", () => {
+    const notice = submitFailureNotice(
+      outcome({ stopReason: "timeout", toolCallsMade: 2 }),
+    );
+    expect(notice?.retryable).toBe(false);
+    expect(notice?.text).toContain("earlier steps may have completed");
+  });
+
+  it("explains context exhaustion without offering a same-session retry", () => {
+    expect(
+      submitFailureNotice(
+        outcome({ stopReason: "compact_unable_at_critical" }),
+      ),
+    ).toEqual({
+      text: "Vex stopped because this conversation ran out of usable context. Start a new session or try a narrower request.",
+      retryable: false,
+    });
+  });
+
+  it.each([
+    null,
+    "approval_required",
+    "waiting_for_wake",
+    "plan_acceptance_required",
+  ] as const)("leaves %s to its existing transcript or control UI", (stopReason) => {
+    expect(submitFailureNotice(outcome({ stopReason }))).toBeNull();
+  });
+
+  it("preserves the existing stopped and mission-goal success copy", () => {
+    expect(submitSuccessText(outcome({ stopReason: "user_stopped" }))).toBe(
+      "Stopped.",
+    );
+    expect(submitSuccessText(outcome({ treatedAsInitialGoal: true }))).toBe(
+      "Mission goal received.",
+    );
+  });
+
+  // `ChatSubmitResult` carries only a `toolCallsMade` COUNT — it does not
+  // (and, within this package's renderer+chat.ts scope, cannot safely)
+  // identify which specific tools ran or whether any of them was
+  // mutating. The renderer has no reliable, registry-backed way to
+  // classify a tool as read-only vs. mutating (that classification lives
+  // in the privileged `src/vex-agent/tools/registry/*` `mutating` flags,
+  // which the untrusted renderer must not duplicate or import). So the
+  // retry gate stays deliberately conservative: ANY executed tool call —
+  // read-only or mutating — withholds one-click Retry, because a
+  // renderer-side guess at "this one was safe" could be wrong and would
+  // then blindly replay a turn that already took a real action. These
+  // cases pin that this is intentional, not an oversight: a turn whose
+  // only executed tool looks read-only-shaped (by name) is treated
+  // identically to one whose tool looks mutating-shaped.
+  it.each([
+    ["a read-only-shaped tool name", "wallet_balances"],
+    ["a mutating-shaped tool name", "wallet_send_confirm"],
+  ])(
+    "withholds retry after exactly one completed tool call regardless of its apparent kind (%s)",
+    (_label, _toolNameHint) => {
+      // The renderer only ever sees the count — the tool name itself never
+      // reaches `ChatSubmitResult` — so both cases reduce to the same
+      // input. Asserting on that input is the pin: the gate cannot and
+      // must not special-case a "read-only-looking" count of 1.
+      const notice = submitFailureNotice(
+        outcome({ stopReason: "iteration_limit", toolCallsMade: 1 }),
+      );
+      expect(notice?.retryable).toBe(false);
+      expect(notice?.text).toContain("earlier steps may have completed");
+    },
+  );
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/missionHistoryModel.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/missionHistoryModel.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Mission History display model — pure functions. The key invariant under
+ * test: `missionDisplayOutcome` maps a deadline-reached run to the neutral
+ * "timeBoxed" outcome (never "failed"), and that outcome counts as a
+ * completion for win-rate purposes — deadline semantics stay out of SQL and
+ * UI components, living ONLY in this one pure mapper.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { MissionResultDto } from "@shared/schemas/mission.js";
+import {
+  computeWinRate,
+  formatDurationS,
+  formatEth,
+  isCompletionLike,
+  missionDisplayOutcome,
+  pnlUsd,
+  sumPnlEth,
+} from "../missionHistoryModel.js";
+
+function result(over: Partial<MissionResultDto> = {}): MissionResultDto {
+  return {
+    missionRunId: "run-1",
+    seqNo: 1,
+    goalSnippet: "grow ETH",
+    startedAt: "2026-07-12T18:00:00.000Z",
+    endedAt: "2026-07-12T19:00:00.000Z",
+    durationS: 3600,
+    bankrollStartEth: 0.01,
+    bankrollEndEth: 0.011,
+    pnlEth: 0.001,
+    pnlPct: 10,
+    ethPriceUsdEnd: 3000,
+    trades: 2,
+    outcome: "completed",
+    stopReason: "goal_reached",
+    openPositionsCount: 0,
+    ...over,
+  };
+}
+
+describe("missionDisplayOutcome", () => {
+  it("maps a deadline-reached, non-completed run to the neutral timeBoxed outcome", () => {
+    expect(
+      missionDisplayOutcome({ outcome: "failed", stopReason: "deadline_reached" }),
+    ).toBe("timeBoxed");
+  });
+
+  it("does not remap deadline_reached when the outcome is already completed", () => {
+    expect(
+      missionDisplayOutcome({ outcome: "completed", stopReason: "deadline_reached" }),
+    ).toBe("completed");
+  });
+
+  it("passes through every other (outcome, stopReason) pair unchanged", () => {
+    expect(missionDisplayOutcome({ outcome: "completed", stopReason: "goal_reached" })).toBe("completed");
+    expect(missionDisplayOutcome({ outcome: "cancelled", stopReason: "user_stopped" })).toBe("cancelled");
+    expect(missionDisplayOutcome({ outcome: "failed", stopReason: "system_error" })).toBe("failed");
+    expect(missionDisplayOutcome({ outcome: "stopped", stopReason: "user_stopped" })).toBe("stopped");
+    expect(missionDisplayOutcome({ outcome: "running", stopReason: null })).toBe("running");
+    expect(missionDisplayOutcome({ outcome: "failed", stopReason: null })).toBe("failed");
+  });
+});
+
+describe("isCompletionLike", () => {
+  it("is true for completed and timeBoxed only", () => {
+    expect(isCompletionLike("completed")).toBe(true);
+    expect(isCompletionLike("timeBoxed")).toBe(true);
+    expect(isCompletionLike("cancelled")).toBe(false);
+    expect(isCompletionLike("failed")).toBe(false);
+    expect(isCompletionLike("stopped")).toBe(false);
+    expect(isCompletionLike("running")).toBe(false);
+  });
+});
+
+describe("computeWinRate", () => {
+  it("counts a deadline_reached (timeBoxed) run as a completion in the win-rate population", () => {
+    const results = [
+      result({ missionRunId: "a", outcome: "completed", stopReason: "goal_reached", pnlEth: 0.002 }),
+      result({ missionRunId: "b", outcome: "failed", stopReason: "deadline_reached", pnlEth: -0.001 }),
+    ];
+    // Both are completion-like (timeBoxed counts) -> population of 2, 1 win.
+    expect(computeWinRate(results)).toBe(50);
+  });
+
+  it("excludes cancelled/stopped/running/failed(non-deadline) runs from the population", () => {
+    const results = [
+      result({ missionRunId: "a", outcome: "completed", pnlEth: 0.001 }),
+      result({ missionRunId: "b", outcome: "cancelled", pnlEth: null }),
+      result({ missionRunId: "c", outcome: "stopped", pnlEth: null }),
+      result({ missionRunId: "d", outcome: "running", pnlEth: null }),
+      result({ missionRunId: "e", outcome: "failed", stopReason: "system_error", pnlEth: -0.005 }),
+    ];
+    expect(computeWinRate(results)).toBe(100); // only "a" is eligible
+  });
+
+  it("is null when no run is eligible", () => {
+    expect(computeWinRate([result({ outcome: "running", pnlEth: null })])).toBeNull();
+    expect(computeWinRate([])).toBeNull();
+  });
+
+  it("excludes a completion-like run with unknown (null) PnL from the population", () => {
+    const results = [result({ outcome: "completed", pnlEth: null })];
+    expect(computeWinRate(results)).toBeNull();
+  });
+});
+
+describe("sumPnlEth", () => {
+  it("sums known PnL and ignores nulls", () => {
+    const results = [
+      result({ pnlEth: 0.002 }),
+      result({ pnlEth: -0.001 }),
+      result({ pnlEth: null }),
+    ];
+    expect(sumPnlEth(results)).toBeCloseTo(0.001, 9);
+  });
+
+  it("is zero for an empty list", () => {
+    expect(sumPnlEth([])).toBe(0);
+  });
+});
+
+describe("formatEth", () => {
+  it("formats unsigned by default", () => {
+    expect(formatEth(0.0012)).toBe("0.0012");
+    expect(formatEth(-0.0012)).toBe("0.0012");
+  });
+  it("signs positive/negative/zero when requested", () => {
+    expect(formatEth(0.001, { signed: true })).toBe("+0.0010");
+    expect(formatEth(-0.001, { signed: true })).toBe("-0.0010");
+    expect(formatEth(0, { signed: true })).toBe("0.0000");
+  });
+  it("renders an em dash for null/non-finite", () => {
+    expect(formatEth(null)).toBe("—");
+    expect(formatEth(Number.NaN)).toBe("—");
+  });
+});
+
+describe("pnlUsd", () => {
+  it("multiplies pnlEth by the close price", () => {
+    expect(pnlUsd(0.001, 3000)).toBeCloseTo(3, 9);
+  });
+  it("is null when either input is unknown", () => {
+    expect(pnlUsd(null, 3000)).toBeNull();
+    expect(pnlUsd(0.001, null)).toBeNull();
+  });
+});
+
+describe("formatDurationS", () => {
+  it("formats seconds/minutes/hours", () => {
+    expect(formatDurationS(42)).toBe("42s");
+    expect(formatDurationS(125)).toBe("2m");
+    expect(formatDurationS(3725)).toBe("1h 02m");
+  });
+  it("renders an em dash for null/negative/non-finite", () => {
+    expect(formatDurationS(null)).toBe("—");
+    expect(formatDurationS(-5)).toBe("—");
+  });
+});

--- a/vex-app/src/renderer/features/appShell/agentActivity.ts
+++ b/vex-app/src/renderer/features/appShell/agentActivity.ts
@@ -1,0 +1,48 @@
+import type { TranscriptEntry } from "./transcriptRowModel.js";
+
+/**
+ * React key for a transcript entry. One source DTO id can appear on multiple
+ * rendered entries, so tool variants are prefixed to keep keys distinct.
+ */
+export function transcriptEntryKey(entry: TranscriptEntry): string {
+  if (entry.variant === "tool_group") return `tg-${entry.id}`;
+  if (entry.variant === "tool") return `t-${entry.id}`;
+  return String(entry.id);
+}
+
+/** Whether this row owns an assistant avatar in `TranscriptMessage`. */
+function hasAgentAvatar(entry: TranscriptEntry): boolean {
+  return (
+    entry.variant === "assistant" ||
+    entry.variant === "assistant_stopped" ||
+    (entry.variant === "tool" &&
+      entry.toolKind === "call" &&
+      entry.content.length > 0)
+  );
+}
+
+/**
+ * Select the newest assistant avatar after the current turn's user message.
+ * A previous turn must never start spinning while the new turn has not yet
+ * produced assistant prose.
+ */
+export function findWorkingAgentEntryKey(
+  rows: readonly TranscriptEntry[],
+  chatSubmitting: boolean,
+): string | null {
+  if (!chatSubmitting) return null;
+  let latestUserIndex = -1;
+  for (let i = rows.length - 1; i >= 0; i -= 1) {
+    if (rows[i]?.variant === "user") {
+      latestUserIndex = i;
+      break;
+    }
+  }
+  for (let i = rows.length - 1; i > latestUserIndex; i -= 1) {
+    const row = rows[i];
+    if (row !== undefined && hasAgentAvatar(row)) {
+      return transcriptEntryKey(row);
+    }
+  }
+  return null;
+}

--- a/vex-app/src/renderer/features/appShell/book/GlobalWalletAddresses.tsx
+++ b/vex-app/src/renderer/features/appShell/book/GlobalWalletAddresses.tsx
@@ -1,0 +1,139 @@
+/**
+ * Global wallet addresses — carries the session-mode sidebar's wallet/funds
+ * presentation (`DepositAddresses`) onto the welcome/empty state (no active
+ * session), per the owner's request: the primary wallet shown by default,
+ * any additional configured wallets listed below.
+ *
+ * Data: `useAvailableWallets` → `AvailableWalletsDto` (the config-backed
+ * inventory, up to 3 EVM + 3 Solana wallets — the same source the onboarding
+ * multi-wallet UI and the session-create picker already use). NO new IPC
+ * surface. The "primary" wallet per family is the first inventory entry
+ * (insertion order); any remaining wallets render as a secondary group below.
+ *
+ * Balance honesty: the portfolio TOTAL rendered alongside this block
+ * (`PositionBlock`'s `TotalRow`, unchanged) is the GLOBAL aggregate across
+ * EVERY configured wallet. For the common case (one wallet per family) that
+ * total genuinely IS the primary wallet's balance. When the user has
+ * configured additional wallets, the total is still the honest combined
+ * figure — this component deliberately does NOT fabricate a per-wallet USD
+ * split, because no current IPC contract attributes portfolio balance rows
+ * to an individual wallet address (`PositionTokenDto` / `ChainTokenDto`
+ * carry no wallet identity). Remaining wallets show address + label only.
+ *
+ * Quiet on loading/error, like `DepositAddresses` — this is a convenience
+ * identity row, not a panel state of its own.
+ */
+
+import type { JSX } from "react";
+import { ETHEREUM_CHAIN_ID, SOLANA_CHAIN_ID } from "@shared/chains/display.js";
+import type {
+  AvailableWalletDto,
+  AvailableWalletsDto,
+} from "@shared/schemas/wallets.js";
+import { useAvailableWallets } from "../../../lib/api/wallet-inventory.js";
+import { AddressDisplay } from "../../../components/common/AddressDisplay.js";
+import { ChainIcon } from "../../../components/common/ChainIcon.js";
+
+export interface WalletPrimaryGrouping {
+  /** First EVM inventory entry, or `null` when no EVM wallet is configured. */
+  readonly primaryEvm: AvailableWalletDto | null;
+  /** First Solana inventory entry, or `null` when none is configured. */
+  readonly primarySolana: AvailableWalletDto | null;
+  /** Every inventory wallet beyond the primary of its family, in the
+   * inventory's own order (EVM entries first, then Solana). */
+  readonly remaining: readonly AvailableWalletDto[];
+}
+
+/**
+ * Pure grouping: primary = the first wallet of each family (stable
+ * insertion order from the config-backed inventory); remaining = everything
+ * else. Never reorders or mutates the input arrays.
+ */
+export function groupWalletsByPrimary(
+  wallets: AvailableWalletsDto,
+): WalletPrimaryGrouping {
+  return {
+    primaryEvm: wallets.evm[0] ?? null,
+    primarySolana: wallets.solana[0] ?? null,
+    remaining: [...wallets.evm.slice(1), ...wallets.solana.slice(1)],
+  };
+}
+
+export function GlobalWalletAddresses(): JSX.Element | null {
+  const query = useAvailableWallets();
+  const wallets = query.data?.ok ? query.data.data : null;
+  if (wallets === null) return null;
+
+  const { primaryEvm, primarySolana, remaining } = groupWalletsByPrimary(wallets);
+  if (primaryEvm === null && primarySolana === null) return null;
+
+  return (
+    <div className="flex flex-col gap-1" data-vex-area="global-wallet-addresses">
+      {primaryEvm !== null ? (
+        <AddressRow
+          chainId={ETHEREUM_CHAIN_ID}
+          caption="EVM"
+          wallet={primaryEvm}
+        />
+      ) : null}
+      {primarySolana !== null ? (
+        <AddressRow
+          chainId={SOLANA_CHAIN_ID}
+          caption="SOL"
+          wallet={primarySolana}
+        />
+      ) : null}
+      {remaining.length > 0 ? (
+        <div className="mt-0.5 flex flex-col gap-1 border-t border-[var(--vex-line)] pt-1.5">
+          <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[var(--vex-text-3)]">
+            {remaining.length} more {remaining.length === 1 ? "wallet" : "wallets"}
+          </span>
+          {remaining.map((wallet) => (
+            <AddressRow
+              key={wallet.id}
+              chainId={wallet.family === "evm" ? ETHEREUM_CHAIN_ID : SOLANA_CHAIN_ID}
+              caption={wallet.family === "evm" ? "EVM" : "SOL"}
+              wallet={wallet}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * One wallet identity row: chain mark + terse family caption + the
+ * wallet's own label (disambiguates multiple wallets per family, unlike
+ * `DepositAddresses`' session pair which needs no label) + the reusable
+ * `AddressDisplay` chip.
+ */
+function AddressRow({
+  chainId,
+  caption,
+  wallet,
+}: {
+  readonly chainId: number;
+  readonly caption: string;
+  readonly wallet: AvailableWalletDto;
+}): JSX.Element {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="flex w-11 shrink-0 items-center gap-1.5">
+        <ChainIcon chainId={chainId} size={13} />
+        <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[var(--vex-text-3)]">
+          {caption}
+        </span>
+      </span>
+      {wallet.label.length > 0 ? (
+        <span className="shrink-0 truncate text-[11px] text-[var(--vex-text-2)]">
+          {wallet.label}
+        </span>
+      ) : null}
+      <AddressDisplay
+        address={wallet.address}
+        className="min-w-0 flex-1 justify-between px-2 py-0.5"
+      />
+    </div>
+  );
+}

--- a/vex-app/src/renderer/features/appShell/book/MovesBlock.tsx
+++ b/vex-app/src/renderer/features/appShell/book/MovesBlock.tsx
@@ -14,12 +14,23 @@
  * status dot · stamp (mono 9px chip: BUY success-tone / SELL paper-tone /
  * SWAP muted; `productType` takes priority — `bridge` → BRIDGE·VENUE,
  * `send`/`transfer` → TRANSFER, both muted) · `IN → OUT` legs · HH:MM. Raw
- * mint addresses never print in full: address-like token strings truncate to
- * `So1111…1112` (full mint on the tooltip) and a deliberately tiny
- * well-known-mint map resolves the unmissable tickers. Short token strings
- * render as uppercase symbols. A leg carries its amount (`0.0017 ETH`) ONLY
- * when the recorded amount is a dotted decimal — raw base-unit integers from
- * legacy captures (wei/lamports) and nulls render nothing.
+ * mint addresses never print in full: a well-known-mint address ALWAYS wins
+ * (ticker + the app's offline brand mark), full mint kept on the tooltip.
+ * Only once no known mint matches does a bounded, sanitized display symbol
+ * from the activity's exact capture item get a turn — captured symbols are
+ * UNTRUSTED (any token can self-declare metadata claiming a brand ticker
+ * such as "SOL"), so brand-ticker claims are always dropped. The activity's
+ * raw token field can be populated from the same provider capture for
+ * bridge-style legs, so it cannot corroborate one either. A known mint
+ * address is the ONLY thing that authorizes a brand LOGO. Short raw token
+ * strings still render as uppercased plain TEXT (so a legacy `ETH`/`SOL` leg
+ * stays readable), but a brand-matching raw string is withheld from the icon
+ * so it never borrows the real asset's mark; non-brand strings may keep the
+ * neutral monogram (see `tokenDisplay` and
+ * `@shared/token-symbol-sanitizer.js`). Address-like fallbacks truncate to
+ * `So1111…1112`. A leg carries its amount (`0.0017 ETH`) ONLY when the
+ * recorded amount is a dotted decimal — raw base-unit integers from legacy
+ * captures (wei/lamports) and nulls render nothing.
  *
  * The ledger shows the 10 newest fills (`MOVES_DISPLAY_CAP`); the header badge
  * still counts the FULL fetched result (server-capped at `MOVES_MAX`). A row
@@ -45,6 +56,8 @@ import {
   explorerAccountUrl,
   explorerTxUrl,
 } from "@shared/explorer-links.js";
+import { sanitizeTokenSymbol } from "@shared/token-symbol-sanitizer.js";
+import { BRAND_ICON_SYMBOLS, TokenIcon } from "../../../components/common/TokenIcon.js";
 import { useMoves } from "../../../lib/api/portfolio.js";
 import { formatClock, truncateAddress } from "../../../lib/format.js";
 import { cn } from "../../../lib/utils.js";
@@ -109,23 +122,81 @@ interface TokenDisplay {
   readonly text: string;
   /** Full value for the tooltip when `text` is lossy, else `null`. */
   readonly full: string | null;
+  /** Safe symbol used by the app's offline token mark; null for raw addresses. */
+  readonly iconSymbol: string | null;
 }
 
 /**
- * Display rule for one swap leg: known mint → ticker, address-like → the
- * canonical `truncateAddress` shortening (`So1111…1112`), short strings →
- * uppercase symbols. Legs are nullable in the tolerant DTO → `?`.
- * Truncated/known forms carry the full mint on the tooltip; symbols are
- * uppercased in JS (not CSS) so base58 case in truncations stays intact.
+ * Display rule for one swap leg, in strict priority order. The GOVERNING
+ * invariant: a brand ticker + brand logo may be rendered ONLY when a
+ * `KNOWN_MINTS` address proves the identity; no untrusted string (captured
+ * symbol or the provider-populated raw `token`) may ever borrow a brand's
+ * name AND logo.
+ *
+ *  1. `token` resolves through the tiny `KNOWN_MINTS` map → canonical ticker
+ *     + brand mark. This is the ONLY brand path, and it is checked BEFORE the
+ *     captured symbol so a scam mint's capture metadata can never override a
+ *     genuinely recognized mint.
+ *  2. Captured symbol (`inputTokenSymbol`/`outputTokenSymbol`), sanitized: an
+ *     UNTRUSTED self-declared label. Allowed ONLY when it is NOT one of the
+ *     app's brand-marked tickers (`BRAND_ICON_SYMBOLS`, case-insensitive) — a
+ *     brand claim like "SOL" is ALWAYS dropped, with no corroboration
+ *     exception (bridge activity rows carry the same provider symbol in
+ *     `token`, so `token` cannot prove it). A permitted non-brand symbol is
+ *     absent from the brand-icon set, so `TokenIcon` renders a neutral
+ *     monogram, never a brand mark.
+ *  3. Address-like raw `token` → the canonical `truncateAddress` shortening
+ *     (`So1111…1112`), full value on the tooltip.
+ *  4. Short raw `token` string, sanitized → uppercased PLAIN TEXT. This
+ *     restores human-readable legacy legs like "ETH"/"SOL". A brand-matching
+ *     raw string is shown as text but its `iconSymbol` is withheld (null), so
+ *     it NEVER reaches `TokenIcon` — text without a borrowed logo. A non-brand
+ *     raw string may keep the neutral monogram. An invalid / Unicode-bearing /
+ *     null / empty raw string → `?`.
+ *
+ * Legs are nullable in the tolerant DTO → `?`. Truncated/known forms carry
+ * the full mint on the tooltip; symbols are uppercased in JS (not CSS) so
+ * base58 case in truncations stays intact.
  */
-function tokenDisplay(token: string | null): TokenDisplay {
-  if (token === null || token.length === 0) return { text: "?", full: null };
-  const ticker = KNOWN_MINTS.get(token);
-  if (ticker !== undefined) return { text: ticker, full: token };
-  if (ADDRESS_LIKE.test(token)) {
-    return { text: truncateAddress(token), full: token };
+function tokenDisplay(
+  token: string | null,
+  capturedSymbol: string | null,
+): TokenDisplay {
+  // Rule 1 — the ONLY brand path: a known mint address proves the identity.
+  const knownTicker = token !== null ? KNOWN_MINTS.get(token) : undefined;
+  if (knownTicker !== undefined) {
+    return { text: knownTicker, full: token, iconSymbol: knownTicker };
   }
-  return { text: token.toUpperCase(), full: null };
+
+  // Rule 2 — captured symbol: untrusted; non-brand only, brand claims dropped.
+  const symbol = sanitizeTokenSymbol(capturedSymbol);
+  if (symbol !== null && !BRAND_ICON_SYMBOLS.has(symbol.toLowerCase())) {
+    return {
+      text: symbol.toUpperCase(),
+      full:
+        token !== null && token.toUpperCase() !== symbol.toUpperCase()
+          ? token
+          : null,
+      iconSymbol: symbol,
+    };
+  }
+
+  // Rule 3 — address-like raw token: truncated-address fallback.
+  if (token !== null && ADDRESS_LIKE.test(token)) {
+    return { text: truncateAddress(token), full: token, iconSymbol: null };
+  }
+
+  // Rule 4 — short raw token string: uppercased plain text. Invalid/Unicode/
+  // null/empty → `?`; brand-matching raw strings render as text but withhold
+  // the icon so they never borrow a brand logo; non-brand keeps the monogram.
+  const safeToken = sanitizeTokenSymbol(token);
+  if (safeToken === null) {
+    return { text: "?", full: null, iconSymbol: null };
+  }
+  const iconSymbol = BRAND_ICON_SYMBOLS.has(safeToken.toLowerCase())
+    ? null
+    : safeToken;
+  return { text: safeToken.toUpperCase(), full: null, iconSymbol };
 }
 
 /** ≤6 significant digits, no grouping — mono-ledger compact figures. */
@@ -249,8 +320,8 @@ export function MovesBlock({ sessionId }: { readonly sessionId: string }): JSX.E
 function MoveRow({ move }: { readonly move: MoveItem }): JSX.Element {
   const state = moveState(move.captureStatus);
   const side = sideStamp(move);
-  const input = tokenDisplay(move.inputToken);
-  const output = tokenDisplay(move.outputToken);
+  const input = tokenDisplay(move.inputToken, move.inputTokenSymbol);
+  const output = tokenDisplay(move.outputToken, move.outputTokenSymbol);
   const inputAmount = amountDisplay(move.inputAmount);
   const outputAmount = amountDisplay(move.outputAmount);
   const time = formatClock(move.createdAt);
@@ -284,13 +355,29 @@ function MoveRow({ move }: { readonly move: MoveItem }): JSX.Element {
       >
         {side.text}
       </span>
-      <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-[var(--vex-text-2)] transition-colors group-hover:text-[var(--vex-text)]">
-        <span title={input.full ?? undefined}>
-          {inputAmount !== null ? `${inputAmount} ${input.text}` : input.text}
+      <span className="flex h-4 min-w-0 flex-1 items-center gap-1.5 overflow-hidden whitespace-nowrap font-mono text-[11px] leading-none text-[var(--vex-text-2)] transition-colors group-hover:text-[var(--vex-text)]">
+        <span
+          title={input.full ?? undefined}
+          className="inline-flex min-w-0 items-center gap-1"
+        >
+          {input.iconSymbol !== null ? (
+            <TokenIcon symbol={input.iconSymbol} size={12} />
+          ) : null}
+          <span className="truncate">
+            {inputAmount !== null ? `${inputAmount} ${input.text}` : input.text}
+          </span>
         </span>
-        <span className="text-[var(--vex-text-3)]">{" → "}</span>
-        <span title={output.full ?? undefined}>
-          {outputAmount !== null ? `${outputAmount} ${output.text}` : output.text}
+        <span className="shrink-0 text-[var(--vex-text-3)]">→</span>
+        <span
+          title={output.full ?? undefined}
+          className="inline-flex min-w-0 items-center gap-1"
+        >
+          {output.iconSymbol !== null ? (
+            <TokenIcon symbol={output.iconSymbol} size={12} />
+          ) : null}
+          <span className="truncate">
+            {outputAmount !== null ? `${outputAmount} ${output.text}` : output.text}
+          </span>
         </span>
       </span>
       {time !== null ? (

--- a/vex-app/src/renderer/features/appShell/book/PositionBlock.tsx
+++ b/vex-app/src/renderer/features/appShell/book/PositionBlock.tsx
@@ -13,9 +13,12 @@
  * most recent snapshot total + PnL when present, and the resolved wallet
  * COUNT. SESSION scope then renders the redesigned register — copy-ready
  * deposit addresses (DepositAddresses) + the per-chain holdings switcher
- * (PositionChains); GLOBAL keeps the legacy flat top-holdings list (capped,
- * remainder noted). Loading / error / empty (no wallets) states are boxless
- * lines on the same register.
+ * (PositionChains); GLOBAL (the welcome/empty state) carries that same
+ * wallet-identity presentation via `GlobalWalletAddresses` — the primary
+ * EVM/Solana wallet from the config inventory shown by default, any
+ * additional configured wallets listed below — ahead of the legacy flat
+ * top-holdings list (capped, remainder noted). Loading / error / empty (no
+ * wallets) states are boxless lines on the same register.
  *
  * Token rows that would print `$0.00` (|USD| below formatUsd's 2-decimal
  * rounding threshold) are hidden — the cap and "+N more" count only rows
@@ -46,6 +49,7 @@ import {
 } from "../../../lib/format.js";
 import { BookBlock } from "./BookBlock.js";
 import { DepositAddresses } from "./DepositAddresses.js";
+import { GlobalWalletAddresses } from "./GlobalWalletAddresses.js";
 import { PositionChains } from "./PositionChains.js";
 
 /** Visible token rows before the "+N more" tail. */
@@ -195,6 +199,7 @@ function PositionBody({
         pnlVsPrev={pnlVsPrev}
         hero={hero}
       />
+      <GlobalWalletAddresses />
       {visible.length > 0 ? (
         // Landing .ws-stat rows: hairline-separated, key muted / value white.
         <ul className="flex flex-col">

--- a/vex-app/src/renderer/features/appShell/book/PositionChains.tsx
+++ b/vex-app/src/renderer/features/appShell/book/PositionChains.tsx
@@ -35,6 +35,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../../../components/ui/dialog.js";
+import { sanitizeTokenSymbol } from "@shared/token-symbol-sanitizer.js";
 import { ChainIcon } from "../../../components/common/ChainIcon.js";
 import { TokenIcon } from "../../../components/common/TokenIcon.js";
 import { formatTokenQuantity, formatUsd } from "../../../lib/format.js";
@@ -231,6 +232,14 @@ function ChainTotalFigure({
  * amount stay visible with a muted em dash for the missing valuation. An
  * empty (or all-sub-cent) list states the fact quietly instead of leaving
  * a gap: Ethereum stays the standing default even with nothing on it.
+ *
+ * `token.symbol` is provider-supplied and UNTRUSTED — any on-chain token can
+ * self-declare arbitrary metadata, including a symbol that impersonates a
+ * well-known asset. It is passed through the shared ASCII-allowlist
+ * `sanitizeTokenSymbol` (rejects control characters, bidi controls,
+ * zero-width characters, and Unicode confusables) BEFORE it reaches display
+ * text or `TokenIcon`'s symbol-keyed brand-mark lookup, so a spoofed symbol
+ * can render neither a deceptive label nor a borrowed brand logo.
  */
 function ChainTokenList({
   chainId,
@@ -253,19 +262,18 @@ function ChainTokenList({
   }
   return (
     <ul className="flex flex-col">
-      {displayable.map((token) => {
-        const quantity = formatTokenQuantity(token.amount, token.symbol);
+      {displayable.map((token, index) => {
+        const symbol = sanitizeTokenSymbol(token.symbol);
+        const quantity = formatTokenQuantity(token.amount, symbol);
         return (
           <li
-            key={`${chainId}:${token.symbol ?? "—"}`}
+            key={`${chainId}:${symbol ?? "—"}:${index}`}
             className="flex items-center justify-between gap-3 border-b border-[var(--vex-line)] py-1.5 last:border-b-0"
           >
             <span className="flex min-w-0 flex-1 items-center gap-2">
-              <TokenIcon symbol={token.symbol} size={13} />
+              <TokenIcon symbol={symbol} size={13} />
               <span className="truncate font-mono text-[11px] text-[var(--vex-text-2)]">
-                {token.symbol !== null && token.symbol.length > 0
-                  ? token.symbol
-                  : "—"}
+                {symbol !== null && symbol.length > 0 ? symbol : "—"}
               </span>
             </span>
             <span className="flex shrink-0 items-baseline gap-2 font-mono text-[11px] tabular-nums">

--- a/vex-app/src/renderer/features/appShell/book/__tests__/GlobalWalletAddresses.test.ts
+++ b/vex-app/src/renderer/features/appShell/book/__tests__/GlobalWalletAddresses.test.ts
@@ -1,0 +1,72 @@
+/**
+ * groupWalletsByPrimary — the pure model behind `GlobalWalletAddresses`
+ * (WP-L): the primary wallet per family is the first inventory entry
+ * (stable insertion order), everything else is "remaining". Pure, no
+ * rendering — the component render behavior is covered separately in
+ * `appShell/__tests__/GlobalWalletAddresses.test.tsx`.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { AvailableWalletDto } from "@shared/schemas/wallets.js";
+import { groupWalletsByPrimary } from "../GlobalWalletAddresses.js";
+
+function wallet(
+  id: string,
+  family: "evm" | "solana",
+  address: string,
+  label = "",
+): AvailableWalletDto {
+  return { id, family, address, label };
+}
+
+describe("groupWalletsByPrimary", () => {
+  it("returns null primaries and an empty remainder for an empty inventory", () => {
+    const grouping = groupWalletsByPrimary({ evm: [], solana: [] });
+    expect(grouping).toEqual({
+      primaryEvm: null,
+      primarySolana: null,
+      remaining: [],
+    });
+  });
+
+  it("picks the first wallet of each family as primary with no remainder for a single-wallet-per-family inventory", () => {
+    const evm = wallet("evm-1", "evm", "0xAAA");
+    const solana = wallet("sol-1", "solana", "SoAAA");
+    const grouping = groupWalletsByPrimary({ evm: [evm], solana: [solana] });
+    expect(grouping.primaryEvm).toBe(evm);
+    expect(grouping.primarySolana).toBe(solana);
+    expect(grouping.remaining).toEqual([]);
+  });
+
+  it("groups only the EVM family when Solana is unconfigured", () => {
+    const evm = wallet("evm-1", "evm", "0xAAA");
+    const grouping = groupWalletsByPrimary({ evm: [evm], solana: [] });
+    expect(grouping.primaryEvm).toBe(evm);
+    expect(grouping.primarySolana).toBeNull();
+    expect(grouping.remaining).toEqual([]);
+  });
+
+  it("keeps every wallet beyond the first of each family in insertion order (EVM before Solana)", () => {
+    const evm1 = wallet("evm-1", "evm", "0xAAA");
+    const evm2 = wallet("evm-2", "evm", "0xBBB");
+    const evm3 = wallet("evm-3", "evm", "0xCCC");
+    const sol1 = wallet("sol-1", "solana", "SoAAA");
+    const sol2 = wallet("sol-2", "solana", "SoBBB");
+    const grouping = groupWalletsByPrimary({
+      evm: [evm1, evm2, evm3],
+      solana: [sol1, sol2],
+    });
+    expect(grouping.primaryEvm).toBe(evm1);
+    expect(grouping.primarySolana).toBe(sol1);
+    expect(grouping.remaining).toEqual([evm2, evm3, sol2]);
+  });
+
+  it("never mutates the input arrays", () => {
+    const evm = [wallet("evm-1", "evm", "0xAAA"), wallet("evm-2", "evm", "0xBBB")];
+    const solana = [wallet("sol-1", "solana", "SoAAA")];
+    const before = { evm: [...evm], solana: [...solana] };
+    groupWalletsByPrimary({ evm, solana });
+    expect(evm).toEqual(before.evm);
+    expect(solana).toEqual(before.solana);
+  });
+});

--- a/vex-app/src/renderer/features/appShell/composer-helpers.ts
+++ b/vex-app/src/renderer/features/appShell/composer-helpers.ts
@@ -64,6 +64,74 @@ export function submitSuccessText(data: ChatSubmitResult): string | null {
   return null;
 }
 
+/**
+ * A chat submit can resolve successfully at the IPC boundary while the agent
+ * itself stopped before finishing. These runtime guards are not transport
+ * errors, so they arrive in `ChatSubmitResult.stopReason` rather than the
+ * `Result` error channel. Translate only the terminal, operator-actionable
+ * failure reasons here; approval and mission pause states already have their
+ * own dedicated UI.
+ */
+export interface SubmitFailureNotice {
+  readonly text: string;
+  readonly retryable: boolean;
+}
+
+/**
+ * Retry stays gated on the RAW count, never a read-only/mutating split:
+ * `ChatSubmitResult` carries no per-tool identity, and the authoritative
+ * "is this tool mutating" classification lives in the privileged
+ * `src/vex-agent/tools/registry/*` `mutating` flags — untrusted renderer
+ * code must not duplicate or guess at that classification (a wrong guess
+ * would blindly replay a turn that already took a real action). Any
+ * executed tool call, regardless of apparent kind, withholds one-click
+ * Retry (see composer-helpers.test.ts for the pinned read-only-vs-mutating
+ * case).
+ */
+function incompleteTurnNotice(
+  data: ChatSubmitResult,
+  reason: string,
+): SubmitFailureNotice {
+  if (data.toolCallsMade === 0) {
+    return { text: reason, retryable: true };
+  }
+  return {
+    text:
+      `${reason} Review the transcript before trying again; ` +
+      "earlier steps may have completed.",
+    retryable: false,
+  };
+}
+
+export function submitFailureNotice(
+  data: ChatSubmitResult,
+): SubmitFailureNotice | null {
+  switch (data.stopReason) {
+    case "iteration_limit":
+      return incompleteTurnNotice(
+        data,
+        "Vex stopped before completing the task after reaching this turn's action limit.",
+      );
+    case "timeout":
+      return incompleteTurnNotice(
+        data,
+        "Vex stopped before completing the task because this turn timed out.",
+      );
+    case "system_error":
+      return incompleteTurnNotice(
+        data,
+        "Vex stopped before completing the task because of an internal error.",
+      );
+    case "compact_unable_at_critical":
+      return {
+        text: "Vex stopped because this conversation ran out of usable context. Start a new session or try a narrower request.",
+        retryable: false,
+      };
+    default:
+      return null;
+  }
+}
+
 export function placeholderFor(session: SessionListItem | null): string {
   if (session?.mode !== "mission") return "What do you want Vex to do?";
   const goal = session.initialGoal?.trim();

--- a/vex-app/src/renderer/features/appShell/missionHistoryModel.ts
+++ b/vex-app/src/renderer/features/appShell/missionHistoryModel.ts
@@ -1,0 +1,88 @@
+/**
+ * Mission History — pure display model.
+ *
+ * Every function here is pure (data in, derived value out) so the math is
+ * unit-tested independently of React.
+ *
+ * `missionDisplayOutcome` is the ONE place the raw ledger
+ * `(outcome, stopReason)` pair maps to a presentation-level outcome —
+ * deadline semantics stay out of SQL (mission-results.ts / the migration)
+ * and out of every component that renders this data. A run whose ledger
+ * `outcome` is terminal-but-not-goal and whose `stopReason` is
+ * "deadline_reached" displays as "timeBoxed": a neutral, medium-level
+ * outcome ("the time-box was reached"), never a failure.
+ *
+ * Naming: this is a "mission result (ETH)" — an honest PnL record, never
+ * "performance" anywhere in this module or its consumers.
+ */
+
+import type { MissionResultDto } from "@shared/schemas/mission.js";
+
+export const EM_DASH = "—";
+
+export type MissionDisplayOutcome =
+  | "completed"
+  | "timeBoxed"
+  | "cancelled"
+  | "failed"
+  | "stopped"
+  | "running";
+
+/** Raw ledger (outcome, stopReason) -> the presentation-level outcome. */
+export function missionDisplayOutcome(
+  result: Pick<MissionResultDto, "outcome" | "stopReason">,
+): MissionDisplayOutcome {
+  if (result.stopReason === "deadline_reached" && result.outcome !== "completed") {
+    return "timeBoxed";
+  }
+  return result.outcome;
+}
+
+/** Completed AND time-boxed runs count as a "completion" for stats (the win-rate population). */
+export function isCompletionLike(displayOutcome: MissionDisplayOutcome): boolean {
+  return displayOutcome === "completed" || displayOutcome === "timeBoxed";
+}
+
+/**
+ * Win-rate (%) over completion-like runs with a known PnL sign. `null` when
+ * no run is eligible (e.g. history has only cancelled/still-running rows).
+ */
+export function computeWinRate(results: readonly MissionResultDto[]): number | null {
+  const eligible = results.filter(
+    (r) => isCompletionLike(missionDisplayOutcome(r)) && r.pnlEth !== null,
+  );
+  if (eligible.length === 0) return null;
+  const wins = eligible.filter((r) => (r.pnlEth as number) > 0).length;
+  return (wins / eligible.length) * 100;
+}
+
+/** Sum of known ETH PnL across all results (a null/unknown PnL contributes 0). */
+export function sumPnlEth(results: readonly MissionResultDto[]): number {
+  return results.reduce((total, r) => total + (r.pnlEth ?? 0), 0);
+}
+
+const ETH_DECIMALS = 4;
+
+/** Fixed-precision ETH amount; `signed` prefixes +/-. `null`/non-finite -> em dash. */
+export function formatEth(value: number | null, opts: { signed?: boolean } = {}): string {
+  if (value === null || !Number.isFinite(value)) return EM_DASH;
+  const sign = opts.signed ? (value > 0 ? "+" : value < 0 ? "-" : "") : "";
+  return `${sign}${Math.abs(value).toFixed(ETH_DECIMALS)}`;
+}
+
+/** USD value implied by an ETH PnL at the run's close price; null if either input is unknown. */
+export function pnlUsd(pnlEth: number | null, ethPriceUsdEnd: number | null): number | null {
+  if (pnlEth === null || ethPriceUsdEnd === null) return null;
+  return pnlEth * ethPriceUsdEnd;
+}
+
+/** `Xs` / `Xm` / `Xh Ym` for a run's persisted duration in seconds; em dash when unknown. */
+export function formatDurationS(durationS: number | null): string {
+  if (durationS === null || !Number.isFinite(durationS) || durationS < 0) return EM_DASH;
+  const totalMinutes = Math.floor(durationS / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours > 0) return `${hours}h ${String(minutes).padStart(2, "0")}m`;
+  if (totalMinutes > 0) return `${totalMinutes}m`;
+  return `${durationS}s`;
+}

--- a/vex-app/src/renderer/lib/api/__tests__/chat.test.ts
+++ b/vex-app/src/renderer/lib/api/__tests__/chat.test.ts
@@ -18,11 +18,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { createElement } from "react";
 
-import { useSubmitChat } from "../chat.js";
+import { useIsChatSubmitting, useSubmitChat } from "../chat.js";
 import { sessionKeys } from "../sessions.js";
-import { usageKeys } from "../queryKeys.js";
+import { approvalsKeys, usageKeys } from "../queryKeys.js";
 
 const SESSION = "00000000-0000-4000-8000-0000000000c2";
+const OTHER_SESSION = "00000000-0000-4000-8000-0000000000c3";
 const submitMock = vi.fn();
 
 beforeEach(() => {
@@ -109,6 +110,54 @@ describe("useSubmitChat onSuccess invalidation", () => {
 
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
+
+  it("immediately refreshes inline and global approvals when the turn enqueues one", async () => {
+    submitMock.mockReturnValue({
+      promise: Promise.resolve({
+        ok: true,
+        data: { text: null, pendingApprovals: ["approval-1"] },
+      }),
+      cancel: vi.fn(),
+    });
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(() => useSubmitChat(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await result.current.mutateAsync({ sessionId: SESSION, message: "send it" });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: approvalsKeys.pending(SESSION),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: approvalsKeys.pendingAll(),
+    });
+  });
+
+  it("does not refresh approvals when the turn enqueues none", async () => {
+    submitMock.mockReturnValue({
+      promise: Promise.resolve({
+        ok: true,
+        data: { text: null, pendingApprovals: [] },
+      }),
+      cancel: vi.fn(),
+    });
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(() => useSubmitChat(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await result.current.mutateAsync({ sessionId: SESSION, message: "hello" });
+
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: approvalsKeys.pending(SESSION),
+    });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: approvalsKeys.pendingAll(),
+    });
+  });
 });
 
 describe("useSubmitChat stop / cancel ownership (9-5b)", () => {
@@ -181,5 +230,62 @@ describe("useSubmitChat stop / cancel ownership (9-5b)", () => {
       settle2({ ok: true, data: { text: null } });
       await Promise.resolve();
     });
+  });
+});
+
+describe("useIsChatSubmitting session isolation (stale-session spinner guard)", () => {
+  // The working-avatar spinner (agentActivity.ts / SessionTranscript) reads
+  // this hook per-session. A submit still in flight for a session the user
+  // has since navigated AWAY from must never make the newly active session
+  // read as submitting — the mutation-cache lookup keys strictly on
+  // `mutation.state.variables.sessionId`, never on "most recent mutation".
+  it("keeps a pending submit's status scoped to its own sessionId, not a session navigated to afterward", async () => {
+    let settle!: (r: { ok: true; data: { text: null } }) => void;
+    submitMock.mockReturnValue({
+      promise: new Promise<{ ok: true; data: { text: null } }>((res) => {
+        settle = res;
+      }),
+      cancel: vi.fn(),
+    });
+    const client = new QueryClient();
+    const wrapper = makeWrapper(client);
+
+    const submitHook = renderHook(() => useSubmitChat(), { wrapper });
+    void submitHook.result.current.mutate({ sessionId: SESSION, message: "hi" });
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+
+    // Reading a DIFFERENT (freshly navigated-to) session must stay false —
+    // the in-flight mutation belongs to SESSION, not OTHER_SESSION.
+    const otherSessionHook = renderHook(
+      () => useIsChatSubmitting(OTHER_SESSION),
+      { wrapper },
+    );
+    expect(otherSessionHook.result.current).toBe(false);
+
+    // The original session correctly reads true while its own submit is
+    // still pending.
+    const originalSessionHook = renderHook(() => useIsChatSubmitting(SESSION), {
+      wrapper,
+    });
+    expect(originalSessionHook.result.current).toBe(true);
+
+    await act(async () => {
+      settle({ ok: true, data: { text: null } });
+      await Promise.resolve();
+    });
+
+    // Once the turn settles, both sessions read false again.
+    otherSessionHook.rerender();
+    originalSessionHook.rerender();
+    await waitFor(() => expect(originalSessionHook.result.current).toBe(false));
+    expect(otherSessionHook.result.current).toBe(false);
+  });
+
+  it("returns false for a null sessionId (welcome / no active session)", () => {
+    const client = new QueryClient();
+    const { result } = renderHook(() => useIsChatSubmitting(null), {
+      wrapper: makeWrapper(client),
+    });
+    expect(result.current).toBe(false);
   });
 });

--- a/vex-app/src/renderer/lib/api/chat.ts
+++ b/vex-app/src/renderer/lib/api/chat.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from "react";
 import {
   useMutation,
+  useMutationState,
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
@@ -9,7 +10,7 @@ import type {
   ChatSubmitInput,
   ChatSubmitResult,
 } from "@shared/schemas/chat.js";
-import { isUsageQueryForSession } from "./queryKeys.js";
+import { approvalsKeys, isUsageQueryForSession } from "./queryKeys.js";
 import { sessionKeys } from "./sessions.js";
 
 /**
@@ -37,12 +38,33 @@ export type UseSubmitChatResult = UseMutationResult<
   ChatSubmitInput
 > & { readonly stop: () => void };
 
+export const CHAT_SUBMIT_MUTATION_KEY = ["chat", "submit"] as const;
+
+/**
+ * Read the shared mutation cache instead of creating another submit observer.
+ * This keeps shell-level status indicators live for the entire IPC request,
+ * including quiet gaps between provider streams and tool execution.
+ */
+export function useIsChatSubmitting(sessionId: string | null): boolean {
+  const pendingSessionIds = useMutationState({
+    filters: {
+      mutationKey: CHAT_SUBMIT_MUTATION_KEY,
+      status: "pending",
+    },
+    select: (mutation) =>
+      (mutation.state.variables as ChatSubmitInput | undefined)?.sessionId ??
+      null,
+  });
+  return sessionId !== null && pendingSessionIds.includes(sessionId);
+}
+
 export function useSubmitChat(): UseSubmitChatResult {
   const queryClient = useQueryClient();
   const cancelRef = useRef<(() => void) | null>(null);
   const activeSubmitRef = useRef<symbol | null>(null);
 
   const mutation = useMutation({
+    mutationKey: CHAT_SUBMIT_MUTATION_KEY,
     mutationFn: (input: ChatSubmitInput) => {
       const invocation = window.vex.chat.submit(input);
       cancelRef.current = invocation.cancel;
@@ -62,6 +84,17 @@ export function useSubmitChat(): UseSubmitChatResult {
       void queryClient.invalidateQueries({
         queryKey: sessionKeys.plan(variables.sessionId),
       });
+      // A restricted turn can enqueue an approval before chat.submit returns.
+      // Refresh both the inline card and the app-wide inbox immediately instead
+      // of waiting for their polling fallback.
+      if (result.data.pendingApprovals?.length > 0) {
+        void queryClient.invalidateQueries({
+          queryKey: approvalsKeys.pending(variables.sessionId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: approvalsKeys.pendingAll(),
+        });
+      }
       // A completed turn advances usage rows + the session token_count, so
       // refresh the runtime bar immediately (usage totals, last-turn, and
       // context window). The transcript-append live-sync is the backstop

--- a/vex-app/src/renderer/lib/api/mission.ts
+++ b/vex-app/src/renderer/lib/api/mission.ts
@@ -32,6 +32,8 @@ import type {
   MissionGetDiffResult,
   MissionGetDraftResult,
   MissionGetRenewableSourceResult,
+  MissionGetResultForRunResult,
+  MissionListResultsResult,
   MissionRecoverInput,
   MissionRecoverResult,
   MissionRenewInput,
@@ -112,6 +114,47 @@ export function useRenewableMissionSource(
   sessionId: string | null,
 ): UseQueryResult<Result<MissionGetRenewableSourceResult>> {
   return useQuery(renewableSourceOptions(sessionId ?? ""));
+}
+
+/**
+ * WP-J — per-wallet mission results ledger, newest first. The Mission
+ * History panel resolves the wallet address itself (primary wallet by
+ * default); this hook is a thin per-wallet read, never "list every wallet".
+ */
+function missionResultsOptions(walletAddress: string) {
+  return queryOptions({
+    queryKey: missionKeys.results(walletAddress),
+    queryFn: () => window.vex.mission.listResults({ walletAddress }),
+    staleTime: STALE_MS,
+    enabled: walletAddress.length > 0,
+  });
+}
+
+export function useMissionResults(
+  walletAddress: string | null,
+): UseQueryResult<Result<MissionListResultsResult>> {
+  return useQuery(missionResultsOptions(walletAddress ?? ""));
+}
+
+/**
+ * WP-J — the finalized ledger row for a single run (e.g. the post-mission
+ * summary card shown inline after a mission finishes). Returns null while
+ * the run hasn't finalized (or was never opened).
+ */
+function missionResultForRunOptions(missionRunId: string, walletAddress: string) {
+  return queryOptions({
+    queryKey: missionKeys.resultForRun(missionRunId, walletAddress),
+    queryFn: () => window.vex.mission.getResultForRun({ missionRunId, walletAddress }),
+    staleTime: STALE_MS,
+    enabled: missionRunId.length > 0 && walletAddress.length > 0,
+  });
+}
+
+export function useMissionResultForRun(
+  missionRunId: string | null,
+  walletAddress: string | null,
+): UseQueryResult<Result<MissionGetResultForRunResult>> {
+  return useQuery(missionResultForRunOptions(missionRunId ?? "", walletAddress ?? ""));
 }
 
 // ── Mutations ───────────────────────────────────────────────────

--- a/vex-app/src/renderer/lib/api/queryKeys.ts
+++ b/vex-app/src/renderer/lib/api/queryKeys.ts
@@ -146,6 +146,12 @@ export const missionKeys = {
    */
   renewableSource: (sessionId: string) =>
     ["mission", "renewableSource", sessionId] as const,
+  /** WP-J — per-wallet mission results ledger history, newest first. */
+  results: (walletAddress: string) =>
+    ["mission", "results", walletAddress] as const,
+  /** WP-J — single-run ledger read (e.g. the post-mission summary card). */
+  resultForRun: (missionRunId: string, walletAddress: string) =>
+    ["mission", "resultForRun", missionRunId, walletAddress] as const,
 };
 
 export const approvalsKeys = {

--- a/vex-app/src/renderer/stores/uiStore.ts
+++ b/vex-app/src/renderer/stores/uiStore.ts
@@ -65,7 +65,9 @@ export type AppShellView =
   | "session"
   | "sessionsLibrary"
   // Read-only long-term + session-memory panel (stage 7-2a, S9 rewire).
-  | "memory";
+  | "memory"
+  // Read-only mission results ledger (WP-J).
+  | "missionHistory";
 
 export interface UiLogEntry {
   readonly id: string;

--- a/vex-app/src/shared/__tests__/token-symbol-sanitizer.test.ts
+++ b/vex-app/src/shared/__tests__/token-symbol-sanitizer.test.ts
@@ -1,0 +1,70 @@
+/**
+ * token-symbol-sanitizer — the ASCII-allowlist trust boundary shared by
+ * moves-db.ts (main) and MovesBlock.tsx / PositionChains.tsx (renderer) for
+ * every provider/capture-supplied token display symbol.
+ *
+ * Spoofing fixtures use explicit `\uXXXX` escapes (never raw invisible
+ * bytes) so the exact character under test stays reviewable in a diff.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  TOKEN_SYMBOL_MAX_LENGTH,
+  sanitizeTokenSymbol,
+} from "../token-symbol-sanitizer.js";
+
+describe("sanitizeTokenSymbol", () => {
+  it("trims surrounding whitespace on an otherwise valid symbol", () => {
+    expect(sanitizeTokenSymbol("  SOL  ")).toBe("SOL");
+  });
+
+  it("accepts real-world tickers with allowlisted punctuation", () => {
+    expect(sanitizeTokenSymbol("USDC")).toBe("USDC");
+    expect(sanitizeTokenSymbol("ansem")).toBe("ansem");
+    expect(sanitizeTokenSymbol("WIF-PERP")).toBe("WIF-PERP");
+    expect(sanitizeTokenSymbol("W.ETH")).toBe("W.ETH");
+    // Must start alphanumeric — "$"-prefixed meme tickers are out of scope
+    // for this pass; the allowlist stays as small as the known usages need.
+    expect(sanitizeTokenSymbol("$WIF")).toBe(null);
+  });
+
+  it("rejects non-string, empty, and over-length values", () => {
+    expect(sanitizeTokenSymbol(null)).toBe(null);
+    expect(sanitizeTokenSymbol(undefined)).toBe(null);
+    expect(sanitizeTokenSymbol(42)).toBe(null);
+    expect(sanitizeTokenSymbol("")).toBe(null);
+    expect(sanitizeTokenSymbol("   ")).toBe(null);
+    expect(sanitizeTokenSymbol("x".repeat(TOKEN_SYMBOL_MAX_LENGTH))).toBe(
+      "x".repeat(TOKEN_SYMBOL_MAX_LENGTH),
+    );
+    expect(sanitizeTokenSymbol("x".repeat(TOKEN_SYMBOL_MAX_LENGTH + 1))).toBe(
+      null,
+    );
+  });
+
+  it("rejects control characters and internal whitespace", () => {
+    expect(sanitizeTokenSymbol("BAD\nSYMBOL")).toBe(null); // LF
+    expect(sanitizeTokenSymbol("BAD\tSYMBOL")).toBe(null); // TAB
+    expect(sanitizeTokenSymbol("BAD SYMBOL")).toBe(null); // internal space
+    expect(sanitizeTokenSymbol("BAD\u0000SYMBOL")).toBe(null); // NUL
+    expect(sanitizeTokenSymbol("BAD\u007fSYMBOL")).toBe(null); // DEL
+    expect(sanitizeTokenSymbol("BADSYMBOL")).toBe("BADSYMBOL"); // control-free, passes
+  });
+
+  it("rejects zero-width and bidi-control spoofing characters spliced into a real ticker", () => {
+    expect(sanitizeTokenSymbol("S\u200bOL")).toBe(null); // zero-width space
+    expect(sanitizeTokenSymbol("S\u200cOL")).toBe(null); // zero-width non-joiner
+    expect(sanitizeTokenSymbol("S\u200dOL")).toBe(null); // zero-width joiner
+    expect(sanitizeTokenSymbol("\ufeffSOL")).toBe(null); // BOM / zero-width no-break space
+    expect(sanitizeTokenSymbol("SOL\u202e")).toBe(null); // right-to-left override
+    expect(sanitizeTokenSymbol("\u202aSOL")).toBe(null); // left-to-right embedding
+    expect(sanitizeTokenSymbol("\u2066SOL\u2069")).toBe(null); // bidi isolate pair
+    expect(sanitizeTokenSymbol("\u061cSOL")).toBe(null); // Arabic letter mark
+  });
+
+  it("rejects Unicode confusable homoglyphs of well-known tickers", () => {
+    expect(sanitizeTokenSymbol("\u0405OL")).toBe(null); // Cyrillic Es for Latin S ("SOL")
+    expect(sanitizeTokenSymbol("US\u0414C")).toBe(null); // Cyrillic De for Latin D ("USDC")
+    expect(sanitizeTokenSymbol("\uff33OL")).toBe(null); // fullwidth Latin capital S
+  });
+});

--- a/vex-app/src/shared/ipc/channels.ts
+++ b/vex-app/src/shared/ipc/channels.ts
@@ -150,6 +150,8 @@ export const CH = {
     stop: "vex:mission:stop",
     getRenewableSource: "vex:mission:getRenewableSource",
     setAutoRetry: "vex:mission:setAutoRetry",
+    listResults: "vex:mission:listResults",
+    getResultForRun: "vex:mission:getResultForRun",
   },
 
   // Approvals — queue browsing + decisions. Pending/get/history are

--- a/vex-app/src/shared/schemas/__tests__/portfolio-moves.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/portfolio-moves.test.ts
@@ -41,8 +41,10 @@ describe("move item schema (tolerant)", () => {
       productType: "spot",
       venue: "kyberswap",
       inputToken: "USDC",
+      inputTokenSymbol: "USDC",
       inputAmount: "100",
       outputToken: "ETH",
+      outputTokenSymbol: "ETH",
       outputAmount: "0.03",
       valueUsd: 100,
       captureStatus: "executed",
@@ -106,8 +108,10 @@ describe("move item schema (tolerant)", () => {
           productType: null,
           venue: null,
           inputToken: null,
+          inputTokenSymbol: null,
           inputAmount: null,
           outputToken: null,
+          outputTokenSymbol: null,
           outputAmount: null,
           valueUsd: null,
           captureStatus: null,
@@ -139,6 +143,18 @@ describe("move item schema (tolerant)", () => {
     expect(moveItemSchema.safeParse(withoutChain).success).toBe(false);
   });
 
+  it("accepts absent token symbols as null and bounds present symbols", () => {
+    expect(
+      moveItemSchema.safeParse(
+        itemFixture({ inputTokenSymbol: null, outputTokenSymbol: null }),
+      ).success,
+    ).toBe(true);
+    expect(
+      moveItemSchema.safeParse(itemFixture({ outputTokenSymbol: "x".repeat(65) }))
+        .success,
+    ).toBe(false);
+  });
+
   it("rejects an unknown key (strict)", () => {
     expect(
       moveItemSchema.safeParse(itemFixture({ rawResult: "0xdeadbeef" })).success,
@@ -159,8 +175,10 @@ describe("moves dto schema (array + cap)", () => {
     productType: null,
     venue: null,
     inputToken: "USDC",
+    inputTokenSymbol: null,
     inputAmount: "1",
     outputToken: "SOL",
+    outputTokenSymbol: null,
     outputAmount: "1",
     valueUsd: null,
     captureStatus: "filled",

--- a/vex-app/src/shared/schemas/__tests__/runtime.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/runtime.test.ts
@@ -77,7 +77,7 @@ describe("runtime schemas", () => {
 });
 
 describe("runtime per-action discriminated unions", () => {
-  it("requestPause accepts all 5 outcomes", () => {
+  it("requestPause accepts all 6 outcomes", () => {
     expect(
       runtimeRequestPauseResultSchema.safeParse({
         outcome: "queued",
@@ -105,6 +105,12 @@ describe("runtime per-action discriminated unions", () => {
         outcome: "terminal",
         status: "stopped",
       }).success,
+    ).toBe(true);
+    // WP-C: a `running` run with a dead lease is refused up front instead
+    // of being enqueued and stranded forever (issue #12's bug class).
+    expect(
+      runtimeRequestPauseResultSchema.safeParse({ outcome: "already_parked" })
+        .success,
     ).toBe(true);
   });
 

--- a/vex-app/src/shared/schemas/mission.ts
+++ b/vex-app/src/shared/schemas/mission.ts
@@ -1,7 +1,8 @@
 /**
  * Mission schemas barrel — splits the original monolith into
- * `mission/draft.ts` (read-only DTO + acceptance projection) and
- * `mission/commands.ts` (9 per-command discriminated unions).
+ * `mission/draft.ts` (read-only DTO + acceptance projection),
+ * `mission/commands.ts` (9 per-command discriminated unions), and
+ * `mission/results.ts` (WP-J: the read-only mission results ledger DTO).
  *
  * The split keeps each file under the project's 350-LOC budget per
  * the puzzle-04 phase-6 codex review.
@@ -14,3 +15,4 @@
 
 export * from "./mission/draft.js";
 export * from "./mission/commands.js";
+export * from "./mission/results.js";

--- a/vex-app/src/shared/schemas/mission/results.ts
+++ b/vex-app/src/shared/schemas/mission/results.ts
@@ -1,0 +1,82 @@
+/**
+ * Mission results ledger — read-only transport schemas for
+ * `mission.listResults` / `mission.getResultForRun`.
+ *
+ * The ledger is written by the engine (migration 041 + capture hooks in
+ * `engine/mission/mission-results-capture.ts`); these are the renderer-
+ * facing reads for the Mission History view and the post-mission summary
+ * card. Both queries are PER-WALLET — there is no "list every wallet's
+ * missions" read.
+ *
+ * Naming: "mission result (ETH)", never "performance" — the number is an
+ * honest ETH-denominated PnL record, not a guarantee of future results.
+ * `stopReason` is the raw engine `StopReason` (mirrors
+ * `src/vex-agent/engine/types.ts`); mapping it to a display outcome (e.g. a
+ * reached time-box is not a failure) is a pure function in the renderer
+ * model, never in this schema or in SQL.
+ */
+
+import { z } from "zod";
+
+const MAX_RESULTS_LIMIT = 100;
+const DEFAULT_RESULTS_LIMIT = 50;
+
+/** Mirrors `mission_results.outcome` (migration 041) — the RAW run-level outcome. */
+export const missionResultOutcomeSchema = z.enum([
+  "running",
+  "completed",
+  "cancelled",
+  "failed",
+  "stopped",
+]);
+export type MissionResultOutcome = z.infer<typeof missionResultOutcomeSchema>;
+
+export const missionResultDtoSchema = z
+  .object({
+    missionRunId: z.string().min(1),
+    seqNo: z.number().int().positive(),
+    goalSnippet: z.string().nullable(),
+    startedAt: z.string().datetime({ offset: true }),
+    endedAt: z.string().datetime({ offset: true }).nullable(),
+    durationS: z.number().int().nullable(),
+    bankrollStartEth: z.number().nullable(),
+    bankrollEndEth: z.number().nullable(),
+    pnlEth: z.number().nullable(),
+    pnlPct: z.number().nullable(),
+    ethPriceUsdEnd: z.number().nullable(),
+    trades: z.number().int().nonnegative(),
+    outcome: missionResultOutcomeSchema,
+    /** Raw engine StopReason (e.g. "goal_reached", "deadline_reached"), or null. */
+    stopReason: z.string().nullable(),
+    openPositionsCount: z.number().int().nonnegative(),
+  })
+  .strict();
+export type MissionResultDto = z.infer<typeof missionResultDtoSchema>;
+
+// ── listResults (per-wallet history, newest first) ──────────────
+
+export const missionListResultsInputSchema = z
+  .object({
+    walletAddress: z.string().min(1),
+    limit: z.number().int().min(1).max(MAX_RESULTS_LIMIT).optional(),
+  })
+  .strict();
+export type MissionListResultsInput = z.infer<typeof missionListResultsInputSchema>;
+
+export const missionListResultsResultSchema = z.array(missionResultDtoSchema);
+export type MissionListResultsResult = z.infer<typeof missionListResultsResultSchema>;
+
+export const DEFAULT_MISSION_RESULTS_LIMIT = DEFAULT_RESULTS_LIMIT;
+
+// ── getResultForRun (single run, e.g. the post-mission summary card) ────
+
+export const missionGetResultForRunInputSchema = z
+  .object({
+    missionRunId: z.string().min(1),
+    walletAddress: z.string().min(1),
+  })
+  .strict();
+export type MissionGetResultForRunInput = z.infer<typeof missionGetResultForRunInputSchema>;
+
+export const missionGetResultForRunResultSchema = missionResultDtoSchema.nullable();
+export type MissionGetResultForRunResult = z.infer<typeof missionGetResultForRunResultSchema>;

--- a/vex-app/src/shared/schemas/mission/transcript.ts
+++ b/vex-app/src/shared/schemas/mission/transcript.ts
@@ -58,6 +58,19 @@ export const missionRenewResultSchema = z.discriminatedUnion("outcome", [
       runStatus: z.string(),
     })
     .strict(),
+  /**
+   * The session already holds an un-started (`draft`/`ready`) mission.
+   * Closes the duplicate-draft-storm race transactionally (WP-D): the
+   * engine checks this INSIDE the same session-locked transaction as the
+   * clone, so two renews racing before the first commits cannot both
+   * succeed — the renderer/resolver-level guard alone was not sufficient.
+   */
+  z
+    .object({
+      outcome: z.literal("session_has_pending_draft"),
+      missionId: z.string(),
+    })
+    .strict(),
 ]);
 export type MissionRenewResult = z.infer<typeof missionRenewResultSchema>;
 

--- a/vex-app/src/shared/schemas/portfolio-moves.ts
+++ b/vex-app/src/shared/schemas/portfolio-moves.ts
@@ -26,6 +26,7 @@
  */
 
 import { z } from "zod";
+import { TOKEN_SYMBOL_MAX_LENGTH } from "../token-symbol-sanitizer.js";
 
 /**
  * Fixed server-side row cap. Shared by BOTH the SQL `LIMIT` and the DTO
@@ -34,6 +35,14 @@ import { z } from "zod";
  * validation). The renderer displays its own, smaller window by slicing.
  */
 export const MOVES_MAX = 50;
+
+/**
+ * Maximum display-symbol length extracted from a capture item. Re-exports
+ * the shared sanitizer's bound so the SQL `LEFT(...)` clamp, the JS-side
+ * `sanitizeTokenSymbol` check, and this IPC schema's `.max(...)` can never
+ * drift apart.
+ */
+export const MOVE_TOKEN_SYMBOL_MAX = TOKEN_SYMBOL_MAX_LENGTH;
 
 /**
  * IPC input for `vex.portfolio.listMoves`. `.strict()` rejects any extra key;
@@ -63,6 +72,14 @@ export type MovesReadInput = z.infer<typeof movesReadInputSchema>;
  *                      tolerance even though the DDL is NOT NULL.
  *  - `inputToken` / `inputAmount` / `outputToken` / `outputAmount` — the swap
  *                      legs as the engine recorded them (all nullable).
+ *  - `inputTokenSymbol` / `outputTokenSymbol` — bounded, display-only symbols
+ *                      recovered from the activity row's exact capture item
+ *                      (`protocol_capture_items.trade_capture`); nullable for
+ *                      historical/incomplete captures. UNTRUSTED: any on-chain
+ *                      token can self-declare this metadata, so the renderer
+ *                      must never let it override `inputToken`/`outputToken`
+ *                      identity or claim a brand icon without independent
+ *                      corroboration — see `token-symbol-sanitizer.ts`.
  *  - `valueUsd`      — notional USD; `null` when the engine could not price it.
  *  - `captureStatus` — the trade-capture lifecycle status string (tolerant).
  *  - `instrumentKey` — opaque instrument identifier; `null` when absent.
@@ -89,8 +106,10 @@ export const moveItemSchema = z
     productType: z.string().nullable(),
     venue: z.string().nullable(),
     inputToken: z.string().nullable(),
+    inputTokenSymbol: z.string().min(1).max(MOVE_TOKEN_SYMBOL_MAX).nullable(),
     inputAmount: z.string().nullable(),
     outputToken: z.string().nullable(),
+    outputTokenSymbol: z.string().min(1).max(MOVE_TOKEN_SYMBOL_MAX).nullable(),
     outputAmount: z.string().nullable(),
     valueUsd: z.number().nullable(),
     captureStatus: z.string().nullable(),

--- a/vex-app/src/shared/schemas/runtime.ts
+++ b/vex-app/src/shared/schemas/runtime.ts
@@ -90,6 +90,22 @@ export const runtimeRequestPauseResultSchema = z.discriminatedUnion("outcome", [
       status: missionRunStatusSchema,
     })
     .strict(),
+  /**
+   * `status === 'running'` but the lease is NOT active — no runner is
+   * observing, so enqueueing `pause_after_step` would be unobservable (it
+   * would sit pending forever, same bug class as issue #12's stop dead-end).
+   * The run is effectively already parked/idle; the safe next actions are
+   * Resume/Retry (reclaim) or Stop (end).
+   *
+   * IPC-LEVEL CONTRACT, no renderer consumer yet: `runtime.requestPause` has
+   * no call-site in the renderer today (`useRequestPause` is defined but
+   * unused, and there is no Pause control in the UI). Like the sibling
+   * `already_paused` outcome, this is a total-classification result the
+   * handler must return; when a Pause control is added, map it to a neutral
+   * "run is already parked — nothing to pause" notice, NOT an error. This
+   * comment intentionally does NOT claim any current UI mapping.
+   */
+  z.object({ outcome: z.literal("already_parked") }).strict(),
 ]);
 export type RuntimeRequestPauseResult = z.infer<typeof runtimeRequestPauseResultSchema>;
 

--- a/vex-app/src/shared/token-symbol-sanitizer.ts
+++ b/vex-app/src/shared/token-symbol-sanitizer.ts
@@ -1,0 +1,57 @@
+/**
+ * Token symbol sanitizer — the trust boundary for display-only token labels
+ * sourced from provider/capture data (moves-db trade-capture JSON, portfolio
+ * balance rows). These strings are attacker-influenceable: any on-chain
+ * token can self-declare arbitrary metadata, including a symbol that
+ * impersonates a well-known asset ("SOL", "USDC", …). Every captured/provider
+ * symbol MUST pass through `sanitizeTokenSymbol` before it is used as
+ * display text or handed to a symbol-keyed icon lookup (e.g. `TokenIcon`).
+ *
+ * Pure, dependency-free (no main/renderer/electron imports) so BOTH the main
+ * process (moves-db.ts, extracting from capture JSON) and the untrusted
+ * renderer (MovesBlock.tsx, PositionChains.tsx, rendering provider-supplied
+ * symbols) consume one sanitizer and can never drift.
+ *
+ * Strategy: allowlist, not blocklist. Real token tickers are short ASCII
+ * strings. Restricting to `[A-Za-z0-9._$-]` (starting with an alphanumeric)
+ * rejects, in one pass and WITHOUT a Unicode confusables database:
+ *   - control characters (the original narrower `moves-db` regex covered
+ *     only this class);
+ *   - bidi control characters (RLO/LRO/embeddings/isolates, U+061C ALM);
+ *   - zero-width characters (ZWSP/ZWNJ/ZWJ, BOM/ZWNBSP, word joiner);
+ *   - Unicode confusables (Cyrillic/Greek/other lookalike glyphs) — none of
+ *     them are ASCII, so none pass the allowlist.
+ * Surrounding whitespace is trimmed before the check so legitimate captures
+ * like `"  SOL  "` still resolve; internal whitespace/control content is
+ * rejected outright rather than stripped, so a partially-hostile string
+ * never silently degrades into a look-alike survivor.
+ */
+
+/** Shared bound: capture-item/provider symbols are extracted length-bounded
+ * at 64 chars server-side (moves-db SQL `LEFT(...)`) and validated again here
+ * and at the IPC schema boundary — all three sites must agree on one number. */
+export const TOKEN_SYMBOL_MAX_LENGTH = 64;
+
+const SAFE_TOKEN_SYMBOL = /^[A-Za-z0-9][A-Za-z0-9._$-]*$/;
+
+// Strip ONLY ASCII surrounding whitespace. Deliberately NOT
+// `String.prototype.trim`, which also removes exotic Unicode whitespace —
+// crucially U+FEFF (BOM/zero-width no-break space) — and would silently
+// let a spoofing character slip past the allowlist by trimming it away.
+const ASCII_EDGE_WHITESPACE = /^[ \t\r\n]+|[ \t\r\n]+$/g;
+
+/**
+ * Returns the trimmed symbol when it is a non-empty, length-bounded, ASCII
+ * allowlisted string; `null` otherwise (wrong type, empty, over-length, or
+ * containing any character outside the allowlist — including control,
+ * bidi-control, zero-width, and Unicode-confusable characters anywhere in
+ * the value).
+ */
+export function sanitizeTokenSymbol(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.replace(ASCII_EDGE_WHITESPACE, "");
+  if (trimmed.length === 0 || trimmed.length > TOKEN_SYMBOL_MAX_LENGTH) {
+    return null;
+  }
+  return SAFE_TOKEN_SYMBOL.test(trimmed) ? trimmed : null;
+}

--- a/vex-app/src/shared/types/bridge/agent/mission.ts
+++ b/vex-app/src/shared/types/bridge/agent/mission.ts
@@ -10,6 +10,10 @@ import type {
   MissionGetDraftResult,
   MissionGetRenewableSourceInput,
   MissionGetRenewableSourceResult,
+  MissionGetResultForRunInput,
+  MissionGetResultForRunResult,
+  MissionListResultsInput,
+  MissionListResultsResult,
   MissionRecoverInput,
   MissionRecoverResult,
   MissionRenewInput,
@@ -74,4 +78,12 @@ export interface MissionBridge {
   readonly setAutoRetry: (
     input: MissionSetAutoRetryInput,
   ) => Promise<Result<MissionSetAutoRetryResult>>;
+  /** Per-wallet mission results ledger history, newest first (WP-J). */
+  readonly listResults: (
+    input: MissionListResultsInput,
+  ) => Promise<Result<MissionListResultsResult>>;
+  /** Single-run ledger read, e.g. the post-mission summary card (WP-J). */
+  readonly getResultForRun: (
+    input: MissionGetResultForRunInput,
+  ) => Promise<Result<MissionGetResultForRunResult>>;
 }


### PR DESCRIPTION
## Summary

Remediation wave resolving the post-0.1.2 issue/PR queue. Five work packages, each
adversarially reviewed per-worktree before fusion:

- **Provider-outcome honesty** — relay.bridge fails honestly on terminal failure/refund and
  unverifiable status (fail-closed pre-broadcast for untrackable quotes); khalani.bridge
  polls to terminal state (was pending-forever); polymarket buy/sell/bulk-cancels report
  venue rejections; uniswap/kyberswap record the economic trade side.
  (refs #27, #28 by @mandatedisrael; #29 by @Nishant-Adhikari)
- **Docker self-heal** — non-destructive recreate on both stale bind-mount paths; the
  post-setup contact-support dead-end is gone. (ref #26 by @ellygeronline-lab)
- **Runtime dispatch contracts** — dead-lease running runs can be stopped/resumed/retried;
  renew is transactionally idempotent. (refs #12, #15 by @Nishant-Adhikari)
- **Wallet-send approval handoff** — approval card appears immediately after prepare;
  synthetic confirm is provenance-stamped; plus honest incomplete-turn status.
  (refs #20, #24 by @alexastro01)
- **Mission time-box + results ledger** — hard deadline frozen into the run snapshot,
  neutral countdown, per-wallet ETH ledger with Mission History (migration 041).
  (refs #23, #22 by @Nishant-Adhikari)
- **Trusted token labels** — brand name/logo only via known mint address; Unicode-safe
  symbol sanitizer; welcome-screen wallet panel. (ref #18 by @alexastro01)

## Verification

Root: tsc clean; 7091 passed / 7 skipped / 1 failed (pre-existing on main, unrelated).
vex-app: 3058/3058; lint + type-ratchet + process-boundaries green.
Each package additionally verified in isolation (14 adversarial review rounds).