### PR TITLE
fix(uniswap): classify wrapped-native (WETH-address) spends as buys — harden classifyEconomicSide

### DIFF
--- a/src/__tests__/vex-agent/tools/protocols/uniswap-economic-side.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/uniswap-economic-side.test.ts
@@ -3,39 +3,117 @@
  * direction (which way native flows), not which tool was invoked. A token can
  * be bought via `uniswap.swap.sell` (native-in) or sold via `uniswap.swap.buy`
  * (native-out), so the tool's `side` is not a reliable accounting label.
+ *
+ * A native leg is either the `eth`/`native` sentinel (`isNative`) OR the chain's
+ * wrapped-native (WETH) ERC-20 address passed directly — the manifest documents
+ * `tokenIn` as "CONTRACT ADDRESS or native ETH", so a WETH-funded buy arrives as
+ * a plain ERC-20 leg with `isNative:false`. Both must classify identically.
  */
 
 import { describe, it, expect } from "vitest";
 import { classifyEconomicSide } from "@vex-agent/tools/protocols/uniswap/handlers/swap.js";
 
+const WETH = "0x4200000000000000000000000000000000000006";
+const TOKEN = "0x8Ff92566f2e81BDd68EDfAa8cde73942A723796b";
+const OTHER = "0xc6911796042b15d7Fa4F6CDe69e245DdCd3d9c31";
+
 describe("classifyEconomicSide", () => {
   // ── native → token is always a BUY, regardless of the tool invoked ──────────
 
   it("native → token = buy via the buy-tool", () => {
-    expect(classifyEconomicSide({ tokenInIsNative: true, tokenOutIsNative: false, side: "buy" })).toBe("buy");
+    expect(
+      classifyEconomicSide({
+        tokenIn: { address: WETH, isNative: true },
+        tokenOut: { address: TOKEN, isNative: false },
+        wrappedNative: WETH,
+        side: "buy",
+      }),
+    ).toBe("buy");
   });
 
   it("native → token = buy even when routed via the sell-tool (the bug)", () => {
-    expect(classifyEconomicSide({ tokenInIsNative: true, tokenOutIsNative: false, side: "sell" })).toBe("buy");
+    expect(
+      classifyEconomicSide({
+        tokenIn: { address: WETH, isNative: true },
+        tokenOut: { address: TOKEN, isNative: false },
+        wrappedNative: WETH,
+        side: "sell",
+      }),
+    ).toBe("buy");
   });
 
   // ── token → native is always a SELL, regardless of the tool invoked ─────────
 
   it("token → native = sell via the sell-tool", () => {
-    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: true, side: "sell" })).toBe("sell");
+    expect(
+      classifyEconomicSide({
+        tokenIn: { address: TOKEN, isNative: false },
+        tokenOut: { address: WETH, isNative: true },
+        wrappedNative: WETH,
+        side: "sell",
+      }),
+    ).toBe("sell");
   });
 
   it("token → native = sell even when routed via the buy-tool", () => {
-    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: true, side: "buy" })).toBe("sell");
+    expect(
+      classifyEconomicSide({
+        tokenIn: { address: TOKEN, isNative: false },
+        tokenOut: { address: WETH, isNative: true },
+        wrappedNative: WETH,
+        side: "buy",
+      }),
+    ).toBe("sell");
   });
 
   // ── token ↔ token has no native anchor: fall back to the tool's side ────────
 
   it("token → token falls back to the tool side (buy)", () => {
-    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: false, side: "buy" })).toBe("buy");
+    expect(
+      classifyEconomicSide({
+        tokenIn: { address: OTHER, isNative: false },
+        tokenOut: { address: TOKEN, isNative: false },
+        wrappedNative: WETH,
+        side: "buy",
+      }),
+    ).toBe("buy");
   });
 
   it("token → token falls back to the tool side (sell)", () => {
-    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: false, side: "sell" })).toBe("sell");
+    expect(
+      classifyEconomicSide({
+        tokenIn: { address: OTHER, isNative: false },
+        tokenOut: { address: TOKEN, isNative: false },
+        wrappedNative: WETH,
+        side: "sell",
+      }),
+    ).toBe("sell");
+  });
+
+  // ── wrapped-native (WETH) ERC-20 address, NOT the sentinel (isNative:false) ──
+  // Regression: a WETH-funded spend passed as the contract address must classify
+  // by economic direction, not fall back to the tool `side`. Case differences in
+  // the address must not defeat the match.
+
+  it("WETH-address in = buy even with isNative:false, routed via the sell-tool", () => {
+    expect(
+      classifyEconomicSide({
+        tokenIn: { address: WETH.toUpperCase(), isNative: false },
+        tokenOut: { address: TOKEN, isNative: false },
+        wrappedNative: WETH,
+        side: "sell",
+      }),
+    ).toBe("buy");
+  });
+
+  it("WETH-address out = sell even with isNative:false, routed via the buy-tool", () => {
+    expect(
+      classifyEconomicSide({
+        tokenIn: { address: TOKEN, isNative: false },
+        tokenOut: { address: WETH.toUpperCase(), isNative: false },
+        wrappedNative: WETH,
+        side: "buy",
+      }),
+    ).toBe("sell");
   });
 });

