### PR TITLE
fix(web): block SSRF via private destinations in web_research

### DIFF
--- a/src/__tests__/vex-agent/tools/internal/public-http-url.test.ts
+++ b/src/__tests__/vex-agent/tools/internal/public-http-url.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  assertPublicHttpUrl,
+  isBlockedIp,
+  isHttpUrl,
+  tryDecimalIpv4,
+  PublicHttpUrlError,
+} from "../../../../vex-agent/tools/internal/public-http-url.js";
+
+describe("isHttpUrl", () => {
+  it("allows http and https only", () => {
+    expect(isHttpUrl("https://example.com")).toBe(true);
+    expect(isHttpUrl("http://example.com/path")).toBe(true);
+    expect(isHttpUrl("file:///etc/passwd")).toBe(false);
+    expect(isHttpUrl("gopher://x")).toBe(false);
+    expect(isHttpUrl("not a url")).toBe(false);
+  });
+});
+
+describe("isBlockedIp", () => {
+  it("blocks loopback and private IPv4", () => {
+    expect(isBlockedIp("127.0.0.1")).toBe(true);
+    expect(isBlockedIp("127.1.2.3")).toBe(true);
+    expect(isBlockedIp("10.0.0.1")).toBe(true);
+    expect(isBlockedIp("192.168.1.1")).toBe(true);
+    expect(isBlockedIp("172.16.0.1")).toBe(true);
+    expect(isBlockedIp("172.31.255.255")).toBe(true);
+    expect(isBlockedIp("169.254.169.254")).toBe(true);
+    expect(isBlockedIp("100.64.0.1")).toBe(true);
+    expect(isBlockedIp("0.0.0.0")).toBe(true);
+  });
+
+  it("allows public IPv4 examples", () => {
+    expect(isBlockedIp("8.8.8.8")).toBe(false);
+    expect(isBlockedIp("1.1.1.1")).toBe(false);
+    expect(isBlockedIp("93.184.216.34")).toBe(false); // example.com-ish public
+  });
+
+  it("blocks IPv6 loopback, link-local, ULA", () => {
+    expect(isBlockedIp("::1")).toBe(true);
+    expect(isBlockedIp("fe80::1")).toBe(true);
+    expect(isBlockedIp("fd12:3456:789a::1")).toBe(true);
+    expect(isBlockedIp("fc00::1")).toBe(true);
+  });
+
+  it("blocks IPv4-mapped private", () => {
+    expect(isBlockedIp("::ffff:127.0.0.1")).toBe(true);
+    expect(isBlockedIp("::ffff:10.0.0.1")).toBe(true);
+  });
+});
+
+describe("tryDecimalIpv4", () => {
+  it("maps 2130706433 to 127.0.0.1", () => {
+    expect(tryDecimalIpv4("2130706433")).toBe("127.0.0.1");
+  });
+
+  it("returns null for non-decimal hostnames", () => {
+    expect(tryDecimalIpv4("example.com")).toBeNull();
+    expect(tryDecimalIpv4("127.0.0.1")).toBeNull();
+  });
+});
+
+describe("assertPublicHttpUrl", () => {
+  it("rejects private literal IPs without DNS", async () => {
+    await expect(assertPublicHttpUrl("http://127.0.0.1/secret")).rejects.toMatchObject({
+      code: "private_destination",
+    });
+    await expect(assertPublicHttpUrl("http://169.254.169.254/latest/meta-data/")).rejects.toMatchObject({
+      code: "private_destination",
+    });
+    await expect(assertPublicHttpUrl("http://192.168.0.1/")).rejects.toMatchObject({
+      code: "private_destination",
+    });
+  });
+
+  it("rejects localhost hostname", async () => {
+    await expect(assertPublicHttpUrl("http://localhost:8080/")).rejects.toMatchObject({
+      code: "private_destination",
+    });
+  });
+
+  it("rejects decimal loopback hostname", async () => {
+    await expect(assertPublicHttpUrl("http://2130706433/secret")).rejects.toMatchObject({
+      code: "private_destination",
+    });
+  });
+
+  it("rejects file scheme", async () => {
+    await expect(assertPublicHttpUrl("file:///etc/passwd")).rejects.toMatchObject({
+      code: "scheme",
+    });
+  });
+
+  it("rejects embedded credentials", async () => {
+    await expect(
+      assertPublicHttpUrl("http://user:pass@example.com/"),
+    ).rejects.toMatchObject({ code: "invalid_url" });
+  });
+
+  it("rejects DNS that resolves to private IP (rebinding-style)", async () => {
+    await expect(
+      assertPublicHttpUrl("http://evil.example/", {
+        lookup: async () => "127.0.0.1",
+      }),
+    ).rejects.toMatchObject({ code: "private_destination" });
+
+    await expect(
+      assertPublicHttpUrl("http://evil.example/", {
+        lookup: async () => "10.1.2.3",
+      }),
+    ).rejects.toMatchObject({ code: "private_destination" });
+  });
+
+  it("allows public host when DNS returns public IP", async () => {
+    const result = await assertPublicHttpUrl("https://example.com/path", {
+      lookup: async () => "93.184.216.34",
+    });
+    expect(result.address).toBe("93.184.216.34");
+    expect(result.url.hostname).toBe("example.com");
+  });
+
+  it("surfaces PublicHttpUrlError with stable name", async () => {
+    try {
+      await assertPublicHttpUrl("http://127.0.0.1/");
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(PublicHttpUrlError);
+      expect((e as PublicHttpUrlError).name).toBe("PublicHttpUrlError");
+    }
+  });
+});

