### PR TITLE
fix(wallet): classify corrupt Solana keystore separately from wrong password

### DIFF
--- a/src/__tests__/solana/solana-keystore.test.ts
+++ b/src/__tests__/solana/solana-keystore.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Keypair } from "@solana/web3.js";
 import { ErrorCodes } from "../../errors.js";
+import { encryptSecretBytes } from "@tools/wallet/keystore.js";
 import {
   decryptSolanaSecretKey,
   deriveSolanaAddress,
@@ -92,6 +93,24 @@ describe("solana keystore helpers", () => {
         decryptSolanaSecretKey(keystore, "wrong-password");
       } catch (err: unknown) {
         expect((err as { code: string }).code).toBe(ErrorCodes.KEYSTORE_DECRYPT_FAILED);
+      }
+    });
+  });
+
+  describe("decrypt with correct password but structurally bad payload", () => {
+    it("throws KEYSTORE_CORRUPT (not KEYSTORE_DECRYPT_FAILED) when a successful decrypt yields a non-64-byte payload", () => {
+      // Encrypt a payload of the wrong length directly (bypassing encryptSolanaSecretKey's
+      // own length guard) so the password/crypto succeeds and the post-decrypt length
+      // check is the only thing that fails. This is a structural/corrupt condition,
+      // not a wrong-password condition, and must not be mislabeled as one.
+      const keystore = encryptSecretBytes(new Uint8Array(32), "correct-password");
+
+      expect(() => decryptSolanaSecretKey(keystore, "correct-password")).toThrow();
+      try {
+        decryptSolanaSecretKey(keystore, "correct-password");
+      } catch (err: unknown) {
+        expect((err as { code: string }).code).toBe(ErrorCodes.KEYSTORE_CORRUPT);
+        expect((err as { code: string }).code).not.toBe(ErrorCodes.KEYSTORE_DECRYPT_FAILED);
       }
     });
   });

--- a/src/tools/wallet/solana-keystore.ts
+++ b/src/tools/wallet/solana-keystore.ts
@@ -67,7 +67,17 @@ export function encryptSolanaSecretKey(secretKey: Uint8Array, password: string):
 export function decryptSolanaSecretKey(keystore: KeystoreV1, password: string): Uint8Array {
   const secretKey = decryptSecretBytes(keystore, password);
   if (secretKey.length !== SOLANA_SECRET_KEY_LENGTH) {
-    throw new VexError(ErrorCodes.KEYSTORE_DECRYPT_FAILED, `Solana secret key must be ${SOLANA_SECRET_KEY_LENGTH} bytes after decrypt`);
+    // Decrypt already succeeded (right password, valid AES-GCM auth tag) — a
+    // wrong-length payload past that point is a structural/corrupt keystore,
+    // not a wrong-password condition. Keep KEYSTORE_DECRYPT_FAILED reserved
+    // for actual crypto failures (see decryptSecretBytes) so wallets-runner's
+    // "wrong password or corrupted keystore" mapping isn't shown for a
+    // corrupt-but-decryptable file.
+    throw new VexError(
+      ErrorCodes.KEYSTORE_CORRUPT,
+      `Solana secret key must be ${SOLANA_SECRET_KEY_LENGTH} bytes after decrypt`,
+      "Re-import your private key or restore from backup.",
+    );
   }
   return secretKey;
 }


### PR DESCRIPTION
Post-decrypt structural failure (payload ≠ 64 bytes after a successful AES-GCM decrypt) now throws `KEYSTORE_CORRUPT` instead of `KEYSTORE_DECRYPT_FAILED`, so a corrupt/mismatched keystore no longer reads as a possible wrong password. Crypto/auth-tag failures keep the decrypt-failed code; `wallets-runner` already maps the corrupt code. Reproduction-first test proves the prior mislabel. Sibling of the vault-side classification fix proposed in #43 — same defect class, wallet keystore path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)