### PR TITLE
fix(kyberswap): classify wrapped-native legs as economic native on the recording path

### DIFF
--- a/src/__tests__/kyberswap/kyberswap-evm-config-rpc.test.ts
+++ b/src/__tests__/kyberswap/kyberswap-evm-config-rpc.test.ts
@@ -1,0 +1,17 @@
+/**
+ * DEFAULT_RPC — regression coverage for the plasma/megaeth dead-endpoint fix
+ * (verified live, chainId-matched 2026-07-19).
+ */
+
+import { describe, it, expect } from "vitest";
+import { DEFAULT_RPC } from "@tools/kyberswap/evm/config.js";
+
+describe("DEFAULT_RPC", () => {
+  it("uses the live plasma RPC endpoint", () => {
+    expect(DEFAULT_RPC.plasma).toBe("https://rpc.plasma.to");
+  });
+
+  it("uses the live megaeth RPC endpoint", () => {
+    expect(DEFAULT_RPC.megaeth).toBe("https://mainnet.megaeth.com/rpc");
+  });
+});

--- a/src/__tests__/kyberswap/kyberswap-wrapped-native.test.ts
+++ b/src/__tests__/kyberswap/kyberswap-wrapped-native.test.ts
@@ -1,0 +1,61 @@
+/**
+ * getKyberWrappedNativeAddress — per-chain wrapped-native registry. Coverage
+ * must be EXACTLY the `aggregator: true` chains in chains.ts: fail-closed
+ * (throw) for any chain slug without a registered entry.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getKyberWrappedNativeAddress } from "@tools/kyberswap/wrapped-native.js";
+import { getKyberChains } from "@tools/kyberswap/chains.js";
+import type { KyberChainSlug } from "@tools/kyberswap/types.js";
+import { VexError } from "../../errors.js";
+
+describe("getKyberWrappedNativeAddress", () => {
+  it("resolves the wrapped-native address for every aggregator chain", () => {
+    const expected: Partial<Record<KyberChainSlug, string>> = {
+      ethereum: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      bsc: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+      arbitrum: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      polygon: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+      optimism: "0x4200000000000000000000000000000000000006",
+      avalanche: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+      base: "0x4200000000000000000000000000000000000006",
+      linea: "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
+      mantle: "0x78c1b0C915c4FAA5FffA6CAbf0219DA63d7f4cb8",
+      sonic: "0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38",
+      berachain: "0x6969696969696969696969696969696969696969",
+      ronin: "0xe514d9DEB7966c8BE0ca922de8a064264eA6bcd4",
+      unichain: "0x4200000000000000000000000000000000000006",
+      hyperevm: "0x5555555555555555555555555555555555555555",
+      plasma: "0x6100e367285b01f48d07953803a2d8dca5d19873",
+      etherlink: "0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb",
+      monad: "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A",
+      megaeth: "0x4200000000000000000000000000000000000006",
+      robinhood: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
+    };
+
+    for (const slug of Object.keys(expected) as KyberChainSlug[]) {
+      const address = expected[slug];
+      expect(address).toBeDefined();
+      expect(getKyberWrappedNativeAddress(slug).toLowerCase()).toBe((address ?? "").toLowerCase());
+    }
+  });
+
+  it("throws a VexError for a non-aggregator chain (scroll)", () => {
+    expect(() => getKyberWrappedNativeAddress("scroll")).toThrow(VexError);
+  });
+
+  it("throws a VexError for a non-aggregator chain (zksync)", () => {
+    expect(() => getKyberWrappedNativeAddress("zksync")).toThrow(VexError);
+  });
+
+  it("covers EXACTLY the aggregator: true chains from the chain registry", () => {
+    for (const chain of getKyberChains()) {
+      if (chain.aggregator) {
+        expect(() => getKyberWrappedNativeAddress(chain.slug)).not.toThrow();
+      } else {
+        expect(() => getKyberWrappedNativeAddress(chain.slug)).toThrow(VexError);
+      }
+    }
+  });
+});

--- a/src/__tests__/vex-agent/tools/protocols/kyberswap-economic-side.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/kyberswap-economic-side.test.ts
@@ -1,0 +1,169 @@
+/**
+ * classifyEconomicSide + isEconomicallyNativeLeg — the recorded trade side and
+ * native-leg bookkeeping must follow the ECONOMIC direction (which way native
+ * value flows), not which tool was invoked and not a sentinel-only address
+ * check. A token can be bought via `kyberswap.swap.sell` (native-in) or sold
+ * via `kyberswap.swap.buy` (native-out), so the tool's `side` alone is not a
+ * reliable accounting label — and a caller passing the WRAPPED-native
+ * contract address directly (instead of the "native"/"eth" keyword or the
+ * aggregator sentinel) is still economically spending/receiving native value.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Address } from "viem";
+import {
+  classifyEconomicSide,
+  isEconomicallyNativeLeg,
+  resolveRecordedTradeSide,
+} from "@vex-agent/tools/protocols/kyberswap/handlers/swap.js";
+import { getKyberWrappedNativeAddress } from "@tools/kyberswap/wrapped-native.js";
+import { NATIVE_TOKEN_ADDRESS } from "@tools/kyberswap/constants.js";
+import type { KyberChainSlug } from "@tools/kyberswap/types.js";
+
+const ARBITRARY_TOKEN: Address = "0x1111111111111111111111111111111111111111";
+
+describe("classifyEconomicSide", () => {
+  // ── native → token is always a BUY, regardless of the tool invoked ──────────
+
+  it("native → token = buy via the buy-tool", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: true, tokenOutIsNative: false, side: "buy" })).toBe("buy");
+  });
+
+  it("native → token = buy even when routed via the sell-tool (the bug)", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: true, tokenOutIsNative: false, side: "sell" })).toBe("buy");
+  });
+
+  // ── token → native is always a SELL, regardless of the tool invoked ─────────
+
+  it("token → native = sell via the sell-tool", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: true, side: "sell" })).toBe("sell");
+  });
+
+  it("token → native = sell even when routed via the buy-tool", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: true, side: "buy" })).toBe("sell");
+  });
+
+  // ── token ↔ token has no native anchor: fall back to the tool's side ────────
+
+  it("token → token falls back to the tool side (buy)", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: false, side: "buy" })).toBe("buy");
+  });
+
+  it("token → token falls back to the tool side (sell)", () => {
+    expect(classifyEconomicSide({ tokenInIsNative: false, tokenOutIsNative: false, side: "sell" })).toBe("sell");
+  });
+});
+
+describe("isEconomicallyNativeLeg", () => {
+  it("is true for the aggregator sentinel address on any aggregator chain", () => {
+    expect(isEconomicallyNativeLeg("ethereum", { address: NATIVE_TOKEN_ADDRESS, isNative: true })).toBe(true);
+    expect(isEconomicallyNativeLeg("mantle", { address: NATIVE_TOKEN_ADDRESS, isNative: true })).toBe(true);
+  });
+
+  it("is false for an unrelated ERC-20 address", () => {
+    expect(isEconomicallyNativeLeg("ethereum", { address: ARBITRARY_TOKEN, isNative: false })).toBe(false);
+  });
+
+  // ── per-chain wrapped-native address recognized even though isNative=false ──
+  // (resolveTokenMetadataStrict only sets isNative for the sentinel, so a
+  // caller passing the wrapped contract address directly resolves isNative:
+  // false — the predicate must still classify it as economically native.)
+
+  const WRAPPED_NATIVE_CASES: ReadonlyArray<{ chain: KyberChainSlug; symbol: string; address: Address }> = [
+    { chain: "bsc", symbol: "WBNB", address: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c" },
+    { chain: "polygon", symbol: "WPOL", address: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270" },
+    { chain: "mantle", symbol: "WMNT", address: "0x78c1b0C915c4FAA5FffA6CAbf0219DA63d7f4cb8" },
+    { chain: "sonic", symbol: "wS", address: "0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38" },
+    { chain: "berachain", symbol: "WBERA", address: "0x6969696969696969696969696969696969696969" },
+    { chain: "hyperevm", symbol: "WHYPE", address: "0x5555555555555555555555555555555555555555" },
+    { chain: "etherlink", symbol: "WXTZ", address: "0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb" },
+    { chain: "monad", symbol: "WMON", address: "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A" },
+    { chain: "avalanche", symbol: "WAVAX", address: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7" },
+    { chain: "optimism", symbol: "WETH (0x4200…0006)", address: "0x4200000000000000000000000000000000000006" },
+  ];
+
+  for (const { chain, symbol, address } of WRAPPED_NATIVE_CASES) {
+    it(`recognizes ${symbol} on ${chain} as economically native (isNative=false)`, () => {
+      expect(isEconomicallyNativeLeg(chain, { address, isNative: false })).toBe(true);
+    });
+
+    it(`in-leg wrapped ${symbol} on ${chain} → buy`, () => {
+      const tokenInIsNative = isEconomicallyNativeLeg(chain, { address, isNative: false });
+      const tokenOutIsNative = isEconomicallyNativeLeg(chain, { address: ARBITRARY_TOKEN, isNative: false });
+      expect(classifyEconomicSide({ tokenInIsNative, tokenOutIsNative, side: "sell" })).toBe("buy");
+    });
+
+    it(`out-leg wrapped ${symbol} on ${chain} → sell`, () => {
+      const tokenInIsNative = isEconomicallyNativeLeg(chain, { address: ARBITRARY_TOKEN, isNative: false });
+      const tokenOutIsNative = isEconomicallyNativeLeg(chain, { address, isNative: false });
+      expect(classifyEconomicSide({ tokenInIsNative, tokenOutIsNative, side: "buy" })).toBe("sell");
+    });
+  }
+
+  it("is case-insensitive on the wrapped-native address", () => {
+    const upper = "0xBB4CDB9CBD36B01BD1CBAEBF2DE08D9173BC095C" as Address; // WBNB, uppercased
+    expect(isEconomicallyNativeLeg("bsc", { address: upper, isNative: false })).toBe(true);
+  });
+
+  it("Mantle bridged WETH (a DIFFERENT asset from WMNT) does NOT classify as native", () => {
+    // Mantle's bridged "WETH" is a distinct bridged asset from the chain's own
+    // wrapped-native WMNT — same symbol as many unrelated chains' native
+    // wrapper, which is exactly why classification must be address-only.
+    const mantleBridgedWeth: Address = "0xdEAddEAddEAddEAddEAddEAddEAddEAddEAd1111";
+    expect(isEconomicallyNativeLeg("mantle", { address: mantleBridgedWeth, isNative: false })).toBe(false);
+  });
+
+  it("throws for a chain with no registered wrapped-native (fail-closed, non-aggregator chain)", () => {
+    expect(() => isEconomicallyNativeLeg("scroll", { address: ARBITRARY_TOKEN, isNative: false })).toThrow();
+  });
+});
+
+describe("resolveRecordedTradeSide — native \u2194 wrapped-native disambiguation", () => {
+  // Both legs are economically native here; classifyEconomicSide alone would
+  // record every such trade as a buy (in-leg-first rule). The raw sentinel
+  // roles must decide instead.
+
+  const sentinelLeg = { address: NATIVE_TOKEN_ADDRESS, isNative: true } as const;
+
+  it("sentinel \u2192 wrapped-native records as a BUY of the wrapper (bsc/WBNB)", () => {
+    const wbnb = { address: getKyberWrappedNativeAddress("bsc"), isNative: false } as const;
+    expect(resolveRecordedTradeSide("bsc", sentinelLeg, wbnb, "sell")).toBe("buy");
+  });
+
+  it("wrapped-native \u2192 sentinel records as a SELL of the wrapper (bsc/WBNB) — the regression", () => {
+    const wbnb = { address: getKyberWrappedNativeAddress("bsc"), isNative: false } as const;
+    expect(resolveRecordedTradeSide("bsc", wbnb, sentinelLeg, "buy")).toBe("sell");
+  });
+
+  it("wrapped-native \u2192 sentinel = SELL regardless of declared side (ethereum/WETH)", () => {
+    const weth = { address: getKyberWrappedNativeAddress("ethereum"), isNative: false } as const;
+    expect(resolveRecordedTradeSide("ethereum", weth, sentinelLeg, "sell")).toBe("sell");
+    expect(resolveRecordedTradeSide("ethereum", weth, sentinelLeg, "buy")).toBe("sell");
+  });
+
+  it("wrapped-address casing does not defeat the disambiguation (polygon/WPOL)", () => {
+    const wpol = { address: getKyberWrappedNativeAddress("polygon").toUpperCase().replace("0X", "0x") as Address, isNative: false } as const;
+    expect(resolveRecordedTradeSide("polygon", wpol, sentinelLeg, "buy")).toBe("sell");
+  });
+
+  // Non-both-native paths must be untouched by the disambiguation.
+
+  it("wrapped-native \u2192 arbitrary token still records as a buy-side spend of native value", () => {
+    const wbnb = { address: getKyberWrappedNativeAddress("bsc"), isNative: false } as const;
+    const token = { address: ARBITRARY_TOKEN, isNative: false } as const;
+    expect(resolveRecordedTradeSide("bsc", wbnb, token, "sell")).toBe("buy");
+  });
+
+  it("arbitrary token \u2192 wrapped-native still records as a sell", () => {
+    const wbnb = { address: getKyberWrappedNativeAddress("bsc"), isNative: false } as const;
+    const token = { address: ARBITRARY_TOKEN, isNative: false } as const;
+    expect(resolveRecordedTradeSide("bsc", token, wbnb, "buy")).toBe("sell");
+  });
+
+  it("token \u2192 token falls through to the declared side", () => {
+    const a = { address: ARBITRARY_TOKEN, isNative: false } as const;
+    const b = { address: "0x2222222222222222222222222222222222222222" as Address, isNative: false } as const;
+    expect(resolveRecordedTradeSide("bsc", a, b, "buy")).toBe("buy");
+    expect(resolveRecordedTradeSide("bsc", a, b, "sell")).toBe("sell");
+  });
+});

--- a/src/tools/kyberswap/evm/config.ts
+++ b/src/tools/kyberswap/evm/config.ts
@@ -96,10 +96,10 @@ export const DEFAULT_RPC: Record<string, string> = {
   ronin: "https://api.roninchain.com/rpc",
   unichain: "https://mainnet.unichain.org",
   hyperevm: "https://rpc.hyperliquid.xyz/evm",
-  plasma: "https://rpc.plasma.digital",
+  plasma: "https://rpc.plasma.to",
   etherlink: "https://node.mainnet.etherlink.com",
   monad: "https://rpc.monad.xyz",
-  megaeth: "https://rpc.megaeth.com",
+  megaeth: "https://mainnet.megaeth.com/rpc",
   scroll: "https://rpc.scroll.io",
   zksync: "https://mainnet.era.zksync.io",
 };

--- a/src/tools/kyberswap/wrapped-native.ts
+++ b/src/tools/kyberswap/wrapped-native.ts
@@ -1,0 +1,64 @@
+/**
+ * KyberSwap wrapped-native token registry — the wrapped-native ERC-20 address
+ * per aggregator chain, keyed by chain slug.
+ *
+ * Used ONLY to classify a swap leg as economically native for RECORDING
+ * (trade side, benchmark/settlement asset keys) when the caller passes the
+ * wrapped contract address directly instead of the native sentinel/keyword —
+ * never for routing, allowance, or execution, where a wrapped token remains
+ * an ordinary ERC-20.
+ *
+ * Coverage is EXACTLY the `aggregator: true` chains in `chains.ts` — every
+ * aggregator chain has a wrapped-native asset by construction, so a missing
+ * entry is a registry bug, not a legitimate "no wrapped native" case. Fail
+ * closed (throw) rather than returning `undefined`.
+ *
+ * Addresses are the identity key (verified on-chain 2026-07-19); the symbol in
+ * each comment is for human reporting ONLY. Never compare by symbol: several
+ * chains have a token literally named "WETH" that is a DIFFERENT bridged asset
+ * from the chain's own wrapped-native (e.g. Mantle's bridged WETH is not
+ * WMNT), and Sonic's wrapped-native symbol is lowercase `wS`.
+ */
+
+import type { Address } from "viem";
+
+import { VexError, ErrorCodes } from "../../errors.js";
+import type { KyberChainSlug } from "./types.js";
+
+const WRAPPED_NATIVE_ADDRESS: Partial<Record<KyberChainSlug, Address>> = {
+  ethereum: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH
+  bsc: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c", // WBNB
+  arbitrum: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", // WETH
+  polygon: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270", // WPOL
+  optimism: "0x4200000000000000000000000000000000000006", // WETH
+  avalanche: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7", // WAVAX
+  base: "0x4200000000000000000000000000000000000006", // WETH
+  linea: "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f", // WETH
+  mantle: "0x78c1b0C915c4FAA5FffA6CAbf0219DA63d7f4cb8", // WMNT — NOT the bridged "WETH" on Mantle
+  sonic: "0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38", // wS (lowercase symbol)
+  berachain: "0x6969696969696969696969696969696969696969", // WBERA
+  ronin: "0xe514d9DEB7966c8BE0ca922de8a064264eA6bcd4", // WRON
+  unichain: "0x4200000000000000000000000000000000000006", // WETH
+  hyperevm: "0x5555555555555555555555555555555555555555", // WHYPE
+  plasma: "0x6100e367285b01f48d07953803a2d8dca5d19873", // WXPL
+  etherlink: "0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb", // WXTZ
+  monad: "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A", // WMON
+  megaeth: "0x4200000000000000000000000000000000000006", // WETH
+  robinhood: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73", // WETH
+};
+
+/**
+ * Get the wrapped-native ERC-20 address for a KyberSwap aggregator chain.
+ * Fail-closed: throws for any slug without a registered entry (non-aggregator
+ * chains such as scroll/zksync, or an unknown slug).
+ */
+export function getKyberWrappedNativeAddress(slug: KyberChainSlug): Address {
+  const address = WRAPPED_NATIVE_ADDRESS[slug];
+  if (!address) {
+    throw new VexError(
+      ErrorCodes.KYBER_UNSUPPORTED_CHAIN,
+      `No wrapped-native token registered for KyberSwap chain "${slug}"`,
+    );
+  }
+  return address;
+}