--- a/src/__tests__/vex-agent/tools/internal/web.test.ts
+++ b/src/__tests__/vex-agent/tools/internal/web.test.ts
@@ -21,6 +21,19 @@ vi.mock("@tavily/core", () => ({
   tavily: () => ({ search: mockTavilySearch, extract: mockTavilyExtract }),
 }));
 
+// SSRF policy resolves hostnames; pin public A records so tests do not depend
+// on live DNS / NXDOMAIN. Private literals (127.0.0.1) never hit this path.
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(async (hostname: string) => {
+    const h = hostname.toLowerCase();
+    if (h === "localhost" || h.endsWith(".localhost")) {
+      return { address: "127.0.0.1", family: 4 };
+    }
+    // Stable public address for *.example.com and any other test host
+    return { address: "93.184.216.34", family: 4 };
+  }),
+}));
+
 const { handleWebResearch } = await import("../../../../vex-agent/tools/internal/web.js");
 import { makeTestContext } from "../_test-context.js";
 
@@ -149,6 +162,87 @@ describe("web_research", () => {
   // ── Fetch branch (replaces old web_fetch) ─────────────────────
 
   describe("fetch branch", () => {
+    // ── SSRF destination policy ─────────────────────────────────
+    it("blocks loopback URL before Tavily or raw fetch (SSRF)", async () => {
+      const origKey = process.env.TAVILY_API_KEY;
+      process.env.TAVILY_API_KEY = "test-key";
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      const result = await handleWebResearch(
+        { url: "http://127.0.0.1:27134/secret" },
+        baseContext,
+      );
+      expect(result.success).toBe(false);
+      expect(result.output.toLowerCase()).toMatch(/private|loopback|refusing/);
+      expect(mockTavilyExtract).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mockCacheFetchResult).not.toHaveBeenCalled();
+
+      fetchSpy.mockRestore();
+      if (origKey) process.env.TAVILY_API_KEY = origKey;
+      else delete process.env.TAVILY_API_KEY;
+    });
+
+    it("blocks cloud metadata link-local URL (SSRF)", async () => {
+      const result = await handleWebResearch(
+        { url: "http://169.254.169.254/latest/meta-data/" },
+        baseContext,
+      );
+      expect(result.success).toBe(false);
+      expect(result.output.toLowerCase()).toMatch(/private|loopback|refusing/);
+      expect(mockCacheFetchResult).not.toHaveBeenCalled();
+    });
+
+    it("blocks decimal loopback 2130706433 (SSRF encoding)", async () => {
+      const result = await handleWebResearch(
+        { url: "http://2130706433/secret" },
+        baseContext,
+      );
+      expect(result.success).toBe(false);
+      expect(result.output.toLowerCase()).toMatch(/private|loopback|refusing/);
+    });
+
+    it("blocks redirect hop to loopback and does not cache (SSRF)", async () => {
+      const origKey = process.env.TAVILY_API_KEY;
+      delete process.env.TAVILY_API_KEY; // force raw HTTP path
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 302,
+            headers: { Location: "http://127.0.0.1/secret" },
+          }),
+        );
+
+      const result = await handleWebResearch(
+        { url: "https://public.example.com/start" },
+        baseContext,
+      );
+      expect(result.success).toBe(false);
+      expect(result.output.toLowerCase()).toMatch(/private|loopback|refusing/);
+      // First hop may call fetch; must not cache private outcome.
+      expect(mockCacheFetchResult).not.toHaveBeenCalled();
+
+      fetchSpy.mockRestore();
+      if (origKey) process.env.TAVILY_API_KEY = origKey;
+    });
+
+    it("uses redirect:manual on raw HTTP fetch", async () => {
+      const origKey = process.env.TAVILY_API_KEY;
+      delete process.env.TAVILY_API_KEY;
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        new Response("<html><title>OK</title><body>hi</body></html>", { status: 200 }),
+      );
+
+      await handleWebResearch({ url: "https://ok.example.com/" }, baseContext);
+      expect(fetchSpy).toHaveBeenCalled();
+      const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect(init?.redirect).toBe("manual");
+
+      fetchSpy.mockRestore();
+      if (origKey) process.env.TAVILY_API_KEY = origKey;
+    });
+
     it("rejects non-http url at Zod boundary (and skips Tavily entirely)", async () => {
       const origKey = process.env.TAVILY_API_KEY;
       process.env.TAVILY_API_KEY = "test-key";

--- a/src/vex-agent/tools/internal/public-http-url.ts
+++ b/src/vex-agent/tools/internal/public-http-url.ts
@@ -1,0 +1,252 @@
+/**
+ * Public HTTP destination policy for agent-initiated fetches (SSRF guard).
+ *
+ * `web_research` (and any future agent HTTP) must not reach loopback, RFC1918,
+ * link-local, CGNAT, or IPv6 ULA destinations. Resolve DNS, then classify the
+ * address — hostname string checks alone are bypassable (decimal IPs, rebinding).
+ *
+ * Used by `web.ts` before every raw HTTP hop (including redirects).
+ */
+
+import { lookup as dnsLookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+export type PublicHttpUrlErrorCode =
+  | "invalid_url"
+  | "scheme"
+  | "private_destination"
+  | "dns";
+
+export class PublicHttpUrlError extends Error {
+  constructor(
+    message: string,
+    readonly code: PublicHttpUrlErrorCode,
+  ) {
+    super(message);
+    this.name = "PublicHttpUrlError";
+  }
+}
+
+export type LookupFn = (hostname: string) => Promise<string>;
+
+const DEFAULT_LOOKUP: LookupFn = async (hostname) => {
+  const r = await dnsLookup(hostname, { verbatim: true });
+  return r.address;
+};
+
+/** True when `http:` / `https:` only (mirrors prior web.ts scheme guard). */
+export function isHttpUrl(value: string): boolean {
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Classify a literal IP string (IPv4 or IPv6). Returns true if the agent must
+ * not fetch it. Unknown/unparseable forms fail closed (blocked).
+ */
+export function isBlockedIp(ip: string): boolean {
+  const v = isIP(ip);
+  if (v === 4) return isBlockedIpv4(ip);
+  if (v === 6) return isBlockedIpv6(ip);
+  return true;
+}
+
+function parseIpv4(ip: string): [number, number, number, number] | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  const nums: number[] = [];
+  for (const p of parts) {
+    if (!/^\d{1,3}$/.test(p)) return null;
+    const n = Number(p);
+    if (n > 255) return null;
+    // Disallow octal-looking leading zeros except "0" itself — Node URL may
+    // still hand us normal dotted form after resolution.
+    nums.push(n);
+  }
+  return nums as [number, number, number, number];
+}
+
+function isBlockedIpv4(ip: string): boolean {
+  const o = parseIpv4(ip);
+  if (!o) return true;
+  const [a, b] = o;
+
+  // 0.0.0.0/8 — "this" network
+  if (a === 0) return true;
+  // 10.0.0.0/8
+  if (a === 10) return true;
+  // 127.0.0.0/8 loopback
+  if (a === 127) return true;
+  // 169.254.0.0/16 link-local (incl. cloud IMDS)
+  if (a === 169 && b === 254) return true;
+  // 172.16.0.0/12
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16
+  if (a === 192 && b === 168) return true;
+  // 100.64.0.0/10 CGNAT
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  // 192.0.0.0/24 IETF protocol assignments (special)
+  if (a === 192 && b === 0 && o[2] === 0) return true;
+  // Documentation / benchmark / multicast / reserved
+  if (a === 192 && b === 0 && o[2] === 2) return true; // 192.0.2.0/24
+  if (a === 198 && b === 51 && o[2] === 100) return true; // 198.51.100.0/24
+  if (a === 203 && b === 0 && o[2] === 113) return true; // 203.0.113.0/24
+  if (a === 198 && b === 18) return true; // 198.18.0.0/15 benchmarking (partial)
+  if (a === 198 && b === 19) return true;
+  if (a >= 224) return true; // multicast + reserved + broadcast
+
+  return false;
+}
+
+function isBlockedIpv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  // Loopback
+  if (lower === "::1") return true;
+  // Unspecified
+  if (lower === "::") return true;
+
+  // IPv4-mapped ::ffff:a.b.c.d
+  const mapped = lower.match(/^:ffff:(\d+\.\d+\.\d+\.\d+)$/i)
+    ?? lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (mapped?.[1]) return isBlockedIpv4(mapped[1]);
+
+  // Compress-friendly prefix checks via expanded form is heavy; use common
+  // string prefixes after normalizing stripped brackets (URL already strips).
+  // fe80::/10 link-local
+  if (
+    lower.startsWith("fe8") ||
+    lower.startsWith("fe9") ||
+    lower.startsWith("fea") ||
+    lower.startsWith("feb")
+  ) {
+    return true;
+  }
+  // fc00::/7 unique local (fc… and fd…)
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  // 2001:db8::/32 documentation
+  if (lower.startsWith("2001:db8:") || lower === "2001:db8::") return true;
+
+  return false;
+}
+
+/**
+ * Hostnames that must never be fetched even before DNS (fail closed).
+ * DNS rebinding is still handled by post-resolve IP checks.
+ */
+function isBlockedHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/\.$/, "");
+  if (h === "localhost") return true;
+  if (h.endsWith(".localhost")) return true;
+  if (h.endsWith(".local")) return true;
+  if (h === "0.0.0.0") return true;
+  return false;
+}
+
+/**
+ * Some URL parsers leave "decimal IPv4" as a hostname (e.g. 2130706433 → 127.0.0.1).
+ * Convert pure-decimal hostnames to dotted form when in IPv4 range.
+ */
+export function tryDecimalIpv4(hostname: string): string | null {
+  if (!/^\d+$/.test(hostname)) return null;
+  // Bound: max IPv4 as integer is 4294967295
+  let n: bigint;
+  try {
+    n = BigInt(hostname);
+  } catch {
+    return null;
+  }
+  if (n < 0n || n > 0xffffffffn) return null;
+  const v = Number(n);
+  return [
+    (v >>> 24) & 0xff,
+    (v >>> 16) & 0xff,
+    (v >>> 8) & 0xff,
+    v & 0xff,
+  ].join(".");
+}
+
+/**
+ * Assert `raw` is a public http(s) URL. Returns the parsed URL + resolved IP.
+ * Throws {@link PublicHttpUrlError} on any policy failure.
+ */
+export async function assertPublicHttpUrl(
+  raw: string,
+  options: { readonly lookup?: LookupFn } = {},
+): Promise<{ readonly url: URL; readonly address: string }> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new PublicHttpUrlError("Invalid URL.", "invalid_url");
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new PublicHttpUrlError(
+      "Only http:// and https:// URLs are allowed.",
+      "scheme",
+    );
+  }
+
+  // Reject embedded credentials (user:pass@host) — common SSRF smuggle form.
+  if (url.username || url.password) {
+    throw new PublicHttpUrlError(
+      "URLs with embedded credentials are not allowed.",
+      "invalid_url",
+    );
+  }
+
+  const hostname = url.hostname;
+  if (!hostname) {
+    throw new PublicHttpUrlError("Invalid URL host.", "invalid_url");
+  }
+
+  if (isBlockedHostname(hostname)) {
+    throw new PublicHttpUrlError(
+      "Refusing to fetch private or loopback destination.",
+      "private_destination",
+    );
+  }
+
+  // Literal IP or decimal IPv4 hostname
+  const decimal = tryDecimalIpv4(hostname);
+  if (decimal !== null) {
+    if (isBlockedIp(decimal)) {
+      throw new PublicHttpUrlError(
+        "Refusing to fetch private or loopback destination.",
+        "private_destination",
+      );
+    }
+    return { url, address: decimal };
+  }
+
+  if (isIP(hostname)) {
+    if (isBlockedIp(hostname)) {
+      throw new PublicHttpUrlError(
+        "Refusing to fetch private or loopback destination.",
+        "private_destination",
+      );
+    }
+    return { url, address: hostname };
+  }
+
+  const lookupFn = options.lookup ?? DEFAULT_LOOKUP;
+  let address: string;
+  try {
+    address = await lookupFn(hostname);
+  } catch {
+    throw new PublicHttpUrlError("DNS lookup failed.", "dns");
+  }
+
+  if (isBlockedIp(address)) {
+    throw new PublicHttpUrlError(
+      "Refusing to fetch private or loopback destination.",
+      "private_destination",
+    );
+  }
+
+  return { url, address };
+}

