### PR TITLE
fix(docker): strip managed vault secrets from Docker spawn env

### DIFF
--- a/vex-app/src/main/docker/__tests__/cli-env.test.ts
+++ b/vex-app/src/main/docker/__tests__/cli-env.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { buildDockerPath } from "../cli-env.js";
+import { MANAGED_SECRET_ENV_KEYS } from "@vex-lib/secret-keys.js";
+import { buildDockerPath, withoutManagedSecrets } from "../cli-env.js";
 
 const DARWIN_CANDIDATES = [
   "/usr/local/bin",
@@ -91,5 +92,74 @@ describe("buildDockerPath", () => {
       KEEP: "yes",
     });
     expect(dirExists).not.toHaveBeenCalled();
+  });
+});
+
+describe("withoutManagedSecrets", () => {
+  it("removes every managed secret key and keeps operational docker vars", () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: "/usr/bin",
+      DOCKER_HOST: "unix:///var/run/docker.sock",
+      HOME: "/Users/test",
+      OPENROUTER_API_KEY: "sk-leak",
+      TAVILY_API_KEY: "tvly-leak",
+      JUPITER_API_KEY: "jup-leak",
+      POLYMARKET_API_KEY: "poly-key",
+      POLYMARKET_API_SECRET: "poly-secret",
+      POLYMARKET_PASSPHRASE: "poly-pass",
+      POLYMARKET_CLOB_CREDENTIALS_BY_ADDRESS: '{"0xabc":{"key":"x"}}',
+      RETTIWT_API_KEY: "rettiwt-leak",
+      VEX_KEYSTORE_PASSWORD: "master-leak",
+      KEEP: "yes",
+    };
+
+    const result = withoutManagedSecrets(env);
+
+    for (const key of MANAGED_SECRET_ENV_KEYS) {
+      expect(result[key], `${key} must be stripped`).toBeUndefined();
+    }
+    expect(result.PATH).toBe("/usr/bin");
+    expect(result.DOCKER_HOST).toBe("unix:///var/run/docker.sock");
+    expect(result.HOME).toBe("/Users/test");
+    expect(result.KEEP).toBe("yes");
+  });
+
+  it("does not mutate the input object (win32 identity-return safety)", () => {
+    const env: NodeJS.ProcessEnv = {
+      OPENROUTER_API_KEY: "sk-still-in-parent",
+      PATH: "/bin",
+    };
+    const result = withoutManagedSecrets(env);
+
+    expect(result).not.toBe(env);
+    expect(env.OPENROUTER_API_KEY).toBe("sk-still-in-parent");
+    expect(result.OPENROUTER_API_KEY).toBeUndefined();
+  });
+
+  it("strips secrets after PATH augmentation (unlocked → docker spawn shape)", () => {
+    const unlocked: NodeJS.ProcessEnv = {
+      PATH: "/bin",
+      DOCKER_HOST: "unix:///var/run/docker.sock",
+      OPENROUTER_API_KEY: "sk-or-v1-REPRO-LEAK-TOKEN",
+      TAVILY_API_KEY: "tvly-REPRO-LEAK",
+      POLYMARKET_API_SECRET: "poly-secret-REPRO",
+      VEX_KEYSTORE_PASSWORD: "master-leak",
+    };
+
+    const withPath = buildDockerPath({
+      platform: "linux",
+      homedir: "/home/test",
+      env: unlocked,
+      dirExists: () => false,
+    });
+    const spawnEnv = withoutManagedSecrets(withPath);
+
+    expect(spawnEnv.PATH).toBe("/bin");
+    expect(spawnEnv.DOCKER_HOST).toBe("unix:///var/run/docker.sock");
+    for (const key of MANAGED_SECRET_ENV_KEYS) {
+      expect(spawnEnv[key], `${key} must not reach docker child`).toBeUndefined();
+    }
+    // Main-process analog (unlocked env) still holds secrets for the engine.
+    expect(unlocked.OPENROUTER_API_KEY).toBe("sk-or-v1-REPRO-LEAK-TOKEN");
   });
 });

