### PR TITLE
fix(polymarket): validate all nine raw CLOB reward/rebate/market responses

### DIFF
--- a/src/__tests__/polymarket/polymarket-clob-rewards-validation.test.ts
+++ b/src/__tests__/polymarket/polymarket-clob-rewards-validation.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateSimplifiedMarketsResponse, validateRebatesResponse,
+  validateCurrentRewardsResponse, validateMarketRewardsResponse,
+  validateMultiMarketRewardsResponse, validateUserEarningsResponse,
+  validateUserTotalEarningsResponse, validateUserRewardPercentagesResponse,
+  validateUserEarningsMarketsResponse,
+} from "@tools/polymarket/clob/validation/rewards.js";
+
+const rewardsToken = { token_id: "111", outcome: "Yes", price: 0.8 };
+const rewardsConfig = {
+  id: 1, asset_address: "0x9c4E1703476E875070EE25b56A58B008CFb8FA78",
+  start_date: "2026-01-01", end_date: "2026-02-01", rate_per_day: 0.25, total_rewards: 92,
+};
+
+describe("validateSimplifiedMarketsResponse", () => {
+  const validMarket = {
+    condition_id: "0xbd31dc8a20211944f6b70f31557f1001557b59905b7738480ca09bd4532f84af",
+    rewards: { rates: [{ asset_address: "0x9c4E1703476E875070EE25b56A58B008CFb8FA78", rewards_daily_rate: 10 }], min_size: 100, max_spread: 3 },
+    tokens: [{ token_id: "111", outcome: "Yes", price: 0.8, winner: false }],
+    active: true, closed: false, archived: false, accepting_orders: true,
+  };
+
+  it("parses a valid paginated response", () => {
+    const r = validateSimplifiedMarketsResponse({ limit: 100, next_cursor: "LTE=", count: 1, data: [validMarket] });
+    expect(r.data).toHaveLength(1);
+    expect(r.data[0].condition_id).toBe(validMarket.condition_id);
+  });
+
+  it("accepts unknown extra keys at every level but strips them from the parsed output", () => {
+    const r = validateSimplifiedMarketsResponse({
+      limit: 100, next_cursor: "", count: 1,
+      data: [{ ...validMarket, futureField: "x", rewards: { ...validMarket.rewards, futureRewardField: 1 } }],
+      futureEnvelopeField: true,
+    });
+    expect((r as unknown as Record<string, unknown>).futureEnvelopeField).toBeUndefined();
+    expect((r.data[0] as unknown as Record<string, unknown>).futureField).toBeUndefined();
+    expect((r.data[0].rewards as unknown as Record<string, unknown>).futureRewardField).toBeUndefined();
+    expect(r.count).toBe(1);
+    expect(r.data[0].condition_id).toBe(validMarket.condition_id);
+  });
+
+  it("rejects a non-object root", () => {
+    expect(() => validateSimplifiedMarketsResponse(null)).toThrow();
+    expect(() => validateSimplifiedMarketsResponse("bad")).toThrow();
+  });
+
+  it("rejects a malformed market (wrong field type)", () => {
+    expect(() => validateSimplifiedMarketsResponse({
+      limit: 100, next_cursor: "", count: 1,
+      data: [{ ...validMarket, active: "yes" }],
+    })).toThrow();
+  });
+
+  it("rejects an oversized data array", () => {
+    const data = Array.from({ length: 501 }, () => validMarket);
+    expect(() => validateSimplifiedMarketsResponse({ limit: 500, next_cursor: "", count: 501, data })).toThrow();
+  });
+});
+
+describe("validateRebatesResponse", () => {
+  const validEntry = {
+    date: "2026-02-27",
+    condition_id: "0xbd31dc8a20211944f6b70f31557f1001557b59905b7738480ca09bd4532f84af",
+    asset_address: "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
+    maker_address: "0xFeA4cB3dD4ca7CefD3368653B7D6FF9BcDFca604",
+    rebated_fees_usdc: "0.237519",
+  };
+
+  it("parses a valid array", () => {
+    const r = validateRebatesResponse([validEntry]);
+    expect(r).toHaveLength(1);
+    expect(r[0].rebated_fees_usdc).toBe("0.237519");
+  });
+
+  it("accepts unknown extra keys but strips them from the parsed output", () => {
+    const r = validateRebatesResponse([{ ...validEntry, futureField: 1 }]);
+    expect((r[0] as unknown as Record<string, unknown>).futureField).toBeUndefined();
+    expect(r).toHaveLength(1);
+  });
+
+  it("rejects a non-array root", () => {
+    expect(() => validateRebatesResponse({})).toThrow();
+    expect(() => validateRebatesResponse(null)).toThrow();
+  });
+
+  it("rejects an oversized array", () => {
+    expect(() => validateRebatesResponse(Array.from({ length: 501 }, () => validEntry))).toThrow();
+  });
+
+  it("rejects a malformed entry", () => {
+    expect(() => validateRebatesResponse([{ ...validEntry, rebated_fees_usdc: 123 }])).toThrow();
+  });
+});
+
+describe("validateCurrentRewardsResponse", () => {
+  const validReward = {
+    condition_id: "0xbd31dc8a20211944f6b70f31557f1001557b59905b7738480ca09bd4532f84af",
+    rewards_max_spread: 3, rewards_min_size: 100, rewards_config: [rewardsConfig],
+  };
+
+  it("parses a valid response, optional fields absent", () => {
+    const r = validateCurrentRewardsResponse({ limit: 500, count: 1, next_cursor: "LTE=", data: [validReward] });
+    expect(r.data[0].sponsored_daily_rate).toBeUndefined();
+    expect(r.data[0].rewards_config[0].rate_per_day).toBe(0.25);
+  });
+
+  it("parses optional sponsor fields when present", () => {
+    const r = validateCurrentRewardsResponse({
+      limit: 500, count: 1, next_cursor: "",
+      data: [{ ...validReward, sponsored_daily_rate: 5, sponsors_count: 2, native_daily_rate: 1, total_daily_rate: 6 }],
+    });
+    expect(r.data[0].sponsors_count).toBe(2);
+  });
+
+  it("rejects malformed root", () => {
+    expect(() => validateCurrentRewardsResponse([])).toThrow();
+  });
+
+  it("rejects an oversized nested rewards_config array", () => {
+    const oversized = { ...validReward, rewards_config: Array.from({ length: 101 }, () => rewardsConfig) };
+    expect(() => validateCurrentRewardsResponse({ limit: 500, count: 1, next_cursor: "", data: [oversized] })).toThrow();
+  });
+});
+
+describe("validateMarketRewardsResponse", () => {
+  const validReward = {
+    condition_id: "0xbd31dc8a20211944f6b70f31557f1001557b59905b7738480ca09bd4532f84af",
+    question: "Will X happen?", market_slug: "will-x-happen", event_slug: "x-event", image: "https://img",
+    rewards_max_spread: 3, rewards_min_size: 100, market_competitiveness: 0.5,
+    tokens: [rewardsToken], rewards_config: [rewardsConfig],
+  };
+
+  it("parses a valid response", () => {
+    const r = validateMarketRewardsResponse({ limit: 500, count: 1, next_cursor: "", data: [validReward] });
+    expect(r.data[0].tokens[0].token_id).toBe("111");
+  });
+
+  it("accepts unknown extra keys on the market entry but strips them from the parsed output", () => {
+    const r = validateMarketRewardsResponse({ limit: 500, count: 1, next_cursor: "", data: [{ ...validReward, extra: "z" }] });
+    expect((r.data[0] as unknown as Record<string, unknown>).extra).toBeUndefined();
+    expect(r.data).toHaveLength(1);
+  });
+
+  it("rejects a missing required field", () => {
+    const { question: _question, ...withoutQuestion } = validReward;
+    expect(() => validateMarketRewardsResponse({ limit: 500, count: 1, next_cursor: "", data: [withoutQuestion] })).toThrow();
+  });
+});
+
+describe("validateMultiMarketRewardsResponse", () => {
+  const validInfo = {
+    condition_id: "0xabc", event_id: "e1", event_slug: "event-1", created_at: "2026-01-01T00:00:00Z",
+    group_item_title: "Trump wins", image: "https://img", market_competitiveness: 0.9, market_id: "m1",
+    market_slug: "trump-wins", one_day_price_change: 0.02, question: "Will Trump win?",
+    rewards_max_spread: 3, rewards_min_size: 100, spread: 0.01, end_date: "2026-12-31",
+    tokens: [rewardsToken], volume_24hr: 10000, rewards_config: [rewardsConfig],
+  };
+
+  it("parses a valid response", () => {
+    const r = validateMultiMarketRewardsResponse({ limit: 100, count: 1, next_cursor: "", data: [validInfo] });
+    expect(r.data[0].market_id).toBe("m1");
+  });
+
+  it("rejects an oversized data array", () => {
+    const data = Array.from({ length: 501 }, () => validInfo);
+    expect(() => validateMultiMarketRewardsResponse({ limit: 500, count: 501, next_cursor: "", data })).toThrow();
+  });
+
+  it("rejects a non-object root", () => {
+    expect(() => validateMultiMarketRewardsResponse(undefined)).toThrow();
+  });
+});
+
+describe("validateUserEarningsResponse", () => {
+  const validEarning = {
+    date: "2024-03-26T00:00:00Z",
+    condition_id: "0xbd31dc8a20211944f6b70f31557f1001557b59905b7738480ca09bd4532f84af",
+    asset_address: "0x9c4E1703476E875070EE25b56A58B008CFb8FA78",
+    maker_address: "0xFeA4cB3dD4ca7CefD3368653B7D6FF9BcDFca604",
+    earnings: 0.237519, asset_rate: 1,
+  };
+
+  it("parses a valid paginated response", () => {
+    const r = validateUserEarningsResponse({ limit: 100, count: 1, next_cursor: "LTE=", data: [validEarning] });
+    expect(r.data[0].earnings).toBe(0.237519);
+  });
+
+  it("rejects a malformed earnings field", () => {
+    expect(() => validateUserEarningsResponse({
+      limit: 100, count: 1, next_cursor: "", data: [{ ...validEarning, earnings: "bad" }],
+    })).toThrow();
+  });
+});
+
+describe("validateUserTotalEarningsResponse", () => {
+  const validEntry = {
+    date: "2024-04-09T00:00:00Z", asset_address: "0x9c4E1703476E875070EE25b56A58B008CFb8FA78",
+    maker_address: "0xD527CCdBEB6478488c848465F9947bDA3C2e6994", earnings: 1.59984, asset_rate: 0.999357,
+  };
+
+  it("parses a valid array response", () => {
+    const r = validateUserTotalEarningsResponse([validEntry]);
+    expect(r).toHaveLength(1);
+    expect(r[0].earnings).toBe(1.59984);
+  });
+
+  it("accepts unknown extra keys but strips them from the parsed output", () => {
+    const r = validateUserTotalEarningsResponse([{ ...validEntry, extra: true }]);
+    expect((r[0] as unknown as Record<string, unknown>).extra).toBeUndefined();
+    expect(r).toHaveLength(1);
+  });
+
+  it("rejects a non-array root", () => {
+    expect(() => validateUserTotalEarningsResponse({})).toThrow();
+  });
+
+  it("rejects an oversized array", () => {
+    expect(() => validateUserTotalEarningsResponse(Array.from({ length: 501 }, () => validEntry))).toThrow();
+  });
+});
+
+describe("validateUserRewardPercentagesResponse", () => {
+  it("parses a valid condition_id → percentage map", () => {
+    const r = validateUserRewardPercentagesResponse({
+      "0x296ea2f3ad438ce7ead77f40d0159bf3e5d8be146f6f615fa253b00e02243f5c": 20,
+      "0xbd31dc8a20211944f6b70f31557f1001557b59905b7738480ca09bd4532f84af": 20,
+    });
+    expect(r["0x296ea2f3ad438ce7ead77f40d0159bf3e5d8be146f6f615fa253b00e02243f5c"]).toBe(20);
+  });
+
+  it("rejects a non-object root", () => {
+    expect(() => validateUserRewardPercentagesResponse(null)).toThrow();
+    expect(() => validateUserRewardPercentagesResponse([])).toThrow();
+  });
+
+  it("rejects a non-numeric value", () => {
+    expect(() => validateUserRewardPercentagesResponse({ "0xabc": "20" })).toThrow();
+  });
+
+  it("rejects an oversized map", () => {
+    const oversized: Record<string, number> = {};
+    for (let i = 0; i < 501; i++) oversized[`0x${i}`] = i;
+    expect(() => validateUserRewardPercentagesResponse(oversized)).toThrow();
+  });
+});
+
+describe("validateUserEarningsMarketsResponse", () => {
+  const validMarket = {
+    condition_id: "0xabc", market_id: "m1", event_id: "e1", question: "Will Trump win Iowa?",
+    market_slug: "trump-iowa", event_slug: "iowa-2024", image: "https://img",
+    rewards_max_spread: 3, rewards_min_size: 100, volume_24hr: 5000, spread: 0.01,
+    market_competitiveness: 0.7, tokens: [rewardsToken], rewards_config: [rewardsConfig],
+    maker_address: "0xFeA4cB3dD4ca7CefD3368653B7D6FF9BcDFca604", earning_percentage: 30,
+    earnings: [{ asset_address: "0x9c4E1703476E875070EE25b56A58B008CFb8FA78", earnings: 12.3, asset_rate: 1.001 }],
+  };
+
+  it("parses a valid response including total_count", () => {
+    const r = validateUserEarningsMarketsResponse({ limit: 100, count: 1, total_count: 1, next_cursor: "LTE=", data: [validMarket] });
+    expect(r.total_count).toBe(1);
+    expect(r.data[0].earnings[0].asset_rate).toBe(1.001);
+  });
+
+  it("rejects an oversized nested earnings array", () => {
+    const oversized = { ...validMarket, earnings: Array.from({ length: 101 }, () => validMarket.earnings[0]) };
+    expect(() => validateUserEarningsMarketsResponse({ limit: 100, count: 1, total_count: 1, next_cursor: "", data: [oversized] })).toThrow();
+  });
+
+  it("rejects a malformed root", () => {
+    expect(() => validateUserEarningsMarketsResponse("bad")).toThrow();
+  });
+});

