### PR TITLE
fix(vault): stop labeling a correct master password as incorrect (fund-loss path)

### DIFF
--- a/src/__tests__/config/local-secret-vault.test.ts
+++ b/src/__tests__/config/local-secret-vault.test.ts
@@ -348,4 +348,112 @@ describe("local secret vault", () => {
       expect(statSync(vaultFile).mtimeMs).toBe(beforeMtime);
     });
   });
+
+  /**
+   * F-03: post-decrypt schema/version failures must NOT be labeled
+   * `invalid_password` (that advances unlock throttle and misleads users).
+   */
+  describe("F-03 password vs incompatible vault classification", () => {
+    const PASSWORD = "correct-horse-battery-staple";
+
+    function writeForgedContentsVault(contents: unknown): void {
+      const salt = randomBytes(16);
+      const iv = randomBytes(12);
+      const key = scryptSync(PASSWORD, salt, CURRENT_KDF_PARAMS.dkLen, {
+        N: CURRENT_KDF_PARAMS.N,
+        r: CURRENT_KDF_PARAMS.r,
+        p: CURRENT_KDF_PARAMS.p,
+        maxmem: 256 * 1024 * 1024,
+      });
+      const cipher = createCipheriv("aes-256-gcm", key, iv);
+      const ciphertext = Buffer.concat([
+        cipher.update(Buffer.from(JSON.stringify(contents), "utf8")),
+        cipher.final(),
+      ]);
+      const file = {
+        version: 1,
+        kdf: CURRENT_KDF_PARAMS,
+        salt: salt.toString("base64"),
+        iv: iv.toString("base64"),
+        tag: cipher.getAuthTag().toString("base64"),
+        ciphertext: ciphertext.toString("base64"),
+      };
+      writeFileSync(vaultFile, `${JSON.stringify(file, null, 2)}\n`, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+    }
+
+    it("unlocks a vault that contains an unknown future secret key (correct password)", () => {
+      writeForgedContentsVault({
+        version: 1,
+        secrets: {
+          OPENROUTER_API_KEY: "sk-known",
+          FUTURE_SECRET_KEY_FROM_NEWER_BUILD: "future-value",
+        },
+      });
+
+      const unlocked = unlockSecretVault(PASSWORD, { filePath: vaultFile });
+      expect(unlocked.secrets.OPENROUTER_API_KEY).toBe("sk-known");
+      expect(unlocked.extraSecrets?.FUTURE_SECRET_KEY_FROM_NEWER_BUILD).toBe(
+        "future-value",
+      );
+    });
+
+    it("throws incompatible (not invalid_password) for contents version > VAULT_VERSION", () => {
+      writeForgedContentsVault({
+        version: 2,
+        secrets: { OPENROUTER_API_KEY: "sk-known" },
+      });
+
+      let caught: unknown = null;
+      try {
+        unlockSecretVault(PASSWORD, { filePath: vaultFile });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(LocalSecretVaultError);
+      if (caught instanceof LocalSecretVaultError) {
+        expect(caught.code).toBe("incompatible");
+        expect(caught.code).not.toBe("invalid_password");
+      }
+    });
+
+    it("still throws invalid_password for a genuinely wrong password", () => {
+      createSecretVault(PASSWORD, { filePath: vaultFile });
+      let caught: unknown = null;
+      try {
+        unlockSecretVault("WRONG-PASSWORD", { filePath: vaultFile });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(LocalSecretVaultError);
+      if (caught instanceof LocalSecretVaultError) {
+        expect(caught.code).toBe("invalid_password");
+      }
+    });
+
+    it("round-trips unknown extra secrets through unlock + write", () => {
+      writeForgedContentsVault({
+        version: 1,
+        secrets: {
+          OPENROUTER_API_KEY: "sk-known",
+          FUTURE_SECRET_KEY_FROM_NEWER_BUILD: "future-value",
+        },
+      });
+
+      writeSecretVaultSecrets(
+        PASSWORD,
+        { JUPITER_API_KEY: "jup-added" },
+        { filePath: vaultFile },
+      );
+
+      const unlocked = unlockSecretVault(PASSWORD, { filePath: vaultFile });
+      expect(unlocked.secrets.OPENROUTER_API_KEY).toBe("sk-known");
+      expect(unlocked.secrets.JUPITER_API_KEY).toBe("jup-added");
+      expect(unlocked.extraSecrets?.FUTURE_SECRET_KEY_FROM_NEWER_BUILD).toBe(
+        "future-value",
+      );
+    });
+  });
 });

--- a/src/lib/local-secret-vault/crypto.ts
+++ b/src/lib/local-secret-vault/crypto.ts
@@ -43,14 +43,23 @@ const vaultFileSchema = z
   })
   .strict();
 