--- a/src/vex-agent/tools/internal/web.ts
+++ b/src/vex-agent/tools/internal/web.ts
@@ -11,6 +11,10 @@
  * uncached URLs (server-side parallelization) with the original query
  * passed through for targeted chunk extraction.
  *
+ * SSRF: every raw HTTP hop (and the url-branch entry) runs
+ * {@link assertPublicHttpUrl} so loopback / private / link-local destinations
+ * never enter tool output or fetch_cache. Redirects are manual and re-checked.
+ *
  * Validation lives in {@link WebResearchParams} so the boundary contract is
  * explicit (rule 20: validate at boundaries; rule 00.8: fail clearly).
  */
@@ -22,6 +26,11 @@ import type { ToolResult } from "../types.js";
 import type { InternalToolContext } from "./types.js";
 import { ok, fail } from "./types.js";
 import logger from "@utils/logger.js";
+import {
+  assertPublicHttpUrl,
+  isHttpUrl,
+  PublicHttpUrlError,
+} from "./public-http-url.js";
 
 const DEFAULT_SEARCH_LIMIT = 10;   // search returns up to N results
 const DEFAULT_FETCH_TOP = 5;       // auto-scrape top N when fetchTop is omitted
@@ -29,17 +38,8 @@ const MAX_FETCH_TOP = 10;          // hard cap per call (Tavily allows up to 20)
 const FETCH_TIMEOUT_MS = 15_000;
 const SEARCH_TIMEOUT_S = 30;
 const EXTRACT_TIMEOUT_S = 25;