--- a/src/tools/polymarket/clob/client.ts
+++ b/src/tools/polymarket/clob/client.ts
@@ -22,6 +22,13 @@ import {
   validateBatchMidpointsResponse, validateBatchSpreadsResponse,
   validateBatchLastTradesPricesResponse, validateOrderScoringResponse,
 } from "./validation.js";
+import {
+  validateSimplifiedMarketsResponse, validateRebatesResponse,
+  validateCurrentRewardsResponse, validateMarketRewardsResponse,
+  validateMultiMarketRewardsResponse, validateUserEarningsResponse,
+  validateUserTotalEarningsResponse, validateUserRewardPercentagesResponse,
+  validateUserEarningsMarketsResponse,
+} from "./validation/rewards.js";
 import logger from "../../../utils/logger.js";
 import { buildClobUrl, clobErrorMessage, buildClobAuthHeaders } from "./client/http.js";
 import type { VexError } from "../../../errors.js";
@@ -29,6 +36,9 @@ import type {
   OrderBookSummary, SendOrderRequest, SendOrderResponse,
   OpenOrder, PaginatedOrders, CancelResponse, PaginatedTrades,
   PriceHistoryResponse, BookRequest, LastTradePrice, OrderScoringResponse,
+  PaginatedSimplifiedMarkets, RebateEntry, PaginatedCurrentRewards,
+  PaginatedMarketRewards, PaginatedMultiMarketInfo, PaginatedUserEarnings,
+  UserTotalEarningEntry, UserRewardPercentages, PaginatedUserRewardsMarkets,
 } from "./types.js";
 
 /**
@@ -233,50 +243,50 @@ export class PolyClobClient {
     }, body);
   }
 
-  getSimplifiedMarkets(nextCursor?: string): Promise<unknown> {
-    return this.requestPublic("/simplified-markets", (raw) => raw, nextCursor ? { next_cursor: nextCursor } : undefined);
+  getSimplifiedMarkets(nextCursor?: string): Promise<PaginatedSimplifiedMarkets> {
+    return this.requestPublic("/simplified-markets", validateSimplifiedMarketsResponse, nextCursor ? { next_cursor: nextCursor } : undefined);
   }
 
-  getRebates(date: string, makerAddress: string): Promise<unknown> {
-    return this.requestPublic("/rebates/current", (raw) => raw, { date, maker_address: makerAddress });
+  getRebates(date: string, makerAddress: string): Promise<RebateEntry[]> {
+    return this.requestPublic("/rebates/current", validateRebatesResponse, { date, maker_address: makerAddress });
   }
 
   // ── Rewards (public) ───────────────────────────────────────────────
 
-  getActiveRewards(opts?: { sponsored?: boolean; next_cursor?: string }): Promise<unknown> {
-    return this.requestPublic("/rewards/markets/current", (raw) => raw, {
+  getActiveRewards(opts?: { sponsored?: boolean; next_cursor?: string }): Promise<PaginatedCurrentRewards> {
+    return this.requestPublic("/rewards/markets/current", validateCurrentRewardsResponse, {
       sponsored: opts?.sponsored != null ? String(opts.sponsored) : undefined,
       next_cursor: opts?.next_cursor,
     });
   }
 
-  getMarketRewards(conditionId: string, opts?: { sponsored?: boolean; next_cursor?: string }): Promise<unknown> {
-    return this.requestPublic(`/rewards/markets/${encodeURIComponent(conditionId)}`, (raw) => raw, {
+  getMarketRewards(conditionId: string, opts?: { sponsored?: boolean; next_cursor?: string }): Promise<PaginatedMarketRewards> {
+    return this.requestPublic(`/rewards/markets/${encodeURIComponent(conditionId)}`, validateMarketRewardsResponse, {
       sponsored: opts?.sponsored != null ? String(opts.sponsored) : undefined,
       next_cursor: opts?.next_cursor,
     });
   }
 
-  getMultiMarketRewards(opts?: Record<string, string | undefined>): Promise<unknown> {
-    return this.requestPublic("/rewards/markets/multi", (raw) => raw, opts);
+  getMultiMarketRewards(opts?: Record<string, string | undefined>): Promise<PaginatedMultiMarketInfo> {
+    return this.requestPublic("/rewards/markets/multi", validateMultiMarketRewardsResponse, opts);
   }
 
   // ── Rewards (authenticated) ────────────────────────────────────────
 
-  getUserEarnings(auth: ClobAuthContext, opts: Record<string, string | undefined>): Promise<unknown> {
-    return this.requestAuth(auth, "GET", "/rewards/user", (raw) => raw, undefined, opts);
+  getUserEarnings(auth: ClobAuthContext, opts: Record<string, string | undefined>): Promise<PaginatedUserEarnings> {
+    return this.requestAuth(auth, "GET", "/rewards/user", validateUserEarningsResponse, undefined, opts);
   }
 
-  getUserTotalEarnings(auth: ClobAuthContext, opts: Record<string, string | undefined>): Promise<unknown> {
-    return this.requestAuth(auth, "GET", "/rewards/user/total", (raw) => raw, undefined, opts);
+  getUserTotalEarnings(auth: ClobAuthContext, opts: Record<string, string | undefined>): Promise<UserTotalEarningEntry[]> {
+    return this.requestAuth(auth, "GET", "/rewards/user/total", validateUserTotalEarningsResponse, undefined, opts);
   }
 
-  getUserRewardPercentages(auth: ClobAuthContext, opts?: Record<string, string | undefined>): Promise<unknown> {
-    return this.requestAuth(auth, "GET", "/rewards/user/percentages", (raw) => raw, undefined, opts);
+  getUserRewardPercentages(auth: ClobAuthContext, opts?: Record<string, string | undefined>): Promise<UserRewardPercentages> {
+    return this.requestAuth(auth, "GET", "/rewards/user/percentages", validateUserRewardPercentagesResponse, undefined, opts);
   }
 
-  getUserEarningsMarkets(auth: ClobAuthContext, opts?: Record<string, string | undefined>): Promise<unknown> {
-    return this.requestAuth(auth, "GET", "/rewards/user/markets", (raw) => raw, undefined, opts);
+  getUserEarningsMarkets(auth: ClobAuthContext, opts?: Record<string, string | undefined>): Promise<PaginatedUserRewardsMarkets> {
+    return this.requestAuth(auth, "GET", "/rewards/user/markets", validateUserEarningsMarketsResponse, undefined, opts);
   }
 
   getOrderScoring(auth: ClobAuthContext, orderId: string): Promise<OrderScoringResponse> {

--- a/src/tools/polymarket/clob/types.ts
+++ b/src/tools/polymarket/clob/types.ts
@@ -150,3 +150,192 @@ export interface PriceHistoryPoint {
 export interface PriceHistoryResponse {
   history: PriceHistoryPoint[];
 }
+
+// ── Rewards / Rebates / Simplified Markets ───────────────────────────
+
+export interface RewardsToken {
+  token_id: string;
+  outcome: string;
+  price: number;
+}
+
+export interface RewardsConfigItem {
+  id: number;
+  asset_address: string;
+  start_date: string;
+  end_date: string;
+  rate_per_day: number;
+  total_rewards: number;
+  remaining_reward_amount?: number;
+  total_days?: number;
+}
+
+export interface SimplifiedMarketRewardsRate {
+  asset_address: string;
+  rewards_daily_rate: number;
+}
+
+export interface SimplifiedMarketRewards {
+  rates: SimplifiedMarketRewardsRate[];
+  min_size: number;
+  max_spread: number;
+}
+
+export interface SimplifiedMarketToken {
+  token_id: string;
+  outcome: string;
+  price: number;
+  winner: boolean;
+}
+
+export interface SimplifiedMarket {
+  condition_id: string;
+  rewards: SimplifiedMarketRewards;
+  tokens: SimplifiedMarketToken[];
+  active: boolean;
+  closed: boolean;
+  archived: boolean;
+  accepting_orders: boolean;
+}
+
+export interface PaginatedSimplifiedMarkets {
+  limit: number;
+  next_cursor: string;
+  count: number;
+  data: SimplifiedMarket[];
+}
+
+export interface RebateEntry {
+  date: string;
+  condition_id: string;
+  asset_address: string;
+  maker_address: string;
+  rebated_fees_usdc: string;
+}
+
+export interface CurrentReward {
+  condition_id: string;
+  rewards_max_spread: number;
+  rewards_min_size: number;
+  rewards_config: RewardsConfigItem[];
+  sponsored_daily_rate?: number;
+  sponsors_count?: number;
+  native_daily_rate?: number;
+  total_daily_rate?: number;
+}
+
+export interface PaginatedCurrentRewards {
+  limit: number;
+  count: number;
+  next_cursor: string;
+  data: CurrentReward[];
+}
+
+export interface MarketReward {
+  condition_id: string;
+  question: string;
+  market_slug: string;
+  event_slug: string;
+  image: string;
+  rewards_max_spread: number;
+  rewards_min_size: number;
+  market_competitiveness: number;
+  tokens: RewardsToken[];
+  rewards_config: RewardsConfigItem[];
+}
+
+export interface PaginatedMarketRewards {
+  limit: number;
+  count: number;
+  next_cursor: string;
+  data: MarketReward[];
+}
+
+export interface MultiMarketInfo {
+  condition_id: string;
+  event_id: string;
+  event_slug: string;
+  created_at: string;
+  group_item_title: string;
+  image: string;
+  market_competitiveness: number;
+  market_id: string;
+  market_slug: string;
+  one_day_price_change: number;
+  question: string;
+  rewards_max_spread: number;
+  rewards_min_size: number;
+  spread: number;
+  end_date: string;
+  tokens: RewardsToken[];
+  volume_24hr: number;
+  rewards_config: RewardsConfigItem[];
+}
+
+export interface PaginatedMultiMarketInfo {
+  limit: number;
+  count: number;
+  next_cursor: string;
+  data: MultiMarketInfo[];
+}
+
+export interface UserEarning {
+  date: string;
+  condition_id: string;
+  asset_address: string;
+  maker_address: string;
+  earnings: number;
+  asset_rate: number;
+}
+
+export interface PaginatedUserEarnings {
+  limit: number;
+  count: number;
+  next_cursor: string;
+  data: UserEarning[];
+}
+
+export interface UserTotalEarningEntry {
+  date: string;
+  asset_address: string;
+  maker_address: string;
+  earnings: number;
+  asset_rate: number;
+}
+
+/** `condition_id → reward percentage`, per `/rewards/user/percentages`. */
+export type UserRewardPercentages = Record<string, number>;
+
+export interface AssetEarning {
+  asset_address: string;
+  earnings: number;
+  asset_rate: number;
+}
+
+export interface UserRewardsMarket {
+  condition_id: string;
+  market_id: string;
+  event_id: string;
+  question: string;
+  market_slug: string;
+  event_slug: string;
+  image: string;
+  rewards_max_spread: number;
+  rewards_min_size: number;
+  volume_24hr: number;
+  spread: number;
+  market_competitiveness: number;
+  tokens: RewardsToken[];
+  rewards_config: RewardsConfigItem[];
+  maker_address: string;
+  earning_percentage: number;
+  earnings: AssetEarning[];
+}
+
+export interface PaginatedUserRewardsMarkets {
+  limit: number;
+  count: number;
+  total_count: number;
+  next_cursor: string;
+  data: UserRewardsMarket[];
+}