--- a/src/vex-agent/tools/protocols/uniswap/handlers/swap.ts
+++ b/src/vex-agent/tools/protocols/uniswap/handlers/swap.ts
@@ -62,14 +62,26 @@ function isNativeInput(input: string): boolean {
  * is a SELL. Token↔token has no native anchor, so we fall back to the tool's
  * declared side. This is used ONLY for what is recorded/reported — never for
  * routing, quoting, or execution.
+ *
+ * A leg counts as native either when it is the `eth`/`native` sentinel
+ * (`isNative`) OR when the caller funded it with the chain's wrapped-native
+ * (WETH) ERC-20 address directly — the manifest documents `tokenIn` as
+ * "CONTRACT ADDRESS or native ETH", so a WETH-funded buy arrives as a plain
+ * ERC-20 leg with `isNative:false`. Spending WETH is economically identical to
+ * spending ETH, so both forms must classify the same way; otherwise a
+ * WETH→TOKEN buy routed via `uniswap.swap.sell` is recorded as a sell and the
+ * buy-side veto is skipped. The address compare is case-insensitive.
  */
 export function classifyEconomicSide(args: {
-  readonly tokenInIsNative: boolean;
-  readonly tokenOutIsNative: boolean;
+  readonly tokenIn: { readonly address: string; readonly isNative: boolean };
+  readonly tokenOut: { readonly address: string; readonly isNative: boolean };
+  readonly wrappedNative: string;
   readonly side: "buy" | "sell";
 }): "buy" | "sell" {
-  if (args.tokenInIsNative) return "buy"; // spending native to acquire a token = BUY
-  if (args.tokenOutIsNative) return "sell"; // selling a token back to native = SELL
+  const isNativeLeg = (leg: { address: string; isNative: boolean }) =>
+    leg.isNative || leg.address.toLowerCase() === args.wrappedNative.toLowerCase();
+  if (isNativeLeg(args.tokenIn)) return "buy"; // spending native/WETH to acquire a token = BUY
+  if (isNativeLeg(args.tokenOut)) return "sell"; // selling a token back to native/WETH = SELL
   return args.side; // token↔token: fall back to the tool's side
 }
 
@@ -243,8 +255,9 @@ async function executeUniswapSwap(
   // Economic direction for RECORDING/reporting — derived from the native leg,
   // not the tool name (`side`). `side` still drives routing/execution below.
   const economicSide = classifyEconomicSide({
-    tokenInIsNative: tokenIn.isNative,
-    tokenOutIsNative: tokenOut.isNative,
+    tokenIn: { address: tokenIn.address, isNative: tokenIn.isNative },
+    tokenOut: { address: tokenOut.address, isNative: tokenOut.isNative },
+    wrappedNative: deployment.weth,
     side,
   });
 


### PR DESCRIPTION
Follow-up to #30 (the economic-direction trade-side classifier). That PR
records a swap's side from the native leg — spending native to acquire a
token is a **buy**, selling back to native is a **sell** — instead of
trusting which tool (`uniswap.swap.buy`/`.sell`) routed it.

### The gap
`classifyEconomicSide` only treats a leg as native when it is the
`eth`/`native` **sentinel** (`isNative`). But the Uniswap manifest documents
`tokenIn` as *"CONTRACT ADDRESS or native ETH"*, so a buy **funded with the
WETH contract address** (not the sentinel) resolves `isNative:false`, falls
through to the tool `side`, and records a `WETH → TOKEN` **buy as a sell** —
and skips the buy-side exit-safety veto. Same class of bug #30 was meant to kill.

### The fix (one helper)
Treat a leg as economically native when it is the sentinel **OR** its address
equals the chain's wrapped-native (`deployment.weth`), case-insensitive.
Spending WETH is economically identical to spending ETH, so both funding forms
now classify the same way.

Only the economic classification changes — the value that flows to `tradeSide`,
`instrumentKey`, `settlementAssetKey`, `meta.side`, `output.side`, and the
buy-side veto gate. **Routing, quoting, execution, balance guards, and
`buildSwapTx`'s native-value flag are untouched** — a WETH-address spend is
still a real ERC-20 transfer, not a native-value send.

### Test
Regression cases for a **WETH-address** in-leg (`isNative:false`) classifying
as **buy** and a WETH-address out-leg as **sell**, regardless of which tool
routed it and regardless of address casing. Existing economic-side cases stay
green (8/8 pass; full uniswap suite 28/28; `tsc --noEmit` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
