### PR TITLE
fix(mission): auto-retry transient provider blips, reconcile draft readiness, operator paused_error alert

### DIFF
--- a/src/__tests__/vex-agent/db/repos/runtime-control-requests.test.ts
+++ b/src/__tests__/vex-agent/db/repos/runtime-control-requests.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the runtime-control-requests repo. Pool is mocked; no DB.
+ *
+ * Scripted-client pattern matches `loop-wake.test.ts` for consistency:
+ * assert the SQL sent to the mocked pool and the params it carries.
+ *
+ * Focus: WP5 fix — `enqueueRequest`'s `initialStatus` opt-in. A
+ * `cancel_wake` audit row for a control action already applied
+ * synchronously must be inserted already `'cleared'` (with `cleared_at`
+ * set in the SAME statement) instead of `'pending'`, because nothing ever
+ * observes/clears a `cancel_wake` row and a stranded pending row makes the
+ * kind-agnostic `pending_control_kind` lookup treat the session as
+ * permanently busy.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+type PoolQueryOneMock = Mock<
+  (sql: string, params?: unknown[]) => Promise<Record<string, unknown> | null>
+>;
+
+let mockQueryOneWith: PoolQueryOneMock;
+
+function makeQueryOneWithMock(): PoolQueryOneMock {
+  return vi
+    .fn<(sql: string, params?: unknown[]) => Promise<Record<string, unknown> | null>>()
+    .mockResolvedValue(null);
+}
+
+vi.mock("@vex-agent/db/client.js", () => ({
+  getPool: () => ({}),
+  queryOneWith: (_exec: unknown, sql: string, params?: unknown[]) =>
+    mockQueryOneWith(sql, params),
+  executeWith: vi.fn(),
+  queryWith: vi.fn(),
+  query: vi.fn().mockResolvedValue([]),
+}));
+
+mockQueryOneWith = makeQueryOneWithMock();
+
+const repo = await import("@vex-agent/db/repos/runtime-control-requests.js");
+
+const SESSION = "session-abc";
+const NOW = new Date("2026-07-17T10:00:00.000Z");
+
+function makeRow(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    session_id: SESSION,
+    mission_run_id: null,
+    kind: "cancel_wake",
+    status: "pending",
+    requested_by: "user",
+    reason: null,
+    correlation_id: null,
+    created_at: NOW,
+    observed_at: null,
+    cleared_at: null,
+    expires_at: null,
+    ...overrides,
+  };
+}
+
+describe("runtime-control-requests repo — enqueueRequest", () => {
+  beforeEach(() => {
+    mockQueryOneWith = makeQueryOneWithMock();
+  });
+
+  it("defaults to a pending row (existing callers unaffected)", async () => {
+    mockQueryOneWith.mockResolvedValueOnce(makeRow());
+    const result = await repo.enqueueRequest({
+      sessionId: SESSION,
+      kind: "pause_after_step",
+      requestedBy: "user",
+    });
+
+    expect(result.status).toBe("pending");
+    expect(result.clearedAt).toBeNull();
+
+    const [sql, params] = mockQueryOneWith.mock.calls[0];
+    expect(sql).toContain("INSERT INTO runtime_control_requests");
+    expect(sql).toContain(
+      "(session_id, mission_run_id, kind, requested_by, reason, correlation_id, expires_at, status, cleared_at)",
+    );
+    expect(sql).toContain("CASE WHEN $8 = 'cleared' THEN NOW() ELSE NULL END");
+    // Positional params: sessionId, missionRunId, kind, requestedBy, reason,
+    // correlationId, expiresAt, status — status defaults to 'pending'.
+    expect(params).toEqual([SESSION, null, "pause_after_step", "user", null, null, null, "pending"]);
+  });
+
+  it("inserts a cancel_wake row already 'cleared' with cleared_at set, single statement", async () => {
+    mockQueryOneWith.mockResolvedValueOnce(
+      makeRow({ status: "cleared", cleared_at: NOW }),
+    );
+    const result = await repo.enqueueRequest({
+      sessionId: SESSION,
+      kind: "cancel_wake",
+      requestedBy: "user",
+      correlationId: "req-1",
+      reason: "cancelled=1",
+      initialStatus: "cleared",
+    });
+
+    expect(result.status).toBe("cleared");
+    expect(result.clearedAt).not.toBeNull();
+
+    // Single INSERT — no follow-up UPDATE against the mocked pool.
+    expect(mockQueryOneWith).toHaveBeenCalledTimes(1);
+    const [, params] = mockQueryOneWith.mock.calls[0];
+    expect(params?.[7]).toBe("cleared");
+  });
+
+  it("passes 'pending' explicitly through the same param slot when initialStatus is omitted", async () => {
+    mockQueryOneWith.mockResolvedValueOnce(makeRow({ kind: "stop_terminal" }));
+    await repo.enqueueRequest({
+      sessionId: SESSION,
+      kind: "stop_terminal",
+      requestedBy: "system",
+    });
+    const [, params] = mockQueryOneWith.mock.calls[0];
+    expect(params?.[7]).toBe("pending");
+  });
+});

--- a/src/__tests__/vex-agent/engine/abort-mission-run.test.ts
+++ b/src/__tests__/vex-agent/engine/abort-mission-run.test.ts
@@ -22,6 +22,7 @@ const mockClearMissionApprovedAt = vi.fn();
 const mockCancelForSession = vi.fn();
 const mockGetPendingApprovals = vi.fn();
 const mockRejectApproval = vi.fn();