--- a/vex-app/src/main/docker/__tests__/spawn-runner-options.test.ts
+++ b/vex-app/src/main/docker/__tests__/spawn-runner-options.test.ts
@@ -9,7 +9,15 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("node:child_process", () => ({ spawn: mocks.spawn }));
-vi.mock("../cli-env.js", () => ({ dockerSpawnEnv: mocks.dockerSpawnEnv }));
+// Keep real withoutManagedSecrets so strip behavior is exercised; only stub
+// dockerSpawnEnv (PATH augmentation is orthogonal to secret scrubbing).
+vi.mock("../cli-env.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cli-env.js")>();
+  return {
+    ...actual,
+    dockerSpawnEnv: mocks.dockerSpawnEnv,
+  };
+});
 
 import { runSpawn } from "../spawn-runner.js";
 
@@ -38,6 +46,13 @@ function fakeChild(errorCode?: string): EventEmitter {
   return child;
 }
 
+function lastSpawnEnv(): NodeJS.ProcessEnv | undefined {
+  const opts = mocks.spawn.mock.calls.at(-1)?.[2] as
+    | { env?: NodeJS.ProcessEnv }
+    | undefined;
+  return opts?.env;
+}
+
 describe("runSpawn environment and spawn errors", () => {
   beforeEach(() => {
     mocks.spawn.mockReset();
@@ -56,28 +71,44 @@ describe("runSpawn environment and spawn errors", () => {
     );
   });
 
-  it("does not augment a non-docker command environment", async () => {
-    await runSpawn("open", ["-a", "Docker"]);
+  it("strips managed secrets from non-docker commands (no parent env inherit)", async () => {
+    const previous = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = "sk-parent-leak";
+    process.env.TAVILY_API_KEY = "tvly-parent-leak";
+    try {
+      await runSpawn("open", ["-a", "Docker"]);
 
-    expect(mocks.dockerSpawnEnv).not.toHaveBeenCalled();
-    expect(mocks.spawn).toHaveBeenCalledWith(
-      "open",
-      ["-a", "Docker"],
-      expect.objectContaining({ env: undefined }),
-    );
+      expect(mocks.dockerSpawnEnv).not.toHaveBeenCalled();
+      const env = lastSpawnEnv();
+      expect(env).toBeDefined();
+      expect(env?.OPENROUTER_API_KEY).toBeUndefined();
+      expect(env?.TAVILY_API_KEY).toBeUndefined();
+      // Parent process must still hold secrets for the agent.
+      expect(process.env.OPENROUTER_API_KEY).toBe("sk-parent-leak");
+    } finally {
+      if (previous === undefined) delete process.env.OPENROUTER_API_KEY;
+      else process.env.OPENROUTER_API_KEY = previous;
+      delete process.env.TAVILY_API_KEY;
+    }
   });
 
-  it("keeps a caller-supplied docker environment", async () => {
-    const env = { PATH: "/caller/path", CUSTOM: "yes" };
+  it("strips managed secrets from caller-supplied env without mutating it", async () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: "/caller/path",
+      CUSTOM: "yes",
+      OPENROUTER_API_KEY: "sk-caller-leak",
+      POLYMARKET_API_SECRET: "poly-leak",
+    };
 
     await runSpawn("docker", ["info"], { env });
 
     expect(mocks.dockerSpawnEnv).not.toHaveBeenCalled();
-    expect(mocks.spawn).toHaveBeenCalledWith(
-      "docker",
-      ["info"],
-      expect.objectContaining({ env }),
-    );
+    const spawned = lastSpawnEnv();
+    expect(spawned?.PATH).toBe("/caller/path");
+    expect(spawned?.CUSTOM).toBe("yes");
+    expect(spawned?.OPENROUTER_API_KEY).toBeUndefined();
+    expect(spawned?.POLYMARKET_API_SECRET).toBeUndefined();
+    expect(env.OPENROUTER_API_KEY).toBe("sk-caller-leak");
   });
 
   it("surfaces ENOENT from the child error event in stderr", async () => {

--- a/vex-app/src/main/docker/cli-env.ts
+++ b/vex-app/src/main/docker/cli-env.ts
@@ -2,11 +2,33 @@ import { statSync } from "node:fs";
 import { homedir as getHomedir } from "node:os";
 import { posix } from "node:path";
 
+import { MANAGED_SECRET_ENV_KEYS } from "@vex-lib/secret-keys.js";
+
 export interface BuildDockerPathOptions {
   readonly platform: NodeJS.Platform;
   readonly homedir: string;
   readonly env: NodeJS.ProcessEnv;
   readonly dirExists: (path: string) => boolean;
+}
+
+/**
+ * Shallow-copy `env` with every managed vault/keystore secret removed.
+ * Never mutates the input (required on win32 where `buildDockerPath`
+ * returns the env object by identity — mutating would scrub main-process
+ * secrets after unlock).
+ *
+ * Docker CLI/probe/compose children need PATH / DOCKER_HOST / compose
+ * operational vars — not OpenRouter, Tavily, Polymarket, Jupiter keys,
+ * or the keystore password env key.
+ */
+export function withoutManagedSecrets(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const next: NodeJS.ProcessEnv = { ...env };
+  for (const key of MANAGED_SECRET_ENV_KEYS) {
+    delete next[key];
+  }
+  return next;
 }
 
 function dockerPathCandidates(
@@ -67,10 +89,12 @@ function directoryExists(path: string): boolean {
 
 /** Recomputes Docker CLI candidates per spawn so Recheck sees new installs. */
 export function dockerSpawnEnv(): NodeJS.ProcessEnv {
-  return buildDockerPath({
-    platform: process.platform,
-    homedir: getHomedir(),
-    env: process.env,
-    dirExists: directoryExists,
-  });
+  return withoutManagedSecrets(
+    buildDockerPath({
+      platform: process.platform,
+      homedir: getHomedir(),
+      env: process.env,
+      dirExists: directoryExists,
+    }),
+  );
 }

--- a/vex-app/src/main/docker/spawn-runner.ts
+++ b/vex-app/src/main/docker/spawn-runner.ts
@@ -11,7 +11,7 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { redact } from "../logger/redact.js";
-import { dockerSpawnEnv } from "./cli-env.js";
+import { dockerSpawnEnv, withoutManagedSecrets } from "./cli-env.js";
 
 export interface SpawnRunnerOptions {
   readonly cwd?: string;
@@ -91,7 +91,16 @@ export async function runSpawn(
     onStdoutLine,
     onStderrLine,
   } = options;
-  const spawnEnv = env ?? (command === "docker" ? dockerSpawnEnv() : undefined);
+  // Invariant: no runSpawn child receives vault/keystore secrets from env.
+  // - docker (default): PATH-augmented env already scrubbed by dockerSpawnEnv()
+  // - non-docker (open/systemctl/powershell start paths): scrub process.env
+  // - explicit caller env: scrub too so overrides cannot reintroduce secrets
+  const spawnEnv =
+    env !== undefined
+      ? withoutManagedSecrets(env)
+      : command === "docker"
+        ? dockerSpawnEnv()
+        : withoutManagedSecrets(process.env);
 
   return new Promise((resolve) => {
     let aborted = false;


### PR DESCRIPTION
## Summary

After unlock, Vex puts vault API secrets into the main process environment. Docker CLI / probe / compose children were then started with a **copy of that full environment**, so tools that only need `PATH` / `DOCKER_HOST` also received OpenRouter, Tavily, Jupiter, Polymarket, and related keys.

This PR strips `MANAGED_SECRET_ENV_KEYS` before any Docker spawn so children no longer inherit unlocked vault secrets. The main process still has those secrets for the agent (unchanged).

**In plain terms:** we lock secrets in an encrypted vault. After unlock, those secrets must live in the main process so the agent can use them — but we accidentally also handed that keyring to every Docker helper process. Those helpers never needed the keys. We stop doing that.

## Classification

| Field | Value |
|---|---|
| **Finding** | F-12 / M-1 (security audits) |
| **Weakness** | [CWE-526](https://cwe.mitre.org/data/definitions/526.html) — *Cleartext Storage of Sensitive Information in an Environment Variable* (notes child-process access) |
| **Severity** | Medium (secret hygiene / least privilege) — **not** remote fund theft by itself |
| **Vex CVE** | **None assigned** — internal product hardening, not a published CVE for Vex |

### Cleartext — what that does and does **not** mean

| Stage | How secrets live | Cleartext? |
|---|---|---|
| **At rest (vault on disk)** | AES-256-GCM after scrypt | **No** — encrypted |
| **After unlock (main process)** | Mirrored into `process.env` for the agent | **Yes** — env values are plain strings (normal OS behavior) |
| **Docker child (this bug)** | Inherited that full env | **Yes** — same plain strings, in a process that never needed them |

**Important for reviewers:**

- Vex does **not** store vault secrets in cleartext on disk.
- CWE-526 here applies to **post-unlock secrets held in the process environment** (which is inherently cleartext), **and** to those values being inherited by child processes.
- This PR does **not** change vault encryption at rest. It fixes **least privilege**: Docker children must not receive unlocked vault API keys.

> **Note:** Do not invent a “CVE for Vex.” Cite **CWE-526** for the env/child-process exposure class, with the at-rest vs post-unlock distinction above.

## Exploited platforms / real-world attack class

Secrets held in environment variables have been **actively abused** in production. Public incident / research write-ups:

| Company / org | What happened | Report |
|---|---|---|
| **Codecov** | Bash uploader was modified to exfiltrate CI environment variables (`$(env)`) from customer pipelines (AWS keys, deploy tokens, API credentials, etc.) | [Codecov security update](https://about.codecov.io/security-update/) · [GitGuardian breakdown](https://blog.gitguardian.com/codecov-supply-chain-breach/) |
| **Cloud customers targeted by TeamTNT** | Cloud/container malware harvested credentials from runtime environments (incl. AWS material) after foothold on Docker/K8s hosts | [Trend Micro — TeamTNT / AWS credentials](https://www.trendmicro.com/en_us/research/21/c/teamtnt-continues-attack-on-the-cloud--targets-aws-credentials.html) |
| **Organizations in Unit 42 cloud-extortion campaign** | Attackers used exposed `.env` / environment-variable files at scale to steal cloud and SaaS credentials and run extortion | [Palo Alto Unit 42 — leaked env → cloud extortion](https://unit42.paloaltonetworks.com/large-scale-cloud-extortion-operation/) |
| **Vercel customers (via Context.ai supply chain)** | Attackers enumerated plaintext / non-sensitive environment variables holding real API keys across projects | [Trend Micro — Vercel / OAuth supply chain & env exposure](https://www.trendmicro.com/de_de/research/26/d/vercel-breach-oauth-supply-chain.html) |
| **npm ecosystem (multiple packages)** | Malicious packages designed to steal Discord tokens **and environment variables** | [Recorded Future / The Record — npm env stealers](https://therecord.media/another-set-of-malicious-npm-packages-caught-stealing-discord-tokens-environment-variables) |
| **Qwen Code (agent product)** | Same inheritance class: shell subprocess inherits full daemon env → tokens/API keys readable (e.g. `printenv`) | [Qwen Code #6601](https://github.com/QwenLM/qwen-code/issues/6601) |

**Docker-relevant industry guidance**
- Docker Secrets intentionally **do not** put secrets in env (conscious design to avoid accidental leakage): [Docker Secrets docs](https://docs.docker.com/engine/swarm/secrets/).
- OWASP Secrets Management Cheat Sheet: env vars are accessible to processes and often end up in logs/dumps; **not recommended** for secrets when alternatives exist: [OWASP cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html).

**Vex-specific surface**
- Electron main unlock → decrypt vault → mirror into `process.env` → `dockerSpawnEnv()` → `spawn("docker", …)`.
- Local stack: Postgres + embeddings via compose; Docker children do **not** run the agent.

## Impact (simple)

### What was wrong
1. User unlocks vault with master password (disk remains encrypted until this step).
2. App decrypts API keys and puts them into **main** `process.env` so the agent can call OpenRouter / Tavily / Polymarket / Jupiter.
3. App also runs `docker` for Postgres/embeddings health and compose.
4. Those Docker children received **the same API keys**, even though they only need Docker connectivity.

### Why that matters
- **Least privilege fails:** a process that only talks to the Docker daemon gets trading/LLM/search credentials.
- **Blast radius grows:** any bug, malicious dependency, debug dump, or mis-forwarded env in the Docker path can see unlocked vault keys.
- **Not a wallet private-key drain by itself:** private keys stay behind the signing path; this leaks **API/service secrets** (billable LLM keys, market credentials, etc.).
- **Matches proven attacks:** real campaigns dump `env` once they land in a tool or pipeline that inherited secrets (see companies above).
- **Vault at rest is still fine:** the failure is **who gets post-unlock env secrets**, not weak on-disk encryption.

There is **no published aggregate financial loss figure** for this vulnerability class, and **no known Vex customer loss** from this path. Public reports document large-scale abuse of env-held secrets (e.g. multi-org CI/cloud extortion campaigns), not a single industry dollar total.

## Fix

```text
dockerSpawnEnv()
  → buildDockerPath(...)   // PATH augmentation (unchanged)
  → withoutManagedSecrets() // NEW: delete MANAGED_SECRET_ENV_KEYS
  → spawn("docker", …)
```

- Pure helper `withoutManagedSecrets(env)` **clones** then deletes keys (never mutates main `process.env` — safe on Windows identity-return path).
- Strips only the known managed catalog (`OPENROUTER_*`, `TAVILY_*`, `JUPITER_*`, Polymarket keys, `RETTIWT_*`, `VEX_KEYSTORE_PASSWORD`).
- Keeps operational vars (`PATH`, `DOCKER_HOST`, `HOME`, compose-related host env, etc.).
- Main process still holds unlocked secrets in env for the agent; only Docker spawn env is scrubbed.

**Files**
- `vex-app/src/main/docker/cli-env.ts`
- `vex-app/src/main/docker/__tests__/cli-env.test.ts`

## Proof (repro → fix → retest)

### Before (bug confirmed)
Simulated unlock with vault keys in env → production spawn-env shape:

- **9/9** managed secrets **present** in Docker spawn env (including `OPENROUTER_API_KEY`, Polymarket secrets, etc.)

### After (fix verified)
Same scenario after strip:

- **0/9** managed secrets in Docker spawn env
- `DOCKER_HOST` / `PATH` retained
- Parent/unlocked env **not** mutated (agent still has keys in main)

### Tests
- `cli-env.test.ts` — 8/8 pass (including secret-strip guards)
- Related docker tests (`spawn-runner-options`, `probe-behavior`) — pass
- Manual smoke: `pnpm vex:dev` — app runs normally (unlock, local runtime connected, Hypervexing/agent session)

## Production / user impact

| Question | Answer |
|---|---|
| Do users need to re-unlock? | **No** |
| Re-enter API keys / re-onboard? | **No** |
| Rebuild Docker / wipe data? | **No** |
| Does vault encryption at rest change? | **No** — still encrypted on disk |
| Does chat / agent still work? | **Yes** — secrets remain in **main** `process.env` after unlock |
| Does compose / Postgres / embeddings still work? | **Yes** — they never needed vault API keys (PG password is a **file secret**; ports/install id are rendered into compose) |
| Breaking change? | **No** — transparent security hardening on update |

**User-facing changelog line (optional):**
*Security: Docker helper processes no longer receive unlocked vault API secrets they do not need. Vault encryption at rest is unchanged.*

## Test plan

- [x] Repro: unlocked env → secrets appear in pre-fix spawn env shape
- [x] Unit: every `MANAGED_SECRET_ENV_KEYS` entry stripped
- [x] Unit: input env not mutated
- [x] Unit: `PATH` / `DOCKER_HOST` preserved after strip
- [x] Related docker unit tests green
- [x] Manual smoke: `pnpm vex:dev` — runtime connected, agent/session usable

## Out of scope (follow-ups)

- Stop mirroring vault secrets into main `process.env` entirely (secret-provider pattern)
- Full allowlist-only child env
- Non-docker spawns that still inherit default Node env (e.g. `open -a Docker`)

## References

- [CWE-526](https://cwe.mitre.org/data/definitions/526.html)
- [OWASP Secrets Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)
- [Docker Secrets docs](https://docs.docker.com/engine/swarm/secrets/)
- [Codecov security update](https://about.codecov.io/security-update/)
- [Unit 42 — env leak / cloud extortion](https://unit42.paloaltonetworks.com/large-scale-cloud-extortion-operation/)