-
-// Zod's `z.string().url()` accepts every RFC-3986 scheme (ftp, file, mailto,
-// data, …). Tavily and our HTTP fallback only handle http(s); guard explicitly.
-function isHttpUrl(value: string): boolean {
-  try {
-    const protocol = new URL(value).protocol;
-    return protocol === "http:" || protocol === "https:";
-  } catch {
-    return false;
-  }
-}
+/** Max redirect hops for raw HTTP (each hop re-validated for public dest). */
+const MAX_REDIRECT_HOPS = 5;
 
 const WebResearchParams = z
   .object({
@@ -108,6 +108,17 @@ type FetchedPage = {
 };
 
 async function fetchUrl(url: string): Promise<ToolResult> {
+  // Fail closed before cache / Tavily / raw HTTP so private destinations never
+  // re-surface from a pre-policy cache entry either.
+  try {
+    await assertPublicHttpUrl(url);
+  } catch (err) {
+    if (err instanceof PublicHttpUrlError) {
+      return fail(`web_research: ${err.message}`);
+    }
+    throw err;
+  }
+
   const cached = await searchRepo.getCachedFetch(url);
   if (cached) {
     logger.debug("web.fetch.cache_hit", { url: url.slice(0, 60) });
@@ -153,23 +164,75 @@ async function fetchUrl(url: string): Promise<ToolResult> {
 
 // Raw HTTP fetch + parse <title> + slice. Returns FetchedPage shape so it can
 // be reused in the batch path's failure recovery without a wrapper.
+// Every hop (initial + redirects) is re-validated with assertPublicHttpUrl.
 async function fetchUrlRawHttp(url: string): Promise<FetchedPage> {
   try {
-    const res = await fetch(url, {
-      headers: { "User-Agent": "Vex/2.0" },
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-    if (!res.ok) {
-      return { url, title: null, content: "", ok: false, error: `HTTP ${res.status}` };
+    let current = url;
+    for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+      try {
+        await assertPublicHttpUrl(current);
+      } catch (err) {
+        if (err instanceof PublicHttpUrlError) {
+          return {
+            url: current,
+            title: null,
+            content: "",
+            ok: false,
+            error: err.message,
+          };
+        }
+        throw err;
+      }
+
+      const res = await fetch(current, {
+        headers: { "User-Agent": "Vex/2.0" },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        redirect: "manual",
+      });
+
+      if (res.status >= 300 && res.status < 400) {
+        const loc = res.headers.get("location");
+        if (!loc) {
+          return {
+            url: current,
+            title: null,
+            content: "",
+            ok: false,
+            error: `HTTP ${res.status}`,
+          };
+        }
+        // Resolve relative Location against the current hop.
+        current = new URL(loc, current).href;
+        if (hop === MAX_REDIRECT_HOPS) {
+          return {
+            url: current,
+            title: null,
+            content: "",
+            ok: false,
+            error: "Too many redirects",
+          };
+        }
+        continue;
+      }
+
+      if (!res.ok) {
+        return { url: current, title: null, content: "", ok: false, error: `HTTP ${res.status}` };
+      }
+      const text = await res.text();
+      const titleMatch = text.match(/<title[^>]*>([^<]+)<\/title>/i);
+      const title = titleMatch?.[1]?.trim() ?? null;
+      const markdown = text.slice(0, 50_000);
+      // Cache under the original request URL (caller identity) only after a
+      // successful public fetch — never for blocked private hops.
+      await searchRepo.cacheFetchResult(url, markdown, title);
+      const content = `# ${title ?? "Fetched page"}\n\nSource: ${current}\n\n${markdown}`;
+      return { url: current, title, content, ok: true };
     }
-    const text = await res.text();
-    const titleMatch = text.match(/<title[^>]*>([^<]+)<\/title>/i);
-    const title = titleMatch?.[1]?.trim() ?? null;
-    const markdown = text.slice(0, 50_000);
-    await searchRepo.cacheFetchResult(url, markdown, title);
-    const content = `# ${title ?? "Fetched page"}\n\nSource: ${url}\n\n${markdown}`;
-    return { url, title, content, ok: true };
+    return { url, title: null, content: "", ok: false, error: "Too many redirects" };
   } catch (err) {
+    if (err instanceof PublicHttpUrlError) {
+      return { url, title: null, content: "", ok: false, error: err.message };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { url, title: null, content: "", ok: false, error: msg };
   }


### PR DESCRIPTION
## Summary

`web_research` could perform **SSRF** (server-side request forgery from the agent’s point of view): the Vex main process would fetch **any** `http`/`https` URL—including **loopback and private networks**—with **no approval** (`mutating: false`). Response bodies entered tool output (and could be cached), so the agent could read **unwarranted local data** the user never meant to expose as “research.”

This PR adds a **destination policy** before every raw HTTP hop: resolve the host, reject non-public IPs, and refuse redirects into private space.

## Why this matters for Vex’s product promise

Vex’s public contract ([projectvex.ai](https://www.projectvex.ai/)):

- *“The model can only **propose**… in restricted mode nothing signs until **you approve**.”*
- *“Nothing trades past the **safety gate**.”*
- *“**Your keys** never leave **your machine**.”*
- *“**Your AI. Your limits. Your receipts.**”*
- *“The only outbound calls are the protocol and model endpoints you **explicitly enable**.”*

Those claims protect the **signing / custody boundary**. This bug did **not** break signing by itself — it broke the assumption **underneath** it:

> User control is enforced at the **safety gate**. Without a destination policy, the agent could **read off the map** first — so the user stayed in control of **who can sign**, not of **what the agent was never allowed to know**.

Enabling web research is consent for **public market research**, not for “GET anything on `127.0.0.1`, the LAN, or cloud instance metadata.”

## Problem (SSRF)

In `web.ts` (before this PR):

1. Scheme check only (`http`/`https`) — allowed `127.0.0.1`, RFC1918, `169.254.169.254`, decimal loopback (`2130706433`), etc.
2. `fetchUrlRawHttp` used undici `fetch` with **default redirect following** and **no** IP policy.
3. Bodies (up to ~50KB) returned to the model and could hit `fetch_cache`.
4. Raw HTTP is the fallback when Tavily is missing/fails — a **production path**.

## User scenario

1. Something steers the agent (malicious market content, scraped page, pasted prompt, or model error).
2. Agent calls `web_research({ url: "http://127.0.0.1:…" })` or a URL that **redirects** there — **no approval**.
3. Vex fetches **from the user’s machine**.
4. Local/private response enters context as “research,” may be cached, and can:
   - leak local HTTP service data into the session;
   - poison the agent’s world-model;
   - under **restricted**, manufacture a false basis for approval;
   - under **full**, feed autonomy on a lie-shaped picture of the world.

## Extreme worst case (chained; assumptions explicit)

**Not** “remote stranger drains the wallet via SSRF alone.”

**Worst case:** Influence the agent → SSRF private/loopback (or redirect there) → inject response into context (optional cache) → optional second hop to an attacker URL for exfil. With exposed local HTTP (or cloud IMDS), impact ranges from **privacy / secondary credential exposure** to **poisoned research**. Under **`permission: "full"`**, poison can drive **unattended** path-to-execution; under **restricted**, it can still **social-engineer** approval. Signing-key custody can remain perfect while **local confidentiality** and **research integrity** are broken.

| Product claim | Signing/custody | Under SSRF |
|---|---|---|
| Model proposes / you approve | Holds | Proposal can be built on **unwarranted local data** |
| Safety gate always on | Holds | Gate still runs; intent can be **epistemically poisoned** |
| Full mode = fewer prompts | Holds | Autonomy on a **compromised world-model** |
| Keys never leave machine | Key material holds | **Other** local/LAN/IMDS data can enter context |
| Outbound you enable | Partial | “Web research” ≠ “localhost proxy” |

## Fix

1. **`assertPublicHttpUrl`** (`public-http-url.ts`) — `http`/`https` only; block embedded credentials; block `localhost` / `.local`; decimal IPv4; DNS resolve; reject loopback, RFC1918, link-local, CGNAT, ULA, multicast/reserved; IPv4-mapped IPv6.
2. **`fetchUrl`** — policy **before** cache/Tavily/raw HTTP (no private re-hit via old cache).
3. **`fetchUrlRawHttp`** — `redirect: "manual"`; re-validate every hop; never cache blocked outcomes.
4. **Tests** — policy unit tests + handler SSRF cases (loopback, IMDS, decimal, redirect-to-loopback, `redirect:manual`).

## Before / after

| Input | Before | After |
|-------|--------|--------|
| `http://127.0.0.1/…` | Body in tool output | **Blocked** (`private_destination`) |
| `http://169.254.169.254/…` | Allowed by scheme | **Blocked** |
| `http://2130706433/…` | Could reach loopback | **Blocked** |
| Public → 302 → loopback | Followed | **Blocked** on redirect hop |
| `https://example.com` | OK | OK |
| `file://` | Rejected | Still rejected |

## Tests run

```bash
pnpm exec vitest run \
  src/__tests__/vex-agent/tools/internal/public-http-url.test.ts \
  src/__tests__/vex-agent/tools/internal/web.test.ts
# 43 passed (15 policy + 28 web, incl. 5 new SSRF cases)
```

## Files

- `src/vex-agent/tools/internal/public-http-url.ts` (new)
- `src/vex-agent/tools/internal/web.ts`
- `src/__tests__/vex-agent/tools/internal/public-http-url.test.ts` (new)
- `src/__tests__/vex-agent/tools/internal/web.test.ts`

## Checklist

- [x] Private/loopback/link-local blocked after resolve
- [x] Redirects cannot land on private IPs
- [x] Public http(s) still works
- [x] Blocked fetches not written to fetch_cache
- [x] Unit tests cover encodings + redirect-to-loopback
- [x] Does not over-claim seed theft; claims **SSRF / local trust boundary / epistemic integrity**