+const mockReconcileDraftReadiness = vi.fn();
 
 vi.mock("@vex-agent/db/repos/mission-runs.js", () => ({
   getRun: (...a: unknown[]) => mockGetRun(...a),
@@ -42,6 +43,15 @@ vi.mock("@vex-agent/db/repos/approvals.js", () => ({
   getPending: (...a: unknown[]) => mockGetPendingApprovals(...a),
   reject: (...a: unknown[]) => mockRejectApproval(...a),
   approve: vi.fn(),
+}));
+
+// WP3 (issue #41): `stopMissionRunForEdit` reconciles draft readiness right
+// after it sets the mission back to 'draft' — mocked here so these tests
+// control the promoted/not-promoted outcome directly, independent of
+// `draft-readiness.test.ts`'s own behavior coverage.
+vi.mock("../../../vex-agent/engine/mission/draft-readiness.js", () => ({
+  reconcileDraftReadiness: (...a: unknown[]) =>
+    mockReconcileDraftReadiness(...a),
 }));
 
 const {
@@ -185,12 +195,21 @@ describe("stopActiveMissionForEdit", () => {
     mockCancelForSession.mockReset();
     mockGetPendingApprovals.mockReset();
     mockRejectApproval.mockReset();
+    mockReconcileDraftReadiness.mockReset();
     mockCancelForSession.mockResolvedValue(0);
     mockGetPendingApprovals.mockResolvedValue([]);
+    // Default: not promoted. Individual tests override to cover both
+    // branches of the WP3 reconciliation outcome.
+    mockReconcileDraftReadiness.mockResolvedValue({ promoted: false });
     if (hasMissionRunAbortController("run-edit")) unregisterMissionRunAbortController("run-edit");
   });
 
-  it("stops an active run for editing without cancelling the mission", async () => {
+  // WP3 (issue #41): `finalStatus` used to hard-code "draft" regardless of
+  // whether the stopped-for-edit mission was actually complete — that's the
+  // bug (drafts trapped in "Preparing"). It now reflects
+  // `reconcileDraftReadiness`'s outcome. Two deliberate variants replace the
+  // single always-"draft" assertion this test used to make.
+  it("stops an active run for editing and promotes a complete draft to ready", async () => {
     mockGetActiveRunBySession.mockResolvedValue({ id: "run-edit" });
     mockGetRun.mockResolvedValue({
       id: "run-edit",
@@ -198,11 +217,12 @@ describe("stopActiveMissionForEdit", () => {
       sessionId: "sess-edit",
       status: "paused_wake",
     });
+    mockReconcileDraftReadiness.mockResolvedValue({ promoted: true });
 
     const result = await stopActiveMissionForEdit("sess-edit");
 
     expect(result?.stopped).toBe(true);
-    expect(result?.finalStatus).toBe("draft");
+    expect(result?.finalStatus).toBe("ready");
     expect(mockCancelForSession).toHaveBeenCalledWith("sess-edit", "user_edit");
     expect(mockUpdateRunStatus).toHaveBeenCalledWith(
       "run-edit",
@@ -211,8 +231,30 @@ describe("stopActiveMissionForEdit", () => {
       { summary: "Mission stopped for operator edit" },
     );
     expect(mockClearMissionApprovedAt).toHaveBeenCalledWith("mission-edit");
+    // setStatus('draft') always fires first — reconcile decides the
+    // reported finalStatus, not whether this write happens.
     expect(mockSetMissionStatus).toHaveBeenCalledWith("mission-edit", "draft");
     expect(mockSetMissionStatus).not.toHaveBeenCalledWith("mission-edit", "cancelled");
+    expect(mockReconcileDraftReadiness).toHaveBeenCalledWith("mission-edit");
+  });
+
+  it("stops an active run for editing and leaves an incomplete draft as draft", async () => {
+    mockGetActiveRunBySession.mockResolvedValue({ id: "run-edit" });
+    mockGetRun.mockResolvedValue({
+      id: "run-edit",
+      missionId: "mission-edit",
+      sessionId: "sess-edit",
+      status: "paused_wake",
+    });
+    mockReconcileDraftReadiness.mockResolvedValue({ promoted: false });
+
+    const result = await stopActiveMissionForEdit("sess-edit");
+
+    expect(result?.stopped).toBe(true);
+    expect(result?.finalStatus).toBe("draft");
+    expect(mockSetMissionStatus).toHaveBeenCalledWith("mission-edit", "draft");
+    expect(mockSetMissionStatus).not.toHaveBeenCalledWith("mission-edit", "cancelled");
+    expect(mockReconcileDraftReadiness).toHaveBeenCalledWith("mission-edit");
   });
 
   it("signals a live running loop before returning the mission to draft", async () => {

--- a/src/__tests__/vex-agent/engine/core/mission-auto-retry.test.ts
+++ b/src/__tests__/vex-agent/engine/core/mission-auto-retry.test.ts
@@ -44,8 +44,13 @@ function lockedRow(over: Record<string, unknown> = {}) {
   };
 }
 
+// WP1 (deliberate test update): the classifier no longer parses `err.message`
+// — `mission-error-classifier.ts` now classifies exclusively from the
+// `status`/`statusCode`/`causeCode` own-properties, so this fixture must
+// carry a real `status` own-property instead of a "returned NNN" message.
 const transientErr = (() => {
   const e = new Error("Provider returned 503");
+  Object.assign(e, { status: 503 });
   return e;
 })();
 
@@ -118,6 +123,38 @@ describe("persistErrorPauseWithMaybeAutoRetry", () => {
     incrementErrorRetryCount.mockResolvedValueOnce(3);
     const decision = await call(transientErr);
     expect(decision.scheduled).toEqual({ attempt: 3, dueAt: new Date(8000).toISOString() });
+  });
+
+  it("evidence carries classified/statusCode/causeCode from the reader, and NEVER errorName", async () => {
+    queryOneWith.mockResolvedValueOnce(lockedRow());
+    const transportErr = Object.assign(new Error("connection reset"), {
+      causeCode: "ECONNRESET",
+    });
+    await call(transportErr);
+    const [, , , payload] = updateStatus.mock.calls[0];
+    const evidence = (payload as { evidence: Record<string, unknown> }).evidence;
+    expect(evidence.classified).toBe("transient");
+    expect(evidence.statusCode).toBeNull();
+    expect(evidence.causeCode).toBe("ECONNRESET");
+    // fix-wave BLOCKER 1: `errorName` (arbitrary `err.name` text) must never
+    // reach persisted evidence — dropped in favor of the bounded
+    // `errorClass` (`err.constructor.name`) evidenceBase already carries.
+    expect(evidence).not.toHaveProperty("errorName");
+    // stop_reason vocabulary is unchanged — claim-auto-retry.ts hard-gates on it.
+    const [, status, reason] = updateStatus.mock.calls[0];
+    expect(status).toBe("paused_error");
+    expect(reason).toBe("provider_error");
+  });
+
+  it("evidence for a permanent 401 carries statusCode and a null causeCode", async () => {
+    queryOneWith.mockResolvedValueOnce(lockedRow());
+    const authErr = Object.assign(new Error("invalid key"), { status: 401 });
+    await call(authErr);
+    const [, , , payload] = updateStatus.mock.calls[0];
+    const evidence = (payload as { evidence: Record<string, unknown> }).evidence;
+    expect(evidence.classified).toBe("permanent");
+    expect(evidence.statusCode).toBe(401);
+    expect(evidence.causeCode).toBeNull();
   });
 });
 

--- a/src/__tests__/vex-agent/engine/core/mission-error-classifier.test.ts
+++ b/src/__tests__/vex-agent/engine/core/mission-error-classifier.test.ts
@@ -17,12 +17,17 @@ function err(
 
 describe("classifyMissionRunError", () => {
   describe("transient", () => {
-    it("429 via message", () => {
-      expect(classifyMissionRunError(err("Provider returned 429 rate limited"))).toBe("transient");
+    // fix #2 (deliberate test update): the classifier no longer parses
+    // `err.message` at all — every status-carrying error must classify from
+    // the `status`/`statusCode` own-property. These two tests used to build
+    // their fixtures from a "returned NNN" message string (the regex this
+    // change removes); rewritten to set the status own-property instead.
+    it("429 via status own-property (message parsing removed)", () => {
+      expect(classifyMissionRunError(err("Provider rate limited", { status: 429 }))).toBe("transient");
     });
-    it("5xx via message (502/503/504/500)", () => {
+    it("5xx via status own-property (502/503/504/500) (message parsing removed)", () => {
       for (const s of [500, 502, 503, 504]) {
-        expect(classifyMissionRunError(err(`upstream returned ${s}`))).toBe("transient");
+        expect(classifyMissionRunError(err("upstream failure", { status: s }))).toBe("transient");
       }
     });
     it("status field 429/503", () => {
@@ -33,6 +38,20 @@ describe("classifyMissionRunError", () => {
       for (const code of ["ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "EPIPE"]) {
         expect(classifyMissionRunError(err("net", { code }))).toBe("transient");
       }
+    });
+    it("causeCode transient allow-list (own-property, no message parsing)", () => {
+      for (const causeCode of [
+        "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "EPIPE",
+        "UND_ERR_CONNECT_TIMEOUT", "UND_ERR_HEADERS_TIMEOUT", "UND_ERR_BODY_TIMEOUT", "UND_ERR_SOCKET",
+      ]) {
+        expect(classifyMissionRunError(err("transport failure", { causeCode }))).toBe("transient");
+      }
+    });
+    it("normalized-shaped error with causeCode:'ECONNRESET' (no status) is transient", () => {
+      const normalized = err("OpenRouter streaming chat completion failed: unknown error", {
+        causeCode: "ECONNRESET",
+      });
+      expect(classifyMissionRunError(normalized)).toBe("transient");
     });
     it("HTTP_TIMEOUT vex code (even when surfaced as AbortError)", () => {
       expect(classifyMissionRunError(err("timed out", { code: "HTTP_TIMEOUT", name: "AbortError" }))).toBe("transient");
@@ -118,6 +137,27 @@ describe("classifyMissionRunError", () => {
       expect(classifyMissionRunError(err("x", { retryable: true, status: 404 }))).toBe("permanent");
       // …but a 503 with retryable:true is still transient (consistent).
       expect(classifyMissionRunError(err("x", { retryable: true, status: 503 }))).toBe("transient");
+    });
+
+    it("causeCode hard-exclusions (incl. ABORT_ERR) always classify permanent", () => {
+      for (const causeCode of [
+        "ABORT_ERR", "UND_ERR_ABORTED", "ENOTFOUND", "UND_ERR_CLOSED",
+        "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+      ]) {
+        expect(classifyMissionRunError(err("x", { causeCode }))).toBe("permanent");
+      }
+    });
+
+    it("an unknown errno-shaped causeCode stays permanent (not on any allow-list)", () => {
+      expect(classifyMissionRunError(err("x", { causeCode: "SOME_UNKNOWN_ERRNO" }))).toBe("permanent");
+    });
+
+    it("a hard-exclusion causeCode beats a contradictory retryable:true (the operator-abort loophole)", () => {
+      // If some other mapper wrongly stamped retryable:true on a normalized
+      // abort, the hard-exclusion must still win — this is the ONLY defense
+      // against auto-retrying an operator stop once `err.name` is erased.
+      expect(classifyMissionRunError(err("x", { retryable: true, causeCode: "ABORT_ERR" }))).toBe("permanent");
+      expect(classifyMissionRunError(err("x", { retryable: true, causeCode: "ENOTFOUND" }))).toBe("permanent");
     });
   });
 });

--- a/src/__tests__/vex-agent/engine/core/runner/mission-error-signal.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/mission-error-signal.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `readMissionErrorSignal` — own-property + shape-validation coverage.
+ *
+ * Two properties this reader must guarantee (BLOCKER 1, fix-wave):
+ *   - own-properties ONLY — a value inherited from the prototype chain
+ *     (e.g. `Error.prototype.name`) must never be misread as an
+ *     attacker/provider-attached signal.
+ *   - `causeCode` is shape-validated (errno-shaped:
+ *     `/^[A-Z][A-Z0-9_]{2,59}$/`) because it is persisted into mission
+ *     evidence / bug-report context — arbitrary prose must never reach a
+ *     persisted record under this field.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readMissionErrorSignal } from "../../../../../vex-agent/engine/core/runner/mission-error-signal.js";
+
+describe("readMissionErrorSignal", () => {
+  it("reads own-property status/code/causeCode/retryable/name", () => {
+    const e = new Error("boom");
+    Object.assign(e, {
+      status: 503,
+      code: "PROVIDER_5XX",
+      causeCode: "ECONNRESET",
+      retryable: true,
+      name: "CustomError",
+    });
+
+    const signal = readMissionErrorSignal(e);
+
+    expect(signal).toEqual({
+      status: 503,
+      code: "PROVIDER_5XX",
+      causeCode: "ECONNRESET",
+      retryable: true,
+      name: "CustomError",
+    });
+  });
+
+  it("returns null for a causeCode/status inherited from the prototype (own-only)", () => {
+    // Build an error whose "causeCode" and "status" exist only on a
+    // prototype in its chain — never assigned as an own-property on the
+    // instance itself. Ordinary indexing (`err.causeCode`) would still
+    // resolve these; the own-property guard must not.
+    class PoisonedBase extends Error {}
+    (PoisonedBase.prototype as unknown as Record<string, unknown>).causeCode = "ECONNRESET";
+    (PoisonedBase.prototype as unknown as Record<string, unknown>).status = 503;
+
+    const e = new PoisonedBase("boom");
+
+    // Sanity check: ordinary indexing WOULD see these (proves the fixture is
+    // actually exercising the own-vs-inherited distinction).
+    expect((e as unknown as Record<string, unknown>).causeCode).toBe("ECONNRESET");
+    expect((e as unknown as Record<string, unknown>).status).toBe(503);
+
+    const signal = readMissionErrorSignal(e);
+
+    expect(signal.causeCode).toBeNull();
+    expect(signal.status).toBeNull();
+  });
+
+  it("returns null for a causeCode that is prose / oversized / lowercase / contains spaces", () => {
+    const cases = [
+      "connection reset by peer", // prose + spaces + lowercase
+      "econnreset", // lowercase
+      "ECONN RESET", // contains a space
+      "E", // too short (< 3 chars total)
+      "1CONNRESET", // does not start with [A-Z]
+      "E" + "C".repeat(60), // oversized (> 60 chars)
+    ];
+
+    for (const causeCode of cases) {
+      const e = new Error("boom");
+      Object.assign(e, { causeCode });
+      expect(readMissionErrorSignal(e).causeCode).toBeNull();
+    }
+  });
+
+  it("returns a valid errno-shaped causeCode (e.g. ECONNRESET)", () => {
+    const e = new Error("boom");
+    Object.assign(e, { causeCode: "ECONNRESET" });
+    expect(readMissionErrorSignal(e).causeCode).toBe("ECONNRESET");
+  });
+
+  it("non-Error input returns the all-null signal", () => {
+    expect(readMissionErrorSignal("not an error")).toEqual({
+      status: null,
+      code: null,
+      causeCode: null,
+      retryable: null,
+      name: null,
+    });
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/runner/mission-finalize-edit-readiness.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/mission-finalize-edit-readiness.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Mission-finalize regression — the async edit finalizer's returned status
+ * (BLOCKER 2, fix-wave prs-17-07-2026).
+ *
+ * `finalizeMissionRunStatus`'s `user_stopped` + edit-abort-intent branch
+ * awaits `reconcileDraftReadiness(missionId)` and previously IGNORED its
+ * `{ promoted }` result, always returning the hard-coded `"draft"`. That
+ * return value becomes the observable `TurnResult.missionStatus`
+ * (`mission-run.ts`), so a mission that was actually complete when the
+ * operator stopped-for-edit was reported back as "draft" instead of
+ * "ready" — mirrors the fix already applied to the SYNC path in
+ * `abort.ts`'s `stopActiveMissionForEdit` (see `abort-mission-run.test.ts`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockMissionRunsUpdateStatus = vi.fn();
+const mockMissionRunsGetRun = vi.fn();
+const mockMissionsSetStatus = vi.fn();
+const mockMissionsClearApprovedAt = vi.fn();
+const mockConsumeAbortIntent = vi.fn();
+const mockScheduleRuntimeContinuation = vi.fn();
+const mockIsContinuableRuntimeStop = vi.fn().mockReturnValue(false);
+const mockReconcileDraftReadiness = vi.fn();
+const mockCaptureMissionFinal = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@vex-agent/db/repos/missions.js", () => ({
+  setStatus: (...a: unknown[]) => mockMissionsSetStatus(...a),
+  clearApprovedAt: (...a: unknown[]) => mockMissionsClearApprovedAt(...a),
+}));
+
+vi.mock("@vex-agent/db/repos/mission-runs.js", () => ({
+  updateStatus: (...a: unknown[]) => mockMissionRunsUpdateStatus(...a),
+  // emitFinalizeControlState re-reads the run for the post-finalize broadcast;
+  // returning null makes it a safe, deterministic no-op for this test's scope.
+  getRun: (...a: unknown[]) => mockMissionRunsGetRun(...a),
+}));
+
+vi.mock("../../../../../vex-agent/engine/core/runner/abort.js", () => ({
+  consumeMissionRunAbortIntent: (...a: unknown[]) => mockConsumeAbortIntent(...a),
+}));
+
+vi.mock("../../../../../vex-agent/engine/core/runner/runtime-continuation.js", () => ({
+  isContinuableRuntimeStop: (...a: unknown[]) => mockIsContinuableRuntimeStop(...a),
+  scheduleRuntimeContinuation: (...a: unknown[]) =>
+    mockScheduleRuntimeContinuation(...a),
+}));
+
+// WP3 (issue #41) idiom — same reconcile-mock as abort-mission-run.test.ts:
+// mocked so this test controls the promoted/not-promoted outcome directly,
+// independent of `draft-readiness.test.ts`'s own behavior coverage.
+vi.mock("@vex-agent/engine/mission/draft-readiness.js", () => ({
+  reconcileDraftReadiness: (...a: unknown[]) => mockReconcileDraftReadiness(...a),
+}));
+
+vi.mock("@vex-agent/engine/mission/mission-results-capture.js", () => ({
+  captureMissionFinal: (...a: unknown[]) => mockCaptureMissionFinal(...a),
+}));
+
+import { finalizeMissionRunStatus } from "../../../../../vex-agent/engine/core/runner/mission-finalize.js";
+
+describe("finalizeMissionRunStatus — user_stopped edit-abort-intent branch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsContinuableRuntimeStop.mockReturnValue(false);
+    mockConsumeAbortIntent.mockReturnValue("edit");
+    mockMissionRunsGetRun.mockResolvedValue(null);
+    mockCaptureMissionFinal.mockResolvedValue(undefined);
+  });
+
+  it('returns "ready" when reconcileDraftReadiness resolves { promoted: true }', async () => {
+    mockReconcileDraftReadiness.mockResolvedValue({ promoted: true });
+
+    const result = await finalizeMissionRunStatus(
+      "mission-1",
+      "run-1",
+      "session-1",
+      "user_stopped",
+    );
+
+    expect(result).toBe("ready");
+    expect(mockReconcileDraftReadiness).toHaveBeenCalledWith("mission-1");
+    expect(mockMissionRunsUpdateStatus).toHaveBeenCalledWith(
+      "run-1",
+      "stopped",
+      "user_stopped",
+      undefined,
+    );
+    expect(mockMissionsClearApprovedAt).toHaveBeenCalledWith("mission-1");
+    expect(mockMissionsSetStatus).toHaveBeenCalledWith("mission-1", "draft");
+  });
+
+  it('returns "draft" when reconcileDraftReadiness resolves { promoted: false }', async () => {
+    mockReconcileDraftReadiness.mockResolvedValue({ promoted: false });
+
+    const result = await finalizeMissionRunStatus(
+      "mission-1",
+      "run-1",
+      "session-1",
+      "user_stopped",
+    );
+
+    expect(result).toBe("draft");
+    expect(mockReconcileDraftReadiness).toHaveBeenCalledWith("mission-1");
+  });
+});

--- a/src/__tests__/vex-agent/engine/mission/draft-readiness.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/draft-readiness.test.ts
@@ -1,0 +1,146 @@
+/**
+ * `reconcileDraftReadiness` (issue #41) — one-way, row-locked, status-
+ * guarded draft → ready promotion.
+ *
+ * Covers:
+ *   - a complete draft promotes to 'ready';
+ *   - an incomplete draft stays 'draft' (no write);
+ *   - a `ready` mission is NEVER touched (never demotes);
+ *   - a missing mission row is a no-op;
+ *   - passing a client reuses it (no nested transaction); omitting one
+ *     opens `withTransaction` and locks the row itself.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetMissionForUpdate = vi.fn();
+const mockSetStatus = vi.fn();
+const mockWithTransaction = vi.fn(
+  async (fn: (client: unknown) => unknown) => fn({ __fakeClient: true }),
+);
+
+vi.mock("@vex-agent/db/client.js", () => ({
+  withTransaction: (fn: (client: unknown) => unknown) =>
+    mockWithTransaction(fn),
+}));
+
+vi.mock("@vex-agent/db/repos/missions.js", () => ({
+  getMissionForUpdate: (...a: unknown[]) => mockGetMissionForUpdate(...a),
+  setStatus: (...a: unknown[]) => mockSetStatus(...a),
+}));
+
+const { reconcileDraftReadiness } = await import(
+  "../../../../vex-agent/engine/mission/draft-readiness.js"
+);
+
+const MISSION = "mission-1";
+
+/** A mission row satisfying every `MISSION_DRAFT_REQUIRED_FIELDS` entry. */
+function completeMission(overrides: Record<string, unknown> = {}) {
+  return {
+    id: MISSION,
+    rootSessionId: "session-1",
+    status: "draft",
+    title: "SOL DCA",
+    goal: "Accumulate 10 SOL",
+    constraintsJson: {},
+    successCriteriaJson: ["Accumulated 10 SOL"],
+    stopConditionsJson: ["capital_depleted"],
+    riskProfile: "conservative",
+    capitalSourceJson: { type: "wallet", amount: "500 USDC" },
+    allowedProtocols: ["jupiter"],
+    allowedChains: ["solana"],
+    allowedWallets: ["solana"],
+    ...overrides,
+  };
+}
+
+/** An incomplete draft — missing `goal`. */
+function incompleteMission(overrides: Record<string, unknown> = {}) {
+  return completeMission({ goal: null, ...overrides });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithTransaction.mockImplementation(
+    async (fn: (client: unknown) => unknown) => fn({ __fakeClient: true }),
+  );
+  mockSetStatus.mockResolvedValue(undefined);
+});
+
+describe("reconcileDraftReadiness", () => {
+  it("promotes a complete draft to ready", async () => {
+    mockGetMissionForUpdate.mockResolvedValue(completeMission());
+
+    const result = await reconcileDraftReadiness(MISSION);
+
+    expect(result).toEqual({ promoted: true });
+    expect(mockSetStatus).toHaveBeenCalledWith(
+      MISSION,
+      "ready",
+      expect.anything(),
+    );
+  });
+
+  it("leaves an incomplete draft at draft (no write)", async () => {
+    mockGetMissionForUpdate.mockResolvedValue(incompleteMission());
+
+    const result = await reconcileDraftReadiness(MISSION);
+
+    expect(result).toEqual({ promoted: false });
+    expect(mockSetStatus).not.toHaveBeenCalled();
+  });
+
+  it("never demotes — a ready mission is left untouched even if it were invalid", async () => {
+    mockGetMissionForUpdate.mockResolvedValue(
+      incompleteMission({ status: "ready" }),
+    );
+
+    const result = await reconcileDraftReadiness(MISSION);
+
+    expect(result).toEqual({ promoted: false });
+    expect(mockSetStatus).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for a mission in any other status (e.g. running)", async () => {
+    mockGetMissionForUpdate.mockResolvedValue(
+      completeMission({ status: "running" }),
+    );
+
+    const result = await reconcileDraftReadiness(MISSION);
+
+    expect(result).toEqual({ promoted: false });
+    expect(mockSetStatus).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the mission row is missing", async () => {
+    mockGetMissionForUpdate.mockResolvedValue(null);
+
+    const result = await reconcileDraftReadiness(MISSION);
+
+    expect(result).toEqual({ promoted: false });
+    expect(mockSetStatus).not.toHaveBeenCalled();
+  });
+
+  it("reuses the caller's client and does not open its own transaction", async () => {
+    mockGetMissionForUpdate.mockResolvedValue(completeMission());
+    const callerClient = { __callerClient: true };
+
+    const result = await reconcileDraftReadiness(MISSION, callerClient as never);
+
+    expect(result).toEqual({ promoted: true });
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+    expect(mockGetMissionForUpdate).toHaveBeenCalledWith(callerClient, MISSION);
+    expect(mockSetStatus).toHaveBeenCalledWith(MISSION, "ready", callerClient);
+  });
+
+  it("opens its own transaction and locks the row when no client is passed", async () => {
+    mockGetMissionForUpdate.mockResolvedValue(completeMission());
+
+    await reconcileDraftReadiness(MISSION);
+
+    expect(mockWithTransaction).toHaveBeenCalledTimes(1);
+    const txClient = mockGetMissionForUpdate.mock.calls[0]![0];
+    expect(mockSetStatus).toHaveBeenCalledWith(MISSION, "ready", txClient);
+  });
+});

--- a/src/__tests__/vex-agent/engine/mission/renew.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/renew.test.ts
@@ -14,6 +14,7 @@ const mockGetActiveRunBySession = vi.fn();
 const mockCloneMissionAsDraft = vi.fn();
 const mockLockSessionForRenew = vi.fn();
 const mockGetPendingDraftForSession = vi.fn();
+const mockReconcileDraftReadiness = vi.fn();
 
 vi.mock("@vex-agent/db/repos/missions.js", () => ({
   getMissionForUpdate: (...a: unknown[]) => mockGetMissionForUpdate(...a),
@@ -29,6 +30,16 @@ vi.mock("@vex-agent/db/repos/mission-runs.js", () => ({
 
 vi.mock("../../../../vex-agent/engine/mission/renew-internals.js", () => ({
   cloneMissionAsDraft: (...a: unknown[]) => mockCloneMissionAsDraft(...a),
+}));
+
+// `cloneMissionAsDraft` returns `Promise<void>` (see renew-internals.ts) —
+// its mock cannot return a row, so the complete→ready / incomplete→draft
+// behavior is NOT testable here. That behavior lives in
+// `draft-readiness.test.ts`; this file only asserts the wiring: called
+// with the NEW mission id and the SAME tx client the clone used.
+vi.mock("../../../../vex-agent/engine/mission/draft-readiness.js", () => ({
+  reconcileDraftReadiness: (...a: unknown[]) =>
+    mockReconcileDraftReadiness(...a),
 }));
 
 const fakeClientQuery = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
@@ -105,6 +116,7 @@ describe("renewMission", () => {
     vi.clearAllMocks();
     mockLockSessionForRenew.mockResolvedValue(undefined);
     mockGetPendingDraftForSession.mockResolvedValue(null);
+    mockReconcileDraftReadiness.mockResolvedValue({ promoted: false });
   });
 
   it("returns previous_mission_not_found when source is missing", async () => {
@@ -198,6 +210,29 @@ describe("renewMission", () => {
     // (client, sourceMissionId, newMissionId, targetSessionId)
     expect(args[1]).toBe("mission-source");
     expect(args[3]).toBe("session-1");
+  });
+
+  it("reconciles the NEW mission's draft readiness in the SAME tx client as the clone", async () => {
+    mockGetMissionForUpdate.mockResolvedValueOnce(makeMission());
+    mockGetActiveRun.mockResolvedValueOnce(null);
+    mockGetActiveRunBySession.mockResolvedValueOnce(null);
+
+    const outcome = await renewMission({
+      sessionId: "session-1",
+      previousMissionId: "mission-source",
+    });
+
+    expect(outcome.outcome).toBe("renewed");
+    expect(mockReconcileDraftReadiness).toHaveBeenCalledTimes(1);
+    const cloneArgs = mockCloneMissionAsDraft.mock.calls[0]!;
+    const reconcileArgs = mockReconcileDraftReadiness.mock.calls[0]!;
+    const newMissionId =
+      outcome.outcome === "renewed" ? outcome.newMissionId : null;
+    // Called with the NEW mission id, not the source.
+    expect(reconcileArgs[0]).toBe(newMissionId);
+    expect(reconcileArgs[0]).not.toBe("mission-source");
+    // Same tx client the clone insert used.
+    expect(reconcileArgs[1]).toBe(cloneArgs[0]);
   });
 
   it("acquires the session-scoped advisory lock before any precondition check", async () => {

--- a/src/__tests__/vex-agent/engine/types.test.ts
+++ b/src/__tests__/vex-agent/engine/types.test.ts
@@ -18,7 +18,10 @@ import type {
   MessageMetadata,
 } from "../../../vex-agent/engine/types.js";
 
-import { MISSION_DRAFT_REQUIRED_FIELDS } from "../../../vex-agent/engine/types.js";
+import {
+  MISSION_DRAFT_REQUIRED_FIELDS,
+  MissionRunPausedError,
+} from "../../../vex-agent/engine/types.js";
 
 describe("engine types", () => {
   // ── Session axes ────────────────────────────────────────────────
@@ -261,6 +264,53 @@ describe("engine types", () => {
       };
       expect(result.stopReason).toBe("goal_reached");
       expect(result.missionStatus).toBe("completed");
+    });
+  });
+
+  // ── MissionRunPausedError — wrapper propagation (WP1 step 6) ───
+
+  describe("MissionRunPausedError", () => {
+    it("copies statusCode/causeCode from a normalized 503/ECONNRESET-shaped cause", () => {
+      const cause = Object.assign(
+        new Error("OpenRouter chat completion failed: status=503 | unavailable"),
+        { statusCode: 503, causeCode: "ECONNRESET" },
+      );
+      const wrapper = new MissionRunPausedError({
+        runId: "run-1", missionId: "mission-1", sessionId: "session-1", cause,
+      });
+      expect(wrapper.statusCode).toBe(503);
+      expect(wrapper.causeCode).toBe("ECONNRESET");
+      expect(wrapper.cause).toBe(cause);
+    });
+
+    it("is null for a cause with no matching validated own-property", () => {
+      const wrapper = new MissionRunPausedError({
+        runId: "run-1", missionId: "mission-1", sessionId: "session-1",
+        cause: new Error("plain failure"),
+      });
+      expect(wrapper.statusCode).toBeNull();
+      expect(wrapper.causeCode).toBeNull();
+    });
+
+    it("rejects a non-finite statusCode and a non-errno-shaped causeCode", () => {
+      const cause = Object.assign(new Error("weird"), {
+        statusCode: NaN,
+        causeCode: "not an errno shape!",
+      });
+      const wrapper = new MissionRunPausedError({
+        runId: "run-1", missionId: "mission-1", sessionId: "session-1", cause,
+      });
+      expect(wrapper.statusCode).toBeNull();
+      expect(wrapper.causeCode).toBeNull();
+    });
+
+    it("handles a non-Error cause without throwing", () => {
+      const wrapper = new MissionRunPausedError({
+        runId: "run-1", missionId: "mission-1", sessionId: "session-1", cause: "boom",
+      });
+      expect(wrapper.statusCode).toBeNull();
+      expect(wrapper.causeCode).toBeNull();
+      expect(wrapper.message).toBe("boom");
     });
   });
 

--- a/src/__tests__/vex-agent/inference/openrouter-midstream-error.test.ts
+++ b/src/__tests__/vex-agent/inference/openrouter-midstream-error.test.ts
@@ -1,0 +1,141 @@
+/**
+ * WP1 step 3 — mid-stream (post-first-chunk) error normalization.
+ *
+ * `yield* consumeOpenRouterStream(stream)` used to sit OUTSIDE the try/catch
+ * that wraps `client.chat.send`, so a rejection thrown by the stream's async
+ * iterator AFTER at least one chunk was yielded reached callers as a raw SDK
+ * error — bypassing both classifier metadata (own-property `causeCode`) and
+ * message redaction. This pins the fixed behavior: such a rejection now goes
+ * through `normalizeOpenRouterError` exactly like the pre-send path.
+ *
+ * `stream-consumer.ts` (provider-agnostic) is a SEPARATE layer and is
+ * deliberately untouched by this change — see its own test file.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const sendMock = vi.fn();
+
+vi.mock("@openrouter/sdk", () => ({
+  OpenRouter: class {
+    readonly models = { list: vi.fn() };
+    readonly chat = { send: sendMock };
+    readonly credits = {};
+    readonly apiKeys = {};
+    constructor(_opts: unknown) {}
+  },
+}));
+
+const loggerMock = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+}));
+vi.mock("@utils/logger.js", () => ({
+  default: loggerMock,
+  logger: loggerMock,
+  createChildLogger: () => loggerMock,
+}));
+
+const { OpenRouterProvider } = await import("../../../vex-agent/inference/openrouter.js");
+
+import type {
+  InferenceConfig,
+  ProviderMessage,
+  StreamChunk,
+} from "../../../vex-agent/inference/types.js";
+
+function makeConfig(): InferenceConfig {
+  return {
+    provider: "openrouter",
+    model: "deepseek/deepseek-v4-flash",
+    contextLimit: 128_000,
+    maxOutputTokens: 4096,
+    inputPricePerM: 3,
+    outputPricePerM: 15,
+    priceCurrency: "USD",
+    cachePricePerM: null,
+    cacheWritePricePerM: null,
+    reasoningPricePerM: null,
+  };
+}
+
+const MESSAGES: ProviderMessage[] = [{ role: "user", content: "hi" }];
+
+/** Read a (non-enumerable) own-property the way the classifier does. */
+function field(err: Error, key: string): unknown {
+  return (err as unknown as Record<string, unknown>)[key];
+}
+
+describe("OpenRouterProvider.chatCompletionStream — mid-stream error normalization", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    sendMock.mockReset();
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("AGENT_") || key.startsWith("OPENROUTER_")) {
+        delete process.env[key];
+      }
+    }
+    process.env.OPENROUTER_API_KEY = "sk-or-test";
+    process.env.AGENT_MODEL = "deepseek/deepseek-v4-flash";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("normalizes a post-first-chunk generator rejection (scrubbed message, causeCode preserved)", async () => {
+    // Yields one content chunk, then the async iterator's `next()` rejects —
+    // the shape a dropped connection produces mid-stream — never a chunk
+    // with `.error`, so this exercises ONLY the new outer try/catch around
+    // `yield* consumeOpenRouterStream(stream)`.
+    const asyncIterable = {
+      [Symbol.asyncIterator]() {
+        let step = 0;
+        return {
+          next: async () => {
+            if (step === 0) {
+              step += 1;
+              return {
+                value: { choices: [{ delta: { content: "partial" } }] },
+                done: false,
+              };
+            }
+            const transportErr = new Error(
+              "socket hang up at https://openrouter.ai/api/v1 Bearer sk-or-leak",
+            );
+            Object.assign(transportErr, { cause: { code: "ECONNRESET" } });
+            throw transportErr;
+          },
+        };
+      },
+    };
+    sendMock.mockResolvedValue(asyncIterable);
+
+    const provider = new OpenRouterProvider();
+    const chunks: StreamChunk[] = [];
+    let caught: unknown = null;
+    try {
+      for await (const chunk of provider.chatCompletionStream(MESSAGES, [], makeConfig())) {
+        chunks.push(chunk);
+      }
+    } catch (streamErr) {
+      caught = streamErr;
+    }
+
+    expect(chunks).toEqual([{ type: "content", text: "partial" }]);
+    expect(caught).toBeInstanceOf(Error);
+    const normalized = caught as Error;
+    expect(normalized.message).toContain(
+      "OpenRouter streaming chat completion (mid-stream) failed",
+    );
+    // Scrubbed — the raw URL/bearer token never reaches the surfaced message.
+    expect(normalized.message).not.toContain("openrouter.ai");
+    expect(normalized.message).not.toContain("sk-or-leak");
+    // causeCode preserved (own-property) for the mission classifier.
+    expect(field(normalized, "causeCode")).toBe("ECONNRESET");
+  });
+});

--- a/src/vex-agent/db/repos/runtime-control-requests.ts
+++ b/src/vex-agent/db/repos/runtime-control-requests.ts
@@ -96,18 +96,27 @@ export interface EnqueueInput {
   readonly reason?: string | null;
   readonly correlationId?: string | null;
   readonly expiresAt?: Date | null;
+  /**
+   * Narrow two-value union (NOT the full `ControlRequestStatus`) — a caller
+   * that already applied the control action synchronously (e.g. cancel_wake)
+   * can insert the audit row already `'cleared'` instead of enqueueing a
+   * `'pending'` row nothing will ever observe or clear. Defaults to
+   * `'pending'`, the historical behavior for every other caller.
+   */
+  readonly initialStatus?: "pending" | "cleared";
 }
 
-/** INSERT a new pending control request. Returns the inserted row. */
+/** INSERT a new control request. Returns the inserted row. */
 export async function enqueueRequest(
   input: EnqueueInput,
   exec?: Executor,
 ): Promise<ControlRequest> {
+  const status = input.initialStatus ?? "pending";
   const row = await queryOneWith<ControlRequestRow>(
     exec ?? (await import("../client.js")).getPool(),
     `INSERT INTO runtime_control_requests
-       (session_id, mission_run_id, kind, requested_by, reason, correlation_id, expires_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)
+       (session_id, mission_run_id, kind, requested_by, reason, correlation_id, expires_at, status, cleared_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, CASE WHEN $8 = 'cleared' THEN NOW() ELSE NULL END)
      RETURNING id, session_id, mission_run_id, kind, status, requested_by,
                reason, correlation_id, created_at, observed_at, cleared_at, expires_at`,
     [
@@ -118,6 +127,7 @@ export async function enqueueRequest(
       input.reason ?? null,
       input.correlationId ?? null,
       input.expiresAt ?? null,
+      status,
     ],
   );
   if (row === null) {

--- a/src/vex-agent/engine/core/runner/abort.ts
+++ b/src/vex-agent/engine/core/runner/abort.ts
@@ -38,6 +38,7 @@ import * as missionsRepo from "@vex-agent/db/repos/missions.js";
 import * as loopWakeRepo from "@vex-agent/db/repos/loop-wake.js";
 import logger from "@utils/logger.js";
 import { rejectPendingApprovalsForSession } from "./approvals-cleanup.js";
+import { reconcileDraftReadiness } from "../../mission/draft-readiness.js";
 
 // ── In-process AbortController registry ─────────────────────────
 
@@ -214,11 +215,19 @@ export async function stopMissionRunForEdit(
   );
   await missionsRepo.clearApprovedAt(run.missionId);
   await missionsRepo.setStatus(run.missionId, "draft");
+  // A draft that was already complete before the stop-for-edit (e.g. the
+  // operator just wanted to re-review, not change anything) would otherwise
+  // sit at 'draft' forever — no model patch is coming to promote it.
+  const reconciled = await reconcileDraftReadiness(run.missionId);
   logger.info("engine.mission.edit_finalized", {
     runId,
     sessionId: run.sessionId,
     previousStatus: run.status,
   });
 
-  return { stopped: true, finalStatus: "draft", rejectedApprovals };
+  return {
+    stopped: true,
+    finalStatus: reconciled.promoted ? "ready" : "draft",
+    rejectedApprovals,
+  };
 }

--- a/src/vex-agent/engine/core/runner/mission-auto-retry.ts
+++ b/src/vex-agent/engine/core/runner/mission-auto-retry.ts
@@ -23,6 +23,7 @@ import type { PoolClient } from "pg";
 import * as missionRunsRepo from "../../../db/repos/mission-runs.js";
 import * as loopWakeRepo from "../../../db/repos/loop-wake.js";
 import { classifyMissionRunError } from "./mission-error-classifier.js";
+import { readMissionErrorSignal } from "./mission-error-signal.js";
 import {
   AUTO_RETRY_WAKE_TRIGGER,
   MAX_AUTO_RETRIES,
@@ -64,6 +65,7 @@ export async function persistErrorPauseWithMaybeAutoRetry(
   nowMs: number,
 ): Promise<ErrorPauseDecision> {
   const classified = classifyMissionRunError(input.err);
+  const signal = readMissionErrorSignal(input.err);
   return withTransaction(async (client: PoolClient) => {
     const row = await queryOneWith<LockedRunRow>(
       client,
@@ -84,7 +86,20 @@ export async function persistErrorPauseWithMaybeAutoRetry(
       row.permission === "full" &&
       snapshotAutoRetryEnabled(row.contract_snapshot_json);
 
-    const evidence: Record<string, unknown> = { ...input.evidenceBase };
+    // Error-diagnostics phase (D-RUNTIME): stamp the classification + the
+    // reader's own-property signals on every paused_error row's evidence, so
+    // a human recovering the run (or a later dashboard) can see WHY the
+    // auto-retry decision went the way it did without re-deriving it.
+    // `errorName` (raw `err.name`) is deliberately NOT persisted here — it is
+    // arbitrary caller-controlled text, unlike the bounded `errorClass`
+    // (`err.constructor.name`) evidenceBase already carries upstream and the
+    // shape-validated `causeCode` below.
+    const evidence: Record<string, unknown> = {
+      ...input.evidenceBase,
+      classified,
+      statusCode: signal.status,
+      causeCode: signal.causeCode,
+    };
     let scheduled: { attempt: number; dueAt: string } | null = null;
 
     if (eligible) {

--- a/src/vex-agent/engine/core/runner/mission-error-classifier.ts
+++ b/src/vex-agent/engine/core/runner/mission-error-classifier.ts
@@ -17,14 +17,23 @@
  * Note the layering: the OpenRouter SDK only retries 5XX internally by default
  * (`retryCodes: ['5XX']`); 429 is NOT retried by the SDK and is owned by this
  * mission auto-retry layer. `normalizeOpenRouterError` attaches the HTTP status
- * as a lean `statusCode`/`status` own-property on the error it throws, so a
- * transient 429/5xx is classified `"transient"` here from the STATUS PROPERTY
- * (not a message regex) and the run auto-retries instead of pausing.
+ * as a lean `statusCode`/`status` own-property, and the errno-shaped transport
+ * cause code as a lean `causeCode` own-property (never `.code` — normalization
+ * never sets it), on the error it throws. Classification below reads BOTH
+ * exclusively from these own-properties (via `readMissionErrorSignal`) —
+ * never from `err.message` — so a scrubbed/redacted message can never change
+ * the auto-retry decision.
  */
+
+import { readMissionErrorSignal } from "./mission-error-signal.js";
 
 export type MissionErrorClass = "transient" | "permanent";
 
-/** Socket / DNS / connection-reset errors — transient by nature. */
+/**
+ * Socket / DNS / connection-reset errors — transient by nature. Checked
+ * against the RAW `.code` own-property (a direct Node/undici throw that never
+ * passed through the OpenRouter normalizer).
+ */
 const TRANSIENT_NODE_CODES: ReadonlySet<string> = new Set([
   "ETIMEDOUT",
   "ECONNRESET",
@@ -33,36 +42,54 @@ const TRANSIENT_NODE_CODES: ReadonlySet<string> = new Set([
   "EPIPE",
 ]);
 
+/**
+ * Transient allow-list checked against the normalizer's `causeCode`
+ * own-property — the ONLY transport signal a normalized OpenRouter error
+ * carries, since normalization never sets `.code`. Superset of
+ * `TRANSIENT_NODE_CODES` plus undici transport timeout/socket codes.
+ */
+const TRANSIENT_CAUSE_CODES: ReadonlySet<string> = new Set([
+  ...TRANSIENT_NODE_CODES,
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/**
+ * NEVER transient, regardless of any allow-list match above — checked BEFORE
+ * the `retryable` marker fallback so a (possibly wrong) `retryable:true`
+ * stamped by some other mapper can never promote one of these into an
+ * auto-retry. Checked against both `.code` and `.causeCode`.
+ *   - `ABORT_ERR` / `UND_ERR_ABORTED`: the normalizer erases `err.name` (see
+ *     `openrouter/errors.ts`), so this allow-list is the ONLY remaining
+ *     defense against auto-retrying an operator stop once a normalized error
+ *     is in play.
+ *   - `ENOTFOUND`: DNS resolution failure — retrying the same host wastes the
+ *     backoff budget on a name that will not resolve.
+ *   - `UND_ERR_CLOSED`: the connection was intentionally closed, not dropped.
+ *   - TLS verification codes: a certificate problem does not self-heal on
+ *     retry (same set `inference/openrouter.ts` uses for its
+ *     `api_unreachable` hint selection — duplicated here, not imported, to
+ *     avoid coupling the classifier to a specific provider module).
+ */
+const NEVER_TRANSIENT_CODES: ReadonlySet<string> = new Set([
+  "ABORT_ERR",
+  "UND_ERR_ABORTED",
+  "ENOTFOUND",
+  "UND_ERR_CLOSED",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "CERT_HAS_EXPIRED",
+]);
+
 /** VexError codes that represent a transient request-level failure. */
 const TRANSIENT_VEX_CODES: ReadonlySet<string> = new Set(["HTTP_TIMEOUT"]);
 
-/**
- * Read an arbitrary own-property off an Error (status/code/retryable live on
- * subclasses, not on the base type). The `unknown` hop is required because
- * `Error` has no index signature; it is read-only and locally contained here.
- */
-function field(err: Error, key: string): unknown {
-  return (err as unknown as Record<string, unknown>)[key];
-}
-
-/** Read an HTTP status from common error shapes, or null. */
-function statusFrom(err: Error): number | null {
-  for (const key of ["status", "statusCode"]) {
-    const v = field(err, key);
-    if (typeof v === "number" && Number.isFinite(v)) return v;
-  }
-  // OpenRouter/HTTP errors embed "... returned 503 ..." in the message.
-  const m = /\breturned\s+(\d{3})\b/i.exec(err.message);
-  return m ? Number(m[1]) : null;
-}
-
 function isTransientStatus(status: number): boolean {
   return status === 429 || (status >= 500 && status <= 599);
-}
-
-function codeOf(err: Error): string | null {
-  const v = field(err, "code");
-  return typeof v === "string" ? v : null;
 }
 
 /**
@@ -73,28 +100,41 @@ function codeOf(err: Error): string | null {
 export function classifyMissionRunError(err: unknown): MissionErrorClass {
   if (!(err instanceof Error)) return "permanent";
 
-  const code = codeOf(err);
+  const signal = readMissionErrorSignal(err);
 
   // A genuine request timeout is transient even if it surfaces as an AbortError
   // (millisecond-timer abort) — check the explicit timeout code FIRST so it is
-  // not swallowed by the user-abort guard below.
-  if (code !== null && TRANSIENT_VEX_CODES.has(code)) return "transient";
+  // not swallowed by the user-abort / hard-exclusion guards below.
+  if (signal.code !== null && TRANSIENT_VEX_CODES.has(signal.code)) return "transient";
 
-  // Any other abort (notably a user stop) is never auto-retried.
+  // Any other abort (notably a user stop) is never auto-retried. Only catches
+  // RAW (non-normalized) abort errors that still carry their original `.name`
+  // — the hard-exclusion check below is what catches normalized ones (whose
+  // `.name` the normalizer erases).
   if (err.name === "AbortError") return "permanent";
+
+  // Hard exclusions — see NEVER_TRANSIENT_CODES doc above.
+  if (
+    (signal.code !== null && NEVER_TRANSIENT_CODES.has(signal.code)) ||
+    (signal.causeCode !== null && NEVER_TRANSIENT_CODES.has(signal.causeCode))
+  ) {
+    return "permanent";
+  }
 
   // HTTP status is authoritative and beats a (possibly contradictory) retryable
   // marker: a 401/403/404/422 stays permanent even if some mapper set
   // retryable:true. Only 429 + 5xx are transient.
-  const status = statusFrom(err);
-  if (status !== null) return isTransientStatus(status) ? "transient" : "permanent";
+  if (signal.status !== null) return isTransientStatus(signal.status) ? "transient" : "permanent";
 
   // No status — honor an explicit transient marker from a mapper
   // (Khalani/DexScreener set this on 429/5xx they couldn't tag with a status).
-  if (field(err, "retryable") === true) return "transient";
+  if (signal.retryable === true) return "transient";
 
-  // Socket / connection-level transient errors.
-  if (code !== null && TRANSIENT_NODE_CODES.has(code)) return "transient";
+  // Socket / connection-level transient errors (raw `.code`).
+  if (signal.code !== null && TRANSIENT_NODE_CODES.has(signal.code)) return "transient";
+
+  // Transient causeCode (normalizer-attached, own-property).
+  if (signal.causeCode !== null && TRANSIENT_CAUSE_CODES.has(signal.causeCode)) return "transient";
 
   // Unknown shape → conservative permanent (never auto-retry on uncertainty).
   return "permanent";

--- a/src/vex-agent/engine/core/runner/mission-error-signal.ts
+++ b/src/vex-agent/engine/core/runner/mission-error-signal.ts
@@ -1,0 +1,93 @@
+/**
+ * Own-property reader for a thrown mission/inference error's transport/HTTP
+ * shape. `mission-error-classifier.ts` (auto-retry classification) reads
+ * from this; `engine/types.ts` `MissionRunPausedError` intentionally does
+ * NOT (that file stays dependency-light — see its own header comment — and
+ * duplicates the same reader idiom locally instead of importing this module).
+ *
+ * Own-properties ONLY — this never walks `.cause`. The OpenRouter normalizer
+ * contract (`inference/openrouter/errors.ts`) guarantees a normalized error
+ * carries no `.cause` (walking would re-open the exact PII/body re-leak path
+ * the normalizer exists to close), and walking an arbitrary caller's `.cause`
+ * chain here would let something like `ABORT_ERR` buried at depth 1+ get
+ * misread as the top-level signal for an error that is not actually an abort
+ * at this layer.
+ */
+
+/** Validated own-property signals read off a thrown value's transport shape. */
+export interface MissionErrorSignal {
+  readonly status: number | null;
+  readonly code: string | null;
+  readonly causeCode: string | null;
+  readonly retryable: boolean | null;
+  readonly name: string | null;
+}
+
+const EMPTY_SIGNAL: MissionErrorSignal = {
+  status: null,
+  code: null,
+  causeCode: null,
+  retryable: null,
+  name: null,
+};
+
+/**
+ * Read an arbitrary OWN-property off an Error (status/code/retryable live on
+ * subclasses, not on the base type). The `unknown` hop is required because
+ * `Error` has no index signature; it is read-only and locally contained here.
+ * Own-property guard: ordinary indexing would also resolve inherited
+ * prototype properties (e.g. `Error.prototype.name`), letting a caller
+ * "read" a signal that was never actually attached to this value.
+ */
+function field(err: Error, key: string): unknown {
+  if (!Object.prototype.hasOwnProperty.call(err, key)) return undefined;
+  return (err as unknown as Record<string, unknown>)[key];
+}
+
+function numberField(err: Error, keys: readonly string[]): number | null {
+  for (const key of keys) {
+    const v = field(err, key);
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
+function stringField(err: Error, key: string): string | null {
+  const v = field(err, key);
+  return typeof v === "string" ? v : null;
+}
+
+/** Errno-shaped code guard — mirrors `lib/error-cause.ts` (not exported there; duplicated). */
+const ERRNO_SHAPE = /^[A-Z][A-Z0-9_]{2,59}$/;
+
+/**
+ * `causeCode` is persisted into mission evidence / bug-report context, so it
+ * must be shape-validated here (not just own-read) — an arbitrary attacker-
+ * or provider-controlled string must never reach a persisted record under
+ * this field.
+ */
+function causeCodeField(err: Error, key: string): string | null {
+  const v = field(err, key);
+  return typeof v === "string" && ERRNO_SHAPE.test(v) ? v : null;
+}
+
+function booleanField(err: Error, key: string): boolean | null {
+  const v = field(err, key);
+  return typeof v === "boolean" ? v : null;
+}
+
+/**
+ * Read the transport/HTTP own-properties off an unknown thrown value.
+ * Non-Error inputs return all-null. Own-properties only — never follows
+ * `.cause`.
+ */
+export function readMissionErrorSignal(err: unknown): MissionErrorSignal {
+  if (!(err instanceof Error)) return EMPTY_SIGNAL;
+  return {
+    status: numberField(err, ["status", "statusCode"]),
+    code: stringField(err, "code"),
+    causeCode: causeCodeField(err, "causeCode"),
+    retryable: booleanField(err, "retryable"),
+    name: stringField(err, "name"),
+  };
+}

--- a/src/vex-agent/engine/core/runner/mission-finalize.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize.ts
@@ -21,6 +21,7 @@ import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
 import logger from "@utils/logger.js";
 import { consumeMissionRunAbortIntent } from "./abort.js";
 import { captureMissionFinal } from "../../mission/mission-results-capture.js";
+import { reconcileDraftReadiness } from "../../mission/draft-readiness.js";
 import {
   isContinuableRuntimeStop,
   scheduleRuntimeContinuation,
@@ -29,6 +30,7 @@ import {
   enqueueAutoRetryWake,
   persistErrorPauseWithMaybeAutoRetry,
 } from "./mission-auto-retry.js";
+import { readMissionErrorSignal } from "./mission-error-signal.js";
 
 const ERROR_MESSAGE_LIMIT = 4096;
 
@@ -88,9 +90,14 @@ export async function finalizeMissionRunStatus(
       await missionRunsRepo.updateStatus(runId, "stopped", stopReason, stopPayload);
       await missionsRepo.clearApprovedAt(missionId);
       await missionsRepo.setStatus(missionId, "draft");
+      // The async finalizer runs AFTER `stopMissionRunForEdit` already
+      // reconciled once (abort.ts) — this demote-then-finalize sequence is
+      // exactly the timing window issue #41 needs closed at every write
+      // site, not just the first one.
+      const reconciled = await reconcileDraftReadiness(missionId);
       await emitFinalizeControlState(sessionId, runId);
       await captureMissionFinal({ missionId, runId, sessionId, outcome: "stopped", stopReason });
-      return "draft";
+      return reconciled.promoted ? "ready" : "draft";
     }
 
     const status: MissionStatus = stopReason === "goal_reached"
@@ -194,6 +201,9 @@ export async function finalizeMissionRunError(
 ): Promise<void> {
   const errorMessage = formatErrorMessage(err);
   const errorClass = err instanceof Error ? err.constructor.name : typeof err;
+  // Errno-shaped transport signal (own-property, never message text) — fed
+  // into both the persisted evidence below AND the bug-report `context`.
+  const causeCode = readMissionErrorSignal(err).causeCode;
   // Log first — even if the DB write below fails, the failure stays visible.
   logger.error("engine.mission.runtime_throw", {
     runId,
@@ -214,6 +224,7 @@ export async function finalizeMissionRunError(
         evidenceBase: {
           errorMessage,
           errorClass,
+          causeCode,
           occurredAt: new Date().toISOString(),
           missionId,
           runId,
@@ -263,6 +274,13 @@ export async function finalizeMissionRunError(
           missionId,
           missionRunId: runId,
         },
+        // `context` itself is `z.record(z.string(), z.unknown())` (unbounded;
+        // `bug-report-schema.ts`) — redaction happens later in the bug-report
+        // service. The VALUE stored under `causeCode` here is shape-validated
+        // (errno-shaped, own-property-read — see `mission-error-signal.ts`),
+        // never raw message text beyond what already flows through
+        // `description`.
+        context: { causeCode },
         agentContext: {
           stopReason: "provider_error",
           runtimeStatus: "paused_error",

--- a/src/vex-agent/engine/mission/draft-readiness.ts
+++ b/src/vex-agent/engine/mission/draft-readiness.ts
@@ -1,0 +1,66 @@
+/**
+ * Draft readiness reconciler — the ONE-WAY `draft` → `ready` promotion.
+ *
+ * Before this module, the only draft→ready transition was the model-patch
+ * path (`applyMissionPatch` in `./setup.ts`), which fires only when the
+ * model sends a `mission_draft_update` patch. A renewed clone or an
+ * edited-and-resaved mission that is ALREADY complete produces no patch,
+ * so it never promotes — the badge shows "Preparing" forever (issue #41).
+ * This is the reconciliation call every draft-producing write site makes
+ * right after it writes `status = 'draft'`.
+ *
+ * One-way and status-guarded: NEVER demotes `ready` → `draft` (that stays
+ * `setup.ts`'s job — an edit can clear a previously-ready field) and
+ * NEVER promotes an invalid draft. Status is not a security gate:
+ * `ACCEPTABLE_MISSION_STATUSES` (`acceptance.ts`) already accepts
+ * `'draft'` for contract acceptance, so promoting a complete draft to
+ * `'ready'` only changes what the operator sees, not what they can do.
+ */
+
+import type { PoolClient } from "pg";
+
+import { withTransaction } from "@vex-agent/db/client.js";
+import { getMissionForUpdate, setStatus } from "@vex-agent/db/repos/missions.js";
+import { validateDraft } from "./validator.js";
+
+export interface ReconcileDraftReadinessResult {
+  readonly promoted: boolean;
+}
+
+/**
+ * Row-locked draft → ready reconciliation for `missionId`.
+ *
+ * Pass `client` when the caller already holds the row lock (or is inside
+ * a wider transaction) — e.g. `renewMission`'s session-locked tx, so the
+ * clone insert and the readiness check commit atomically. Omit it to have
+ * this function open its own transaction and lock the row itself — the
+ * shape every call site outside an existing tx needs (`abort.ts`,
+ * `mission-finalize.ts`).
+ */
+export async function reconcileDraftReadiness(
+  missionId: string,
+  client?: PoolClient,
+): Promise<ReconcileDraftReadinessResult> {
+  if (client) {
+    return reconcileLocked(client, missionId);
+  }
+  return withTransaction((tx) => reconcileLocked(tx, missionId));
+}
+
+async function reconcileLocked(
+  client: PoolClient,
+  missionId: string,
+): Promise<ReconcileDraftReadinessResult> {
+  const mission = await getMissionForUpdate(client, missionId);
+  if (!mission || mission.status !== "draft") {
+    return { promoted: false };
+  }
+
+  const validation = validateDraft(mission);
+  if (!validation.valid) {
+    return { promoted: false };
+  }
+
+  await setStatus(missionId, "ready", client);
+  return { promoted: true };
+}

--- a/src/vex-agent/engine/mission/renew.ts
+++ b/src/vex-agent/engine/mission/renew.ts
@@ -50,6 +50,7 @@ import {
 } from "../../db/repos/missions.js";
 import * as missionRunsRepo from "../../db/repos/mission-runs.js";
 import { cloneMissionAsDraft } from "./renew-internals.js";
+import { reconcileDraftReadiness } from "./draft-readiness.js";
 import { CONTRACT_HASH_VERSION, LEGACY_CONTRACT_HASH_VERSION, computeContractHash } from "./contract-hash.js";
 import { missionToDraft } from "./mapper.js";
 
@@ -201,6 +202,11 @@ export async function renewMission(
     //      - stamps renewed_from_mission_id = source.id
     const newId = `mission-${Date.now()}-${randomUUID().slice(0, 8)}`;
     await cloneMissionAsDraft(client, source.id, newId, input.sessionId);
+
+    // A cloned source that was already complete would otherwise sit at
+    // 'draft' forever (issue #41) — no model patch is coming to promote it.
+    // Same tx client: the promotion commits atomically with the clone.
+    await reconcileDraftReadiness(newId, client);
 
     return {
       outcome: "renewed",

--- a/src/vex-agent/engine/types.ts
+++ b/src/vex-agent/engine/types.ts
@@ -102,6 +102,35 @@ export const ACTIVE_OR_PAUSED_RUN_STATUSES: ReadonlySet<MissionRunStatus> = new 
 ]);
 
 /**
+ * Read a validated own-property off an unvalidated thrown value — the same
+ * "own-properties only, never `.cause`" idiom as
+ * `core/runner/mission-error-signal.ts` / `inference/openrouter/errors.ts`,
+ * duplicated locally (not imported) so this foundational, DB/inference-free
+ * types file never depends on the runner layer.
+ */
+function ownProperty(value: unknown, key: string): unknown {
+  if (typeof value !== "object" || value === null) return undefined;
+  if (!Object.prototype.hasOwnProperty.call(value, key)) return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+/** Errno-shaped code guard — mirrors `lib/error-cause.ts` (not exported there; duplicated). */
+const ERRNO_SHAPE = /^[A-Z][A-Z0-9_]{2,59}$/;
+
+function validatedStatusCode(cause: unknown): number | null {
+  for (const key of ["status", "statusCode"]) {
+    const v = ownProperty(cause, key);
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
+function validatedCauseCode(cause: unknown): string | null {
+  const v = ownProperty(cause, "causeCode");
+  return typeof v === "string" && ERRNO_SHAPE.test(v) ? v : null;
+}
+
+/**
  * Recoverable failure surfaced by `startMission` / `resumeMissionRun` when a
  * provider call (or the surrounding hydrate / status update / prompt prep)
  * throws. The run is persisted in `paused_error` first, then this error is
@@ -114,6 +143,16 @@ export class MissionRunPausedError extends Error {
   readonly runId: string;
   readonly missionId: string;
   readonly sessionId: string;
+  /**
+   * Lean, validated signals copied from `cause` (never the cause object
+   * itself) so a shell action wrapper that only sees THIS error — not the
+   * original normalized provider error — can still branch on transport/HTTP
+   * shape (e.g. the chat IPC error mapper mapping 401/429/5xx to a specific
+   * user-facing code). `null` when `cause` carries no matching validated
+   * own-property. Never exposes anything else from `cause`.
+   */
+  readonly statusCode: number | null;
+  readonly causeCode: string | null;
   constructor(args: {
     runId: string;
     missionId: string;
@@ -127,6 +166,8 @@ export class MissionRunPausedError extends Error {
     this.runId = args.runId;
     this.missionId = args.missionId;
     this.sessionId = args.sessionId;
+    this.statusCode = validatedStatusCode(args.cause);
+    this.causeCode = validatedCauseCode(args.cause);
   }
 }
 

--- a/src/vex-agent/inference/openrouter.ts
+++ b/src/vex-agent/inference/openrouter.ts
@@ -385,7 +385,17 @@ export class OpenRouterProvider implements InferenceProvider {
       throw normalizeOpenRouterError(err, "streaming chat completion");
     }
 
-    yield* consumeOpenRouterStream(stream);
+    try {
+      // Post-first-chunk (mid-stream) rejections from the async iterator
+      // (dropped connection, upstream disconnect) reach here OUTSIDE the
+      // `client.chat.send` try/catch above — normalize them the same way so
+      // the classifier's own-property signals and the redactor both apply
+      // (a raw SDK rejection would otherwise bypass classification metadata
+      // AND message redaction).
+      yield* consumeOpenRouterStream(stream);
+    } catch (err) {
+      throw normalizeOpenRouterError(err, "streaming chat completion (mid-stream)");
+    }
   }
 
   // ── getBalance ──────────────────────────────────────────────────

--- a/vex-app/docs/LOCAL_RUNTIME.md
+++ b/vex-app/docs/LOCAL_RUNTIME.md
@@ -63,6 +63,12 @@ non-empty absolute path.
 
 ## Clean-slate reset
 
+> **⚠️ Destructive.** `CONFIG_DIR` holds your signing keys — `keystore.json`
+> (EVM) and `solana-keystore.json` (Solana) — plus the `backups/` directory
+> (`src/config/paths.ts:43-51`). Deleting `CONFIG_DIR` deletes all of them
+> with no recovery path. **Before step 3**, export/copy your keystores and
+> backups outside `CONFIG_DIR` — see step 3 below for the exact command.
+
 If a setup gets stuck mid-flow (e.g. corrupt vault, half-applied wizard,
 stale Docker stack), reset:
 
@@ -102,6 +108,55 @@ docker ps -a --filter label=com.docker.compose.project --format '{{.Names}}\t{{.
 ```
 
 ### 3. Delete the config directory
+
+> **⚠️ Destructive — irreversible key loss.** This step permanently deletes
+> `keystore.json`, `solana-keystore.json`, and the `backups/` directory along
+> with the rest of `CONFIG_DIR`. There is no undo. Complete step 3a below
+> before running the delete command in step 3b.
+
+#### 3a. Export keystores and backups first
+
+Copy the entire config directory (or make an encrypted archive of it) to a
+location outside `CONFIG_DIR` — e.g. an external drive or password manager
+attachment — so `keystore.json`, `solana-keystore.json`, and `backups/` all
+survive the reset:
+
+```bash
+# macOS / Linux — replace <dest> with a path outside CONFIG_DIR.
+cp -r "$CONFIG_DIR" <dest>/vex-config-backup-$(date +%Y%m%d)
+```
+
+```powershell
+# Windows (PowerShell) — replace <dest> with a path outside CONFIG_DIR.
+Copy-Item -Recurse -Force "$env:APPDATA\vex" "<dest>\vex-config-backup"
+```
+
+Note: the keystores and `secrets.vault.json` are encrypted at rest — copying
+them does not remove the need for your master password. Keep the password
+itself somewhere separate from the copied files; an unusable password makes
+the backup unusable too.
+
+**Verify the copy before continuing to 3b.** Confirm the destination exists
+and contains `keystore.json`, `solana-keystore.json`, and `backups/` — a
+partial or failed copy here means step 3b's delete is unrecoverable:
+
+```bash
+# macOS / Linux
+ls "<dest>/vex-config-backup-<date>/keystore.json" \
+   "<dest>/vex-config-backup-<date>/solana-keystore.json" \
+   "<dest>/vex-config-backup-<date>/backups"
+```
+
+```powershell
+# Windows (PowerShell)
+Test-Path "<dest>\vex-config-backup\keystore.json"
+Test-Path "<dest>\vex-config-backup\solana-keystore.json"
+Test-Path "<dest>\vex-config-backup\backups"
+```
+
+Do not proceed to 3b until all checks above succeed.
+
+#### 3b. Delete the directory
 
 | OS | Command |
 |---|---|

--- a/vex-app/src/main/ipc/__tests__/chat.test.ts
+++ b/vex-app/src/main/ipc/__tests__/chat.test.ts
@@ -5,6 +5,7 @@ import {
   type TestIpcEvent,
 } from "./test-sender.js";
 import type { SessionListItem } from "@shared/schemas/sessions.js";
+import { MissionRunPausedError } from "@vex-agent/engine/types.js";
 
 type Handler = (
   event: TestIpcEvent,
@@ -203,6 +204,25 @@ describe("registerChatSubmitHandler", () => {
     expect(result.error?.userActionable).toBe(true);
   });
 
+  it("maps a missing inference config failure to a user-actionable chat error", async () => {
+    const row = makeSessionRow({ mode: "mission", initialGoal: "Existing" });
+    mocks.getSessionById.mockResolvedValue({ ok: true, data: row });
+    mocks.submitOperatorInstruction.mockRejectedValue(
+      new Error("No inference config available"),
+    );
+    registerChatSubmitHandler();
+
+    const fn = handlers.get(CH.chat.submit)!;
+    const result = (await fn(trustedSender, {
+      requestId: "r3b",
+      payload: { sessionId: row.id, message: "Continue" },
+    })) as { ok: boolean; error?: { code: string; userActionable: boolean } };
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("provider.unavailable");
+    expect(result.error?.userActionable).toBe(true);
+  });
+
   it("threads ctx.signal (an unaborted AbortSignal) into the engine (9-5b)", async () => {
     const row = makeSessionRow({ mode: "agent", initialGoal: null });
     mocks.getSessionById.mockResolvedValue({ ok: true, data: row });
@@ -218,7 +238,204 @@ describe("registerChatSubmitHandler", () => {
     expect(signal).toBeInstanceOf(AbortSignal);
     expect((signal as AbortSignal).aborted).toBe(false);
   });
+
+  it("falls back to the unchanged internal error for an unrecognized failure shape", async () => {
+    const row = makeSessionRow({ mode: "agent", initialGoal: null });
+    mocks.getSessionById.mockResolvedValue({ ok: true, data: row });
+    mocks.submitOperatorInstruction.mockRejectedValue(new Error("boom"));
+    registerChatSubmitHandler();
+
+    const fn = handlers.get(CH.chat.submit)!;
+    const result = (await fn(trustedSender, {
+      requestId: "r-unknown",
+      payload: { sessionId: row.id, message: "Continue" },
+    })) as { ok: boolean; error?: { code: string; retryable: boolean; userActionable: boolean } };
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("internal.unexpected");
+    expect(result.error?.retryable).toBe(true);
+    expect(result.error?.userActionable).toBe(false);
+  });
+
+  describe("provider error-signal mapping (WP2)", () => {
+    // Each case: a rejection shaped with own-property transport/HTTP signals
+    // → the expected mapped chat error code + retryable flag.
+    const cases: ReadonlyArray<{
+      readonly label: string;
+      readonly signal: { statusCode?: number; causeCode?: string };
+      readonly code: string;
+      readonly retryable: boolean;
+    }> = [
+      { label: "401", signal: { statusCode: 401 }, code: "provider.invalid_api_key", retryable: false },
+      { label: "403", signal: { statusCode: 403 }, code: "provider.invalid_api_key", retryable: false },
+      { label: "402", signal: { statusCode: 402 }, code: "provider.insufficient_credits", retryable: false },
+      { label: "429", signal: { statusCode: 429 }, code: "provider.unavailable", retryable: true },
+      { label: "503", signal: { statusCode: 503 }, code: "provider.unavailable", retryable: true },
+      {
+        label: "causeCode ECONNRESET",
+        signal: { causeCode: "ECONNRESET" },
+        code: "provider.unavailable",
+        retryable: true,
+      },
+    ];
+
+    it.each(cases)(
+      "maps a $label failure to $code (direct own-properties)",
+      async ({ signal, code, retryable }) => {
+        const row = makeSessionRow({ mode: "agent", initialGoal: null });
+        mocks.getSessionById.mockResolvedValue({ ok: true, data: row });
+        mocks.submitOperatorInstruction.mockRejectedValue(
+          makeTransportError(signal),
+        );
+        registerChatSubmitHandler();
+
+        const fn = handlers.get(CH.chat.submit)!;
+        const result = (await fn(trustedSender, {
+          requestId: `r-${code}`,
+          payload: { sessionId: row.id, message: "Continue" },
+        })) as { ok: boolean; error?: { code: string; retryable: boolean } };
+
+        expect(result.ok).toBe(false);
+        expect(result.error?.code).toBe(code);
+        expect(result.error?.retryable).toBe(retryable);
+      },
+    );
+
+    // The production path: mission failures reach this handler wrapped in
+    // MissionRunPausedError (WP1 step 6), never as the raw normalized cause —
+    // repeat the mapping against the ACTUAL wrapper class so the reader is
+    // proven against what really crosses the engine boundary.
+    it.each(cases)(
+      "maps a $label failure to $code (wrapped in MissionRunPausedError)",
+      async ({ signal, code, retryable }) => {
+        const row = makeSessionRow({ mode: "agent", initialGoal: null });
+        mocks.getSessionById.mockResolvedValue({ ok: true, data: row });
+        mocks.submitOperatorInstruction.mockRejectedValue(
+          new MissionRunPausedError({
+            runId: "run-1",
+            missionId: "mission-1",
+            sessionId: row.id,
+            cause: makeTransportError(signal),
+          }),
+        );
+        registerChatSubmitHandler();
+
+        const fn = handlers.get(CH.chat.submit)!;
+        const result = (await fn(trustedSender, {
+          requestId: `r-wrapped-${code}`,
+          payload: { sessionId: row.id, message: "Continue" },
+        })) as { ok: boolean; error?: { code: string; retryable: boolean } };
+
+        expect(result.ok).toBe(false);
+        expect(result.error?.code).toBe(code);
+        expect(result.error?.retryable).toBe(retryable);
+      },
+    );
+
+    it("never maps a wrapped operator-abort to provider.unavailable (negative)", async () => {
+      const row = makeSessionRow({ mode: "agent", initialGoal: null });
+      mocks.getSessionById.mockResolvedValue({ ok: true, data: row });
+      mocks.submitOperatorInstruction.mockRejectedValue(
+        new MissionRunPausedError({
+          runId: "run-1",
+          missionId: "mission-1",
+          sessionId: row.id,
+          cause: makeTransportError({ causeCode: "ABORT_ERR" }),
+        }),
+      );
+      registerChatSubmitHandler();
+
+      const fn = handlers.get(CH.chat.submit)!;
+      const result = (await fn(trustedSender, {
+        requestId: "r-abort",
+        payload: { sessionId: row.id, message: "Continue" },
+      })) as { ok: boolean; error?: { code: string } };
+
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe("internal.unexpected");
+    });
+
+    // WP2 closure (fix-wave prs-17-07-2026): DNS (ENOTFOUND) and TLS
+    // (UNABLE_TO_VERIFY_LEAF_SIGNATURE) causeCodes are in the classifier's
+    // NEVER_TRANSIENT_CODES and are NOT in this handler's transient
+    // allow-list — both must fall through to the unchanged
+    // internal.unexpected fallback, never provider.unavailable.
+    it("never maps a wrapped DNS failure (ENOTFOUND) to provider.unavailable (negative)", async () => {
+      const row = makeSessionRow({ mode: "agent", initialGoal: null });
+      mocks.getSessionById.mockResolvedValue({ ok: true, data: row });
+      mocks.submitOperatorInstruction.mockRejectedValue(
+        new MissionRunPausedError({
+          runId: "run-1",
+          missionId: "mission-1",
+          sessionId: row.id,
+          cause: makeTransportError({ causeCode: "ENOTFOUND" }),
+        }),
+      );
+      registerChatSubmitHandler();
+
+      const fn = handlers.get(CH.chat.submit)!;
+      const result = (await fn(trustedSender, {
+        requestId: "r-dns",
+        payload: { sessionId: row.id, message: "Continue" },
+      })) as { ok: boolean; error?: { code: string } };
+
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe("internal.unexpected");
+    });
+
+    it("never maps a wrapped TLS failure (UNABLE_TO_VERIFY_LEAF_SIGNATURE) to provider.unavailable (negative)", async () => {
+      const row = makeSessionRow({ mode: "agent", initialGoal: null });
+      mocks.getSessionById.mockResolvedValue({ ok: true, data: row });
+      mocks.submitOperatorInstruction.mockRejectedValue(
+        new MissionRunPausedError({
+          runId: "run-1",
+          missionId: "mission-1",
+          sessionId: row.id,
+          cause: makeTransportError({ causeCode: "UNABLE_TO_VERIFY_LEAF_SIGNATURE" }),
+        }),
+      );
+      registerChatSubmitHandler();
+
+      const fn = handlers.get(CH.chat.submit)!;
+      const result = (await fn(trustedSender, {
+        requestId: "r-tls",
+        payload: { sessionId: row.id, message: "Continue" },
+      })) as { ok: boolean; error?: { code: string } };
+
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe("internal.unexpected");
+    });
+  });
 });
+
+/**
+ * Build an Error shaped like a normalized OpenRouter/mission-runner failure:
+ * lean `statusCode`/`status`/`causeCode` own-properties, no message content
+ * asserted on (the mapper never reads `.message`).
+ */
+function makeTransportError(signal: {
+  readonly statusCode?: number;
+  readonly causeCode?: string;
+}): Error {
+  const error = new Error("normalized transport failure");
+  if (signal.statusCode !== undefined) {
+    Object.defineProperty(error, "statusCode", {
+      value: signal.statusCode,
+      enumerable: false,
+    });
+    Object.defineProperty(error, "status", {
+      value: signal.statusCode,
+      enumerable: false,
+    });
+  }
+  if (signal.causeCode !== undefined) {
+    Object.defineProperty(error, "causeCode", {
+      value: signal.causeCode,
+      enumerable: false,
+    });
+  }
+  return error;
+}
 
 function makeSessionRow(args: {
   readonly mode: "agent" | "mission";

--- a/vex-app/src/main/ipc/__tests__/mission/transcript.test.ts
+++ b/vex-app/src/main/ipc/__tests__/mission/transcript.test.ts
@@ -112,6 +112,38 @@ describe("mission.renew", () => {
       newMissionId: "mission-2",
     });
   });
+
+  // WP3 (issue #41): the engine may promote the new draft straight to
+  // 'ready' (reconcileDraftReadiness) — the handler emits a control-state
+  // refresh so the renderer badge picks it up without a remount.
+  it("emits a control-state refresh on a successful renew", async () => {
+    mockRenewMission.mockResolvedValueOnce({
+      outcome: "renewed",
+      newMissionId: "mission-2",
+      sourceMissionId: MISSION,
+    });
+    await call(CH.mission.renew, {
+      sessionId: SESSION,
+      previousMissionId: MISSION,
+    });
+    expect(mockEmitControlStateAfterChange).toHaveBeenCalledWith(
+      SESSION,
+      "11111111-1111-4111-8111-111111111111",
+    );
+  });
+
+  it("does NOT emit a control-state refresh for a non-renewed outcome", async () => {
+    mockRenewMission.mockResolvedValueOnce({
+      outcome: "not_accepted",
+      sourceMissionId: MISSION,
+    });
+    const result = await call(CH.mission.renew, {
+      sessionId: SESSION,
+      previousMissionId: MISSION,
+    });
+    expect(result.data).toMatchObject({ outcome: "not_accepted" });
+    expect(mockEmitControlStateAfterChange).not.toHaveBeenCalled();
+  });
 });
 
 describe("mission.getRenewableSource", () => {

--- a/vex-app/src/main/ipc/__tests__/runtime/cancel-wake.test.ts
+++ b/vex-app/src/main/ipc/__tests__/runtime/cancel-wake.test.ts
@@ -1,0 +1,145 @@
+/**
+ * runtime.cancelWake tests — the born-dead-end audit-row fix.
+ *
+ * The wake cancellation itself runs synchronously in the handler; the
+ * `runtime_control_requests` row is audit-only. Nothing ever
+ * observes/clears a `cancel_wake` row (the checkpoint observer only
+ * matches pause_after_step/stop_terminal), so a `'pending'` row is
+ * permanently stuck. The kind-agnostic `pending_control_kind` LATERAL
+ * (`mission-runs-db.ts`) returns the oldest `status IN ('pending',
+ * 'observed')` row for the session — a stranded pending cancel_wake row
+ * would disable every mission control button for that session forever.
+ * The fix inserts the audit row already `'cleared'`, which the
+ * `pending_control_kind` predicate excludes by construction.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IpcMainInvokeEvent } from "electron";
+import { CH } from "@shared/ipc/channels.js";
+import {
+  createTestWebContents,
+  createTrustedSender,
+} from "../test-sender.js";
+
+const mockCancelForSession = vi.fn();
+const mockEnqueueRequest = vi.fn();
+const mockEnsureEngineDbUrl = vi.fn();
+const mockEmitControlStateAfterChange = vi.fn();
+
+vi.mock("electron", () => {
+  const handlers = new Map<
+    string,
+    (e: IpcMainInvokeEvent, p: unknown) => unknown
+  >();
+  return {
+    ipcMain: {
+      handle: vi.fn(
+        (channel: string, fn: (e: IpcMainInvokeEvent, p: unknown) => unknown) =>
+          handlers.set(channel, fn),
+      ),
+      removeHandler: vi.fn((ch: string) => handlers.delete(ch)),
+    },
+    __handlers: handlers,
+  };
+});
+
+vi.mock("../../runtime/_ensure-engine-db-url.js", () => ({
+  ensureEngineDbUrl: (...a: unknown[]) => mockEnsureEngineDbUrl(...a),
+}));
+vi.mock("../../runtime/_emit-control-state.js", () => ({
+  emitControlStateAfterChange: (...a: unknown[]) =>
+    mockEmitControlStateAfterChange(...a),
+}));
+vi.mock("../../../logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@vex-agent/db/repos/loop-wake.js", () => ({
+  cancelForSession: (...a: unknown[]) => mockCancelForSession(...a),
+}));
+vi.mock("@vex-agent/db/repos/runtime-control-requests.js", () => ({
+  enqueueRequest: (...a: unknown[]) => mockEnqueueRequest(...a),
+}));
+
+const { registerRuntimeCancelWakeHandler } = await import(
+  "../../runtime/cancel-wake.js"
+);
+const electronMock = (await import("electron")) as unknown as {
+  __handlers: Map<string, (e: IpcMainInvokeEvent, p: unknown) => unknown>;
+};
+
+const SESSION = "00000000-0000-4000-8000-00000000cccc";
+const trustedSender = createTrustedSender({ sender: createTestWebContents() });
+
+async function call(payload: unknown) {
+  const handler = electronMock.__handlers.get(CH.runtime.cancelWake);
+  if (!handler) throw new Error("No handler for runtime.cancelWake");
+  return (await handler(trustedSender as unknown as IpcMainInvokeEvent, {
+    requestId: "11111111-1111-4111-8111-111111111111",
+    payload,
+  })) as {
+    ok: boolean;
+    data?: { outcome: string; cancelledCount?: number };
+    error?: { code: string };
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnsureEngineDbUrl.mockResolvedValue({ ok: true, data: undefined });
+  mockEmitControlStateAfterChange.mockResolvedValue(undefined);
+  mockEnqueueRequest.mockResolvedValue({
+    id: "22222222-2222-4222-8222-222222222222",
+  });
+  electronMock.__handlers.clear();
+  registerRuntimeCancelWakeHandler();
+});
+
+describe("runtime.cancelWake", () => {
+  it("inserts the audit row already 'cleared' — never a stranded pending row", async () => {
+    mockCancelForSession.mockResolvedValueOnce(1);
+    const r = await call({ sessionId: SESSION });
+
+    expect(r.data).toEqual({ outcome: "cancelled_wake", cancelledCount: 1 });
+    expect(mockEnqueueRequest).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: SESSION,
+        kind: "cancel_wake",
+        initialStatus: "cleared",
+      }),
+    );
+  });
+
+  it("still inserts a 'cleared' audit row when there was no pending wake to cancel", async () => {
+    mockCancelForSession.mockResolvedValueOnce(0);
+    const r = await call({ sessionId: SESSION });
+
+    expect(r.data).toEqual({ outcome: "no_pending_wake" });
+    expect(mockEnqueueRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ initialStatus: "cleared" }),
+    );
+  });
+
+  // `pending_control_kind` (mission-runs-db.ts) selects the oldest row with
+  // status IN ('pending', 'observed') for the session. Proving the insert
+  // call never carries a 'pending'/omitted status is the in-scope way to
+  // show that predicate can no longer match a cancel_wake row — the repo
+  // itself (runtime-control-requests.test.ts) proves 'cleared' + cleared_at
+  // land atomically in the same INSERT.
+  it("never enqueues a cancel_wake row with the default 'pending' status", async () => {
+    mockCancelForSession.mockResolvedValueOnce(1);
+    await call({ sessionId: SESSION });
+
+    const call0 = mockEnqueueRequest.mock.calls[0]?.[0] as { initialStatus?: string };
+    expect(call0.initialStatus).toBe("cleared");
+    expect(call0.initialStatus).not.toBe("pending");
+    expect(call0.initialStatus).not.toBeUndefined();
+  });
+
+  it("cancellation still runs even if the audit insert path is reached after it", async () => {
+    mockCancelForSession.mockResolvedValueOnce(2);
+    await call({ sessionId: SESSION });
+    expect(mockCancelForSession).toHaveBeenCalledWith(SESSION, "user_cancel");
+    expect(mockEmitControlStateAfterChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vex-app/src/main/ipc/chat.ts
+++ b/vex-app/src/main/ipc/chat.ts
@@ -48,6 +48,42 @@ function providerUnavailableError(correlationId: string): VexError {
   };
 }
 
+function providerTransientError(correlationId: string): VexError {
+  return {
+    code: "provider.unavailable",
+    domain: "chat",
+    message: "The inference provider is temporarily unavailable. Try again shortly.",
+    retryable: true,
+    userActionable: true,
+    redacted: true,
+    correlationId,
+  };
+}
+
+function invalidApiKeyError(correlationId: string): VexError {
+  return {
+    code: "provider.invalid_api_key",
+    domain: "chat",
+    message: "The inference provider rejected the API key. Verify it in provider setup and retry.",
+    retryable: false,
+    userActionable: true,
+    redacted: true,
+    correlationId,
+  };
+}
+
+function insufficientCreditsError(correlationId: string): VexError {
+  return {
+    code: "provider.insufficient_credits",
+    domain: "chat",
+    message: "The inference provider account has insufficient credits. Add funds and retry.",
+    retryable: false,
+    userActionable: true,
+    redacted: true,
+    correlationId,
+  };
+}
+
 function chatFailedError(correlationId: string): VexError {
   return {
     code: "internal.unexpected",
@@ -72,6 +108,50 @@ function dbUnavailableError(correlationId: string): VexError {
   };
 }
 
+/**
+ * Transient transport `causeCode` allow-list — verbatim copy of the mission
+ * runner's closed list (`mission-error-classifier.ts` TRANSIENT_CAUSE_CODES).
+ * Deliberately duplicated rather than imported: the `@vex-agent` alias is the
+ * privileged trust surface (rule 90), and a ~10-line local reader below does
+ * not justify widening it just to reach one module's constant.
+ */
+const TRANSIENT_TRANSPORT_CAUSE_CODES: ReadonlySet<string> = new Set([
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EAI_AGAIN",
+  "EPIPE",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+/**
+ * Local own-property reader — same "own-properties only, never `.cause`"
+ * idiom as `mission-error-signal.ts` / `engine/types.ts`, duplicated here
+ * (not imported) for the same trust-surface reason as the allow-list above.
+ * Reads the lean signals `MissionRunPausedError` propagates from its cause
+ * (`statusCode`, `causeCode`), plus raw `status` for non-wrapped errors.
+ */
+function chatErrorSignal(cause: unknown): { statusCode: number | null; causeCode: string | null } {
+  if (typeof cause !== "object" || cause === null) {
+    return { statusCode: null, causeCode: null };
+  }
+  const rec = cause as Record<string, unknown>;
+  // Own-property reads only — ordinary indexing would also resolve
+  // inherited prototype properties (e.g. `Error.prototype.name`), letting a
+  // caller "read" a signal that was never actually attached to this value.
+  const ownField = (key: string): unknown =>
+    Object.prototype.hasOwnProperty.call(rec, key) ? rec[key] : undefined;
+  const rawStatus = ownField("statusCode") ?? ownField("status");
+  const statusCode =
+    typeof rawStatus === "number" && Number.isFinite(rawStatus) ? rawStatus : null;
+  const rawCauseCode = ownField("causeCode");
+  const causeCode = typeof rawCauseCode === "string" ? rawCauseCode : null;
+  return { statusCode, causeCode };
+}
+
 function classifyEngineError(cause: unknown, correlationId: string): VexError {
   if (
     cause instanceof Error &&
@@ -80,6 +160,22 @@ function classifyEngineError(cause: unknown, correlationId: string): VexError {
   ) {
     return providerUnavailableError(correlationId);
   }
+
+  const signal = chatErrorSignal(cause);
+  if (signal.statusCode === 401 || signal.statusCode === 403) {
+    return invalidApiKeyError(correlationId);
+  }
+  if (signal.statusCode === 402) {
+    return insufficientCreditsError(correlationId);
+  }
+  if (
+    signal.statusCode === 429 ||
+    (signal.statusCode !== null && signal.statusCode >= 500 && signal.statusCode <= 599) ||
+    (signal.causeCode !== null && TRANSIENT_TRANSPORT_CAUSE_CODES.has(signal.causeCode))
+  ) {
+    return providerTransientError(correlationId);
+  }
+
   return chatFailedError(correlationId);
 }
 

--- a/vex-app/src/main/ipc/mission/renew.ts
+++ b/vex-app/src/main/ipc/mission/renew.ts
@@ -18,6 +18,7 @@ import { log } from "../../logger/index.js";
 import { registerHandler } from "../register-handler.js";
 import { controlFailedError } from "../runtime/_errors.js";
 import { ensureEngineDbUrl } from "../runtime/_ensure-engine-db-url.js";
+import { emitControlStateAfterChange } from "../runtime/_emit-control-state.js";
 
 export function registerMissionRenewHandler(): () => void {
   return registerHandler({
@@ -41,6 +42,12 @@ export function registerMissionRenewHandler(): () => void {
             `previousMissionId=${input.previousMissionId} ` +
             `correlationId=${ctx.requestId}`,
         );
+        if (outcome.outcome === "renewed") {
+          // The engine may have promoted the new draft straight to 'ready'
+          // (reconcileDraftReadiness, issue #41) — refresh the renderer so
+          // the badge reflects it without a remount.
+          await emitControlStateAfterChange(input.sessionId, ctx.requestId);
+        }
         return ok(outcome);
       } catch (cause) {
         log.warn(

--- a/vex-app/src/main/ipc/runtime/cancel-wake.ts
+++ b/vex-app/src/main/ipc/runtime/cancel-wake.ts
@@ -38,12 +38,19 @@ export function registerRuntimeCancelWakeHandler(): () => void {
         const { enqueueRequest } = await import(
           "@vex-agent/db/repos/runtime-control-requests.js"
         );
+        // The wake cancellation above already ran synchronously — this row
+        // is audit-only. Nothing ever observes/clears a `cancel_wake` row
+        // (the checkpoint observer only matches pause_after_step/
+        // stop_terminal), so inserting it `pending` would strand it forever
+        // and the kind-agnostic `pending_control_kind` lookup would then
+        // treat the whole session as permanently busy.
         await enqueueRequest({
           sessionId: input.sessionId,
           kind: "cancel_wake",
           requestedBy: "user",
           correlationId: ctx.requestId,
           reason: `cancelled=${cancelledCount}`,
+          initialStatus: "cleared",
         });
         await emitControlStateAfterChange(input.sessionId, ctx.requestId);
         if (cancelledCount === 0) {

--- a/vex-app/src/renderer/features/appShell/MissionControls.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionControls.tsx
@@ -231,35 +231,42 @@ export function MissionControls({
     const canRecover = status === "paused_error";
     const canEdit = status !== "paused_approval";
     return (
-      <div
-        data-vex-area="mission-controls"
-        role="group"
-        aria-label="Mission controls"
-        className="mt-3 flex flex-wrap items-center gap-2"
-      >
-        <ControlButton
-          label="Continue"
-          disabled={disabled || !canContinue}
-          onClick={() => void run(() => cont.mutateAsync({ sessionId }))}
-        />
-        <ControlButton
-          label="Recover"
-          disabled={disabled || !canRecover}
-          onClick={() => void run(() => recover.mutateAsync({ sessionId }))}
-        />
-        <ControlButton
-          label="Edit"
-          disabled={disabled || !canEdit}
-          onClick={() => void run(() => edit.mutateAsync({ sessionId }))}
-        />
-        <ControlButton
-          label="Stop"
-          tone="danger"
-          disabled={disabled}
-          onClick={() => void run(() => stop.mutateAsync({ sessionId }))}
-        />
-        {notice !== null ? <ControlNoticeLine text={notice.text} /> : null}
-      </div>
+      <>
+        {canRecover ? (
+          <MissionErrorAlert stopReason={runtime.stopReason} />
+        ) : null}
+        <div
+          data-vex-area="mission-controls"
+          role="group"
+          aria-label="Mission controls"
+          className="mt-3 flex flex-wrap items-center gap-2"
+        >
+          <ControlButton
+            label="Continue"
+            disabled={disabled || !canContinue}
+            onClick={() => void run(() => cont.mutateAsync({ sessionId }))}
+          />
+          <ControlButton
+            label={recover.isPending ? "Recovering…" : "Recover"}
+            ariaLabel="Recover mission"
+            ariaBusy={recover.isPending}
+            disabled={disabled || !canRecover}
+            onClick={() => void run(() => recover.mutateAsync({ sessionId }))}
+          />
+          <ControlButton
+            label="Edit"
+            disabled={disabled || !canEdit}
+            onClick={() => void run(() => edit.mutateAsync({ sessionId }))}
+          />
+          <ControlButton
+            label="Stop"
+            tone="danger"
+            disabled={disabled}
+            onClick={() => void run(() => stop.mutateAsync({ sessionId }))}
+          />
+          {notice !== null ? <ControlNoticeLine text={notice.text} /> : null}
+        </div>
+      </>
     );
   }
 
@@ -365,23 +372,70 @@ function AcceptancePendingNotice(): JSX.Element {
   );
 }
 
+/**
+ * Standing paused_error alert (issue #42): while the recover-eligible pause
+ * persists, the mission is silently NOT monitoring the market or positions —
+ * that has to be visible, not inferred from an agent reply. Persistent,
+ * state-driven UI: no timers, no dismissal. If a recovery settles and the
+ * refetched runtime is still paused_error, this simply stays/reappears — the
+ * visible-failure signal the operator needs.
+ */
+function MissionErrorAlert({
+  stopReason,
+}: {
+  readonly stopReason: string | null;
+}): JSX.Element {
+  // `provider_error` names the stop reason, not the cause — it covers both
+  // inference and runtime errors, so the copy must not claim a connection
+  // failure. The state is recoverable via the Recover button, so never say
+  // "unrecoverable".
+  const body =
+    stopReason === "provider_error"
+      ? "The mission paused after an inference or runtime error."
+      : "The mission paused after an unexpected error.";
+  return (
+    <div
+      role="alert"
+      data-vex-area="mission-error-alert"
+      className="mb-2 w-full rounded-lg border border-[color-mix(in_oklab,var(--color-destructive)_40%,transparent)] bg-destructive/10 px-3 py-2"
+    >
+      <p className="font-mono text-[10px] font-medium uppercase tracking-[0.26em] text-destructive">
+        Mission paused — error
+      </p>
+      <p className="mt-1 text-xs text-destructive">{body}</p>
+      <p className="mt-1 text-xs text-destructive">
+        The mission is not monitoring the market or your positions until you
+        recover it.
+      </p>
+    </div>
+  );
+}
+
 function ControlButton({
   label,
   onClick,
   disabled,
   tone,
+  ariaLabel,
+  ariaBusy,
 }: {
   readonly label: string;
   readonly onClick: () => void;
   readonly disabled: boolean;
   readonly tone?: "danger";
+  /** Overrides the derived `${label} mission` accessible name — used where
+   * the visible label changes (e.g. "Recovering…") but the accessible name
+   * must stay stable for assistive tech and tests. */
+  readonly ariaLabel?: string;
+  readonly ariaBusy?: boolean;
 }): JSX.Element {
   return (
     <button
       type="button"
       disabled={disabled}
       onClick={onClick}
-      aria-label={`${label} mission`}
+      aria-label={ariaLabel ?? `${label} mission`}
+      aria-busy={ariaBusy}
       className={cn(
         // Toolbar keys: quiet mono-uppercase hairline pills; Stop keeps the
         // destructive tone with the one sanctioned danger fill (/10).

--- a/vex-app/src/renderer/features/appShell/MissionRail.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionRail.tsx
@@ -42,6 +42,7 @@ import type {
   MissionDraftDto,
   MissionGetDiffResult,
 } from "@shared/schemas/mission.js";
+import type { RuntimeStateDto } from "@shared/schemas/runtime.js";
 import type { PlanGetResult } from "@shared/schemas/session-plan.js";
 import type { SessionListItem } from "@shared/schemas/sessions.js";
 import {
@@ -94,6 +95,12 @@ export function MissionRail({
   // hasActiveRun: a running/paused run (mirrors MissionControls' runtime unwrap).
   const hasActiveRun =
     runtimeQuery.data?.ok === true && runtimeQuery.data.data.hasActiveRun === true;
+  // runtimeStatus: read alongside hasActiveRun so the badge can surface the
+  // paused_error state (MissionControls' standing alert) — never derived from
+  // status alone, since a stale/inconsistent status without an active run
+  // must not paint the badge red.
+  const runtimeStatus: RuntimeStateDto["status"] =
+    runtimeQuery.data?.ok === true ? runtimeQuery.data.data.status : null;
   // hasRenewable: a non-null renewable source means a terminal accepted mission
   // exists (completed/failed/stopped/cancelled), proving the contract was accepted.
   const hasRenewable =
@@ -102,8 +109,17 @@ export function MissionRail({
   const [open, setOpen] = useState<OpenModal>("none");
 
   const mission = useMemo(
-    () => deriveMissionBadge(isMission, draft, diff, plan, hasActiveRun, hasRenewable),
-    [isMission, draft, diff, plan, hasActiveRun, hasRenewable],
+    () =>
+      deriveMissionBadge(
+        isMission,
+        draft,
+        diff,
+        plan,
+        hasActiveRun,
+        hasRenewable,
+        runtimeStatus,
+      ),
+    [isMission, draft, diff, plan, hasActiveRun, hasRenewable, runtimeStatus],
   );
   const planBadge = useMemo(
     () => derivePlanBadge(plan, session?.missionStatus ?? null),
@@ -192,8 +208,16 @@ function deriveMissionBadge(
   plan: PlanGetResult | null,
   hasActiveRun: boolean,
   hasRenewable: boolean,
+  runtimeStatus: RuntimeStateDto["status"],
 ): BadgeDerivation | null {
   if (!isMission) return null;
+  // Standing paused_error alert's badge counterpart (issue #42): override to
+  // "error" only when an active run's own status confirms the pause — never
+  // on status alone, since a stale status without an active run is a
+  // defensive inconsistent-state case, not a live error.
+  if (hasActiveRun && runtimeStatus === "paused_error") {
+    return { state: "error", shimmer: false };
+  }
   // A mission past contract-acceptance is "accepted" — never "preparing".
   // hasActiveRun covers running/paused; hasRenewable (a non-null renewable
   // source) covers terminal accepted missions (completed/failed/stopped/

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
@@ -378,3 +378,153 @@ describe("MissionControls", () => {
     expect(screen.queryByRole("button", { name: "Renew mission" })).toBeNull();
   });
 });
+
+describe("MissionControls — paused_error standing alert (issue #42)", () => {
+  it("renders the alert with the eyebrow, provider_error copy, and the warning line", async () => {
+    getStateMock.mockResolvedValue(
+      runtimeState({
+        hasActiveRun: true,
+        status: "paused_error",
+        missionRunId: "r1",
+        stopReason: "provider_error",
+      }),
+    );
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(true));
+    renderControls();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.getAttribute("data-vex-area")).toBe("mission-error-alert");
+    expect(alert.textContent).toMatch(/Mission paused — error/i);
+    expect(alert.textContent).toMatch(
+      /The mission paused after an inference or runtime error\./,
+    );
+    expect(alert.textContent).toMatch(
+      /The mission is not monitoring the market or your positions until you recover it\./,
+    );
+  });
+
+  it("falls back to generic copy for a non-provider_error stopReason", async () => {
+    getStateMock.mockResolvedValue(
+      runtimeState({
+        hasActiveRun: true,
+        status: "paused_error",
+        missionRunId: "r1",
+        stopReason: "unexpected_exception",
+      }),
+    );
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(true));
+    renderControls();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(
+      /The mission paused after an unexpected error\./,
+    );
+    expect(alert.textContent).not.toMatch(/inference or runtime error/);
+  });
+
+  it("does not render the alert for running / paused_wake / paused_approval", async () => {
+    const activeCases = [
+      { hasActiveRun: true, status: "running", missionRunId: "r1" },
+      { hasActiveRun: true, status: "paused_wake", missionRunId: "r1" },
+      { hasActiveRun: true, status: "paused_approval", missionRunId: "r1" },
+    ];
+    for (const over of activeCases) {
+      getStateMock.mockResolvedValue(runtimeState(over));
+      getDraftMock.mockResolvedValue(draftReady());
+      getDiffMock.mockResolvedValue(diffAccepted(true));
+      const { unmount } = renderControls();
+      await screen.findByRole("group", { name: "Mission controls" });
+      expect(
+        document.querySelector('[data-vex-area="mission-error-alert"]'),
+      ).toBeNull();
+      unmount();
+    }
+  });
+
+  it("does not render the alert when there is no active run", async () => {
+    getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+    getDraftMock.mockResolvedValue(ok(null));
+    getRenewableMock.mockResolvedValue(ok(null));
+    renderControls();
+
+    await waitFor(() => expect(getRenewableMock).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 0));
+    expect(
+      document.querySelector('[data-vex-area="mission-error-alert"]'),
+    ).toBeNull();
+  });
+
+  it("shows a visible 'Recovering…' label while pending but keeps the accessible name stable, with aria-busy set", async () => {
+    getStateMock.mockResolvedValue(
+      runtimeState({
+        hasActiveRun: true,
+        status: "paused_error",
+        missionRunId: "r1",
+        stopReason: "provider_error",
+      }),
+    );
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(true));
+    let resolveRetry: (value: unknown) => void = () => {};
+    retryMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRetry = resolve;
+        }),
+    );
+    renderControls();
+
+    const recoverBtn = await screen.findByRole("button", {
+      name: "Recover mission",
+    });
+    fireEvent.click(recoverBtn);
+
+    await waitFor(() => expect(recoverBtn.textContent).toBe("Recovering…"));
+    expect(recoverBtn.getAttribute("aria-label")).toBe("Recover mission");
+    expect(recoverBtn.getAttribute("aria-busy")).toBe("true");
+    // Accessible name (role+name query) stays stable while the visible label
+    // changes — the same element is found by its stable name.
+    expect(
+      screen.getByRole("button", { name: "Recover mission" }),
+    ).toBe(recoverBtn);
+
+    resolveRetry(ok({ outcome: "resumed", runId: "r1" }));
+    await waitFor(() => expect(recoverBtn.textContent).toBe("Recover"));
+    expect(recoverBtn.getAttribute("aria-busy")).toBe("false");
+  });
+
+  it("persists the alert when a recover mutation settles and the refetched state is still paused_error", async () => {
+    getStateMock.mockResolvedValue(
+      runtimeState({
+        hasActiveRun: true,
+        status: "paused_error",
+        missionRunId: "r1",
+        stopReason: "provider_error",
+      }),
+    );
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(true));
+    // The mutation itself reports success, but the mission re-parks (or the
+    // recovery never actually cleared the pause) — the refetched runtime
+    // state getState keeps returning is still paused_error throughout.
+    retryMock.mockResolvedValue(ok({ outcome: "resumed", runId: "r1" }));
+    renderControls();
+
+    const recoverBtn = await screen.findByRole("button", {
+      name: "Recover mission",
+    });
+    await screen.findByRole("alert");
+    fireEvent.click(recoverBtn);
+
+    await waitFor(() => expect(retryMock).toHaveBeenCalledTimes(1));
+    // No failure notice (the mutation "succeeded"), yet the standing alert is
+    // state-driven off runtime.status — it stays visible because the
+    // refetched status is still paused_error.
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(
+      document.querySelector('[data-vex-area="mission-error-alert"]'),
+    ).not.toBeNull();
+  });
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionRail.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionRail.test.tsx
@@ -137,14 +137,16 @@ function plan(over: Partial<PlanGetResult> = {}): PlanGetResult {
   } as PlanGetResult;
 }
 
-// Minimal runtime Result — the rail only reads `hasActiveRun`. Defaults to no
-// active run (agent-mode shape); pass `hasActiveRun: true` for a running mission.
-function runtime(hasActiveRun = false) {
+// Minimal runtime Result — the rail reads `hasActiveRun` and `status`.
+// Defaults to no active run, no status (agent-mode shape); pass
+// `hasActiveRun: true` for a running mission and `status` for a specific
+// mission-run state (e.g. "paused_error" for the badge-override test).
+function runtime(hasActiveRun = false, status: string | null = null) {
   return ok({
     sessionId: SESSION,
     hasActiveRun,
     missionRunId: null,
-    status: null,
+    status,
     stopReason: null,
     lastCheckpointAt: null,
     startedAt: null,
@@ -348,6 +350,33 @@ describe("MissionRail badge derivation", () => {
     const btn = screen.getByRole("button", { name: /Plan ready/i });
     expect(btn.getAttribute("data-vex-state")).toBe("ready");
     expect(btn.classList.contains("vex-badge--shimmer")).toBe(true);
+  });
+
+  it("Mission badge is Error when an active run's status is paused_error (issue #42)", () => {
+    mockUseSession.mockReturnValue({ data: ok(sessionRow({ mode: "mission" })) });
+    mockUseMissionDraft.mockReturnValue({ data: ok(null) });
+    mockUseRuntimeState.mockReturnValue({
+      data: runtime(true, "paused_error"),
+    });
+    rail();
+    expect(
+      screen.getByRole("button", { name: /Mission/i }).getAttribute("data-vex-state"),
+    ).toBe("error");
+  });
+
+  it("Mission badge is NOT Error when status is paused_error but hasActiveRun is false (defensive inconsistent state)", () => {
+    // Guards against overriding on status alone: a stale/inconsistent
+    // status without a confirmed active run must not paint the badge red.
+    mockUseSession.mockReturnValue({ data: ok(sessionRow({ mode: "mission" })) });
+    mockUseMissionDraft.mockReturnValue({ data: ok(READY_DRAFT) });
+    mockUseMissionDiff.mockReturnValue({ data: ok(diff()) });
+    mockUseRuntimeState.mockReturnValue({
+      data: runtime(false, "paused_error"),
+    });
+    rail();
+    expect(
+      screen.getByRole("button", { name: /Mission/i }).getAttribute("data-vex-state"),
+    ).not.toBe("error");
   });
 });
 

--- a/vex-app/src/renderer/lib/api/__tests__/runtime.test.ts
+++ b/vex-app/src/renderer/lib/api/__tests__/runtime.test.ts
@@ -19,7 +19,7 @@ import {
   RUNTIME_STATE_FALLBACK_POLL_MS,
   useControlStateLiveSync,
 } from "../runtime.js";
-import { approvalsKeys, runtimeKeys } from "../queryKeys.js";
+import { approvalsKeys, missionKeys, runtimeKeys } from "../queryKeys.js";
 import {
   CONTROL_STATE_EVENT_TYPE,
   type ControlStateEvent,
@@ -123,6 +123,23 @@ describe("useControlStateLiveSync", () => {
 
     expect(hasKey(spy, runtimeKeys.state(SESSION_A))).toBe(true);
     expect(hasKey(spy, approvalsKeys.pending(SESSION_A))).toBe(true);
+  });
+
+  // WP3 (issue #41): a main-side draft→ready promotion fires a
+  // `controlState` event without any renderer mutation — the badge only
+  // refreshes if this push path also invalidates the mission draft/diff
+  // queries.
+  it("invalidates the mission draft and diff queries on a matching event", () => {
+    const client = freshClient();
+    const spy = vi.spyOn(client, "invalidateQueries");
+    renderHook(() => useControlStateLiveSync(SESSION_A), {
+      wrapper: makeWrapper(client),
+    });
+
+    controlCb?.(controlEvent(SESSION_A));
+
+    expect(hasKey(spy, missionKeys.draft(SESSION_A))).toBe(true);
+    expect(hasKey(spy, ["mission", "diff", SESSION_A])).toBe(true);
   });
 
   it("ignores a foreign-session event", () => {

--- a/vex-app/src/renderer/lib/api/runtime.ts
+++ b/vex-app/src/renderer/lib/api/runtime.ts
@@ -31,7 +31,7 @@ import type {
   RuntimeRequestStopResult,
   RuntimeStateDto,
 } from "@shared/schemas/runtime.js";
-import { approvalsKeys, runtimeKeys } from "./queryKeys.js";
+import { approvalsKeys, missionKeys, runtimeKeys } from "./queryKeys.js";
 
 const STALE_MS = 2_000;
 
@@ -63,15 +63,21 @@ export const RUNTIME_STATE_FALLBACK_POLL_MS = 8_000;
  * Subscribe the active session to the engine control-state spine (F5).
  *
  * Push: every committed control transition (`EV.engine.controlState`)
- * invalidates `runtimeKeys.state(sessionId)` (composer gating) and
- * `approvalsKeys.pending(sessionId)` (inline approval card) for the
- * matching session — near-instant, instead of waiting on a poll. A 30s
- * fallback re-invalidates `runtimeKeys.state` in case an event is
- * missed; pending approvals retain their own faster fallback poll in
- * `ApprovalsRegion` (the `controlState` emit is post-commit on lease
- * release, not part of the approval transaction, so the approval card
- * must not depend on it alone). Pure side effect — mount once per
- * active session (`SessionPanel`).
+ * invalidates `runtimeKeys.state(sessionId)` (composer gating),
+ * `approvalsKeys.pending(sessionId)` (inline approval card),
+ * `missionKeys.draft(sessionId)` (draft badge), and the session's mission
+ * diff queries (contract-status card) for the matching session — near-
+ * instant, instead of waiting on a poll. The draft/diff pair closes issue
+ * #41: a main-side draft→ready promotion (`reconcileDraftReadiness`, e.g.
+ * from the async edit-stop finalizer) fires a `controlState` event but not
+ * a renderer mutation, so `useMissionRenew`'s own `onSuccess` invalidation
+ * never runs — this push path is what reaches the badge. A 30s fallback
+ * re-invalidates `runtimeKeys.state` in case an event is missed; pending
+ * approvals retain their own faster fallback poll in `ApprovalsRegion`
+ * (the `controlState` emit is post-commit on lease release, not part of
+ * the approval transaction, so the approval card must not depend on it
+ * alone). Pure side effect — mount once per active session
+ * (`SessionPanel`).
  */
 export function useControlStateLiveSync(sessionId: string | null): void {
   const queryClient = useQueryClient();
@@ -85,6 +91,17 @@ export function useControlStateLiveSync(sessionId: string | null): void {
       });
       void queryClient.invalidateQueries({
         queryKey: approvalsKeys.pending(sessionId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: missionKeys.draft(sessionId),
+      });
+      // No `missionKeys.diffsForSession(sessionId)` helper exists in
+      // queryKeys.ts (out of this package's write set) — invalidate via
+      // the `missionKeys.diff(sessionId, missionId)` PREFIX instead.
+      // TanStack matches by prefix by default, so this hits every diff
+      // query cached for the session regardless of missionId.
+      void queryClient.invalidateQueries({
+        queryKey: ["mission", "diff", sessionId],
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes the two confirmed HIGH mission-runtime defects reported by @ellygeronline-lab, plus adjacent hardening.

**#42 — transient provider blips permanently parked missions.** The auto-retry classifier read only top-level `code`/`status` and never the `causeCode` the OpenRouter normalizer preserves, so every transient transport blip (fetch failed / undici timeout / socket reset) classified permanent and parked the run. The classifier now reads validated own-properties via a new pure reader (`mission-error-signal.ts`, errno-shape-validated `causeCode`, no message parsing), auto-retries a closed transport allow-list, and hard-excludes operator aborts / DNS / TLS / auth failures even against a contradictory `retryable:true`. Mid-stream stream errors are normalized (closing a redaction bypass), paused rows carry `{classified, statusCode, causeCode}` evidence, and a standing `role="alert"` panel + mission-rail error badge make the paused_error state visible to the operator (the mission is not monitoring the market until recovered). `stop_reason` stays `'provider_error'` and post-broadcast runs stay `auto_retry_unsafe`.

**#41 — renewed/edited complete drafts trapped in "Preparing".** The only draft→ready promotion was the model-patch path, which never fires for an already-complete draft. A new one-way, row-locked `reconcileDraftReadiness` (reuses `validateDraft`; never demotes, never promotes invalid) runs at all three draft-producing write sites: renew clone (same tx), edit-stop, and the async edit finalizer, whose return value now reflects the reconciled status. Renew IPC emits a control-state refresh and the renderer live-sync invalidates draft/diff queries so the badge updates without a remount.

**Adjacent:** chat IPC maps provider 401/403 → `provider.invalid_api_key`, 402 → `provider.insufficient_credits`, 429/5xx/transient transport → `provider.unavailable` (existing codes only — no more permanently-failing Retry); `cancel_wake` audit rows are inserted terminal (`cleared`) so one click can no longer wedge the session's mission-control surface; `LOCAL_RUNTIME.md` clean-slate now warns about irreversible key loss and requires exporting keystores/backups (bash + PowerShell + verification) before deletion.

Fixes #42
Fixes #41

## Verification

- Root `tsc --noEmit` clean; vex-app `lint` (tsc profiles + type-ratchet 436 ≤ baseline + process-boundary check) PASS; vex-app build artifact checks PASS.
- Targeted suites green in isolation: mission-error-signal / classifier / auto-retry / finalize-edit-readiness / draft-readiness / renew / abort / openrouter-midstream (76 tests), chat IPC (22), MissionControls + MissionRail (39), control-requests + cancel-wake.
- Full-suite failures on this machine are pre-existing and load-induced — identical on clean `main`, none in the touched files.
- Named gap: root `test:integration` requires the live embeddings endpoint (env-blocked here). No DB-lifecycle race is introduced: the reconciler is one-way + row-locked, the cancel_wake fix is a single-statement insert.