--- a/src/vex-agent/tools/protocols/kyberswap/handlers/swap.ts
+++ b/src/vex-agent/tools/protocols/kyberswap/handlers/swap.ts
@@ -21,6 +21,7 @@ import {
   KYBERSWAP_FEE_CHARGE_BY,
   KYBERSWAP_FEE_RECEIVER,
 } from "@tools/kyberswap/constants.js";
+import { getKyberWrappedNativeAddress } from "@tools/kyberswap/wrapped-native.js";
 import { ensureErc20Balance } from "@tools/evm-chains/erc20-balance-guard.js";
 import { resolveTokenMetadataStrict, requireFeature, resolveChainWithId } from "@tools/kyberswap/helpers.js";
 import { formatRouteSummary } from "../helpers.js";
@@ -29,6 +30,7 @@ import { isRecord } from "@utils/validation-helpers.js";
 import { VexError, ErrorCodes } from "../../../../../errors.js";
 import type { ChainWallet } from "@tools/wallet/multi-auth.js";
 import { resolveSigningWallet, walletScopeErrorToResult } from "@vex-agent/tools/internal/wallet/resolve.js";
+import type { KyberChainSlug } from "@tools/kyberswap/types.js";
 
 import { parseUnits, formatUnits, getAddress, type Address, type Hex } from "viem";
 import type { ToolResult } from "../../../types.js";
