### PR TITLE
fix(hypervexing): mission contract rail inside the workspace

### DIFF
--- a/vex-app/src/renderer/features/appShell/SessionContext.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionContext.tsx
@@ -12,7 +12,7 @@
  * desk rule stays a single quiet title line.
  */
 
-import type { JSX } from "react";
+import type { JSX, ReactNode } from "react";
 import type { SessionListItem } from "@shared/schemas/sessions.js";
 import { DotmHex3 } from "../../components/ui/dotm-hex-3.js";
 import { Stamp } from "./SessionRows/Stamp.js";
@@ -23,6 +23,14 @@ export interface SessionContextProps {
   readonly activeSessionId: string | null;
   readonly loading: boolean;
   readonly error: string | null;
+  /**
+   * Optional content-agnostic slot rendered at the trailing (right) edge of the
+   * active-session title row. Content-agnostic on purpose: the header stays
+   * unaware of what it hosts, so a caller can attach context (e.g. the mission
+   * badge cluster in the Hypervexing dock) without this shared component gaining
+   * a second reason to change. Absent by default → the shell row is unchanged.
+   */
+  readonly trailing?: ReactNode;
 }
 
 export function SessionContext({
@@ -30,6 +38,7 @@ export function SessionContext({
   activeSessionId,
   loading,
   error,
+  trailing,
 }: SessionContextProps): JSX.Element | null {
   if (loading) {
     return (
@@ -79,6 +88,11 @@ export function SessionContext({
         {/* Mission identity now reads from the MISSION RAIL's Mission badge —
             the small header "mission" stamp was removed to avoid double-
             signalling. The `restricted` exception stamp stays. */}
+        {/* Trailing slot — right-edge context host (see prop doc). The title
+            keeps `flex-1 min-w-0 truncate` so it yields space to the slot and
+            still truncates; a slot whose content renders null adds no box, so
+            the row reserves no ghost space when empty. */}
+        {trailing}
       </div>
     );
   }

--- a/vex-app/src/renderer/features/appShell/SessionPanel.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionPanel.tsx
@@ -31,7 +31,7 @@
  */
 
 import { useMemo } from "react";
-import type { JSX } from "react";
+import type { JSX, ReactNode } from "react";
 import type { SessionListItem } from "@shared/schemas/sessions.js";
 import {
   flattenTranscriptPages,
@@ -52,7 +52,19 @@ import { SessionContext } from "./SessionContext.js";
 import { SessionTranscript } from "./SessionTranscript.js";
 import { SessionWelcomeHero } from "./SessionWelcomeHero.js";
 
-export function SessionPanel(): JSX.Element {
+export interface SessionPanelProps {
+  /**
+   * Optional content-agnostic slot forwarded to the active-session header's
+   * trailing edge (see `SessionContext.trailing`). The normal shell mounts
+   * `<SessionPanel />` with no slot, so its header is unchanged; the Hypervexing
+   * dock passes the mission badge cluster here so the panel stays mode-unaware.
+   */
+  readonly headerTrailing?: ReactNode;
+}
+
+export function SessionPanel({
+  headerTrailing,
+}: SessionPanelProps = {}): JSX.Element {
   const activeSessionId = useUiStore((s) => s.activeSessionId);
   // In the Hypervexing dock the composer is ALWAYS bottom-pinned (user
   // decree): the welcome/idle stage's vertical centering never applies there.
@@ -174,6 +186,7 @@ export function SessionPanel(): JSX.Element {
                 activeSessionId={activeSessionId}
                 loading={detailQuery.isLoading}
                 error={detailError}
+                trailing={headerTrailing}
               />
               {/* The mission contract + action plan no longer render inline:
                   the two tall cards used to push MissionControls + the Accept

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionContext.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionContext.test.tsx
@@ -69,6 +69,27 @@ describe("SessionContext header (slice C)", () => {
     expect(screen.queryByText("restricted")).toBeNull();
   });
 
+  it("renders the trailing slot content inside the active-session header row", () => {
+    const { container } = renderCtx({
+      trailing: createElement("span", { "data-testid": "trailing-slot" }, "X"),
+    });
+    const header = container.querySelector('[data-vex-area="session-header"]');
+    expect(header).not.toBeNull();
+    // The slot content lives inside the title row, not floated elsewhere.
+    expect(header?.querySelector('[data-testid="trailing-slot"]')).not.toBeNull();
+  });
+
+  it("reserves no slot box when no trailing content is supplied", () => {
+    const { container } = renderCtx();
+    expect(
+      container.querySelector('[data-testid="trailing-slot"]'),
+    ).toBeNull();
+    // Header still renders normally with just title + stamp.
+    expect(
+      container.querySelector('[data-vex-area="session-header"]'),
+    ).not.toBeNull();
+  });
+
   it("does not render the header in the loading or not-found states", () => {
     const loading = renderCtx({ loading: true });
     expect(

--- a/vex-app/src/renderer/features/appShell/workspace/HypervexingCopilotDock.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/HypervexingCopilotDock.tsx
@@ -13,15 +13,30 @@
 
 import type { JSX } from "react";
 
+import { useUiStore } from "../../../stores/uiStore.js";
+import { MissionRail } from "../MissionRail.js";
 import { SessionPanel } from "../SessionPanel.js";
 
 export function HypervexingCopilotDock(): JSX.Element {
+  // Same activeSessionId the rest of the workspace reads. MissionRail self-gates
+  // to null for non-mission / plan-off sessions, so passing it always is safe.
+  const activeSessionId = useUiStore((s) => s.activeSessionId);
   return (
     <aside className="flex min-h-0 flex-1 flex-col" aria-label="Vex copilot">
       {/* No status header row: the whole dock belongs to the conversation.
-          The engine tape state stays visible in the normal shell only. */}
+          The engine tape state stays visible in the normal shell only.
+
+          The mission contract/plan badges — and the Accept & Start surface they
+          open — live in the normal shell's DESK RULE header, which this
+          workspace replaces. Without them a mission drafted inside the room
+          strands on the "contract not accepted" notice with no way to accept.
+          We surface the SAME `MissionRail` on the docked chat's title row via
+          SessionContext's content-agnostic `trailing` slot (no mode awareness
+          added to the shared panel/header). */}
       <div className="min-h-0 flex-1">
-        <SessionPanel />
+        <SessionPanel
+          headerTrailing={<MissionRail activeSessionId={activeSessionId} />}
+        />
       </div>
     </aside>
   );

--- a/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingCopilotDock.test.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingCopilotDock.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * HypervexingCopilotDock — the docked chat surface for the Hypervexing room.
+ *
+ * The room replaces the normal shell, which hosts the MISSION RAIL (the mission
+ * contract/plan badges that open the Accept & Start dialogs) in its DESK RULE
+ * header. Without surfacing that rail in the room, a mission drafted inside the
+ * workspace strands on the "contract not accepted" notice with no reachable
+ * Accept control. These tests pin that the dock feeds `MissionRail` into the
+ * docked panel's header slot and that the real rail mounts/self-gates + opens
+ * its contract dialog in the workspace context.
+ *
+ * SessionPanel is stubbed to a surface that renders its `headerTrailing` slot,
+ * so the dock→panel wiring and the REAL MissionRail behaviour are exercised
+ * without pulling in the panel's heavy live-sync hook tree. MissionRail's API
+ * hooks are mocked (no IPC) and its review modals are stubbed to open-markers,
+ * mirroring MissionRail.test.tsx. @hugeicons/react is mocked (ESM-heavy glyph).
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Result } from "@shared/ipc/result.js";
+import type {
+  MissionDraftDto,
+  MissionGetDiffResult,
+} from "@shared/schemas/mission.js";
+import type { PlanGetResult } from "@shared/schemas/session-plan.js";
+import type { SessionListItem } from "@shared/schemas/sessions.js";
+
+vi.mock("@hugeicons/react", () => ({ HugeiconsIcon: () => null }));
+
+// Stub the docked panel to a surface that renders whatever header slot it is
+// given — the dock's contract with SessionPanel is exactly `headerTrailing`.
+vi.mock("../../SessionPanel.js", () => ({
+  SessionPanel: ({ headerTrailing }: { headerTrailing?: ReactNode }) => (
+    <div data-testid="session-panel">{headerTrailing}</div>
+  ),
+}));
+
+const mockUseSession = vi.fn();
+const mockUseMissionDraft = vi.fn();
+const mockUseMissionDiff = vi.fn();
+const mockUseSessionPlan = vi.fn();
+const mockUseRenewableMissionSource = vi.fn();
+const mockUseRuntimeState = vi.fn();
+
+vi.mock("../../../../lib/api/sessions.js", () => ({
+  useSession: (...a: unknown[]) => mockUseSession(...a),
+  useSessionPlan: (...a: unknown[]) => mockUseSessionPlan(...a),
+}));
+vi.mock("../../../../lib/api/mission.js", () => ({
+  useMissionDraft: (...a: unknown[]) => mockUseMissionDraft(...a),
+  useMissionDiff: (...a: unknown[]) => mockUseMissionDiff(...a),
+  useRenewableMissionSource: (...a: unknown[]) =>
+    mockUseRenewableMissionSource(...a),
+}));
+vi.mock("../../../../lib/api/runtime.js", () => ({
+  useRuntimeState: (...a: unknown[]) => mockUseRuntimeState(...a),
+}));
+
+vi.mock("../../MissionContractModal.js", () => ({
+  MissionContractModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="mission-modal-open" /> : null,
+}));
+vi.mock("../../PlanDisplayModal.js", () => ({
+  PlanDisplayModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="plan-modal-open" /> : null,
+}));
+
+const SESSION = "00000000-0000-4000-8000-00000000dc01";
+const MISSION = "mission-1";
+const HASH = "a".repeat(64);
+
+let activeSessionId: string | null = SESSION;
+vi.mock("../../../../stores/uiStore.js", () => ({
+  useUiStore: (selector: (s: { activeSessionId: string | null }) => unknown) =>
+    selector({ activeSessionId }),
+}));
+
+const { HypervexingCopilotDock } = await import("../HypervexingCopilotDock.js");
+
+function ok<T>(data: T): Result<T> {
+  return { ok: true, data };
+}
+
+function sessionRow(over: Partial<SessionListItem> = {}): SessionListItem {
+  return {
+    id: SESSION,
+    mode: "agent",
+    permission: "restricted",
+    title: "hl",
+    initialGoal: null,
+    startedAt: "2026-05-26T10:00:00.000Z",
+    endedAt: null,
+    missionStatus: null,
+    pinnedAt: null,
+    ...over,
+  };
+}
+
+const READY_DRAFT = {
+  missionId: MISSION,
+  sessionId: SESSION,
+  status: "ready",
+  title: "Rebalance LP",
+  goal: "Move USDC.",
+  constraints: {},
+  successCriteria: [],
+  stopConditions: [],
+  riskProfile: "balanced",
+  allowedChains: [],
+  allowedProtocols: [],
+  allowedWallets: [],
+  createdAt: "2026-05-22T08:00:00.000Z",
+  updatedAt: "2026-05-22T09:00:00.000Z",
+  approvedAt: null,
+  acceptance: null,
+  renewedFromMissionId: null,
+} as unknown as MissionDraftDto;
+
+function diff(
+  over: Partial<Extract<MissionGetDiffResult, { outcome: "ready" }>> = {},
+) {
+  return {
+    outcome: "ready" as const,
+    missionId: MISSION,
+    sessionId: SESSION,
+    currentHash: HASH,
+    contractHashVersion: 1,
+    acceptedHash: null,
+    acceptedAt: null,
+    acceptedBy: null,
+    acceptedContractHashVersion: null,
+    isAccepted: false,
+    isDirty: false,
+    ...over,
+  };
+}
+
+function plan(over: Partial<PlanGetResult> = {}): PlanGetResult {
+  return {
+    enabled: false,
+    planMd: "",
+    accepted: false,
+    acceptedAt: null,
+    updatedAt: "2026-05-22T09:15:00.000Z",
+    ...over,
+  } as PlanGetResult;
+}
+
+function runtime(hasActiveRun = false) {
+  return ok({
+    sessionId: SESSION,
+    hasActiveRun,
+    missionRunId: null,
+    status: null,
+    stopReason: null,
+    lastCheckpointAt: null,
+    startedAt: null,
+    iterationCount: null,
+    leaseActive: false,
+    leaseExpiresAt: null,
+    pendingControlKind: null,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  activeSessionId = SESSION;
+  mockUseSession.mockReturnValue({ data: ok(sessionRow()) });
+  mockUseMissionDraft.mockReturnValue({ data: ok(null) });
+  mockUseMissionDiff.mockReturnValue({ data: undefined });
+  mockUseSessionPlan.mockReturnValue({ data: ok(plan()) });
+  mockUseRuntimeState.mockReturnValue({ data: runtime(false) });
+  mockUseRenewableMissionSource.mockReturnValue({ data: ok(null) });
+});
+
+describe("HypervexingCopilotDock mission rail", () => {
+  it("always mounts the docked chat panel", () => {
+    render(<HypervexingCopilotDock />);
+    expect(screen.getByTestId("session-panel")).not.toBeNull();
+  });
+
+  it("surfaces MissionRail in the panel header slot for an unaccepted mission contract", () => {
+    // A drafted-but-unaccepted mission (the bug's exact state): the rail must
+    // appear so its Accept control is reachable inside the room.
+    mockUseSession.mockReturnValue({ data: ok(sessionRow({ mode: "mission" })) });
+    mockUseMissionDraft.mockReturnValue({ data: ok(READY_DRAFT) });
+    mockUseMissionDiff.mockReturnValue({ data: ok(diff({ isAccepted: false })) });
+
+    const { container } = render(<HypervexingCopilotDock />);
+
+    const railInSlot = container
+      .querySelector('[data-testid="session-panel"]')
+      ?.querySelector('[data-vex-area="mission-rail"]');
+    expect(railInSlot).not.toBeNull();
+    expect(screen.getByText("Mission")).not.toBeNull();
+  });
+
+  it("self-gates to null for a plain agent session with plan-mode off (no ghost rail)", () => {
+    mockUseSession.mockReturnValue({ data: ok(sessionRow({ mode: "agent" })) });
+    mockUseSessionPlan.mockReturnValue({ data: ok(plan({ enabled: false })) });
+
+    const { container } = render(<HypervexingCopilotDock />);
+
+    expect(
+      container.querySelector('[data-vex-area="mission-rail"]'),
+    ).toBeNull();
+    // The chat panel is unaffected.
+    expect(screen.getByTestId("session-panel")).not.toBeNull();
+  });
+
+  it("opens the mission contract dialog from the badge inside the room", () => {
+    mockUseSession.mockReturnValue({ data: ok(sessionRow({ mode: "mission" })) });
+    mockUseMissionDraft.mockReturnValue({ data: ok(READY_DRAFT) });
+    mockUseMissionDiff.mockReturnValue({ data: ok(diff({ isAccepted: false })) });
+
+    render(<HypervexingCopilotDock />);
+
+    expect(screen.queryByTestId("mission-modal-open")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Mission/i }));
+    expect(screen.getByTestId("mission-modal-open")).not.toBeNull();
+  });
+
+  it("passes a null active session straight through (rail render-gates off)", () => {
+    activeSessionId = null;
+    mockUseSession.mockReturnValue({ data: undefined });
+
+    const { container } = render(<HypervexingCopilotDock />);
+
+    expect(
+      container.querySelector('[data-vex-area="mission-rail"]'),
+    ).toBeNull();
+    expect(screen.getByTestId("session-panel")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
MissionRail (the Accept/Start surface) rendered only in the normal shell's desk-rule header, which the workspace replaces — missions drafted in Hypervexing stranded unaccepted. The docked chat's session-title row now hosts the same MissionRail via a content-agnostic trailing slot on SessionContext (shell unchanged). 10/10 targeted tests + boundaries green.