### PR TITLE
feat(mission): discoverable review-&-accept bar for pending contracts

### DIFF
--- a/vex-app/src/renderer/features/appShell/MissionControls.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionControls.tsx
@@ -42,6 +42,7 @@ import {
   useMissionContinue,
   useMissionDiff,
   useMissionDraft,
+  useMissionLiveSync,
   useMissionRenew,
   useMissionRetry,
   useMissionStart,
@@ -49,6 +50,8 @@ import {
   useRenewableMissionSource,
 } from "../../lib/api/mission.js";
 import { useRuntimeState } from "../../lib/api/runtime.js";
+import { useIsChatSubmitting } from "../../lib/api/chat.js";
+import { useUiStore } from "../../stores/uiStore.js";
 import { cn } from "../../lib/utils.js";
 
 /**
@@ -58,6 +61,16 @@ import { cn } from "../../lib/utils.js";
  */
 const PRIMARY_KEY =
   "flex h-10 w-full items-center justify-center gap-2 rounded-full bg-[var(--vex-accent)] font-mono text-[11px] font-medium uppercase tracking-[0.16em] text-[var(--vex-accent-contrast)] transition-colors hover:bg-[var(--vex-accent-hover)] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50";
+
+/**
+ * Pre-accept review action — same geometry as PRIMARY_KEY but accent-OUTLINED,
+ * not filled: the solid accent fill stays reserved for the one commitment
+ * action of each stage (Start/Renew here, Accept inside the modal). The
+ * outlined→solid progression is deliberate feedback that accepting advanced
+ * the mission a stage.
+ */
+const REVIEW_KEY =
+  "flex h-10 w-full items-center justify-center gap-2 rounded-full border border-[var(--vex-accent)] font-mono text-[11px] font-medium uppercase tracking-[0.16em] text-[var(--vex-accent-text)] transition-colors hover:bg-[color-mix(in_oklab,var(--vex-accent)_12%,transparent)] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 export interface MissionControlsProps {
   readonly sessionId: string;
@@ -175,6 +188,10 @@ function readRenewable(
 export function MissionControls({
   sessionId,
 }: MissionControlsProps): JSX.Element | null {
+  // Keep the draft/diff fresh against MAIN-process (agent tool) writes — the
+  // review bar must appear the moment the agent finishes the draft, not a
+  // staleTime later.
+  useMissionLiveSync(sessionId);
   const runtimeQuery = useRuntimeState(sessionId);
   const draftQuery = useMissionDraft(sessionId);
   const draft = readDraft(draftQuery.data);
@@ -189,6 +206,18 @@ export function MissionControls({
   const renew = useMissionRenew();
 
   const [notice, setNotice] = useState<ControlNotice>(null);
+  // Opens the contract review dialog owned by MissionRail (shared uiStore
+  // enum — see MissionRail's mutual-exclusion note).
+  const setReviewModal = useUiStore((s) => s.setReviewModal);
+  // Live-turn gate for the review bar: the draft flips `ready` on the TOOL
+  // CALL commit, mid-turn — revealing the bar there beats the agent's own
+  // closing summary (and the contract could still change before the turn
+  // ends). `useIsChatSubmitting` spans the ENTIRE turn IPC — provider streams,
+  // the quiet tool-execution gaps between them, and the closing message. The
+  // stream preview is NOT a substitute: it clears on every intermediate
+  // assistant append, so the bar would flash during tool calls. A cancelled/
+  // failed turn settles the mutation, so the bar can never wedge shut.
+  const turnActive = useIsChatSubmitting(sessionId);
 
   const run = useCallback(
     async <T extends { readonly outcome: string }>(
@@ -333,12 +362,31 @@ export function MissionControls({
     );
   }
 
-  // Contract pending acceptance with nothing else to show → the standing
-  // notice alone, so the block is visible for the whole setup phase.
-  if (pendingAcceptance) {
+  // Contract pending acceptance → ONE next-step surface, never both. Once the
+  // draft is reviewable (status `ready` with a computed diff) the outlined
+  // "Review & accept contract" bar IS the message — it opens the contract
+  // modal, and stacking the warn notice on top of it would just restate the
+  // same fact in a scarier voice. While the draft is still in setup (nothing
+  // to review yet — the modal would only say "add a goal…") the standing
+  // notice carries the why-am-I-blocked signal alone.
+  if (draft !== null && pendingAcceptance) {
+    const reviewable =
+      draft.status === "ready" && diff !== null && !turnActive;
     return (
       <div data-vex-area="mission-controls" className="mt-3">
-        <AcceptancePendingNotice />
+        {reviewable ? (
+          <button
+            type="button"
+            onClick={() => setReviewModal("mission")}
+            aria-label="Review and accept mission contract"
+            data-vex-action="review-contract"
+            className={REVIEW_KEY}
+          >
+            Review &amp; accept contract
+          </button>
+        ) : (
+          <AcceptancePendingNotice />
+        )}
       </div>
     );
   }

--- a/vex-app/src/renderer/features/appShell/MissionRail.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionRail.tsx
@@ -26,16 +26,18 @@
  *     pending acceptance / accepted), and surfaces an "awaiting resume" stale
  *     marker when an accepted plan's run is parked.
  *
- * Modal open-state is local `useState` with MUTUAL EXCLUSION — opening one
- * closes the other so two dialogs never stack. The state is UI-ephemeral (never
- * persisted, never crosses IPC).
+ * Modal open-state is the uiStore's `reviewModal` enum with MUTUAL EXCLUSION —
+ * opening one closes the other so two dialogs never stack. It lives in the
+ * store (not local state) so `MissionControls`' "Review & accept contract" bar
+ * can open the contract modal from outside the rail. The state is UI-ephemeral
+ * (never persisted, never crosses IPC).
  *
  * Trust boundary: 100% renderer presentation over existing hooks. No new IPC,
  * no `src/vex-agent`/DB/wallet imports, and no plan CONTENT is read here — the
  * cluster only derives badge states; the modals own the content render.
  */
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { JSX } from "react";
 import type { Result } from "@shared/ipc/result.js";
 import type {
@@ -51,12 +53,10 @@ import {
 } from "../../lib/api/mission.js";
 import { useRuntimeState } from "../../lib/api/runtime.js";
 import { useSession, useSessionPlan } from "../../lib/api/sessions.js";
+import { useUiStore } from "../../stores/uiStore.js";
 import { MissionContractModal } from "./MissionContractModal.js";
 import { PlanDisplayModal } from "./PlanDisplayModal.js";
 import { PremiumBadge, type PremiumBadgeState } from "./PremiumBadge.js";
-
-/** Which review dialog (if any) is open. Mutually exclusive. */
-type OpenModal = "none" | "mission" | "plan";
 
 export interface MissionRailProps {
   readonly activeSessionId: string | null;
@@ -99,7 +99,8 @@ export function MissionRail({
   const hasRenewable =
     renewableQuery.data?.ok === true && renewableQuery.data.data !== null;
 
-  const [open, setOpen] = useState<OpenModal>("none");
+  const open = useUiStore((s) => s.reviewModal);
+  const setOpen = useUiStore((s) => s.setReviewModal);
 
   const mission = useMemo(
     () => deriveMissionBadge(isMission, draft, diff, plan, hasActiveRun, hasRenewable),
@@ -132,7 +133,7 @@ export function MissionRail({
           state={mission.state}
           shimmer={mission.shimmer}
           expanded={open === "mission"}
-          onClick={() => setOpen((cur) => (cur === "mission" ? "none" : "mission"))}
+          onClick={() => setOpen(open === "mission" ? "none" : "mission")}
         />
       ) : null}
 
@@ -143,7 +144,7 @@ export function MissionRail({
           state={planBadge.state}
           shimmer={planBadge.shimmer}
           expanded={open === "plan"}
-          onClick={() => setOpen((cur) => (cur === "plan" ? "none" : "plan"))}
+          onClick={() => setOpen(open === "plan" ? "none" : "plan")}
         />
       ) : null}
 

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
@@ -11,6 +11,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
 
 import { MissionControls } from "../MissionControls.js";
+import { CHAT_SUBMIT_MUTATION_KEY } from "../../../lib/api/chat.js";
+import { useUiStore } from "../../../stores/uiStore.js";
 
 const SESSION = "00000000-0000-4000-8000-0000000000d1";
 const MISSION = "mission-1";
@@ -30,12 +32,23 @@ const editMock = vi.fn();
 const stopMock = vi.fn();
 const renewMock = vi.fn();
 
+/** Captures the live-sync subscriber so tests can fire transcript appends. */
+let transcriptAppendCb: ((event: { sessionId: string }) => void) | null = null;
+
 function setVex(): void {
   Object.defineProperty(window, "vex", {
     configurable: true,
     writable: true,
     value: {
       runtime: { getState: getStateMock },
+      engine: {
+        onTranscriptAppend: (cb: (event: { sessionId: string }) => void) => {
+          transcriptAppendCb = cb;
+          return () => {
+            transcriptAppendCb = null;
+          };
+        },
+      },
       mission: {
         getDraft: getDraftMock,
         getDiff: getDiffMock,
@@ -90,21 +103,47 @@ function freshClient(): QueryClient {
   });
 }
 
-function Wrapper({ children }: { readonly children: ReactNode }) {
-  return createElement(QueryClientProvider, { client: freshClient() }, children);
-}
-
 function renderControls() {
   setVex();
-  return render(createElement(MissionControls, { sessionId: SESSION }), {
-    wrapper: Wrapper,
+  // One client per render, shared with the test body — the live-turn gate
+  // reads the chat-submit mutation cache, so tests need the same instance.
+  const client = freshClient();
+  function Wrapper({ children }: { readonly children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  }
+  return {
+    ...render(createElement(MissionControls, { sessionId: SESSION }), {
+      wrapper: Wrapper,
+    }),
+    client,
+  };
+}
+
+/**
+ * Register a pending `chat.submit` mutation for the session on the client's
+ * shared mutation cache — what `useIsChatSubmitting` observes for the whole
+ * turn (streams AND quiet tool-execution gaps). Returns the settle handle.
+ */
+function startChatTurn(client: QueryClient): () => void {
+  let finish!: () => void;
+  const turn = new Promise<Record<string, never>>((resolve) => {
+    finish = () => resolve({});
   });
+  const mutation = client.getMutationCache().build(client, {
+    mutationKey: CHAT_SUBMIT_MUTATION_KEY,
+    mutationFn: () => turn,
+  });
+  void mutation.execute({ sessionId: SESSION });
+  return finish;
 }
 
 beforeEach(() => {
   // Default: no renewable source. The hook fires for every render (active or
   // not), so give it a safe value; renew-specific tests override it.
   getRenewableMock.mockResolvedValue(ok(null));
+  // Module-global store: reset the review-modal enum so a click in one test
+  // never leaks an open dialog into the next.
+  useUiStore.setState({ reviewModal: "none" });
 });
 
 afterEach(() => {
@@ -141,9 +180,75 @@ describe("MissionControls", () => {
     await waitFor(() => expect(getDiffMock).toHaveBeenCalled());
     await new Promise((r) => setTimeout(r, 0));
     expect(screen.queryByRole("button", { name: "Start mission" })).toBeNull();
-    // Standing acceptance-pending notice: the runtime gate blocks every
-    // on-chain broadcast pre-acceptance, and the user must SEE that.
-    await screen.findByText(/on-chain actions .* are blocked until you accept/i);
+    // A ready-but-unaccepted contract surfaces the review bar — the
+    // discoverable path to the accept modal (the rail badge reads as status).
+    await screen.findByRole("button", {
+      name: "Review and accept mission contract",
+    });
+    // ONE next-step surface at a time: the bar replaces the warn notice
+    // (stacking both would restate the same fact in a scarier voice).
+    expect(screen.queryByText(/Mission contract not accepted/i)).toBeNull();
+  });
+
+  it("holds the review bar for the WHOLE chat turn (incl. tool-call gaps), reveals it on settle", async () => {
+    getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(false));
+    const { client } = renderControls();
+    // The draft flips `ready` on the tool-call commit, MID-turn — the bar must
+    // wait for the turn to settle, not beat the agent's closing message. The
+    // chat-submit mutation is the only signal that also covers the quiet gaps
+    // between provider streams while a tool executes (the stream preview
+    // clears on every intermediate assistant append and would flash the bar).
+    const finishTurn = startChatTurn(client);
+
+    await screen.findByText(/Mission contract not accepted/i);
+    expect(
+      screen.queryByRole("button", {
+        name: "Review and accept mission contract",
+      }),
+    ).toBeNull();
+
+    // Turn settles (closing message delivered) → bar appears, notice retires.
+    finishTurn();
+    await screen.findByRole("button", {
+      name: "Review and accept mission contract",
+    });
+    expect(screen.queryByText(/Mission contract not accepted/i)).toBeNull();
+  });
+
+  it("refetches the draft on a transcript append for this session (agent-side draft writes)", async () => {
+    getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+    getDraftMock.mockResolvedValue(ok({ missionId: MISSION, status: "draft" }));
+    getDiffMock.mockResolvedValue(diffAccepted(false));
+    renderControls();
+
+    await screen.findByText(/Mission contract not accepted/i);
+    const callsBefore = getDraftMock.mock.calls.length;
+    // The agent finishing `mission_draft_update` lands as a transcript append —
+    // the live-sync hook must invalidate so the bar appears without a remount.
+    getDraftMock.mockResolvedValue(draftReady());
+    transcriptAppendCb?.({ sessionId: SESSION });
+    await waitFor(() =>
+      expect(getDraftMock.mock.calls.length).toBeGreaterThan(callsBefore),
+    );
+    await screen.findByRole("button", {
+      name: "Review and accept mission contract",
+    });
+  });
+
+  it("Review & accept contract opens the contract modal via the uiStore", async () => {
+    getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(false));
+    renderControls();
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Review and accept mission contract",
+      }),
+    );
+    expect(useUiStore.getState().reviewModal).toBe("mission");
   });
 
   it("shows the standing acceptance-pending notice while the draft is still in setup", async () => {
@@ -154,6 +259,13 @@ describe("MissionControls", () => {
 
     await screen.findByText(/Mission contract not accepted/i);
     expect(screen.queryByRole("button", { name: "Start mission" })).toBeNull();
+    // Still in setup → nothing to review yet, so no review bar (the modal
+    // could only say "add a goal…").
+    expect(
+      screen.queryByRole("button", {
+        name: "Review and accept mission contract",
+      }),
+    ).toBeNull();
   });
 
   it("running: Stop + Edit enabled, Continue + Recover disabled", async () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionRail.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionRail.test.tsx
@@ -65,6 +65,7 @@ vi.mock("../PlanDisplayModal.js", () => ({
 }));
 
 const { MissionRail } = await import("../MissionRail.js");
+const { useUiStore } = await import("../../../stores/uiStore.js");
 
 const SESSION = "00000000-0000-4000-8000-00000000dd01";
 const MISSION = "mission-1";
@@ -163,6 +164,9 @@ function renewable(missionId: string | null = null) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The modal-open enum lives in the module-global uiStore now — reset it so
+  // a badge click in one test can never leak an open dialog into the next.
+  useUiStore.setState({ reviewModal: "none" });
   // Sensible defaults: no draft/diff/plan; tests override per case.
   mockUseSession.mockReturnValue({ data: ok(sessionRow()) });
   mockUseMissionDraft.mockReturnValue({ data: ok(null) });

--- a/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingCopilotDock.test.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingCopilotDock.test.tsx
@@ -71,13 +71,11 @@ const SESSION = "00000000-0000-4000-8000-00000000dc01";
 const MISSION = "mission-1";
 const HASH = "a".repeat(64);
 
-let activeSessionId: string | null = SESSION;
-vi.mock("../../../../stores/uiStore.js", () => ({
-  useUiStore: (selector: (s: { activeSessionId: string | null }) => unknown) =>
-    selector({ activeSessionId }),
-}));
-
+// The REAL uiStore (plain Zustand) — MissionRail now reads/writes its
+// `reviewModal` enum reactively, which a static selector fake can't do.
+// Tests drive `activeSessionId` via `useUiStore.setState` instead.
 const { HypervexingCopilotDock } = await import("../HypervexingCopilotDock.js");
+const { useUiStore } = await import("../../../../stores/uiStore.js");
 
 function ok<T>(data: T): Result<T> {
   return { ok: true, data };
@@ -166,7 +164,9 @@ function runtime(hasActiveRun = false) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  activeSessionId = SESSION;
+  // Module-global store: pin the active session and reset the modal-open enum
+  // so a badge click in one test can never leak an open dialog into the next.
+  useUiStore.setState({ activeSessionId: SESSION, reviewModal: "none" });
   mockUseSession.mockReturnValue({ data: ok(sessionRow()) });
   mockUseMissionDraft.mockReturnValue({ data: ok(null) });
   mockUseMissionDiff.mockReturnValue({ data: undefined });
@@ -223,7 +223,7 @@ describe("HypervexingCopilotDock mission rail", () => {
   });
 
   it("passes a null active session straight through (rail render-gates off)", () => {
-    activeSessionId = null;
+    useUiStore.setState({ activeSessionId: null });
     mockUseSession.mockReturnValue({ data: undefined });
 
     const { container } = render(<HypervexingCopilotDock />);

--- a/vex-app/src/renderer/lib/api/mission.ts
+++ b/vex-app/src/renderer/lib/api/mission.ts
@@ -14,6 +14,7 @@
  * `useMissionDraft`.
  */
 
+import { useEffect } from "react";
 import {
   queryOptions,
   useMutation,
@@ -94,6 +95,33 @@ export function useMissionDiff(
     sessionId: sessionId ?? "",
     missionId: missionId ?? "",
   }));
+}
+
+/**
+ * Live sync for the mission contract surfaces. The AGENT mutates the draft
+ * from the main process (`mission_draft_update` & co. tool calls), which no
+ * renderer mutation observes — without this, the draft/diff queries idle at
+ * staleTime until a focus/remount, so the rail badge and the "Review & accept
+ * contract" bar trail the agent's "contract is ready" message by seconds.
+ * Mirrors `useTranscriptLiveSync`: every committed transcript append for the
+ * session (each tool call / message is one) invalidates the draft + diff keys
+ * so every observer refetches immediately. Mount once per active mission
+ * session (`MissionControls`). Pure side effect — no render output.
+ */
+export function useMissionLiveSync(sessionId: string | null): void {
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (sessionId === null || sessionId.length === 0) return;
+    return window.vex.engine.onTranscriptAppend((event) => {
+      if (event.sessionId !== sessionId) return;
+      void queryClient.invalidateQueries({
+        queryKey: missionKeys.draft(sessionId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: missionKeys.diffsForSession(sessionId),
+      });
+    });
+  }, [sessionId, queryClient]);
 }
 
 /**

--- a/vex-app/src/renderer/lib/api/queryKeys.ts
+++ b/vex-app/src/renderer/lib/api/queryKeys.ts
@@ -139,6 +139,13 @@ export const missionKeys = {
   diff: (sessionId: string, missionId: string) =>
     ["mission", "diff", sessionId, missionId] as const,
   /**
+   * Prefix of every `diff` key for a session — TanStack matches partial
+   * keys, so invalidating this hits the diff regardless of which missionId
+   * is current (the live-sync path can't know it).
+   */
+  diffsForSession: (sessionId: string) =>
+    ["mission", "diff", sessionId] as const,
+  /**
    * Puzzle 04 phase 7 — latest terminal accepted mission for
    * `/mission-renew`. Returns `{ missionId }` or null. Invalidated on
    * any mutation that may flip a mission to terminal (start, stop,

--- a/vex-app/src/renderer/stores/uiStore.ts
+++ b/vex-app/src/renderer/stores/uiStore.ts
@@ -55,6 +55,14 @@ export type WizardEntryMode = "setup" | "reconfigure";
 export type UnlockReturnView = "wizard" | "appShell";
 export type SessionModeFilter = "all" | "agent" | "mission";
 /**
+ * Which mission review dialog is open (mission contract / plan). Mutually
+ * exclusive by construction (one enum field — opening one closes the other).
+ * Lives in the store rather than `MissionRail` local state so surfaces outside
+ * the rail (the `MissionControls` "Review & accept contract" bar) can open the
+ * contract modal. UI-ephemeral: NOT persisted (see partialize).
+ */
+export type ReviewModal = "none" | "mission" | "plan";
+/**
  * Sub-view of the app shell panel area. `session` is the default chat/
  * welcome panel; `sessionsLibrary` is the dedicated "browse all sessions"
  * screen; `memory` is the read-only long-term + session-memory panel.
@@ -119,6 +127,8 @@ interface UiState {
    */
   readonly activeSessionId: string | null;
   readonly appShellView: AppShellView;
+  /** Open mission review dialog (contract/plan). NOT persisted. */
+  readonly reviewModal: ReviewModal;
   /**
    * New-session modal state + the first message typed in the welcome
    * composer that should seed creation. NOT persisted (see partialize).
@@ -158,6 +168,7 @@ interface UiState {
   readonly openUnlock: (returnView: UnlockReturnView) => void;
   readonly setActiveSessionId: (value: string | null) => void;
   readonly setAppShellView: (value: AppShellView) => void;
+  readonly setReviewModal: (value: ReviewModal) => void;
   /** Open the new-session modal, optionally seeding the first message. */
   readonly openCreateSession: (initialMessage?: string | null) => void;
   /** Close the modal + clear its draft. Does NOT touch pendingFirstMessage. */
@@ -188,6 +199,7 @@ export const useUiStore = create<UiState>()(
       sessionModeFilter: "all",
       activeSessionId: null,
       appShellView: "session",
+      reviewModal: "none",
       createSessionOpen: false,
       createSessionInitialMessage: null,
       pendingFirstMessage: null,
@@ -209,6 +221,7 @@ export const useUiStore = create<UiState>()(
         set({ currentView: "unlock", unlockReturnView }),
       setActiveSessionId: (activeSessionId) => set({ activeSessionId }),
       setAppShellView: (appShellView) => set({ appShellView }),
+      setReviewModal: (reviewModal) => set({ reviewModal }),
       openCreateSession: (initialMessage = null) => {
         const trimmed =
           typeof initialMessage === "string" ? initialMessage.trim() : "";


### PR DESCRIPTION
## Problem
After the agent finishes drafting a mission, the only way to reach the accept modal is the **MISSION READY** badge in the header — a passive-looking status chip that doesn't read as the next action. Users end up stuck at the agent's "review the contract" message with no visible control to act on, while the yellow "contract not accepted" warning names the block without offering a way through it.

<img width="892" height="1042" alt="Screenshot 2026-07-14 at 8 26 41 PM" src="https://github.com/user-attachments/assets/dad21426-e2a6-4209-afaf-7d500fa71f1e" />


## Fix
The pending-acceptance state now surfaces a full-width, accent-**outlined** "Review & accept contract" bar in the same slot **Start mission** occupies after acceptance. The lifecycle reads as one progression in one place: outlined *Review & accept contract* → solid *Start mission* — the solid accent fill stays reserved for each stage's commitment action, and the theme tokens (`--vex-accent` / `--vex-accent-text`) keep it correct across all three themes.

<img width="882" height="1042" alt="Screenshot 2026-07-14 at 11 21 40 PM" src="https://github.com/user-attachments/assets/13c362d7-8f5b-4755-b2b9-2247ae2ff30f" />


### Wiring
- **Modal-open state moves to the uiStore** (`reviewModal`, UI-ephemeral, not persisted): the contract dialog is owned by `MissionRail`, but the bar lives in `MissionControls` — a shared enum lets it open the dialog from outside the rail while preserving the mission/plan mutual exclusion by construction.
- **`useMissionLiveSync`** invalidates the draft/diff queries on engine transcript appends. The agent writes the draft from the **main process** (`mission_draft_update` tool), which no renderer mutation observes — previously the bar/badge idled at staleTime and trailed the agent's own "ready" message by seconds. Adds `missionKeys.diffsForSession` since the live-sync path can't know the current missionId.
- **Turn gating via `useIsChatSubmitting`**: the draft flips `ready` on the tool-call commit *mid-turn*; revealing the bar there beats the agent's closing summary. The chat-submit mutation is the only signal spanning the whole turn — provider streams **and** the quiet tool-execution gaps (the stream preview clears on every intermediate assistant append and flashed the bar during tool calls). The bar appears exactly once, when the turn settles; a cancelled/failed turn settles too, so it can never wedge shut.
- **One next-step surface at a time**: while reviewable, the bar replaces the standing warn notice; during setup (nothing to review yet) the notice still stands alone.

## Tests
- Bar presence/absence per state (ready-unaccepted / in-setup / accepted-clean).
- Modal-open wiring through the store, live-sync refetch on transcript append, whole-turn hold + settle reveal (driven by a real pending chat-submit mutation on the test client).
- Store-reset hygiene in every suite touching the now-module-global enum; the HypervexingCopilotDock tests switch from a static uiStore mock to the real store, since the rail's `reviewModal` reads are reactive now.
- Full renderer suite: 129 files / 1046 tests green; typecheck unchanged (94 pre-existing baseline errors, none in touched files).

Pairs with #37 (contract modal closes on successful accept): together the flow is *outlined bar → modal → accept closes modal → solid Start mission*.