### PR TITLE
fix(hypervexing): chart never rendered on workspace entry

### DIFF
--- a/vex-app/src/renderer/features/appShell/book/HyperliquidPositionChart.tsx
+++ b/vex-app/src/renderer/features/appShell/book/HyperliquidPositionChart.tsx
@@ -324,8 +324,25 @@ export function HyperliquidPositionChart({
     }
   }, [overlayKey]);
 
-  if (state === "loading") return <p className="mt-2 text-[10px] text-[var(--vex-text-3)]">Loading chart…</p>;
-  if (state === "error") return <p className="mt-2 text-[10px] text-[var(--vex-warn-text)]">Chart unavailable.</p>;
-  if (state === "empty") return <p className="mt-2 text-[10px] text-[var(--vex-text-3)]">No candle history yet.</p>;
-  return <div ref={host} aria-label={`${coin} price chart`} className={fill ? "h-full min-h-[220px] w-full" : "mt-2 h-[180px] w-full"} />;
+  // The host must stay mounted across every state so effect (a) — which owns
+  // the chart for the lifetime of this component and runs only once — can
+  // find it on the FIRST render. On real entry the candles query is still
+  // "loading" on that first render; a host that only mounts once state
+  // becomes "ready" never gets a chart created at all (regression: blank
+  // chart pane on Hypervexing entry). The status text overlays the host
+  // instead of replacing it.
+  return (
+    <div className={fill ? "relative h-full min-h-[220px] w-full" : "relative mt-2 h-[180px] w-full"}>
+      <div ref={host} aria-label={`${coin} price chart`} className="h-full w-full" />
+      {state === "loading" ? (
+        <p className="absolute inset-0 flex items-center justify-center text-[10px] text-[var(--vex-text-3)]">Loading chart…</p>
+      ) : null}
+      {state === "error" ? (
+        <p className="absolute inset-0 flex items-center justify-center text-[10px] text-[var(--vex-warn-text)]">Chart unavailable.</p>
+      ) : null}
+      {state === "empty" ? (
+        <p className="absolute inset-0 flex items-center justify-center text-[10px] text-[var(--vex-text-3)]">No candle history yet.</p>
+      ) : null}
+    </div>
+  );
 }

--- a/vex-app/src/renderer/features/appShell/book/__tests__/HyperliquidPositionChart.viewport.test.tsx
+++ b/vex-app/src/renderer/features/appShell/book/__tests__/HyperliquidPositionChart.viewport.test.tsx
@@ -178,4 +178,18 @@ describe("HyperliquidPositionChart W15 lifecycle", () => {
     expect(spies.fitContent).not.toHaveBeenCalled();
     expect(spies.setVisibleRange).not.toHaveBeenCalled();
   });
+
+  // Regression: on real entry into Hypervexing the candles query is still
+  // "loading" on the very first render, so the chart host must be mounted
+  // (and the chart created) BEFORE the first candle snapshot arrives — a
+  // chart born only in the "ready" render never gets created at all.
+  it("creates the chart while candles are still loading, then renders the first snapshot on ready", () => {
+    const view = render(chart({ state: "loading", candles: null }));
+    expect(spies.createChart).toHaveBeenCalledTimes(1);
+    expect(spies.candleSetData).not.toHaveBeenCalled();
+    view.rerender(chart({ state: "ready", candles: candles() }));
+    expect(spies.createChart).toHaveBeenCalledTimes(1);
+    expect(spies.candleSetData).toHaveBeenCalledTimes(1);
+    expect(spies.fitContent).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Regression from the stable-chart change (39a86d05): the once-only chart-creation effect ran before the host div existed (render gated it behind state==="ready", first render is "loading"), so the canvas was never created and the pane stayed permanently blank. Host is now always mounted with status copy overlaying it. Regression test pins the loading→ready path (fails pre-fix). 70/70 book/workspace tests, lint + boundaries green; verified by adversarial review.