### PR TITLE
fix(hypervexing): per-asset price scale + stable funding stat layout

### DIFF
--- a/vex-app/src/renderer/features/appShell/book/HyperliquidPositionChart.tsx
+++ b/vex-app/src/renderer/features/appShell/book/HyperliquidPositionChart.tsx
@@ -51,6 +51,8 @@ interface PriceLineSeries {
     readonly axisLabelVisible: boolean;
   }): PriceLineHandle;
   removePriceLine(line: PriceLineHandle): void;
+  applyOptions(options: { readonly priceFormat: PriceFormat }): void;
+  priceScale(): { applyOptions(options: { readonly autoScale: boolean }): void };
 }
 
 interface VolumeSeries {
@@ -94,9 +96,32 @@ interface PriceLineState {
 
 const LIVE_EDGE_EPSILON = 0.5;
 
+type PriceFormat = { readonly type: "price"; readonly precision: number; readonly minMove: number };
+
 function renderNumber(value: string): number | null {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : null;
+}
+
+/**
+ * A $64k asset and a $0.19 asset cannot share the chart's default 2-decimal
+ * price format: at 2 decimals a sub-dollar coin's candles round to a handful
+ * of distinct values and the price axis has nothing meaningful to scale
+ * against. Venue candle strings already carry the asset's native decimal
+ * precision (e.g. "0.19310"), so the widest decimal count seen in the
+ * snapshot is the venue-provided precision — no separate market/szDecimals
+ * lookup needed. Never go BELOW 2 decimals so ordinary assets keep their
+ * existing look; cap at 8 (the venue's spot price-decimal ceiling) so a
+ * malformed string cannot blow up tick rendering.
+ */
+function derivePriceFormat(snapshot: readonly HyperliquidCandleDto[]): PriceFormat {
+  let decimals = 0;
+  for (const candle of snapshot) {
+    const dot = candle.close.indexOf(".");
+    if (dot >= 0) decimals = Math.max(decimals, candle.close.length - dot - 1);
+  }
+  const precision = Math.min(Math.max(decimals, 2), 8);
+  return { type: "price", precision, minMove: 10 ** -precision };
 }
 
 /** A semantic revision deliberately excludes `fetchedAt`. */
@@ -264,7 +289,15 @@ export function HyperliquidPositionChart({
     series.setData(nextCandles);
     volume.setData(nextVolume);
     if (loadedMarket.current !== key) {
+      // A new market is a new chart context, not a data update: the
+      // previous asset's price scale must not leak into this one. Re-arm
+      // autoScale and re-derive precision from THIS asset's own candles
+      // before fitting, so a small-price asset never inherits a large-price
+      // asset's stale range (regression: CASHCAT rendering with a -200..500
+      // axis and a flat 0.19 candle line after viewing BTC/ETH).
       savedTimeRange.current = null;
+      series.applyOptions({ priceFormat: derivePriceFormat(snapshot) });
+      series.priceScale().applyOptions({ autoScale: true });
       instance.timeScale().fitContent();
       loadedMarket.current = key;
     } else if (atLiveEdge) {

--- a/vex-app/src/renderer/features/appShell/book/__tests__/HyperliquidPositionChart.viewport.test.tsx
+++ b/vex-app/src/renderer/features/appShell/book/__tests__/HyperliquidPositionChart.viewport.test.tsx
@@ -21,6 +21,8 @@ const spies = vi.hoisted(() => ({
   volumeUpdate: vi.fn(),
   createPriceLine: vi.fn(),
   removePriceLine: vi.fn(),
+  seriesApplyOptions: vi.fn(),
+  seriesAutoScaleApplyOptions: vi.fn(),
 }));
 
 let rangeCallback: ((range: { from: number; to: number } | null) => void) | null = null;
@@ -71,6 +73,8 @@ beforeEach(() => {
     update: spies.candleUpdate,
     createPriceLine: spies.createPriceLine,
     removePriceLine: spies.removePriceLine,
+    applyOptions: spies.seriesApplyOptions,
+    priceScale: () => ({ applyOptions: spies.seriesAutoScaleApplyOptions }),
   };
   const volumeSeries = {
     setData: spies.volumeSetData,
@@ -166,6 +170,38 @@ describe("HyperliquidPositionChart W15 lifecycle", () => {
     view.rerender(chart({ coin: "ETH", interval: "5m", candles: candles({ close: "2" }) }));
     expect(spies.candleSetData).toHaveBeenCalledTimes(1);
     expect(spies.fitContent).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: switching from a large-price asset (BTC ~64k) to a
+  // small-price asset (e.g. CASHCAT ~0.19) previously left the price scale
+  // pinned to the old asset's range and the default 2-decimal price format,
+  // so the new candles rendered as a flat line under a grid that had nothing
+  // to do with the asset on screen.
+  it("re-arms autoscale and adapts price precision to the new asset on a coin switch", () => {
+    const view = render(chart({ candles: candles({ close: "64123.50" }) }));
+    spies.seriesApplyOptions.mockClear(); spies.seriesAutoScaleApplyOptions.mockClear();
+    view.rerender(chart({ coin: "CASHCAT", candles: candles({ close: "0.19310" }) }));
+    expect(spies.seriesApplyOptions).toHaveBeenCalledWith({
+      priceFormat: { type: "price", precision: 5, minMove: 0.00001 },
+    });
+    expect(spies.seriesAutoScaleApplyOptions).toHaveBeenCalledWith({ autoScale: true });
+  });
+
+  it("keeps a floor of 2-decimal precision for an ordinary integer-priced asset", () => {
+    const view = render(chart({ candles: candles({ close: "1" }) }));
+    spies.seriesApplyOptions.mockClear();
+    view.rerender(chart({ coin: "ETH", candles: candles({ close: "1800" }) }));
+    expect(spies.seriesApplyOptions).toHaveBeenCalledWith({
+      priceFormat: { type: "price", precision: 2, minMove: 0.01 },
+    });
+  });
+
+  it("does not re-touch the price format or autoscale for a same-market data update", () => {
+    const view = render(chart());
+    spies.seriesApplyOptions.mockClear(); spies.seriesAutoScaleApplyOptions.mockClear();
+    view.rerender(chart({ candles: candles({ close: "1.6" }) }));
+    expect(spies.seriesApplyOptions).not.toHaveBeenCalled();
+    expect(spies.seriesAutoScaleApplyOptions).not.toHaveBeenCalled();
   });
 
   it("resizes without recreating the chart or changing the saved time range", () => {

--- a/vex-app/src/renderer/features/appShell/workspace/HypervexingChartPane.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/HypervexingChartPane.tsx
@@ -110,13 +110,23 @@ function HeaderStat({
   label,
   value,
   toneClass,
+  caption,
 }: {
   readonly label: string;
   readonly value: string;
   readonly toneClass?: string;
+  /** Renders above `label`, e.g. a ticking countdown — kept fixed-width
+   * (`5ch` fits "MM:SS") so a per-second tick never changes the stat's
+   * footprint or reflows the header. */
+  readonly caption?: string;
 }): JSX.Element {
   return (
     <span className="flex flex-col leading-tight">
+      {caption !== undefined ? (
+        <span className="inline-block w-[5ch] font-mono text-[8px] tabular-nums text-[var(--vex-text-3)]">
+          {caption}
+        </span>
+      ) : null}
       <span className="font-mono text-[8px] uppercase tracking-[0.10em] text-[var(--vex-text-3)]">
         {label}
       </span>
@@ -283,7 +293,7 @@ function PositionEconomicsStrip({
 }
 
 /** Venue cockpit strip: 24h Δ · 24h Vol · OI · Funding + hourly countdown. */
-function MarketStatsStrip({
+export function MarketStatsStrip({
   market,
 }: {
   readonly market: HyperliquidMarketDto;
@@ -292,7 +302,14 @@ function MarketStatsStrip({
   const change = market.change24hPct === null ? null : Number(market.change24hPct);
   const funding = market.fundingRate8hPct === null ? null : Number(market.fundingRate8hPct);
   return (
-    <div className="order-last grid w-full grid-cols-5 gap-x-2 border-t border-[var(--vex-line)] pt-1.5 xl:order-none xl:w-auto xl:border-l xl:border-t-0 xl:pl-2 xl:pt-0">
+    // Always its own full-width row, ordered after every other header item:
+    // `xl:` viewport breakpoints do not track this PANE's actual width in a
+    // multi-pane layout, so a purely responsive (viewport-based) inline mode
+    // let the timeframe selector and this strip compete for the same row at
+    // panes narrower than the viewport suggests. Reserving a dedicated row
+    // makes the header's shape independent of pane width (regression: the
+    // selector overlapping the funding block at narrower panes).
+    <div className="order-last grid w-full grid-cols-5 gap-x-2 border-t border-[var(--vex-line)] pt-1.5">
       <HeaderStat label="Mark" value={market.markPx} toneClass="text-[var(--vex-text)]" />
       <HeaderStat
         label="24h"
@@ -312,7 +329,8 @@ function MarketStatsStrip({
       <HeaderStat label="24h Vol" value={compactUsd(market.dayNtlVlmUsd)} />
       <HeaderStat label="OI" value={compactUsd(market.openInterestUsd)} />
       <HeaderStat
-        label={`Funding · ${countdown}`}
+        label="Funding"
+        caption={countdown}
         value={
           funding === null || !Number.isFinite(funding)
             ? "—"

--- a/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingChartPane.stats.test.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingChartPane.stats.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Regression pins for the funding header stat (owner-reported: ticking
+ * countdown reflowed the header and the timeframe selector could overlap
+ * the funding block at narrower pane widths).
+ */
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HyperliquidMarketDto } from "@shared/schemas/hyperliquid.js";
+import { MarketStatsStrip } from "../HypervexingChartPane.js";
+
+function market(overrides: Partial<HyperliquidMarketDto> = {}): HyperliquidMarketDto {
+  return {
+    coin: "CASHCAT",
+    maxLeverage: 10,
+    markPx: "0.1931",
+    change24hPct: "1.23",
+    openInterestUsd: "1000000",
+    fundingRate8hPct: "0.0001",
+    dayNtlVlmUsd: "500000",
+    szDecimals: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-14T00:00:01.000Z"));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("MarketStatsStrip funding stat", () => {
+  it("stacks the countdown above the FUNDING label instead of inline", () => {
+    render(<MarketStatsStrip market={market()} />);
+    const label = screen.getByText("Funding");
+    const countdown = screen.getByText("59:59");
+    // Countdown renders as its own element ABOVE (preceding in DOM order)
+    // the "Funding" label — never concatenated into one "Funding · 59:59"
+    // string.
+    expect(countdown).not.toBe(label);
+    expect(countdown.compareDocumentPosition(label) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("gives the countdown a fixed width so a per-second tick cannot change its footprint", () => {
+    render(<MarketStatsStrip market={market()} />);
+    const countdown = screen.getByText("59:59");
+    const classNameBefore = countdown.className;
+    expect(classNameBefore).toContain("w-[5ch]");
+    expect(classNameBefore).toContain("tabular-nums");
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    const tickedCountdown = screen.getByText("59:57");
+    expect(tickedCountdown.className).toBe(classNameBefore);
+  });
+
+  it("reserves its own full-width row unconditionally, so the timeframe selector can never share a row with it at any pane width", () => {
+    const { container } = render(<MarketStatsStrip market={market()} />);
+    const strip = container.firstElementChild;
+    expect(strip).not.toBeNull();
+    // No viewport-breakpoint (`xl:`) classes: the row's width/order must not
+    // depend on the browser viewport, since a chart pane's real width can be
+    // far narrower than the viewport in a multi-pane layout.
+    expect(strip?.className).toMatch(/\bw-full\b/);
+    expect(strip?.className).toMatch(/\border-last\b/);
+    expect(strip?.className).not.toMatch(/xl:/);
+  });
+});


### PR DESCRIPTION
Market switch resets the preserved viewport, re-arms autoScale and derives axis precision from the asset's own candles (CASHCAT -200..500 regression); funding countdown stacked above its label at fixed width and the stats strip owns a dedicated row so the timeframe selector can never overlap and ticking never resizes the chart. 15/15 targeted tests + boundaries green.