### PR TITLE
fix(hypervexing): smooth exits and add direct sessions

### DIFF
--- a/vex-app/src/main/ipc/__tests__/hyperliquid.test.ts
+++ b/vex-app/src/main/ipc/__tests__/hyperliquid.test.ts
@@ -275,29 +275,26 @@ describe("Hyperliquid market-data IPC", () => {
 });
 
 describe("Hyperliquid manual workspace entry IPC", () => {
-  it("rejects manual entry without the global risk acknowledgement", async () => {
+  it("accepts first entry without pre-acknowledgement so the renderer can show the risk gate", async () => {
     mocks.preferencesLoad.mockResolvedValueOnce({
       hyperliquid: { riskAcknowledgedAt: null, policy: {} },
     });
 
     const result = await call(CH.hyperliquid.enterWorkspace, { sessionId: SESSION_ID });
 
-    expect(result.ok).toBe(false);
-    expect(result.error?.code).toBe("validation.invalid_input");
-    expect(result.error?.message).toMatch(/agent/i);
+    expect(result).toEqual({ ok: true, data: { accepted: true } });
     expect(mocks.hasSessionEverEntered).not.toHaveBeenCalled();
-    expect(mocks.requestWorkspaceMode).not.toHaveBeenCalled();
+    expect(mocks.requestWorkspaceMode).toHaveBeenCalledWith(SESSION_ID, "hypervexing");
   });
 
-  it("rejects manual entry when the session has never entered Hypervexing", async () => {
+  it("accepts user-requested entry when the session has never entered Hypervexing", async () => {
     mocks.hasSessionEverEntered.mockResolvedValueOnce(false);
 
     const result = await call(CH.hyperliquid.enterWorkspace, { sessionId: SESSION_ID });
 
-    expect(result.ok).toBe(false);
-    expect(result.error?.code).toBe("validation.invalid_input");
-    expect(result.error?.message).toMatch(/agent/i);
-    expect(mocks.requestWorkspaceMode).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: true, data: { accepted: true } });
+    expect(mocks.hasSessionEverEntered).not.toHaveBeenCalled();
+    expect(mocks.requestWorkspaceMode).toHaveBeenCalledWith(SESSION_ID, "hypervexing");
   });
 
   it("accepts manual re-entry when acknowledgement and prior entry are both present", async () => {
@@ -307,14 +304,13 @@ describe("Hyperliquid manual workspace entry IPC", () => {
     expect(mocks.requestWorkspaceMode).toHaveBeenCalledWith(SESSION_ID, "hypervexing");
   });
 
-  it("checks the shared session precondition before manual-entry policy", async () => {
+  it("checks the shared session precondition before requesting entry", async () => {
     mocks.getSessionById.mockResolvedValueOnce({ ok: true, data: null });
 
     const result = await call(CH.hyperliquid.enterWorkspace, { sessionId: SESSION_ID });
 
     expect(result.ok).toBe(false);
     expect(result.error?.code).toBe("validation.invalid_input");
-    expect(mocks.preferencesLoad).not.toHaveBeenCalled();
     expect(mocks.hasSessionEverEntered).not.toHaveBeenCalled();
     expect(mocks.requestWorkspaceMode).not.toHaveBeenCalled();
   });

--- a/vex-app/src/main/ipc/hyperliquid/workspace.ts
+++ b/vex-app/src/main/ipc/hyperliquid/workspace.ts
@@ -1,5 +1,5 @@
 import { CH } from "@shared/ipc/channels.js";
-import { err, ok, type Result } from "@shared/ipc/result.js";
+import { ok, type Result } from "@shared/ipc/result.js";
 import {
   hyperliquidWorkspaceEnterAcceptedSchema,
   hyperliquidWorkspaceEnterInputSchema,
@@ -40,18 +40,6 @@ export function registerHyperliquidWorkspaceModeHandler(): () => void {
   });
 }
 
-function manualEntryRejected(message: string, correlationId: string): Result<never> {
-  return err({
-    code: "validation.invalid_input",
-    domain: "hyperliquid",
-    message,
-    retryable: false,
-    userActionable: true,
-    redacted: true,
-    correlationId,
-  });
-}
-
 export function registerHyperliquidEnterWorkspaceHandler(): () => void {
   return registerHandler({
     channel: CH.hyperliquid.enterWorkspace,
@@ -62,20 +50,9 @@ export function registerHyperliquidEnterWorkspaceHandler(): () => void {
       const sessionError = await requireExistingHyperliquidSession(input.sessionId, ctx.requestId);
       if (sessionError !== null) return sessionError;
 
-      const preferences = await preferencesStore.load();
-      if (preferences.hyperliquid.riskAcknowledgedAt === null) {
-        return manualEntryRejected(
-          "Acknowledge Hyperliquid risk before manual re-entry, or use the agent path to enter Hypervexing.",
-          ctx.requestId,
-        );
-      }
-      if (!await hasSessionEverEnteredHypervexing(input.sessionId)) {
-        return manualEntryRejected(
-          "Manual re-entry is available only after this session has entered Hypervexing once. Use the agent path for first entry.",
-          ctx.requestId,
-        );
-      }
-
+      // User-requested first entry and re-entry share the same main-owned mode
+      // transition. If risk has not been acknowledged, the emitted event is
+      // ack-gated by the renderer before the workspace becomes visible.
       await requestHyperliquidWorkspaceMode(input.sessionId, "hypervexing");
       return ok(hyperliquidWorkspaceEnterAcceptedSchema.parse({ accepted: true }));
     },
@@ -97,4 +74,3 @@ export function registerHyperliquidExitWorkspaceHandler(): () => void {
     },
   });
 }
-

--- a/vex-app/src/renderer/features/appShell/AppShell.tsx
+++ b/vex-app/src/renderer/features/appShell/AppShell.tsx
@@ -32,7 +32,8 @@
  * custom).
  */
 
-import type { JSX } from "react";
+import { useState, type JSX } from "react";
+import { AnimatePresence } from "motion/react";
 import type { SkyTheme } from "./signalSkyShaders.js";
 import type { AppShellView } from "../../stores/uiStore.js";
 import { useUiStore } from "../../stores/uiStore.js";
@@ -73,11 +74,15 @@ export function AppShell(): JSX.Element {
   // and turns each agent request into the right store transition.
   const workspace = useHypervexingWorkspace();
   const inWorkspace = workspace.workspaceMode === "hypervexing";
+  const [composerFocusRequest, setComposerFocusRequest] = useState(0);
 
   // `data-vex-theme` is DERIVED: while the mode is active it reads
   // "hypervexing"; otherwise it is the user's own persisted theme, so EXIT
   // restores navy vs lime exactly. The mode never overwrites `theme`.
-  const derivedTheme: SkyTheme = deriveShellTheme(workspace.workspaceMode, theme);
+  const derivedTheme: SkyTheme = deriveShellTheme(
+    workspace.visualWorkspaceMode,
+    theme,
+  );
 
   // Stage F responsive: below ~1360px the three columns (sidebar + chat +
   // BOOK) no longer fit, so auto-collapse BOOK on the narrowing edge. One-way on
@@ -90,7 +95,8 @@ export function AppShell(): JSX.Element {
   // dimmed behind an active session transcript OR the Hypervexing chart. The
   // uniform itself eases inside SignalSky, so this can flip freely.
   const skyIntensity =
-    inWorkspace || (activeSessionId !== null && appShellView === "session")
+    workspace.visualWorkspaceMode === "hypervexing" ||
+    (activeSessionId !== null && appShellView === "session")
       ? SKY_DIM_INTENSITY
       : 1;
 
@@ -105,20 +111,32 @@ export function AppShell(): JSX.Element {
     >
       <SignalSky intensity={skyIntensity} theme={derivedTheme} />
 
-      {inWorkspace ? (
-        // The 5-zone trading room replaces the normal columns while active. It
-        // reuses the SAME SessionPanel (docked), so chat context is preserved
-        // and only ONE chat surface is ever mounted.
-        <HypervexingWorkspace onExit={workspace.exit} />
-      ) : (
-        <NormalShell
-          appShellView={appShellView}
-          activeSessionId={activeSessionId}
-          bookOpen={bookOpen}
-          toggleBook={toggleBook}
-          onCreate={() => openCreateSession()}
-        />
-      )}
+      <AnimatePresence
+        initial={false}
+        mode="wait"
+        onExitComplete={() => {
+          if (!workspace.exitTransitionPending) return;
+          workspace.completeExitTransition();
+          setComposerFocusRequest((request) => request + 1);
+        }}
+      >
+        {inWorkspace ? (
+          // The 5-zone trading room replaces the normal columns while active. It
+          // reuses the SAME SessionPanel (docked), so chat context is preserved
+          // and only ONE chat surface is ever mounted.
+          <HypervexingWorkspace key="hypervexing" onExit={workspace.exit} />
+        ) : (
+          <NormalShell
+            key="normal"
+            appShellView={appShellView}
+            activeSessionId={activeSessionId}
+            bookOpen={bookOpen}
+            toggleBook={toggleBook}
+            onCreate={() => openCreateSession()}
+            composerFocusRequest={composerFocusRequest}
+          />
+        )}
+      </AnimatePresence>
 
       <SessionCreator
         open={createSessionOpen}
@@ -148,12 +166,14 @@ function NormalShell({
   bookOpen,
   toggleBook,
   onCreate,
+  composerFocusRequest,
 }: {
   readonly appShellView: AppShellView;
   readonly activeSessionId: string | null;
   readonly bookOpen: boolean;
   readonly toggleBook: () => void;
   readonly onCreate: () => void;
+  readonly composerFocusRequest: number;
 }): JSX.Element {
   return (
     <>
@@ -202,7 +222,7 @@ function NormalShell({
           ) : appShellView === "missionHistory" ? (
             <MissionHistory />
           ) : (
-            <SessionPanel />
+            <SessionPanel composerFocusRequest={composerFocusRequest} />
           )}
         </div>
       </section>

--- a/vex-app/src/renderer/features/appShell/SessionComposer.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionComposer.tsx
@@ -109,12 +109,15 @@ export interface SessionComposerProps {
    * and gating are identical in both variants.
    */
   readonly stage?: boolean;
+  /** Monotonic request from the shell to focus the restored composer. */
+  readonly focusRequest?: number;
 }
 
 export function SessionComposer({
   activeSession,
   activeSessionId,
   stage = false,
+  focusRequest = 0,
 }: SessionComposerProps): JSX.Element {
   // Submit/enable gate on the canonical selected id (uiStore), NOT the
   // detail-query object: the engine ingress loads its own session context,
@@ -176,6 +179,7 @@ export function SessionComposer({
   // so it never shuffles under an operator mid-thought.
   const [focused, setFocused] = useState<boolean>(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const handledFocusRequest = useRef(0);
   const formRef = useRef<HTMLFormElement>(null);
   // Synchronous in-flight mutex (render `submitPending` lags a tick) + a mirror
   // of the latest active session so a submit that settles after a session
@@ -190,6 +194,12 @@ export function SessionComposer({
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
   }, [draft]);
+
+  useEffect(() => {
+    if (focusRequest <= handledFocusRequest.current) return;
+    handledFocusRequest.current = focusRequest;
+    textareaRef.current?.focus();
+  }, [focusRequest]);
 
   // Clear the composer notice when the active session changes so a stale
   // error / Retry from one session never renders on (or resends into) another.

--- a/vex-app/src/renderer/features/appShell/SessionCreator.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionCreator.tsx
@@ -61,6 +61,7 @@ export function SessionCreator({
   const createSessionInitialMessage = useUiStore(
     (s) => s.createSessionInitialMessage,
   );
+  const createSessionPreset = useUiStore((s) => s.createSessionPreset);
   const setPendingFirstMessage = useUiStore((s) => s.setPendingFirstMessage);
   const setSigningState = useUiStore((s) => s.setSigningState);
   const createMutation = useCreateSession();
@@ -76,6 +77,9 @@ export function SessionCreator({
   const [selectedEvmWalletId, setSelectedEvmWalletId] = useState<string | null>(null);
   const [selectedSolanaWalletId, setSelectedSolanaWalletId] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [openingWorkspace, setOpeningWorkspace] = useState(false);
+  const [createdHyperliquidSessionId, setCreatedHyperliquidSessionId] =
+    useState<string | null>(null);
   const nameRef = useRef<HTMLInputElement | null>(null);
 
   // Reset state on every (re)open so the next opening starts clean.
@@ -84,15 +88,30 @@ export function SessionCreator({
       setName(
         createSessionInitialMessage !== null
           ? deriveSessionName(createSessionInitialMessage)
-          : "",
+          : createSessionPreset === "hyperliquid"
+            ? "Hyperliquid"
+            : "",
       );
-      setMode(sessionModeFilter === "mission" ? "mission" : "agent");
+      setMode(
+        createSessionPreset === "hyperliquid"
+          ? "agent"
+          : sessionModeFilter === "mission"
+            ? "mission"
+            : "agent",
+      );
       setPermission("restricted");
       setSelectedEvmWalletId(null);
       setSelectedSolanaWalletId(null);
       setSubmitError(null);
+      setOpeningWorkspace(false);
+      setCreatedHyperliquidSessionId(null);
     }
-  }, [open, createSessionInitialMessage, sessionModeFilter]);
+  }, [
+    open,
+    createSessionInitialMessage,
+    createSessionPreset,
+    sessionModeFilter,
+  ]);
 
   // Focus the Name input first when the dialog opens — it is the only
   // text field in this modal. Mission goal capture happens in chat.
@@ -106,12 +125,49 @@ export function SessionCreator({
 
   const trimmedName = name.trim();
   const nameInvalid = trimmedName.length === 0;
-  const submitDisabled = nameInvalid || createMutation.isPending;
+  const submitDisabled =
+    (nameInvalid && createdHyperliquidSessionId === null) ||
+    createMutation.isPending ||
+    openingWorkspace;
+
+  const openHyperliquidWorkspace = useCallback(
+    async (sessionId: string): Promise<boolean> => {
+      setOpeningWorkspace(true);
+      setSubmitError(null);
+      try {
+        const result = await window.vex.hyperliquid.enterWorkspace({ sessionId });
+        if (!result.ok) {
+          setSigningState("idle");
+          setSubmitError(
+            `The session was created, but Hypervexing could not open: ${result.error.message}`,
+          );
+          return false;
+        }
+        setSigningState("signed");
+        setActiveSessionId(sessionId);
+        onOpenChange(false);
+        return true;
+      } catch {
+        setSigningState("idle");
+        setSubmitError(
+          "The session was created, but Hypervexing could not open. Retry opening it.",
+        );
+        return false;
+      } finally {
+        setOpeningWorkspace(false);
+      }
+    },
+    [onOpenChange, setActiveSessionId, setSigningState],
+  );
 
   const onSubmit = useCallback(
     async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
       event.preventDefault();
       if (submitDisabled) return;
+      if (createdHyperliquidSessionId !== null) {
+        await openHyperliquidWorkspace(createdHyperliquidSessionId);
+        return;
+      }
       setSubmitError(null);
       const input: SessionCreateInput =
         mode === "mission"
@@ -128,6 +184,14 @@ export function SessionCreator({
         if (!outcome.ok) {
           setSigningState("idle");
           setSubmitError(outcome.error.message);
+          return;
+        }
+        if (createSessionPreset === "hyperliquid") {
+          // Create first, then ask main to enter before selecting the session.
+          // When selection changes, the workspace controller's authoritative
+          // mode read sees the completed transition without racing a live push.
+          setCreatedHyperliquidSessionId(outcome.data.id);
+          await openHyperliquidWorkspace(outcome.data.id);
           return;
         }
         setSigningState("signed");
@@ -152,7 +216,10 @@ export function SessionCreator({
     [
       createMutation,
       createSessionInitialMessage,
+      createSessionPreset,
+      createdHyperliquidSessionId,
       mode,
+      openHyperliquidWorkspace,
       onOpenChange,
       permission,
       selectedEvmWalletId,
@@ -165,8 +232,21 @@ export function SessionCreator({
     ],
   );
 
+  const handleOpenChange = useCallback(
+    (next: boolean): void => {
+      if (!next && createdHyperliquidSessionId !== null) {
+        // The database create already succeeded. If opening the room failed or
+        // the user dismisses the retry state, continue in that normal session
+        // instead of leaving an invisible duplicate behind.
+        setActiveSessionId(createdHyperliquidSessionId);
+      }
+      onOpenChange(next);
+    },
+    [createdHyperliquidSessionId, onOpenChange, setActiveSessionId],
+  );
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       {/* Brand chrome (raised ink panel, hairline, black/70 no-blur backdrop)
        * is the Dialog base since the rebrand — only width is per-modal. */}
       <DialogContent className="max-w-2xl">
@@ -176,7 +256,11 @@ export function SessionCreator({
              * leading rule). Same <h2>, same aria-labelledby id — only the
              * register changes; text stays "New session" (uppercased by
              * CSS) so the accessible name is untouched. */}
-            <DialogTitle className="vex-eyebrow">New session</DialogTitle>
+            <DialogTitle className="vex-eyebrow">
+              {createSessionPreset === "hyperliquid"
+                ? "New Hyperliquid session"
+                : "New session"}
+            </DialogTitle>
             {/* Ceremony line — the retired welcome headline promoted to the
              * display register (landing .prob-card h3: Archivo 700 19px),
              * read once per new act (where ceremony belongs). */}
@@ -184,28 +268,35 @@ export function SessionCreator({
               Your chain. Your rules. I execute.
             </p>
             <DialogDescription className="text-xs text-[var(--vex-text-3)]">
-              Mode and permission are locked once the session is created.
+              {createSessionPreset === "hyperliquid"
+                ? "Public market scans work without a wallet. Select an EVM wallet to trade; mode and permission lock after creation."
+                : "Mode and permission are locked once the session is created."}
             </DialogDescription>
           </DialogHeader>
 
           <DialogBody className="gap-6 px-8">
-            <NameField name={name} onNameChange={setName} nameRef={nameRef} />
+            <fieldset
+              disabled={createdHyperliquidSessionId !== null}
+              className="contents"
+            >
+              <NameField name={name} onNameChange={setName} nameRef={nameRef} />
 
-            <ModeFieldset mode={mode} onModeChange={setMode} />
+              <ModeFieldset mode={mode} onModeChange={setMode} />
 
-            <PermissionFieldset
-              permission={permission}
-              onPermissionChange={setPermission}
-            />
+              <PermissionFieldset
+                permission={permission}
+                onPermissionChange={setPermission}
+              />
 
-            <WalletFieldset
-              selectedEvmWalletId={selectedEvmWalletId}
-              selectedSolanaWalletId={selectedSolanaWalletId}
-              evmOptions={inventory.evm}
-              solanaOptions={inventory.solana}
-              onEvmChange={setSelectedEvmWalletId}
-              onSolanaChange={setSelectedSolanaWalletId}
-            />
+              <WalletFieldset
+                selectedEvmWalletId={selectedEvmWalletId}
+                selectedSolanaWalletId={selectedSolanaWalletId}
+                evmOptions={inventory.evm}
+                solanaOptions={inventory.solana}
+                onEvmChange={setSelectedEvmWalletId}
+                onSolanaChange={setSelectedSolanaWalletId}
+              />
+            </fieldset>
 
             <SubmitError submitError={submitError} />
           </DialogBody>
@@ -214,17 +305,25 @@ export function SessionCreator({
             <Button
               type="button"
               variant="ghost"
-              onClick={() => onOpenChange(false)}
-              disabled={createMutation.isPending}
+              onClick={() => handleOpenChange(false)}
+              disabled={createMutation.isPending || openingWorkspace}
               className="text-[var(--vex-text-2)] hover:bg-white/[0.06] hover:text-foreground"
             >
-              Cancel
+              {createdHyperliquidSessionId === null ? "Cancel" : "Continue in Vex"}
             </Button>
             {/* THE primary action — the landing's filled cobalt pill
              * (Button default variant: mono uppercase, bg-primary), one
              * step heavier than Cancel (h-10 vs h-9). */}
             <Button type="submit" disabled={submitDisabled} className="h-10 px-6">
-              {createMutation.isPending ? "Creating…" : "Create"}
+              {openingWorkspace
+                ? "Opening…"
+                : createdHyperliquidSessionId !== null
+                  ? "Retry opening"
+                  : createMutation.isPending
+                    ? "Creating…"
+                    : createSessionPreset === "hyperliquid"
+                      ? "Create & open"
+                      : "Create"}
             </Button>
           </DialogFooter>
         </form>

--- a/vex-app/src/renderer/features/appShell/SessionPanel.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionPanel.tsx
@@ -60,10 +60,13 @@ export interface SessionPanelProps {
    * dock passes the mission badge cluster here so the panel stays mode-unaware.
    */
   readonly headerTrailing?: ReactNode;
+  /** Incremented after Hypervexing exits so focus lands on the restored chat. */
+  readonly composerFocusRequest?: number;
 }
 
 export function SessionPanel({
   headerTrailing,
+  composerFocusRequest = 0,
 }: SessionPanelProps = {}): JSX.Element {
   const activeSessionId = useUiStore((s) => s.activeSessionId);
   // In the Hypervexing dock the composer is ALWAYS bottom-pinned (user
@@ -135,7 +138,12 @@ export function SessionPanel({
             live $VEX widget used to sit below the composer here; it moved to
             the sessions rail (SessionsList) to keep the welcome stage clean. */}
         <div className="vex-rise vex-rise-d2 relative z-10 mx-auto w-[min(680px,92%)] shrink-0">
-          <SessionComposer activeSession={null} activeSessionId={null} stage />
+          <SessionComposer
+            activeSession={null}
+            activeSessionId={null}
+            stage
+            focusRequest={composerFocusRequest}
+          />
         </div>
         {/* Trailing spacer — balances the hero zone above (vertical
             centering) and reserves the band the hero's absolute bottom row
@@ -221,6 +229,7 @@ export function SessionPanel({
             activeSession={activeSession}
             activeSessionId={activeSessionId}
             stage={isIdleSession}
+            focusRequest={composerFocusRequest}
           />
         </div>
         {/* Idle-stage trailing spacer — appears AFTER the composer wrapper so

--- a/vex-app/src/renderer/features/appShell/WelcomeIntegrationsRail.tsx
+++ b/vex-app/src/renderer/features/appShell/WelcomeIntegrationsRail.tsx
@@ -30,6 +30,7 @@ import {
 } from "@shared/chains/display.js";
 import { ChainIcon } from "../../components/common/ChainIcon.js";
 import { cn } from "../../lib/utils.js";
+import { useUiStore } from "../../stores/uiStore.js";
 
 interface ProtocolMark {
   readonly name: string;
@@ -62,9 +63,15 @@ const EVM_STACK: readonly number[] = [
   56, // BNB Chain
 ];
 
-function ProtocolChip({ mark }: { readonly mark: ProtocolMark }): JSX.Element {
-  return (
-    <span className="group flex items-center gap-1.5" title={mark.name}>
+function ProtocolChip({
+  mark,
+  onActivate,
+}: {
+  readonly mark: ProtocolMark;
+  readonly onActivate?: () => void;
+}): JSX.Element {
+  const content = (
+    <>
       <span className="h-5 w-5 shrink-0 overflow-hidden rounded-full border border-white/[0.08] bg-white/[0.04]">
         <img
           src={mark.src}
@@ -81,6 +88,23 @@ function ProtocolChip({ mark }: { readonly mark: ProtocolMark }): JSX.Element {
       <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[var(--vex-text-3)] transition-colors group-hover:text-[var(--vex-text-2)]">
         {mark.name}
       </span>
+    </>
+  );
+  if (onActivate !== undefined) {
+    return (
+      <button
+        type="button"
+        onClick={onActivate}
+        aria-label="Create Hyperliquid session"
+        className="group flex min-h-8 items-center gap-1.5 rounded-sm px-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--vex-surface-0)]"
+      >
+        {content}
+      </button>
+    );
+  }
+  return (
+    <span className="group flex items-center gap-1.5" title={mark.name}>
+      {content}
     </span>
   );
 }
@@ -96,6 +120,9 @@ function ChainCoin({ chainId }: { readonly chainId: number }): JSX.Element {
 }
 
 export function WelcomeIntegrationsRail(): JSX.Element {
+  const openCreateHyperliquidSession = useUiStore(
+    (state) => state.openCreateHyperliquidSession,
+  );
   return (
     <div
       data-vex-area="welcome-integrations"
@@ -108,7 +135,15 @@ export function WelcomeIntegrationsRail(): JSX.Element {
       </span>
       <span className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
         {PROTOCOLS.map((mark) => (
-          <ProtocolChip key={mark.name} mark={mark} />
+          <ProtocolChip
+            key={mark.name}
+            mark={mark}
+            onActivate={
+              mark.name === "Hyperliquid"
+                ? openCreateHyperliquidSession
+                : undefined
+            }
+          />
         ))}
       </span>
 

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/welcome-create.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/welcome-create.test.tsx
@@ -113,6 +113,9 @@ const healthMock = vi.fn<() => Promise<Result<HealthReport>>>();
 const messagesListMock = vi.fn();
 const missionGetDraftMock = vi.fn();
 const runtimeGetStateMock = vi.fn();
+const hyperliquidEnterWorkspaceMock = vi.fn();
+const hyperliquidGetWorkspaceModeMock = vi.fn();
+const hyperliquidAcknowledgeRiskMock = vi.fn();
 
 beforeAll(() => {
   const proto = HTMLDialogElement.prototype as unknown as {
@@ -163,6 +166,15 @@ beforeEach(() => {
   healthMock.mockReset();
   missionGetDraftMock.mockReset();
   runtimeGetStateMock.mockReset();
+  hyperliquidEnterWorkspaceMock.mockReset().mockResolvedValue({
+    ok: true,
+    data: { accepted: true },
+  });
+  hyperliquidGetWorkspaceModeMock.mockReset().mockResolvedValue({
+    ok: true,
+    data: { mode: "normal", acknowledged: true, everEntered: true },
+  });
+  hyperliquidAcknowledgeRiskMock.mockReset();
   // SessionComposer queries mission.getDraft + runtime.getState as soon as a
   // session is active (Send gate moved to activeSessionId). Benign defaults:
   // no draft, no run status (free text allowed).
@@ -179,6 +191,7 @@ beforeEach(() => {
     appShellView: "session",
     createSessionOpen: false,
     createSessionInitialMessage: null,
+    createSessionPreset: "standard",
     pendingFirstMessage: null,
   });
   sessionsListMock.mockResolvedValue({ ok: true, data: [] });
@@ -271,7 +284,10 @@ beforeEach(() => {
         onPositionsUpdate: () => () => {},
         onRiskProposalUpdate: () => () => {},
         onWorkspaceMode: () => () => {},
+        getWorkspaceMode: hyperliquidGetWorkspaceModeMock,
+        enterWorkspace: hyperliquidEnterWorkspaceMock,
         exitWorkspace: vi.fn(),
+        acknowledgeRisk: hyperliquidAcknowledgeRiskMock,
       },
       // Agent integration puzzle 2/09 + F5: SessionPanel mounts
       // `useTranscriptLiveSync` + `useStreamPreviewSync` +
@@ -302,6 +318,73 @@ describe("AppShell", () => {
 
     await screen.findByRole("heading", { name: "What should I execute?" });
     expect(screen.getByText(/PREVIEW/)).not.toBeNull();
+  });
+
+  it("creates a Hyperliquid-prefilled session directly from the welcome protocol rail", async () => {
+    renderShell();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create Hyperliquid session" }),
+    );
+    await screen.findByRole("heading", { name: "New Hyperliquid session" });
+    expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe(
+      "Hyperliquid",
+    );
+    expect(screen.getByRole("radio", { name: /Agent/i })).toHaveProperty(
+      "checked",
+      true,
+    );
+    expect(screen.getByRole("radio", { name: /Restricted/i })).toHaveProperty(
+      "checked",
+      true,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create & open" }));
+
+    await waitFor(() =>
+      expect(hyperliquidEnterWorkspaceMock).toHaveBeenCalledWith({
+        sessionId: "a6bf4f85-e645-4df7-9bc5-70ec2eb0bd51",
+      }),
+    );
+    expect(sessionsCreateMock).toHaveBeenCalledWith({
+      mode: "agent",
+      name: "Hyperliquid",
+      permission: "restricted",
+      selectedEvmWalletId: null,
+      selectedSolanaWalletId: null,
+    });
+  });
+
+  it("retries a failed Hypervexing open without creating a duplicate session", async () => {
+    hyperliquidEnterWorkspaceMock
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          code: "internal.unexpected",
+          domain: "hyperliquid",
+          message: "Room unavailable.",
+          retryable: true,
+          userActionable: true,
+          redacted: true,
+          correlationId: "c",
+        },
+      })
+      .mockResolvedValueOnce({ ok: true, data: { accepted: true } });
+    renderShell();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create Hyperliquid session" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create & open" }),
+    );
+
+    await screen.findByText(/Room unavailable/);
+    fireEvent.click(screen.getByRole("button", { name: "Retry opening" }));
+    await waitFor(() =>
+      expect(hyperliquidEnterWorkspaceMock).toHaveBeenCalledTimes(2),
+    );
+    expect(sessionsCreateMock).toHaveBeenCalledTimes(1);
   });
 
   it("welcome composer Send opens the creator with the draft carried + name pre-filled (welcome→create)", async () => {

--- a/vex-app/src/renderer/features/appShell/workspace/HypervexingLeftColumn.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/HypervexingLeftColumn.tsx
@@ -71,7 +71,7 @@ function EarnCard({
 }): JSX.Element {
   const submit = useSubmitChat();
   return (
-    <div className="relative mx-3 mb-2 overflow-hidden rounded-lg bg-[var(--vex-surface-2)] p-3 transition-colors duration-150 hover:bg-[var(--vex-surface-2-up,var(--vex-surface-2))]">
+    <div className="relative mx-3 mb-2 shrink-0 overflow-hidden rounded-lg bg-[var(--vex-surface-2)] p-3 transition-colors duration-150 hover:bg-[var(--vex-surface-2-up,var(--vex-surface-2))]">
       <HlLiquidVeil />
       <p className="relative text-[13px] font-semibold tracking-[0.01em] text-[var(--vex-text)]">
         {title}
@@ -89,7 +89,7 @@ function EarnCard({
             message: `Explain ${title} on Hyperliquid — current APR, how it works, and the risks. Don't move anything.`,
           })
         }
-        className="mt-2.5 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--vex-accent-text)] underline-offset-2 hover:underline disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
+        className="relative mt-2.5 block min-h-6 font-mono text-[10px] uppercase leading-6 tracking-[0.12em] text-[var(--vex-accent-text)] underline-offset-2 hover:underline disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
       >
         {submit.isPending ? "Asking…" : `Ask Vex about ${title === "Staking" ? "staking" : "HLP"}`}
       </button>

--- a/vex-app/src/renderer/features/appShell/workspace/HypervexingTopBar.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/HypervexingTopBar.tsx
@@ -127,7 +127,14 @@ export function HypervexingTopBar({
           type="button"
           onClick={requestExit}
           disabled={exitPending}
-          aria-label="Exit Hypervexing"
+          aria-label={
+            exitPending
+              ? "Exiting Hypervexing"
+              : exitFailed
+                ? "Retry exiting Hypervexing"
+                : "Exit Hypervexing"
+          }
+          aria-busy={exitPending}
           className="rounded-md border border-[var(--vex-line-strong)] px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--vex-text-2)] hover:border-[var(--vex-accent-border)] hover:text-[var(--vex-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ring)]"
         >
           {exitPending ? "Exiting…" : exitFailed ? "Retry exit" : "Exit ✕"}

--- a/vex-app/src/renderer/features/appShell/workspace/HypervexingWorkspace.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/HypervexingWorkspace.tsx
@@ -141,11 +141,20 @@ export function HypervexingWorkspace({
 
   const motionProps = buildWorkspaceTransition(useReducedMotion() ?? false);
   const wideRoom = useWideRoom();
+  const workspaceRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    workspaceRef.current?.focus({ preventScroll: true });
+  }, []);
 
   return (
     <motion.div
+      ref={workspaceRef}
+      role="region"
+      aria-label="Hypervexing trading workspace"
+      tabIndex={-1}
       data-vex-hypervexing-workspace
-      className="absolute inset-0 z-10 grid gap-2.5 overflow-hidden p-2.5"
+      className="absolute inset-0 z-10 grid gap-2.5 overflow-hidden p-2.5 focus:outline-none"
       style={wideRoom ? WIDE_GRID_STYLE : NARROW_GRID_STYLE}
       initial={motionProps.initial}
       animate={motionProps.animate}

--- a/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingLeftColumn.test.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingLeftColumn.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../lib/api/chat.js", () => ({
+  useSubmitChat: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+vi.mock("../../../../lib/api/usage.js", () => ({
+  useSessionUsageTotals: () => ({ data: { ok: true, data: null } }),
+}));
+vi.mock("../../book/HyperliquidRiskBlock.js", () => ({
+  HyperliquidRiskProposalPanel: () => null,
+}));
+vi.mock("../HypervexingRiskSetup.js", () => ({
+  HypervexingRiskSetup: () => null,
+}));
+vi.mock("../HlLiquidVeil.js", () => ({ HlLiquidVeil: () => null }));
+
+const { HypervexingLeftColumn } = await import(
+  "../HypervexingLeftColumn.js"
+);
+
+describe("HypervexingLeftColumn earn cards", () => {
+  it("keeps the action text inside non-shrinking cards on short rooms", () => {
+    render(
+      <HypervexingLeftColumn
+        account={null}
+        upnl={null}
+        sessionId="00000000-0000-4000-8000-000000000001"
+        selectedCoin="BTC"
+      />,
+    );
+
+    for (const name of ["Ask Vex about HLP", "Ask Vex about staking"]) {
+      const action = screen.getByRole("button", { name });
+      expect(action.classList.contains("min-h-6")).toBe(true);
+      expect(action.parentElement?.classList.contains("shrink-0")).toBe(true);
+    }
+  });
+});

--- a/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingTopBar.test.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingTopBar.test.tsx
@@ -12,7 +12,7 @@ describe("HypervexingTopBar exit authority", () => {
     fireEvent.click(screen.getByRole("button", { name: "Exit Hypervexing" }));
     await screen.findByRole("alert");
     expect(screen.getByText("Exit failed. Retry.")).not.toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Exit Hypervexing" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry exiting Hypervexing" }));
     await waitFor(() => expect(onExit).toHaveBeenCalledTimes(2));
   });
 });

--- a/vex-app/src/renderer/features/appShell/workspace/__tests__/useHypervexingWorkspace.test.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/__tests__/useHypervexingWorkspace.test.tsx
@@ -128,6 +128,10 @@ describe("useHypervexingWorkspace", () => {
     expect(exitWorkspace).toHaveBeenCalledWith({ sessionId: SESSION_ID });
     emit("normal", true);
     expect(result.current.workspaceMode).toBe("normal");
+    expect(result.current.visualWorkspaceMode).toBe("hypervexing");
+    expect(result.current.exitTransitionPending).toBe(true);
+    act(() => result.current.completeExitTransition());
+    expect(result.current.visualWorkspaceMode).toBe("normal");
   });
 
   it("an agent 'normal' push exits the mode", () => {
@@ -136,6 +140,7 @@ describe("useHypervexingWorkspace", () => {
     expect(result.current.workspaceMode).toBe("hypervexing");
     emit("normal", true);
     expect(result.current.workspaceMode).toBe("normal");
+    expect(result.current.visualWorkspaceMode).toBe("hypervexing");
   });
 
   it("ignores a push for a DIFFERENT session (no cross-session morph)", () => {

--- a/vex-app/src/renderer/features/appShell/workspace/useHypervexingWorkspace.ts
+++ b/vex-app/src/renderer/features/appShell/workspace/useHypervexingWorkspace.ts
@@ -1,10 +1,10 @@
 /**
- * Hypervexing workspace controller. Bridges agent-driven workspace-mode pushes
+ * Hypervexing workspace controller. Bridges main-owned workspace-mode pushes
  * to the transient `workspaceMode` UI flag, gating first entry on the risk
  * acknowledgment.
  *
  * Ownership split:
- *  - the AGENT decides entry/exit (a main→renderer push, `subscribeWorkspaceMode`);
+ *  - MAIN decides the resulting state for agent- and user-requested transitions;
  *  - the STORE holds the transient flag (`workspaceMode`, never persisted);
  *  - THIS hook holds only the ack-dialog gate state, and turns a decoded action
  *    (`resolveWorkspaceModeEvent`) into the right store/dialog transition.
@@ -29,6 +29,9 @@ import {
 
 export interface HypervexingWorkspaceController {
   readonly workspaceMode: WorkspaceMode;
+  /** Keeps Hypervexing tokens/sky active while the room's exit mask drains. */
+  readonly visualWorkspaceMode: WorkspaceMode;
+  readonly exitTransitionPending: boolean;
   /** The first-entry risk dialog is open (agent asked to enter, not yet acked). */
   readonly ackPending: boolean;
   /** The acknowledgment write is in flight. */
@@ -39,6 +42,8 @@ export interface HypervexingWorkspaceController {
   readonly cancelAck: () => void;
   /** In-mode EXIT: leave the mode (local flip + tell main). */
   readonly exit: () => Promise<boolean>;
+  /** Called by AnimatePresence after the exit mask has completed. */
+  readonly completeExitTransition: () => void;
 }
 
 export function useHypervexingWorkspace(): HypervexingWorkspaceController {
@@ -46,12 +51,14 @@ export function useHypervexingWorkspace(): HypervexingWorkspaceController {
   const setWorkspaceMode = useUiStore((s) => s.setWorkspaceMode);
   const activeSessionId = useUiStore((s) => s.activeSessionId);
   const [ackPending, setAckPending] = useState(false);
+  const [exitTransitionPending, setExitTransitionPending] = useState(false);
   const acknowledge = useAcknowledgeHyperliquidRisk();
   const modeRead = useHyperliquidWorkspaceModeRead(activeSessionId);
 
   const applyAction = useCallback(
     (action: WorkspaceModeAction): void => {
       if (action.type === "enter") {
+        setExitTransitionPending(false);
         setAckPending(false);
         setWorkspaceMode("hypervexing");
       } else if (action.type === "acknowledge") {
@@ -59,6 +66,12 @@ export function useHypervexingWorkspace(): HypervexingWorkspaceController {
         // the mode activates only once the user accepts (confirmAck below).
         setAckPending(true);
       } else {
+        // Preserve the room's visual tokens until AnimatePresence completes
+        // the exit mask. Otherwise the root rethemes one frame before the
+        // workspace unmounts and produces a color/layout flash.
+        setExitTransitionPending(
+          useUiStore.getState().workspaceMode === "hypervexing",
+        );
         setAckPending(false);
         setWorkspaceMode("normal");
       }
@@ -87,20 +100,20 @@ export function useHypervexingWorkspace(): HypervexingWorkspaceController {
   useEffect(() => {
     if (activeSessionId === null) {
       reconciledSessionId.current = null;
-      setAckPending(false);
-      setWorkspaceMode("normal");
+      applyAction({ type: "exit" });
       return;
     }
     if (reconciledSessionId.current === activeSessionId) return;
     if (modeRead.data?.ok !== true) return;
     reconciledSessionId.current = activeSessionId;
     applyAction(resolveWorkspaceModeEvent(modeRead.data.data));
-  }, [activeSessionId, applyAction, modeRead.data, setWorkspaceMode]);
+  }, [activeSessionId, applyAction, modeRead.data]);
 
   const confirmAck = useCallback(() => {
     acknowledge.mutate(undefined, {
       onSuccess: (result) => {
         if (!result.ok) return;
+        setExitTransitionPending(false);
         setAckPending(false);
         setWorkspaceMode("hypervexing");
       },
@@ -116,12 +129,24 @@ export function useHypervexingWorkspace(): HypervexingWorkspaceController {
   // arrives. A failed invoke leaves the workspace intact for a visible retry.
   const exit = useCallback(() => requestWorkspaceExit(activeSessionId), [activeSessionId]);
 
+  const completeExitTransition = useCallback(() => {
+    setExitTransitionPending(false);
+  }, []);
+
+  const visualWorkspaceMode: WorkspaceMode =
+    workspaceMode === "hypervexing" || exitTransitionPending
+      ? "hypervexing"
+      : "normal";
+
   return {
     workspaceMode,
+    visualWorkspaceMode,
+    exitTransitionPending,
     ackPending,
     ackSaving: acknowledge.isPending,
     confirmAck,
     cancelAck,
     exit,
+    completeExitTransition,
   };
 }

--- a/vex-app/src/renderer/features/appShell/workspace/workspaceBridge.ts
+++ b/vex-app/src/renderer/features/appShell/workspace/workspaceBridge.ts
@@ -2,10 +2,9 @@
  * Hypervexing workspace bridge adapter — the ONE place the renderer touches
  * the main-process workspace surface.
  *
- * Product contract: the mode is HIDDEN and AGENT-DRIVEN. Entry is a main→
- * renderer push (`onWorkspaceMode`); the only renderer→main request is EXIT
- * (`exitWorkspace`). There is deliberately NO renderer "enter" invoke — the
- * agent decides.
+ * Product contract: main owns the per-session mode. Agent requests and explicit
+ * user entry both converge on the same main→renderer push (`onWorkspaceMode`),
+ * while renderer requests remain session-scoped and schema-validated.
  *
  * Every access is optional-chained so the renderer never crashes if the bridge
  * surface is absent (older preload, a shell test that stubs a partial

--- a/vex-app/src/renderer/stores/__tests__/uiStore.test.ts
+++ b/vex-app/src/renderer/stores/__tests__/uiStore.test.ts
@@ -138,6 +138,16 @@ describe("uiStore", () => {
     expect(useUiStore.getState().createSessionInitialMessage).toBeNull();
   });
 
+  it("opens a Hyperliquid-prefilled creator and resets the preset on close", () => {
+    useUiStore.getState().openCreateHyperliquidSession();
+    expect(useUiStore.getState().createSessionOpen).toBe(true);
+    expect(useUiStore.getState().createSessionInitialMessage).toBeNull();
+    expect(useUiStore.getState().createSessionPreset).toBe("hyperliquid");
+
+    useUiStore.getState().closeCreateSession();
+    expect(useUiStore.getState().createSessionPreset).toBe("standard");
+  });
+
   it("closeCreateSession clears modal state but NOT the pending hand-off", () => {
     useUiStore.getState().openCreateSession("seed");
     useUiStore
@@ -178,6 +188,7 @@ describe("uiStore", () => {
     });
     expect(parsed.state.createSessionOpen).toBeUndefined();
     expect(parsed.state.createSessionInitialMessage).toBeUndefined();
+    expect(parsed.state.createSessionPreset).toBeUndefined();
     expect(parsed.state.pendingFirstMessage).toBeUndefined();
     expect(raw).not.toContain("super secret first message");
   });

--- a/vex-app/src/renderer/stores/uiStore.ts
+++ b/vex-app/src/renderer/stores/uiStore.ts
@@ -54,6 +54,7 @@ export type View =
 export type WizardEntryMode = "setup" | "reconfigure";
 export type UnlockReturnView = "wizard" | "appShell";
 export type SessionModeFilter = "all" | "agent" | "mission";
+export type SessionCreationPreset = "standard" | "hyperliquid";
 /**
  * Sub-view of the app shell panel area. `session` is the default chat/
  * welcome panel; `sessionsLibrary` is the dedicated "browse all sessions"
@@ -125,6 +126,7 @@ interface UiState {
    */
   readonly createSessionOpen: boolean;
   readonly createSessionInitialMessage: string | null;
+  readonly createSessionPreset: SessionCreationPreset;
   readonly pendingFirstMessage: PendingFirstMessage | null;
   /**
    * Signing-stroke state for the sidebar's New-session key: "signing"
@@ -160,6 +162,8 @@ interface UiState {
   readonly setAppShellView: (value: AppShellView) => void;
   /** Open the new-session modal, optionally seeding the first message. */
   readonly openCreateSession: (initialMessage?: string | null) => void;
+  /** Open the new-session modal prefilled for a user-requested Hyperliquid room. */
+  readonly openCreateHyperliquidSession: () => void;
   /** Close the modal + clear its draft. Does NOT touch pendingFirstMessage. */
   readonly closeCreateSession: () => void;
   readonly setPendingFirstMessage: (value: PendingFirstMessage) => void;
@@ -190,6 +194,7 @@ export const useUiStore = create<UiState>()(
       appShellView: "session",
       createSessionOpen: false,
       createSessionInitialMessage: null,
+      createSessionPreset: "standard",
       pendingFirstMessage: null,
       signingState: "idle",
       reasoningEffortBySession: {},
@@ -215,10 +220,21 @@ export const useUiStore = create<UiState>()(
         set({
           createSessionOpen: true,
           createSessionInitialMessage: trimmed.length > 0 ? trimmed : null,
+          createSessionPreset: "standard",
         });
       },
+      openCreateHyperliquidSession: () =>
+        set({
+          createSessionOpen: true,
+          createSessionInitialMessage: null,
+          createSessionPreset: "hyperliquid",
+        }),
       closeCreateSession: () =>
-        set({ createSessionOpen: false, createSessionInitialMessage: null }),
+        set({
+          createSessionOpen: false,
+          createSessionInitialMessage: null,
+          createSessionPreset: "standard",
+        }),
       setPendingFirstMessage: (pendingFirstMessage) =>
         set({ pendingFirstMessage }),
       clearPendingFirstMessage: () => set({ pendingFirstMessage: null }),

--- a/vex-app/src/shared/schemas/hyperliquid.ts
+++ b/vex-app/src/shared/schemas/hyperliquid.ts
@@ -376,7 +376,7 @@ export const hyperliquidWorkspaceModeDtoSchema = z.object({
 }).strict();
 export type HyperliquidWorkspaceModeDto = z.infer<typeof hyperliquidWorkspaceModeDtoSchema>;
 
-/** Manual entry is main-gated to acknowledged sessions with prior entry. */
+/** User-requested entry; first entry remains gated by the risk acknowledgment. */
 export const hyperliquidWorkspaceEnterInputSchema = z.object({
   sessionId: z.string().uuid(),
 }).strict();

--- a/vex-app/src/shared/types/bridge/agent/hyperliquid.ts
+++ b/vex-app/src/shared/types/bridge/agent/hyperliquid.ts
@@ -82,7 +82,7 @@ export interface HyperliquidBridge {
     input: HyperliquidSessionRiskPolicyReadInput,
   ) => Promise<Result<HyperliquidSessionRiskPolicyDto>>;
   readonly acknowledgeRisk: () => Promise<Result<Preferences>>;
-  /** Manual re-entry is main-gated by acknowledgement and prior entry. */
+  /** User-requested entry; first entry remains risk-acknowledgment gated. */
   readonly enterWorkspace: (
     input: HyperliquidWorkspaceEnterInput,
   ) => Promise<Result<HyperliquidWorkspaceEnterAccepted>>;


### PR DESCRIPTION
## What changed

- Coordinate the Hypervexing exit with `AnimatePresence`, keep the trading-room theme active through the drain animation, and restore keyboard focus to the normal chat composer afterward.
- Turn the Hyperliquid protocol chip on the welcome screen into an accessible entry point for a prefilled session flow, then enter Hypervexing directly without spending an agent turn.
- Preserve the existing first-entry leverage-risk acknowledgment; failed workspace opens stay retryable without creating duplicate sessions.
- Prevent the HLP vault and Staking cards from flex-shrinking and clipping their mint `Ask Vex` actions in shorter windows.

## Why

The workspace declared an exit animation but was removed by a hard conditional before that animation could run, while the shell theme changed immediately underneath it. Hyperliquid first entry was also restricted to an agent-triggered path, and the Earn cards could shrink below their content height because they are children of a constrained flex column.

## User impact

- Exit now drains cleanly back to the user's normal Vex/Robinhood theme instead of flashing or snapping.
- Users can create and open a Hyperliquid-focused session from the welcome protocol rail while retaining the normal name, mode, permission, and wallet choices.
- Entry and exit have explicit focus handoffs, keyboard focus styles, busy state semantics, and reduced-motion behavior.
- Earn-card action text remains fully visible and the left column scrolls when space is constrained.

## Verification

- `pnpm --dir vex-app test` — 352 files / 3,139 tests passed
- `pnpm --dir vex-app run lint` — TypeScript baseline and process-boundary checks passed
- `pnpm --dir vex-app run build` — main, preload, and renderer production builds passed
- `npx -y react-doctor@latest . --verbose --scope changed --base main` — no new correctness, hooks, security, or performance findings; one pre-existing Fast Refresh warning remains for the existing `nextPositionAutoFollow` helper export