--- a/src/tools/polymarket/clob/validation/rewards.ts
+++ b/src/tools/polymarket/clob/validation/rewards.ts
@@ -1,0 +1,307 @@
+/**
+ * Rewards / rebates / simplified-markets CLOB validators.
+ *
+ * These nine endpoints (`getSimplifiedMarkets`, `getRebates`,
+ * `getActiveRewards`, `getMarketRewards`, `getMultiMarketRewards`,
+ * `getUserEarnings`, `getUserTotalEarnings`, `getUserRewardPercentages`,
+ * `getUserEarningsMarkets` in `../client.ts`) used a `(raw) => raw` identity
+ * parser: the provider response reached `handlers-rewards.ts` (`ok(data)` →
+ * `ToolResult`, shown to the user/LLM near-verbatim) completely unvalidated.
+ *
+ * Unlike the LENIENT-DEFAULTING order/trade/price validators in this
+ * directory (a malformed field never fails the whole response), these are
+ * pure informational reporting data — reward/rebate/earnings figures and
+ * market metadata — where silently defaulting a garbled number to `0` would
+ * misrepresent a real value to the user. So each schema is STRICT: a
+ * missing/wrong-typed required field, or a pagination/nested array beyond its
+ * bound, rejects the WHOLE response with a plain `Error`, matching the
+ * "Expected X" convention used across `../validation.ts`. Unknown keys are
+ * ACCEPTED but STRIPPED (zod's default): these parsed responses are serialized
+ * near-verbatim into tool output / the LLM transcript, so unmodeled provider
+ * content must never ride along unbounded. A new provider field the client
+ * wants to surface gets modeled here first — forward-tolerant, never
+ * forward-leaking.
+ *
+ * Bounds: `MAX_PAGE_ITEMS` mirrors the Polymarket API's own documented
+ * page-size ceiling (500) for pagination arrays. `MAX_NESTED_ITEMS` bounds the
+ * per-entry collections (tokens / reward configs / rates / per-asset
+ * earnings) generously above any realistic market shape — exceeding it is
+ * rejected the same way, since a single entry can only carry a handful of
+ * tokens or reward-config rows in practice.
+ */
+
+import { z } from "zod";
+import type {
+  SimplifiedMarket, PaginatedSimplifiedMarkets,
+  RebateEntry,
+  RewardsConfigItem, CurrentReward, PaginatedCurrentRewards,
+  RewardsToken, MarketReward, PaginatedMarketRewards,
+  MultiMarketInfo, PaginatedMultiMarketInfo,
+  UserEarning, PaginatedUserEarnings,
+  UserTotalEarningEntry, UserRewardPercentages,
+  AssetEarning, UserRewardsMarket, PaginatedUserRewardsMarkets,
+} from "../types.js";
+
+// ── Bounds ────────────────────────────────────────────────────────────
+
+const MAX_PAGE_ITEMS = 500; // matches the API's own documented max page_size/limit
+const MAX_NESTED_ITEMS = 100; // tokens / rewards_config / rates / per-asset earnings per entry
+const MAX_ID_LEN = 100; // condition_id / token_id / asset+maker address / event+market id
+const MAX_SLUG_LEN = 300; // slugs, dates, outcome labels, cursors
+const MAX_TEXT_LEN = 2000; // question / group_item_title free text
+const MAX_URL_LEN = 2000; // image URLs
+
+const idString = z.string().max(MAX_ID_LEN);
+const slugString = z.string().max(MAX_SLUG_LEN);
+const textString = z.string().max(MAX_TEXT_LEN);
+const urlString = z.string().max(MAX_URL_LEN);
+
+// ── Shared nested shapes ────────────────────────────────────────────────
+
+const rewardsTokenSchema: z.ZodType<RewardsToken> = z.object({
+  token_id: idString,
+  outcome: slugString,
+  price: z.number(),
+});
+
+const rewardsConfigItemSchema: z.ZodType<RewardsConfigItem> = z.object({
+  id: z.number(),
+  asset_address: idString,
+  start_date: slugString,
+  end_date: slugString,
+  rate_per_day: z.number(),
+  total_rewards: z.number(),
+  remaining_reward_amount: z.number().optional(),
+  total_days: z.number().optional(),
+});
+
+// ── Simplified markets ──────────────────────────────────────────────────
+
+const simplifiedMarketSchema: z.ZodType<SimplifiedMarket> = z.object({
+  condition_id: idString,
+  rewards: z.object({
+    rates: z.array(z.object({
+      asset_address: idString,
+      rewards_daily_rate: z.number(),
+    })).max(MAX_NESTED_ITEMS),
+    min_size: z.number(),
+    max_spread: z.number(),
+  }),
+  tokens: z.array(z.object({
+    token_id: idString,
+    outcome: slugString,
+    price: z.number(),
+    winner: z.boolean(),
+  })).max(MAX_NESTED_ITEMS),
+  active: z.boolean(),
+  closed: z.boolean(),
+  archived: z.boolean(),
+  accepting_orders: z.boolean(),
+});
+
+const paginatedSimplifiedMarketsSchema: z.ZodType<PaginatedSimplifiedMarkets> = z.object({
+  limit: z.number(),
+  next_cursor: slugString,
+  count: z.number(),
+  data: z.array(simplifiedMarketSchema).max(MAX_PAGE_ITEMS),
+});
+
+export function validateSimplifiedMarketsResponse(raw: unknown): PaginatedSimplifiedMarkets {
+  const parsed = paginatedSimplifiedMarketsSchema.safeParse(raw);
+  if (!parsed.success) throw new Error("Expected simplified markets response");
+  return parsed.data;
+}
+
+// ── Rebates ─────────────────────────────────────────────────────────────
+
+const rebateEntrySchema: z.ZodType<RebateEntry> = z.object({
+  date: slugString,
+  condition_id: idString,
+  asset_address: idString,
+  maker_address: idString,
+  rebated_fees_usdc: slugString,
+});
+
+const rebatesResponseSchema = z.array(rebateEntrySchema).max(MAX_PAGE_ITEMS);
+
+export function validateRebatesResponse(raw: unknown): RebateEntry[] {
+  const parsed = rebatesResponseSchema.safeParse(raw);
+  if (!parsed.success) throw new Error("Expected rebates array");
+  return parsed.data;
+}
+
+// ── Rewards (public) ────────────────────────────────────────────────────
+
+const currentRewardSchema: z.ZodType<CurrentReward> = z.object({
+  condition_id: idString,
+  rewards_max_spread: z.number(),
+  rewards_min_size: z.number(),
+  rewards_config: z.array(rewardsConfigItemSchema).max(MAX_NESTED_ITEMS),
+  sponsored_daily_rate: z.number().optional(),
+  sponsors_count: z.number().optional(),
+  native_daily_rate: z.number().optional(),
+  total_daily_rate: z.number().optional(),
+});
+
+const paginatedCurrentRewardsSchema: z.ZodType<PaginatedCurrentRewards> = z.object({
+  limit: z.number(),
+  count: z.number(),
+  next_cursor: slugString,
+  data: z.array(currentRewardSchema).max(MAX_PAGE_ITEMS),
+});
+
+export function validateCurrentRewardsResponse(raw: unknown): PaginatedCurrentRewards {
+  const parsed = paginatedCurrentRewardsSchema.safeParse(raw);
+  if (!parsed.success) throw new Error("Expected current rewards response");
+  return parsed.data;
+}
+
+const marketRewardSchema: z.ZodType<MarketReward> = z.object({
+  condition_id: idString,
+  question: textString,
+  market_slug: slugString,
+  event_slug: slugString,
+  image: urlString,
+  rewards_max_spread: z.number(),
+  rewards_min_size: z.number(),
+  market_competitiveness: z.number(),
+  tokens: z.array(rewardsTokenSchema).max(MAX_NESTED_ITEMS),
+  rewards_config: z.array(rewardsConfigItemSchema).max(MAX_NESTED_ITEMS),
+});
+
+const paginatedMarketRewardsSchema: z.ZodType<PaginatedMarketRewards> = z.object({
+  limit: z.number(),
+  count: z.number(),
+  next_cursor: slugString,
+  data: z.array(marketRewardSchema).max(MAX_PAGE_ITEMS),
+});
+
+export function validateMarketRewardsResponse(raw: unknown): PaginatedMarketRewards {
+  const parsed = paginatedMarketRewardsSchema.safeParse(raw);
+  if (!parsed.success) throw new Error("Expected market rewards response");
+  return parsed.data;
+}
+
+const multiMarketInfoSchema: z.ZodType<MultiMarketInfo> = z.object({
+  condition_id: idString,
+  event_id: idString,
+  event_slug: slugString,
+  created_at: slugString,
+  group_item_title: textString,
+  image: urlString,
+  market_competitiveness: z.number(),
+  market_id: idString,
+  market_slug: slugString,
+  one_day_price_change: z.number(),
+  question: textString,
+  rewards_max_spread: z.number(),
+  rewards_min_size: z.number(),
+  spread: z.number(),
+  end_date: slugString,
+  tokens: z.array(rewardsTokenSchema).max(MAX_NESTED_ITEMS),
+  volume_24hr: z.number(),
+  rewards_config: z.array(rewardsConfigItemSchema).max(MAX_NESTED_ITEMS),
+});
+
+const paginatedMultiMarketInfoSchema: z.ZodType<PaginatedMultiMarketInfo> = z.object({
+  limit: z.number(),
+  count: z.number(),
+  next_cursor: slugString,
+  data: z.array(multiMarketInfoSchema).max(MAX_PAGE_ITEMS),
+});
+
+export function validateMultiMarketRewardsResponse(raw: unknown): PaginatedMultiMarketInfo {
+  const parsed = paginatedMultiMarketInfoSchema.safeParse(raw);
+  if (!parsed.success) throw new Error("Expected multi-market rewards response");
+  return parsed.data;
+}
+
+// ── Rewards (authenticated) ─────────────────────────────────────────────
+
+const userEarningSchema: z.ZodType<UserEarning> = z.object({
+  date: slugString,
+  condition_id: idString,
+  asset_address: idString,
+  maker_address: idString,
+  earnings: z.number(),
+  asset_rate: z.number(),
+});
+
+const paginatedUserEarningsSchema: z.ZodType<PaginatedUserEarnings> = z.object({
+  limit: z.number(),
+  count: z.number(),
+  next_cursor: slugString,
+  data: z.array(userEarningSchema).max(MAX_PAGE_ITEMS),
+});
+
+export function validateUserEarningsResponse(raw: unknown): PaginatedUserEarnings {
+  const parsed = paginatedUserEarningsSchema.safeParse(raw);
+  if (!parsed.success) throw new Error("Expected user earnings response");
+  return parsed.data;
+}
+
+const userTotalEarningEntrySchema: z.ZodType<UserTotalEarningEntry> = z.object({
+  date: slugString,
+  asset_address: idString,
+  maker_address: idString,
+  earnings: z.number(),
+  asset_rate: z.number(),
+});
+
+const userTotalEarningsResponseSchema = z.array(userTotalEarningEntrySchema).max(MAX_PAGE_ITEMS);
+
+export function validateUserTotalEarningsResponse(raw: unknown): UserTotalEarningEntry[] {
+  const parsed = userTotalEarningsResponseSchema.safeParse(raw);
+  if (!parsed.success) throw new Error("Expected user total earnings array");
+  return parsed.data;
+}
+
+const userRewardPercentagesSchema = z.record(slugString, z.number());
+
+export function validateUserRewardPercentagesResponse(raw: unknown): UserRewardPercentages {
+  const parsed = userRewardPercentagesSchema.safeParse(raw);
+  if (!parsed.success || Object.keys(parsed.data).length > MAX_PAGE_ITEMS) {
+    throw new Error("Expected user reward percentages response");
+  }
+  return parsed.data;
+}
+
+const assetEarningSchema: z.ZodType<AssetEarning> = z.object({
+  asset_address: idString,
+  earnings: z.number(),
+  asset_rate: z.number(),
+});
+
+const userRewardsMarketSchema: z.ZodType<UserRewardsMarket> = z.object({
+  condition_id: idString,
+  market_id: idString,
+  event_id: idString,
+  question: textString,
+  market_slug: slugString,
+  event_slug: slugString,
+  image: urlString,
+  rewards_max_spread: z.number(),
+  rewards_min_size: z.number(),
+  volume_24hr: z.number(),
+  spread: z.number(),
+  market_competitiveness: z.number(),
+  tokens: z.array(rewardsTokenSchema).max(MAX_NESTED_ITEMS),
+  rewards_config: z.array(rewardsConfigItemSchema).max(MAX_NESTED_ITEMS),
+  maker_address: idString,
+  earning_percentage: z.number(),
+  earnings: z.array(assetEarningSchema).max(MAX_NESTED_ITEMS),
+});
+
+const paginatedUserRewardsMarketsSchema: z.ZodType<PaginatedUserRewardsMarkets> = z.object({
+  limit: z.number(),
+  count: z.number(),
+  total_count: z.number(),
+  next_cursor: slugString,
+  data: z.array(userRewardsMarketSchema).max(MAX_PAGE_ITEMS),
+});
+
+export function validateUserEarningsMarketsResponse(raw: unknown): PaginatedUserRewardsMarkets {
+  const parsed = paginatedUserRewardsMarketsSchema.safeParse(raw);
+  if (!parsed.success) throw new Error("Expected user earnings/markets response");
+  return parsed.data;
+}


### PR DESCRIPTION
Every `(raw) => raw` identity parser in the CLOB client (simplified-markets, rebates, 3 public + 4 authenticated reward endpoints) now parses through bounded strict Zod schemas: required fields typed, pagination/nested arrays bounded, unknown keys accepted but stripped so unmodeled provider content never reaches tool output or the LLM transcript. Malformed financial figures reject the response rather than silently defaulting to 0. Resurrects the P1-9 item deferred in #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)