@@ -148,7 +150,9 @@ const VEX_INTEGRATOR_FEE_ROUTE_PARAMS = {
  * declared side. Used ONLY for what is recorded/reported — never for routing,
  * quoting, or execution. Mirrors uniswap's `classifyEconomicSide` (same bug
  * class, same fix shape; kept local per protocol per the repo's "3+ = extract"
- * convention — two occurrences do not yet warrant a shared helper).
+ * convention — two occurrences do not yet warrant a shared helper). Kyberswap's
+ * inputs are hardened beyond uniswap's via `isEconomicallyNativeLeg` below —
+ * uniswap's booleans are still sentinel-only (tracked separately, PR #39).
  */
 export function classifyEconomicSide(args: {
   readonly tokenInIsNative: boolean;
@@ -158,6 +162,55 @@ export function classifyEconomicSide(args: {
   if (args.tokenInIsNative) return "buy";
   if (args.tokenOutIsNative) return "sell";
   return args.side;
+}
+
+/**
+ * True when a resolved swap leg is economically native: the aggregator
+ * sentinel address, OR the chain's wrapped-native ERC-20 contract address
+ * (case-insensitive address compare — NEVER a symbol match, see
+ * `wrapped-native.ts`: several chains have an unrelated bridged token
+ * literally named "WETH" that must not classify as that chain's native).
+ *
+ * RECORDING/classification path ONLY. `leg.isNative` (sentinel-only, from
+ * `resolveTokenMetadataStrict`) is what drives allowance, routing,
+ * `transactionValue`, and execution elsewhere in this file — a wrapped-native
+ * leg stays an ordinary ERC-20 there. This predicate only widens what counts
+ * as "native" for the trade-side/benchmark/settlement bookkeeping below.
+ */
+export function isEconomicallyNativeLeg(
+  chain: KyberChainSlug,
+  leg: { readonly address: Address; readonly isNative: boolean },
+): boolean {
+  if (leg.isNative) return true;
+  return leg.address.toLowerCase() === getKyberWrappedNativeAddress(chain).toLowerCase();
+}
+
+/**
+ * The single recorded-trade-side decision for a kyberswap swap. Composes the
+ * widened per-leg nativeness with one disambiguation `classifyEconomicSide`
+ * cannot make: a native↔wrapped-native trade (ETH↔WETH, BNB↔WBNB, …) marks
+ * BOTH legs economically native, and the classifier's in-leg-first rule would
+ * record every such trade as a buy. In that case the raw sentinel roles
+ * decide: spending the sentinel to acquire the wrapper records as a BUY of
+ * the wrapper; spending the wrapper back into the sentinel records as a SELL
+ * of it. (Same-address legs cannot occur — the venue rejects identical
+ * tokenIn/tokenOut — so exactly one leg carries the sentinel here; the
+ * declared side remains the defensive fallback.)
+ */
+export function resolveRecordedTradeSide(
+  chain: KyberChainSlug,
+  tokenIn: { readonly address: Address; readonly isNative: boolean },
+  tokenOut: { readonly address: Address; readonly isNative: boolean },
+  side: "buy" | "sell",
+): "buy" | "sell" {
+  const tokenInIsNative = isEconomicallyNativeLeg(chain, tokenIn);
+  const tokenOutIsNative = isEconomicallyNativeLeg(chain, tokenOut);
+  if (tokenInIsNative && tokenOutIsNative) {
+    if (tokenIn.isNative) return "buy";
+    if (tokenOut.isNative) return "sell";
+    return side;
+  }
+  return classifyEconomicSide({ tokenInIsNative, tokenOutIsNative, side });
 }
 
 // ── Shared swap execution (sell + buy use same routing, differ in trade_side) ──
@@ -211,13 +264,13 @@ async function executeKyberSwap(p: Record<string, unknown>, side: "buy" | "sell"
   const { routeSummary, routerAddress } = routeResp.data;
   verifyRouterAddress(routerAddress, META_AGGREGATION_ROUTER_V2);
 
-  // Economic direction for RECORDING/reporting — derived from the native leg,
-  // not the tool name (`side`). `side` still drives routing/execution below.
-  const economicSide = classifyEconomicSide({
-    tokenInIsNative: tokenIn.isNative,
-    tokenOutIsNative: tokenOut.isNative,
-    side,
-  });
+  // Economic direction for RECORDING/reporting — derived from the native leg
+  // (sentinel OR that chain's wrapped-native contract address), not the tool
+  // name (`side`) and not the raw sentinel-only `isNative` flag that still
+  // drives routing/allowance/execution below.
+  const tokenInIsNative = isEconomicallyNativeLeg(slug, tokenIn);
+  const tokenOutIsNative = isEconomicallyNativeLeg(slug, tokenOut);
+  const economicSide = resolveRecordedTradeSide(slug, tokenIn, tokenOut, side);
 
   if (p.dryRun === true) {
     return ok({ dryRun: true, side: economicSide, chain: slug, routeSummary: formatRouteSummary(routeSummary), routerAddress });
@@ -265,9 +318,16 @@ async function executeKyberSwap(p: Record<string, unknown>, side: "buy" | "sell"
     value: BigInt(buildResp.data.transactionValue),
   });
 
-  const inputIsNative = tokenIn.address.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase();
-  const outputIsNative = tokenOut.address.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase();
-  const hasNativeLeg = inputIsNative || outputIsNative;
+  // Audit of the four RECORDING-only spots below — all reuse the hardened
+  // tokenInIsNative/tokenOutIsNative (sentinel OR wrapped-native address)
+  // computed above, not a fresh sentinel-only compare:
+  //  - benchmarkAssetKey: benchmark-vs-native PnL is exactly as meaningful for
+  //    a wrapped-native leg (1 wrapped = 1 native by the wrap contract).
+  //  - settlementAssetKey: inherits the hardened `economicSide` automatically.
+  //  - inputValueNative/outputValueNative: feed proj_pnl_lots' cost/proceeds
+  //    "native" columns (benchmark-PnL accounting only, never a balance
+  //    mutation), so the wrapped-native leg's value is equally valid here.
+  const hasNativeLeg = tokenInIsNative || tokenOutIsNative;
 
   // Benchmark: only when native token is one leg
   const { resolveChainBenchmark } = await import("@vex-agent/sync/benchmark.js");
@@ -287,8 +347,8 @@ async function executeKyberSwap(p: Record<string, unknown>, side: "buy" | "sell"
       feeValueUsd: buildResp.data.gasUsd, valuationSource: "kyberswap_exact",
       benchmarkAssetKey: benchmarkAssetKey ?? undefined,
       settlementAssetKey: economicSide === "buy" ? tokenIn.symbol : tokenOut.symbol,
-      inputValueNative: inputIsNative ? formatUnits(amountIn, tokenIn.decimals) : undefined,
-      outputValueNative: outputIsNative ? formatUnits(BigInt(buildResp.data.amountOut), tokenOut.decimals) : undefined,
+      inputValueNative: tokenInIsNative ? formatUnits(amountIn, tokenIn.decimals) : undefined,
+      outputValueNative: tokenOutIsNative ? formatUnits(BigInt(buildResp.data.amountOut), tokenOut.decimals) : undefined,
       meta: { dex: "kyberswap", side: economicSide },
     } },
   };


### PR DESCRIPTION
Adds a fail-closed per-chain wrapped-native registry (19 aggregator chains, every address verified on-chain — on 11 of them wrapped-native ≠ WETH, and a bridged token literally named WETH must NOT classify as native) and hardens the recorded trade side: a leg is economically native when it is the sentinel OR the chain's wrapped-native contract (address compare only, never symbol). Native↔wrapped-native trades disambiguate by raw sentinel roles via `resolveRecordedTradeSide`. Routing, allowance, transactionValue, and execution stay sentinel-only. Also repairs two dead `DEFAULT_RPC` endpoints (plasma, megaeth). Kyberswap sibling of the uniswap hardening in #39 — the code comment already acknowledged the clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)