-const vaultContentsSchema = z
-  .object({
-    version: z.literal(VAULT_VERSION),
-    secrets: z
-      .partialRecord(z.enum(VAULT_SECRET_KEYS), z.string().min(1))
-      .default({}),
-  })
-  .strict();
+/**
+ * Forward-compatible contents schema.
+ *
+ * - `version` is a positive int (not a pinned literal) so we can distinguish
+ *   "too new" (`incompatible`) from "wrong password".
+ * - `secrets` accepts any string keys so a newer build's unknown keys do not
+ *   reject a correct password. Known keys are projected into `secrets`; the
+ *   rest land in `extraSecrets` for round-trip.
+ * - Extra top-level fields are ignored (not `.strict()`) so minor envelope
+ *   growth from newer builds does not brick unlock.
+ */
+const vaultContentsSchema = z.object({
+  version: z.number().int().positive(),
+  secrets: z.record(z.string(), z.string().min(1)).default({}),
+});
+
+const KNOWN_SECRET_KEY_SET = new Set<string>(VAULT_SECRET_KEYS);
 
 export type VaultFile = z.infer<typeof vaultFileSchema>;
 
@@ -91,7 +100,20 @@ export function encryptContents(
   const iv = randomBytes(12);
   const key = deriveKey(password, salt, CURRENT_KDF_PARAMS);
   const cipher = createCipheriv("aes-256-gcm", key, iv);
-  const plaintext = Buffer.from(JSON.stringify(contents), "utf8");
+  // Merge known + extra secrets into one on-disk map so unknown keys from a
+  // newer build survive a downgrade → unlock → re-encrypt cycle.
+  const secretsOnDisk: Record<string, string> = { ...contents.secrets };
+  if (contents.extraSecrets) {
+    for (const [k, v] of Object.entries(contents.extraSecrets)) {
+      if (!KNOWN_SECRET_KEY_SET.has(k) && typeof v === "string" && v.length > 0) {
+        secretsOnDisk[k] = v;
+      }
+    }
+  }
+  const plaintext = Buffer.from(
+    JSON.stringify({ version: VAULT_VERSION, secrets: secretsOnDisk }),
+    "utf8",
+  );
   const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
   const tag = cipher.getAuthTag();
 
@@ -115,6 +137,11 @@ export function vaultFileNeedsKdfUpgrade(file: VaultFile): boolean {
 }
 
 export function decryptContents(file: VaultFile, password: string): LocalSecretVaultContents {
+  // ── Phase 1: cryptography. A failure here — wrong scrypt key or a failed
+  //    AES-GCM auth-tag check — means the password is wrong (or the ciphertext
+  //    was tampered with, which is indistinguishable). ONLY this phase may
+  //    yield `invalid_password`. Never advance unlock throttle on later phases.
+  let plaintext: string;
   try {
     const salt = Buffer.from(file.salt, "base64");
     const iv = Buffer.from(file.iv, "base64");
@@ -123,12 +150,10 @@ export function decryptContents(file: VaultFile, password: string): LocalSecretV
     const key = deriveKey(password, salt, file.kdf);
     const decipher = createDecipheriv("aes-256-gcm", key, iv);
     decipher.setAuthTag(tag);
-    const plaintext = Buffer.concat([
+    plaintext = Buffer.concat([
       decipher.update(ciphertext),
       decipher.final(),
     ]).toString("utf8");
-    const parsed = vaultContentsSchema.parse(JSON.parse(plaintext));
-    return { version: parsed.version, secrets: parsed.secrets };
   } catch (cause) {
     throw new LocalSecretVaultError(
       "Secret vault could not be unlocked.",
@@ -136,4 +161,47 @@ export function decryptContents(file: VaultFile, password: string): LocalSecretV
       cause,
     );
   }
+
+  // ── Phase 2: content parsing. GCM auth tag already verified → password is
+  //    PROVEN correct. JSON/schema/version failures are data/compatibility
+  //    problems and MUST NEVER be reported as `invalid_password` (F-03).
+  let parsed: z.infer<typeof vaultContentsSchema>;
+  try {
+    parsed = vaultContentsSchema.parse(JSON.parse(plaintext));
+  } catch (cause) {
+    throw new LocalSecretVaultError(
+      "Secret vault contents are unreadable after decryption.",
+      "corrupt",
+      cause,
+    );
+  }
+
+  if (parsed.version > VAULT_VERSION) {
+    throw new LocalSecretVaultError(
+      "This vault was created by a newer version of Vex. Update Vex to open it.",
+      "incompatible",
+    );
+  }
+  if (parsed.version < 1) {
+    throw new LocalSecretVaultError(
+      "Secret vault contents are unreadable after decryption.",
+      "corrupt",
+    );
+  }
+
+  const secrets: Partial<Record<(typeof VAULT_SECRET_KEYS)[number], string>> = {};
+  const extraSecrets: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed.secrets)) {
+    if (KNOWN_SECRET_KEY_SET.has(key)) {
+      secrets[key as (typeof VAULT_SECRET_KEYS)[number]] = value;
+    } else {
+      extraSecrets[key] = value;
+    }
+  }
+
+  return {
+    version: VAULT_VERSION,
+    secrets,
+    ...(Object.keys(extraSecrets).length > 0 ? { extraSecrets } : {}),
+  };
 }

--- a/src/lib/local-secret-vault/lifecycle.ts
+++ b/src/lib/local-secret-vault/lifecycle.ts
@@ -63,11 +63,12 @@ export function createSecretVault(
  *
  * Throws `LocalSecretVaultError` with code:
  *   - "missing"          — vault file does not exist
- *   - "corrupt"          — file present but JSON/schema-invalid
- *   - "invalid_password" — bit-flipped ciphertext / auth-tag mismatch is
- *                          indistinguishable from a wrong password; this
- *                          covers both cases. Reserved "corrupt" for
- *                          structurally-invalid file shape only (parseVaultFile).
+ *   - "corrupt"          — envelope invalid, or plaintext unreadable after
+ *                          a successful decrypt
+ *   - "incompatible"     — password verified, but vault version is too new
+ *   - "invalid_password" — scrypt/AES-GCM auth-tag failure only (wrong
+ *                          password or tampered ciphertext; indistinguishable).
+ *                          Never used for post-decrypt schema failures (F-03).
  *
  * Returns `undefined` on success — by design no secrets are returned.
  * No disk write on success or failure (no opportunistic KDF upgrade).
@@ -91,7 +92,8 @@ export function verifySecretVaultPassword(
   // parseVaultFile raises `corrupt` on JSON/schema failure — surface as-is.
   const parsedFile = parseVaultFile(raw);
 
-  // decryptContents wraps any AES-GCM/scrypt failure as `invalid_password`.
+  // decryptContents maps ONLY crypto failures to `invalid_password`;
+  // post-decrypt shape issues surface as `corrupt` / `incompatible`.
   // Discard the decrypted payload — verification only needs to confirm the
   // password unwraps the vault; callers MUST NOT use this to harvest secrets.
   decryptContents(parsedFile, password);
@@ -161,6 +163,11 @@ export function writeSecretVaultSecrets(
   const next: LocalSecretVaultContents = {
     version: VAULT_VERSION,
     secrets: nextSecrets,
+    // Preserve unknown keys from a newer vault so a write on an older build
+    // cannot strip them (forward-compat round-trip).
+    ...(current.extraSecrets && Object.keys(current.extraSecrets).length > 0
+      ? { extraSecrets: current.extraSecrets }
+      : {}),
   };
   atomicWriteJson(resolveVaultPath(options), encryptContents(next, password));
   return next;

--- a/src/lib/local-secret-vault/status.ts
+++ b/src/lib/local-secret-vault/status.ts
@@ -14,12 +14,26 @@ export interface LocalSecretVaultStatus {
 export interface LocalSecretVaultContents {
   readonly version: typeof VAULT_VERSION;
   readonly secrets: Partial<Record<VaultSecretKey, string>>;
+  /**
+   * Secret keys this build does not recognize. Preserved on read so a
+   * newer vault can open on an older build without looking "corrupt", and
+   * round-tripped on the next write so a downgrade cannot strip them.
+   */
+  readonly extraSecrets?: Readonly<Record<string, string>>;
 }
 
 export class LocalSecretVaultError extends Error {
   constructor(
     message: string,
-    readonly code: "missing" | "invalid_password" | "corrupt" | "io",
+    /**
+     * - `invalid_password` — scrypt/AES-GCM failed (wrong password or
+     *   tampered ciphertext; those are indistinguishable).
+     * - `incompatible` — password verified, but plaintext shape/version
+     *   is too new for this build. MUST NOT advance unlock throttle.
+     * - `corrupt` — envelope or plaintext is structurally unreadable.
+     * - `missing` / `io` — file absence / filesystem errors.
+     */
+    readonly code: "missing" | "invalid_password" | "corrupt" | "io" | "incompatible",
     // `override`: shadows Error.cause (lib ES2022+); explicit for
     // vex-app's noImplicitOverride typecheck profile.
     override readonly cause?: unknown,

--- a/vex-app/src/main/secrets/session.ts
+++ b/vex-app/src/main/secrets/session.ts
@@ -51,6 +51,14 @@ export interface SecretPresence {
   readonly secrets: Partial<Record<VaultSecretKey, boolean>>;
 }
 
+/**
+ * Placeholder correlation id for session-layer errors built outside an IPC
+ * handler. `registerHandler` overwrites this with the request's real
+ * `requestId` when the result crosses the IPC boundary (mismatch rewrite).
+ * Must be non-empty so `isValidVexErrorShape` accepts the object.
+ */
+const SESSION_LOCAL_CORRELATION_ID = "secrets-session";
+
 function toPublicError(cause: unknown): Result<never> {
   if (cause instanceof LocalSecretVaultError && cause.code === "invalid_password") {
     return err({
@@ -60,6 +68,33 @@ function toPublicError(cause: unknown): Result<never> {
       retryable: true,
       userActionable: true,
       redacted: true,
+      correlationId: SESSION_LOCAL_CORRELATION_ID,
+    });
+  }
+
+  if (cause instanceof LocalSecretVaultError && cause.code === "incompatible") {
+    return err({
+      code: "wallet.vault_incompatible",
+      domain: "wallet",
+      message:
+        "This vault was created by a newer version of Vex. Update Vex to open it.",
+      retryable: false,
+      userActionable: true,
+      redacted: true,
+      correlationId: SESSION_LOCAL_CORRELATION_ID,
+    });
+  }
+
+  if (cause instanceof LocalSecretVaultError && cause.code === "corrupt") {
+    return err({
+      code: "wallet.keystore_corrupt",
+      domain: "wallet",
+      message:
+        "The secret vault file is unreadable. Restore from backup or contact support — do not wipe your wallet keystores.",
+      retryable: false,
+      userActionable: true,
+      redacted: true,
+      correlationId: SESSION_LOCAL_CORRELATION_ID,
     });
   }
 
@@ -71,6 +106,7 @@ function toPublicError(cause: unknown): Result<never> {
       retryable: false,
       userActionable: true,
       redacted: true,
+      correlationId: SESSION_LOCAL_CORRELATION_ID,
     });
   }
 
@@ -82,6 +118,7 @@ function toPublicError(cause: unknown): Result<never> {
     retryable: true,
     userActionable: true,
     redacted: true,
+    correlationId: SESSION_LOCAL_CORRELATION_ID,
   });
 }
 
@@ -214,6 +251,7 @@ export function requireUnlockedMasterPassword(): Result<string> {
     retryable: false,
     userActionable: true,
     redacted: true,
+    correlationId: SESSION_LOCAL_CORRELATION_ID,
   });
 }
 

--- a/vex-app/src/shared/ipc/__tests__/result-surface.test.ts
+++ b/vex-app/src/shared/ipc/__tests__/result-surface.test.ts
@@ -59,6 +59,7 @@ describe("result barrel surface", () => {
       "wallet.keystore_corrupt",
       "wallet.keystore_missing",
       "wallet.password_invalid",
+      "wallet.vault_incompatible",
       "wallet.vault_not_configured",
       "wallet.cap_reached",
       "wallet.address_exists",

--- a/vex-app/src/shared/ipc/result/codes.ts
+++ b/vex-app/src/shared/ipc/result/codes.ts
@@ -24,6 +24,7 @@ export const VEX_ERROR_CODES = [
   "wallet.keystore_corrupt",
   "wallet.keystore_missing",
   "wallet.password_invalid",
+  "wallet.vault_incompatible",
   "wallet.vault_not_configured",
   "wallet.cap_reached",
   "wallet.address_exists",

--- a/vex-app/src/shared/ipc/result/types.ts
+++ b/vex-app/src/shared/ipc/result/types.ts
@@ -121,6 +121,7 @@ export type VexErrorCode =
   | "wallet.keystore_corrupt"
   | "wallet.keystore_missing"
   | "wallet.password_invalid"
+  | "wallet.vault_incompatible"
   | "wallet.vault_not_configured"
   | "wallet.cap_reached"
   | "wallet.address_exists"

--- a/vex-app/type-baseline.json
+++ b/vex-app/type-baseline.json
@@ -129,7 +129,6 @@
       "src/main/onboarding/wallet-restore.ts::TS2345": 5,
       "src/main/onboarding/wallets-runner.ts::TS2345": 17,
       "src/main/secrets/__tests__/session.test.ts::TS4115": 1,
-      "src/main/secrets/session.ts::TS2345": 4,
       "src/main/support/agent-bug-report-sink.ts::TS2307": 1,
       "src/main/telemetry/sentry-lifecycle.ts::TS2322": 1
     },


### PR DESCRIPTION
## Summary

Vex can tell a user their **correct** master password is wrong. That is not a UI nit — it is a path that can push people into wiping their keystores and permanently losing access to funds.

This PR fixes vault unlock so only real crypto failures count as a wrong password, and so newer vaults surface as a compatibility problem (or still open) instead of a fake password failure.

## Problem

On unlock, Vex decrypts the vault then parses the plaintext. Those two steps lived in **one** `try/catch` that always reported `invalid_password`.

After AES-GCM succeeds, the password is already proven correct. If the contents then fail (unknown secret key from a newer build, future vault version, etc.), Vex still said:

> Master password is incorrect.

That error is the same one used for a real typo. It advances the unlock throttle toward a multi-minute lockout. The user is left believing they forgot the password or that the vault is dead.

Vex’s own clean-slate docs for a stuck/corrupt setup tell people to delete the whole config directory. That directory holds:

- encrypted vault
- **EVM/Solana keystores**
- **backups of those keystores**

Once those files are gone and there is no external seed backup, the user **cannot sign**. Assets remain on-chain; practical result for the user is **total loss of the wallet**.

So the product did not “steal” funds — it **misdiagnosed a good password**, locked the user out of a compatibility issue, and pointed them at a wipe that destroys signing material.

## User scenario (how Vex loses someone their wallet)

1. User runs a **newer** Vex that writes vault data an older build cannot fully understand (e.g. a new secret key, or a future contents version).
2. User opens the vault on an **older** build (downgrade, reinstall of an older release, rollback after a bad update).
3. They type the **correct** master password.
4. **Before this PR:** Vex says the password is wrong and escalates lockout on retries.
5. User assumes the password is lost or the vault is corrupt.
6. They follow Vex’s clean-slate guidance and wipe the config directory.
7. Keystores and in-folder backups are deleted. No more signing keys → **funds are gone from the user’s perspective**.

This only needs a version skew today; when vault contents version is bumped, every downgrade becomes this path.

## Fix

1. **Split unlock phases in `decryptContents`**
   - Crypto failure (scrypt / AES-GCM) → `invalid_password` only
   - Unreadable plaintext after a successful decrypt → `corrupt`
   - Contents version too new for this build → `incompatible`

2. **Forward-compatible secret map**
   - Unknown keys no longer fail unlock
   - Preserved as `extraSecrets` and round-tripped on write so a downgrade cannot strip them

3. **Honest user-facing errors (`session.ts`)**
   - Real wrong password → still “Master password is incorrect” (throttle applies)
   - Too-new vault → `wallet.vault_incompatible`: update Vex — **not** wrong password, **not** throttle
   - Unreadable contents → clear corrupt message that does not equate to “you typed the password wrong”
   - Session-layer `err()` objects include a non-empty `correlationId` so they satisfy `VexError` (type baseline tightened: session.ts TS2345 4 → 0)

4. **IPC code** `wallet.vault_incompatible` added to the shared error catalog

## Before / after

| Case | Password | Before (what Vex told the user) | After |
|------|----------|----------------------------------|--------|
| Baseline known key | correct | Unlock OK | Unlock OK |
| Unknown secret key from newer build | **correct** | **“Password incorrect”** + throttle | **Unlock OK** (extras kept) |
| Contents version too new | **correct** | **“Password incorrect”** + throttle | **`incompatible`** — update Vex |
| Wrong password | wrong | Password incorrect + throttle | Same (correct behavior) |

## Files changed

- `src/lib/local-secret-vault/crypto.ts`
- `src/lib/local-secret-vault/status.ts`
- `src/lib/local-secret-vault/lifecycle.ts`
- `vex-app/src/main/secrets/session.ts`
- `vex-app/src/shared/ipc/result/codes.ts`
- `vex-app/src/shared/ipc/result/types.ts`
- `src/__tests__/config/local-secret-vault.test.ts`
- `vex-app/src/shared/ipc/__tests__/result-surface.test.ts`
- `vex-app/type-baseline.json`

## Tests run

```bash
pnpm exec vitest run src/__tests__/config/local-secret-vault.test.ts
# 18 passed (4 new F-03 cases)

pnpm --dir vex-app run lint
# Type ratchet green (432 known errors at or below baseline); process boundary check passed

pnpm exec tsc --noEmit
# root typecheck exit 0
```

Covered:

- correct password + unknown key unlocks
- correct password + contents version 2 → `incompatible` (never `invalid_password`)
- wrong password still → `invalid_password`
- unknown keys survive unlock + write

## Checklist

- [x] Correct password no longer reported as wrong for unknown keys / too-new version
- [x] Unlock throttle only advances on real `invalid_password`
- [x] User gets an update/incompatible path instead of a fake password failure
- [x] Unit tests added and passing
- [x] `pnpm --dir vex-app run lint` green (no type-baseline inflation)