### PR TITLE
fix(mission): close the contract modal on successful accept

### DIFF
--- a/vex-app/src/renderer/features/appShell/MissionContractModal.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionContractModal.tsx
@@ -118,17 +118,29 @@ export function MissionContractModal({
   }, [draft, diff]);
 
   const onAccept = (hash: string): void => {
-    accept.mutate({
-      sessionId,
-      missionId: draft?.missionId ?? "",
-      contractHash: hash,
-      // Unified accept (Approach A): echo the reviewed plan's `updatedAt` as a
-      // stale guard ONLY when an enabled, non-empty, unaccepted plan exists.
-      // Plan-mode off / no plan → omitted → default single-accept payload.
-      ...(planGate.kind === "ready"
-        ? { planUpdatedAt: planGate.planUpdatedAt }
-        : {}),
-    });
+    accept.mutate(
+      {
+        sessionId,
+        missionId: draft?.missionId ?? "",
+        contractHash: hash,
+        // Unified accept (Approach A): echo the reviewed plan's `updatedAt` as a
+        // stale guard ONLY when an enabled, non-empty, unaccepted plan exists.
+        // Plan-mode off / no plan → omitted → default single-accept payload.
+        ...(planGate.kind === "ready"
+          ? { planUpdatedAt: planGate.planUpdatedAt }
+          : {}),
+      },
+      {
+        // A successful accept closes the modal so the Start mission button it
+        // points at is actually reachable. Every non-`accepted` outcome (and
+        // any transport failure) keeps it open for the in-modal notice.
+        onSuccess: (result) => {
+          if (result.ok && result.data.outcome === "accepted") {
+            onOpenChange(false);
+          }
+        },
+      },
+    );
   };
 
   const acceptOutcome = readAcceptOutcome(accept.data);

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionContractModal.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionContractModal.test.tsx
@@ -132,13 +132,13 @@ function Wrapper(client: QueryClient) {
   };
 }
 
-function renderModal(): void {
+function renderModal(onOpenChange: (next: boolean) => void = () => {}): void {
   render(
     <MissionContractModal
       sessionId={SESSION}
       permission="full"
       open
-      onOpenChange={() => {}}
+      onOpenChange={onOpenChange}
     />,
     { wrapper: Wrapper(makeClient()) },
   );
@@ -175,6 +175,43 @@ describe("MissionContractModal", () => {
         contractHash: HASH,
       });
     });
+  });
+
+  it("closes the modal on a successful accept (Start mission is behind it)", async () => {
+    mockBridge.getDraft.mockResolvedValue({ ok: true, data: SAMPLE_DRAFT });
+    mockBridge.getDiff.mockResolvedValue({ ok: true, data: READY_DIFF });
+    mockBridge.acceptContract.mockResolvedValue({
+      ok: true,
+      data: { outcome: "accepted" },
+    });
+    const onOpenChange = vi.fn();
+    renderModal(onOpenChange);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /^Accept contract$/i }),
+    );
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("keeps the modal open on a non-accepted outcome (notice needs the surface)", async () => {
+    mockBridge.getDraft.mockResolvedValue({ ok: true, data: SAMPLE_DRAFT });
+    mockBridge.getDiff.mockResolvedValue({ ok: true, data: READY_DIFF });
+    mockBridge.acceptContract.mockResolvedValue({
+      ok: true,
+      data: { outcome: "hash_mismatch", providedHash: "a", currentHash: "b" },
+    });
+    const onOpenChange = vi.fn();
+    renderModal(onOpenChange);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /^Accept contract$/i }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/changed since you reviewed/i),
+      ).not.toBeNull();
+    });
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it("unified accept echoes the reviewed plan's updatedAt as planUpdatedAt", async () => {


### PR DESCRIPTION
## Problem
After clicking **Accept contract** in the mission contract modal, the modal stayed open in its "accepted" state — footer saying "Use the **Start mission** button to dispatch" while sitting on top of that exact button.

Contract Modal still persists even after the contract has been accepted
<img width="892" height="1042" alt="Screenshot 2026-07-14 at 8 26 51 PM" src="https://github.com/user-attachments/assets/cded7501-6cba-4404-bb1c-40c7d263173e" />


This creates an awkward dead end in the flow: the UI confirms the acceptance and points to the next action, but that action is hidden behind the modal itself. The only way forward is an extra manual dismiss (Esc / backdrop click) that nothing in the UI asks for, which makes a successful accept feel unresponsive right at the moment the mission is ready to launch.

## Fix
`MissionContractModal` now passes a per-call `onSuccess` to the accept mutation and calls `onOpenChange(false)` **only** when the engine returns `outcome: "accepted"` — accepting lands directly in front of the **Start mission** button, with no dead end in between.

All non-accepted paths intentionally keep the modal open, since their recovery notices render inside it: `plan_stale` (re-review banner + single plan refetch), `plan_missing`, `hash_mismatch`, `status_blocked`, `run_active`, and transport failures.

## Tests
- New: a successful accept calls `onOpenChange(false)`.
- New: a `hash_mismatch` outcome surfaces its notice and does **not** close the modal.
- All 11 tests in `MissionContractModal.test.tsx` pass; renderer typecheck unchanged (94 pre-existing baseline errors, none in this file).


The inline `MissionContractCard` shares the accept logic but isn't a dialog, so it needs no change.