### PR TITLE
fix(portfolio): aggregate positions by normalized token address, gate brand icons on address

### DIFF
--- a/vex-app/src/main/database/__tests__/portfolio-db.test.ts
+++ b/vex-app/src/main/database/__tests__/portfolio-db.test.ts
@@ -719,3 +719,178 @@ describe("portfolio-db getPortfolio — per-chain breakdown (codex plan review)"
     ]);
   });
 });
+
+describe("portfolio-db getPortfolio — address-correct aggregation (position branding)", () => {
+  beforeEach(() => {
+    mocks.listWallets.mockImplementation((family: string) =>
+      family === "evm" ? [{ id: "1", address: WALLET_A, label: "", createdAt: "" }] : [],
+    );
+  });
+
+  const LEGIT_WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+  const SPOOF_WETH = "0x000000000000000000000000000000000000ff";
+
+  it("groups the flat token list by (chain_id, normalized token_address) — semantic identity, never symbol", async () => {
+    scriptPortfolioQueries({ live: "0", tokens: [], snapshot: null });
+    await getPortfolio({ scope: "global" });
+    const tokenSql = String(mocks.query.mock.calls[1]?.[0] ?? "");
+    expect(tokenSql).toContain("token_address");
+    expect(tokenSql).toContain("GROUP BY chain_id, CASE WHEN token_address ~* '^0x' THEN lower(token_address) ELSE token_address END");
+  });
+
+  it("groups the per-chain breakdown by (chain_id, normalized token_address) — semantic identity, never symbol", async () => {
+    scriptPortfolioQueries({ live: "0", tokens: [], snapshot: null });
+    await getPortfolio({ scope: "global" });
+    const breakdownSql = String(mocks.query.mock.calls[2]?.[0] ?? "");
+    expect(breakdownSql).toContain("GROUP BY chain_id, CASE WHEN token_address ~* '^0x' THEN lower(token_address) ELSE token_address END");
+  });
+
+  it("keeps a same-symbol/different-address pair as SEPARATE flat lines with correct totals and ranking (anti-spoof-collision)", async () => {
+    scriptPortfolioQueries({
+      live: "1500",
+      tokens: [
+        // A spoof token declaring the SAME "WETH" symbol as the legit
+        // contract, at a DIFFERENT address — must never merge into one line.
+        { chain_id: "1", token_address: LEGIT_WETH, token_symbol: "WETH", usd: "1000" },
+        { chain_id: "1", token_address: SPOOF_WETH, token_symbol: "WETH", usd: "500" },
+      ],
+      snapshot: null,
+    });
+    const result = await getPortfolio({ scope: "global" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Neither line absorbed the other's balance — both survive at their own
+    // USD figure, ranked biggest-first, each carrying its OWN address.
+    expect(result.data.tokens).toEqual([
+      { chainId: 1, symbol: "WETH", tokenAddress: LEGIT_WETH, balanceUsd: 1000, amount: null },
+      { chainId: 1, symbol: "WETH", tokenAddress: SPOOF_WETH, balanceUsd: 500, amount: null },
+    ]);
+  });
+
+  it("keeps a same-symbol/different-address pair as SEPARATE top-3 lines within one chain's breakdown", async () => {
+    scriptPortfolioQueries({
+      live: "1500",
+      tokens: [],
+      snapshot: null,
+      breakdown: [
+        {
+          chain_id: "1",
+          chain_total: "1500",
+          token_address: LEGIT_WETH,
+          token_symbol: "WETH",
+          token_usd: "1000",
+        },
+        {
+          chain_id: "1",
+          chain_total: "1500",
+          token_address: SPOOF_WETH,
+          token_symbol: "WETH",
+          token_usd: "500",
+        },
+      ],
+    });
+    const result = await getPortfolio({ scope: "global" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.chains).toEqual([
+      {
+        chainId: 1,
+        family: "evm",
+        totalUsd: 1500,
+        tokens: [
+          { symbol: "WETH", tokenAddress: LEGIT_WETH, balanceUsd: 1000, amount: null },
+          { symbol: "WETH", tokenAddress: SPOOF_WETH, balanceUsd: 500, amount: null },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps ONE line for one address whose symbol was updated in place (metadata drift, no double count)", async () => {
+    // Per ONE wallet, `proj_balances` upserts ON CONFLICT (wallet_address,
+    // chain_id, token_address), so a symbol update overwrites the same row.
+    // ACROSS wallets the same address can still carry different/stale symbols
+    // (one row per wallet) — that case is collapsed by the query itself:
+    // GROUP BY normalized address only, with the freshest-synced symbol
+    // selected deterministically (see the SQL-shape assertions below).
+    scriptPortfolioQueries({
+      live: "1000",
+      tokens: [
+        { chain_id: "1", token_address: LEGIT_WETH, token_symbol: "WETH-RENAMED", usd: "1000" },
+      ],
+      snapshot: null,
+    });
+    const result = await getPortfolio({ scope: "global" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.tokens).toEqual([
+      {
+        chainId: 1,
+        symbol: "WETH-RENAMED",
+        tokenAddress: LEGIT_WETH,
+        balanceUsd: 1000,
+        amount: null,
+      },
+    ]);
+  });
+
+  it("threads tokenAddress through the flat mapping (null when the row carries none)", async () => {
+    scriptPortfolioQueries({
+      live: "1",
+      tokens: [{ chain_id: "1", token_address: null, token_symbol: "ETH", usd: "1" }],
+      snapshot: null,
+    });
+    const result = await getPortfolio({ scope: "global" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.tokens[0]?.tokenAddress).toBeNull();
+  });
+});
+
+describe("semantic token identity in aggregation SQL (shape)", () => {
+  // The mocked client cannot execute SQL, so these assert the decisive query
+  // text: one contract aggregates into ONE line even when wallets' rows
+  // differ in EVM address casing or carry stale symbols — grouping must use
+  // the normalized address ONLY (never the raw symbol), and the displayed
+  // symbol must be the deterministic freshest one.
+
+  const NORMALIZED = "CASE WHEN token_address ~* '^0x' THEN lower(token_address) ELSE token_address END";
+  const LATEST_SYMBOL = "(array_agg(token_symbol ORDER BY synced_at DESC NULLS LAST, token_symbol ASC NULLS LAST))[1]";
+
+  it("flat token query groups by normalized address only and selects the latest symbol", async () => {
+    scriptPortfolioQueries({ live: "0", tokens: [], snapshot: null });
+    await getPortfolio({ scope: "global" });
+    const tokenSql = String(mocks.query.mock.calls[1]?.[0] ?? "");
+    expect(tokenSql).toContain(`GROUP BY chain_id, ${NORMALIZED}`);
+    expect(tokenSql).toContain(LATEST_SYMBOL);
+    expect(tokenSql).not.toContain("GROUP BY chain_id, token_address, token_symbol");
+  });
+
+  it("per-chain breakdown CTE groups by normalized address only and selects the latest symbol", async () => {
+    scriptPortfolioQueries({ live: "0", tokens: [], snapshot: null });
+    await getPortfolio({ scope: "global" });
+    const cteSql = String(mocks.query.mock.calls[2]?.[0] ?? "");
+    expect(cteSql).toContain("WITH lines AS");
+    expect(cteSql).toContain(`GROUP BY chain_id, ${NORMALIZED}`);
+    expect(cteSql).toContain(LATEST_SYMBOL);
+    expect(cteSql).not.toContain("GROUP BY chain_id, token_address, token_symbol");
+  });
+
+  it("two wallets sharing one address with different stale symbols arrive as ONE aggregated row (fixture at the query boundary)", async () => {
+    // The DB collapses the two wallet rows via the normalized GROUP BY; the
+    // fixture models exactly what the fixed query returns — one line, the
+    // freshest symbol, summed USD — and the mapping must pass it through
+    // without re-splitting or double counting.
+    scriptPortfolioQueries({
+      live: "1500",
+      tokens: [
+        { chain_id: "1", token_address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", token_symbol: "WETH", usd: "1500" },
+      ],
+      snapshot: null,
+    });
+    const result = await getPortfolio({ scope: "global" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.tokens).toHaveLength(1);
+    expect(result.data.tokens[0]).toMatchObject({ symbol: "WETH", tokenAddress: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", balanceUsd: 1500 });
+  });
+});

--- a/vex-app/src/main/database/portfolio-db.ts
+++ b/vex-app/src/main/database/portfolio-db.ts
@@ -28,6 +28,11 @@
  *    DO NOT lowercase (the engine stores raw checksum/base58 addresses).
  *  - logging records sessionId (if any) + wallet COUNT + token COUNT only;
  *    NEVER raw addresses, balances, or USD figures.
+ *  - token aggregation groups by `(chain_id, NORMALIZED token_address)` —
+ *    never by symbol in any form. A spoof token that self-declares a
+ *    legitimate token's symbol has a DIFFERENT `token_address`, so it can
+ *    never coalesce into that token's line before the renderer's trust gate
+ *    (address-verified brand icon) can act on it.
  */
 
 import { Client, type ClientConfig } from "pg";
@@ -117,6 +122,7 @@ interface LiveTotalRow {
 
 interface TokenRow {
   readonly chain_id: number | string | null;
+  readonly token_address: string;
   readonly token_symbol: string | null;
   readonly usd: number | string | null;
   readonly amount: number | string | null;
@@ -130,6 +136,7 @@ interface SnapshotRow {
 interface ChainBreakdownRow {
   readonly chain_id: number | string;
   readonly chain_total: number | string;
+  readonly token_address: string | null;
   readonly token_symbol: string | null;
   readonly token_usd: number | string | null;
   readonly token_amount: number | string | null;
@@ -157,6 +164,17 @@ const AMOUNT_SUM_SQL = `SUM(
  */
 const MAX_TOKEN_LINES = 500;
 
+// Semantic token identity for aggregation: one contract must aggregate into
+// ONE line even when different wallets' rows carry different address casing
+// (EVM addresses are case-insensitive hex; checksum/casing variants are the
+// same contract) or stale symbols from earlier syncs. EVM (0x…) addresses
+// normalize to lowercase; Solana mints are case-SENSITIVE base58 and must be
+// preserved verbatim. The displayed symbol is the deterministic latest one
+// (freshest `synced_at` wins; symbol text breaks exact ties) — never one
+// arbitrary row's stale label.
+const NORMALIZED_TOKEN_ADDRESS_SQL = `CASE WHEN token_address ~* '^0x' THEN lower(token_address) ELSE token_address END`;
+const LATEST_TOKEN_SYMBOL_SQL = `(array_agg(token_symbol ORDER BY synced_at DESC NULLS LAST, token_symbol ASC NULLS LAST))[1]`;
+
 /**
  * Caps for the per-chain breakdown — mirror `portfolioDtoSchema.chains`
  * (`.max(64)` chains, `.max(3)` tokens each). The SQL emits at most
@@ -183,7 +201,12 @@ function buildChainBreakdown(
   let current: {
     chainId: number;
     totalUsd: number;
-    tokens: { symbol: string | null; balanceUsd: number | null; amount: number | null }[];
+    tokens: {
+      symbol: string | null;
+      tokenAddress: string | null;
+      balanceUsd: number | null;
+      amount: number | null;
+    }[];
   } | null = null;
   for (const row of rows) {
     const chainId = toChainId(row.chain_id);
@@ -219,6 +242,7 @@ function buildChainBreakdown(
     ) {
       current.tokens.push({
         symbol: row.token_symbol,
+        tokenAddress: row.token_address,
         balanceUsd: tokenUsd,
         amount: tokenAmount,
       });
@@ -380,12 +404,13 @@ export async function getPortfolio(
       // `amount` is the human token quantity (see AMOUNT_SUM_SQL).
       const tokensResult = await client.query<TokenRow>(
         `SELECT chain_id,
-                token_symbol,
+                ${NORMALIZED_TOKEN_ADDRESS_SQL} AS token_address,
+                ${LATEST_TOKEN_SYMBOL_SQL} AS token_symbol,
                 SUM(balance_usd)::float8 AS usd,
                 ${AMOUNT_SUM_SQL} AS amount
            FROM proj_balances
           WHERE wallet_address = ANY($1::text[])
-          GROUP BY chain_id, token_symbol
+          GROUP BY chain_id, ${NORMALIZED_TOKEN_ADDRESS_SQL}
           ORDER BY usd DESC NULLS LAST
           LIMIT ${MAX_TOKEN_LINES}`,
         [addrParam],
@@ -395,6 +420,7 @@ export async function getPortfolio(
         .map((row) => ({
           chainId: toChainId(row.chain_id),
           symbol: row.token_symbol,
+          tokenAddress: row.token_address,
           balanceUsd: toNumberOrNull(row.usd),
           amount: toNumberOrNull(row.amount),
         }));
@@ -412,16 +438,17 @@ export async function getPortfolio(
       const breakdownResult = await client.query<ChainBreakdownRow>(
         `WITH lines AS (
            SELECT chain_id,
-                  token_symbol,
+                  ${NORMALIZED_TOKEN_ADDRESS_SQL} AS token_address,
+                  ${LATEST_TOKEN_SYMBOL_SQL} AS token_symbol,
                   SUM(balance_usd)::float8 AS usd,
                   ${AMOUNT_SUM_SQL} AS amount
              FROM proj_balances
             WHERE wallet_address = ANY($1::text[])
               AND chain_id IS NOT NULL
-            GROUP BY chain_id, token_symbol
+            GROUP BY chain_id, ${NORMALIZED_TOKEN_ADDRESS_SQL}
          ),
          ranked AS (
-           SELECT chain_id, token_symbol, usd, amount,
+           SELECT chain_id, token_address, token_symbol, usd, amount,
                   ROW_NUMBER() OVER (
                     PARTITION BY chain_id ORDER BY usd DESC NULLS LAST
                   ) AS rn
@@ -437,6 +464,7 @@ export async function getPortfolio(
          )
          SELECT t.chain_id,
                 t.chain_total,
+                r.token_address,
                 r.token_symbol,
                 r.usd AS token_usd,
                 r.amount AS token_amount

--- a/vex-app/src/renderer/features/appShell/__tests__/GlobalWalletSwitcher.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/GlobalWalletSwitcher.test.tsx
@@ -109,6 +109,51 @@ describe("GlobalWalletSwitcher — default 'All wallets' body", () => {
   });
 });
 
+describe("GlobalWalletSwitcher — token-symbol trust boundary (no branding by symbol)", () => {
+  it("drops a symbol carrying control/zero-width spoofing characters, falling back to the em dash", () => {
+    mockWallets([EVM_1, EVM_2], []);
+    // Zero-width space (U+200B) spliced into "ETH".
+    const spoofed = "E​TH";
+    render(
+      <GlobalWalletSwitcher
+        portfolio={portfolio({
+          tokens: [{ chainId: 1, symbol: spoofed, balanceUsd: 100, amount: null }],
+        })}
+      />,
+    );
+    expect(screen.queryByText("ETH")).toBeNull();
+    expect(screen.queryByText(spoofed)).toBeNull();
+    expect(screen.getByText("—")).not.toBeNull();
+  });
+
+  it("drops an over-length symbol (length-capped)", () => {
+    mockWallets([EVM_1, EVM_2], []);
+    render(
+      <GlobalWalletSwitcher
+        portfolio={portfolio({
+          tokens: [
+            { chainId: 1, symbol: "A".repeat(65), balanceUsd: 100, amount: null },
+          ],
+        })}
+      />,
+    );
+    expect(screen.queryByText("A".repeat(65))).toBeNull();
+    expect(screen.getByText("—")).not.toBeNull();
+  });
+
+  it("renders a legitimate ASCII symbol unchanged", () => {
+    mockWallets([EVM_1, EVM_2], []);
+    render(
+      <GlobalWalletSwitcher
+        portfolio={portfolio({
+          tokens: [{ chainId: 1, symbol: "USDC", balanceUsd: 100, amount: null }],
+        })}
+      />,
+    );
+    expect(screen.getByText("USDC")).not.toBeNull();
+  });
+});
+
 describe("GlobalWalletSwitcher — per-wallet drill-down", () => {
   it("selecting a wallet swaps in the wallet-scoped, chain-grouped view with its own total", () => {
     mockWallets([EVM_1, EVM_2], []);

--- a/vex-app/src/renderer/features/appShell/__tests__/PositionChains.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/PositionChains.test.tsx
@@ -2,7 +2,10 @@
  * PositionChains — pins the token-symbol trust boundary for the POSITION
  * chain switcher's per-chain top holdings (WP-H: the same protection
  * MovesBlock applies to captured symbols, applied here to the portfolio's
- * provider-supplied `token.symbol`, which carries NO mitigation upstream).
+ * provider-supplied `token.symbol`, which carries NO mitigation upstream) AND
+ * the address-correct branding gate (position branding stream): a brand icon
+ * requires `verifiedBrandTicker` to confirm the line's `tokenAddress`, never
+ * the self-declared symbol alone.
  *
  * `token.symbol` is UNTRUSTED: any on-chain token can self-declare arbitrary
  * metadata, including a symbol that impersonates a well-known ticker or
@@ -11,7 +14,9 @@
  * `sanitizeTokenSymbol` allowlist before it becomes display text or reaches
  * `TokenIcon`'s symbol-keyed brand-mark lookup — a rejected symbol renders
  * the existing "—" placeholder and the neutral monogram, never a brand name
- * or logo.
+ * or logo. A plain-ASCII brand impersonation (e.g. literally "ETH") survives
+ * sanitization as TEXT but is denied the brand `<svg>` mark unless its
+ * `tokenAddress` is one of the handful of independently-verified addresses.
  */
 
 import { describe, it, expect } from "vitest";
@@ -20,6 +25,9 @@ import type { PositionChainDto } from "@shared/schemas/portfolio.js";
 import { PositionChains } from "../book/PositionChains.js";
 
 const ETHEREUM_CHAIN_ID = 1;
+const SOLANA_CHAIN_ID = 20011000000;
+const NATIVE_EVM_SENTINEL = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const SOL_MINT = "So11111111111111111111111111111111111111112";
 
 function chain(
   chainId: number,
@@ -113,5 +121,130 @@ describe("PositionChains token-symbol trust boundary", () => {
     );
     expect(container.querySelectorAll("li")).toHaveLength(1);
     expect(screen.getByText("—")).not.toBeNull();
+  });
+});
+
+describe("PositionChains address-correct branding gate", () => {
+  it("withholds the brand icon for a spoofed 'ETH' symbol at an unverified address", () => {
+    const { container } = render(
+      <PositionChains
+        chains={[
+          chain(ETHEREUM_CHAIN_ID, "evm", 100, [
+            {
+              symbol: "ETH",
+              tokenAddress: "0x0000000000000000000000000000000000ffff",
+              balanceUsd: 100,
+              amount: 1,
+            },
+          ]),
+        ]}
+        hasEvmWallet
+        hasSolanaWallet={false}
+      />,
+    );
+    // The sanitized text still renders (no deception in the label itself)...
+    expect(screen.getByText("ETH")).not.toBeNull();
+    // ...but the row's icon is the neutral fallback, never the brand `<svg>`.
+    const row = container.querySelector("li");
+    expect(row?.querySelector("svg")).toBeNull();
+  });
+
+  it("grants the brand icon for a native ETH holding at the verified EVM sentinel address", () => {
+    const { container } = render(
+      <PositionChains
+        chains={[
+          chain(ETHEREUM_CHAIN_ID, "evm", 100, [
+            {
+              symbol: "ETH",
+              tokenAddress: NATIVE_EVM_SENTINEL,
+              balanceUsd: 100,
+              amount: 1,
+            },
+          ]),
+        ]}
+        hasEvmWallet
+        hasSolanaWallet={false}
+      />,
+    );
+    const row = container.querySelector("li");
+    expect(row?.querySelector("svg")).not.toBeNull();
+  });
+
+  it("withholds the brand icon when a symbol has no tokenAddress at all", () => {
+    const { container } = render(
+      <PositionChains
+        chains={[
+          chain(ETHEREUM_CHAIN_ID, "evm", 100, [
+            { symbol: "ETH", balanceUsd: 100, amount: 1 },
+          ]),
+        ]}
+        hasEvmWallet
+        hasSolanaWallet={false}
+      />,
+    );
+    const row = container.querySelector("li");
+    expect(row?.querySelector("svg")).toBeNull();
+  });
+
+  it("withholds the brand icon for a spoofed 'SOL' symbol at an unverified Solana address", () => {
+    const { container } = render(
+      <PositionChains
+        chains={[
+          chain(SOLANA_CHAIN_ID, "solana", 100, [
+            {
+              symbol: "SOL",
+              tokenAddress: "9jk8UbH339rCgnohpBvqiss4a7bXWmicMPCUCFmDrmYK",
+              balanceUsd: 100,
+              amount: 1,
+            },
+          ]),
+        ]}
+        hasEvmWallet={false}
+        hasSolanaWallet
+      />,
+    );
+    expect(screen.getByText("SOL")).not.toBeNull();
+    const row = container.querySelector("li");
+    expect(row?.querySelector("svg")).toBeNull();
+  });
+
+  it("grants the brand icon for the verified Solana native mint", () => {
+    const { container } = render(
+      <PositionChains
+        chains={[
+          chain(SOLANA_CHAIN_ID, "solana", 100, [
+            { symbol: "SOL", tokenAddress: SOL_MINT, balanceUsd: 100, amount: 1 },
+          ]),
+        ]}
+        hasEvmWallet={false}
+        hasSolanaWallet
+      />,
+    );
+    const row = container.querySelector("li");
+    expect(row?.querySelector("svg")).not.toBeNull();
+  });
+
+  it("never gates a non-brand symbol on an address (no impersonation risk to guard)", () => {
+    const { container } = render(
+      <PositionChains
+        chains={[
+          chain(ETHEREUM_CHAIN_ID, "evm", 100, [
+            {
+              symbol: "PEPE",
+              tokenAddress: "0x0000000000000000000000000000000000ffff",
+              balanceUsd: 100,
+              amount: 1,
+            },
+          ]),
+        ]}
+        hasEvmWallet
+        hasSolanaWallet={false}
+      />,
+    );
+    // Non-brand symbols were never gated — TokenIcon just renders its own
+    // neutral monogram (no svg either way), and the text is unaffected.
+    expect(screen.getByText("PEPE")).not.toBeNull();
+    const row = container.querySelector("li");
+    expect(row?.querySelector("svg")).toBeNull();
   });
 });

--- a/vex-app/src/renderer/features/appShell/book/GlobalWalletSwitcher.tsx
+++ b/vex-app/src/renderer/features/appShell/book/GlobalWalletSwitcher.tsx
@@ -29,6 +29,7 @@ import { useState, type JSX } from "react";
 import type { AvailableWalletDto } from "@shared/schemas/wallets.js";
 import type { PortfolioDto, PositionTokenDto } from "@shared/schemas/portfolio.js";
 import { ETHEREUM_CHAIN_ID, SOLANA_CHAIN_ID } from "@shared/chains/display.js";
+import { sanitizeTokenSymbol } from "@shared/token-symbol-sanitizer.js";
 import { useAvailableWallets } from "../../../lib/api/wallet-inventory.js";
 import { useWalletPortfolio } from "../../../lib/api/portfolio.js";
 import { formatTokenQuantity, formatUsd, truncateAddress } from "../../../lib/format.js";
@@ -60,12 +61,13 @@ function hasDisplayableBalance(token: PositionTokenDto): boolean {
 }
 
 /**
- * Stable React key for a (chain, token) bucket. `chainId`/`symbol` can both
- * be `null`; the composite stays unique per aggregated line (the SQL groups
- * by `(chain_id, token_symbol)`, so no two rows share both).
+ * Stable React key for a (chain, token, address) bucket. `chainId`/`symbol`/
+ * `tokenAddress` can each be `null` (or, for `tokenAddress`, absent); the
+ * composite stays unique per aggregated line (the SQL groups by
+ * `(chain_id, token_address, token_symbol)`, so no two rows share all three).
  */
 function tokenKey(token: PositionTokenDto): string {
-  return `${token.chainId ?? "x"}:${token.symbol ?? "x"}`;
+  return `${token.chainId ?? "x"}:${token.tokenAddress ?? "x"}:${token.symbol ?? "x"}`;
 }
 
 export function GlobalWalletSwitcher({
@@ -208,18 +210,25 @@ function DefaultHoldings({
   );
 }
 
+/**
+ * `token.symbol` is provider-supplied and UNTRUSTED — sanitize it through the
+ * shared ASCII-allowlist (`sanitizeTokenSymbol`: rejects control characters,
+ * bidi controls, zero-width characters, Unicode confusables, and anything
+ * over the length cap) before it becomes display text; a rejected symbol
+ * falls back to the existing em-dash placeholder. This row never renders a
+ * brand icon (flat aggregate list, text only), so there is no icon-borrowing
+ * risk to gate — just the raw-string display risk sanitization covers.
+ */
 function TokenRow({ token }: { readonly token: PositionTokenDto }): JSX.Element {
-  const symbol = token.symbol !== null && token.symbol.length > 0
-    ? token.symbol
-    : "—";
+  const symbol = sanitizeTokenSymbol(token.symbol);
   // Quantity is the muted secondary figure; the USD value keeps the white
   // register when priced and drops to a muted em dash when UNPRICED (null —
   // never a fabricated $0.00).
-  const quantity = formatTokenQuantity(token.amount, token.symbol);
+  const quantity = formatTokenQuantity(token.amount, symbol);
   return (
     <li className="flex items-baseline justify-between gap-3 border-b border-[var(--vex-line)] py-1.5 last:border-b-0">
       <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-[var(--vex-text-2)]">
-        {symbol}
+        {symbol ?? "—"}
       </span>
       <span className="flex shrink-0 items-baseline gap-2 font-mono text-[11px] tabular-nums">
         {quantity !== null ? (

--- a/vex-app/src/renderer/features/appShell/book/PositionChains.tsx
+++ b/vex-app/src/renderer/features/appShell/book/PositionChains.tsx
@@ -26,6 +26,7 @@ import {
   EVM_QUICK_CHAIN_IDS,
   SOLANA_CHAIN_ID,
   chainDisplay,
+  familyForChainId,
 } from "@shared/chains/display.js";
 import {
   Dialog,
@@ -37,7 +38,7 @@ import {
 } from "../../../components/ui/dialog.js";
 import { sanitizeTokenSymbol } from "@shared/token-symbol-sanitizer.js";
 import { ChainIcon } from "../../../components/common/ChainIcon.js";
-import { TokenIcon } from "../../../components/common/TokenIcon.js";
+import { BRAND_ICON_SYMBOLS, TokenIcon } from "../../../components/common/TokenIcon.js";
 import { formatTokenQuantity, formatUsd } from "../../../lib/format.js";
 import { cn } from "../../../lib/utils.js";
 
@@ -46,6 +47,56 @@ import { cn } from "../../../lib/utils.js";
  * PositionBlock's legacy rows) — a top-3 line below it would print "$0.00".
  */
 const MIN_DISPLAY_USD = 0.005;
+
+/**
+ * Solana mint → ticker — the EXACT SAME three verified constants
+ * `MovesBlock`'s `KNOWN_MINTS` already trusts. Base58 is case-SENSITIVE (no
+ * `.toLowerCase()` anywhere near this map — unlike EVM hex, a differently
+ * cased Solana address is a DIFFERENT address).
+ */
+const KNOWN_SOLANA_MINTS: ReadonlyMap<string, string> = new Map([
+  ["So11111111111111111111111111111111111111112", "SOL"],
+  ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", "USDC"],
+  ["Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", "USDT"],
+]);
+
+/**
+ * The EVM native-gas placeholder (`NATIVE_TOKEN_ADDRESS` in
+ * `src/tools/kyberswap/constants.ts`) — not a deployable contract address, so
+ * no token can spoof it; used across every EVM chain to mean "this wallet's
+ * native balance". Lower-cased for comparison: EVM checksum casing is
+ * cosmetic, unlike Solana base58.
+ */
+const NATIVE_EVM_SENTINEL = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+/**
+ * The ONLY thing that authorizes `TokenIcon`'s brand mark for a holding
+ * whose sanitized symbol claims a brand ticker (mirrors the Moves feed's
+ * `KNOWN_MINTS` invariant — an address, never a self-declared symbol, proves
+ * identity). Solana holdings are verified against the same three canonical
+ * mints Moves already trusts; the EVM native sentinel is independently
+ * verifiable and always denotes "ETH" — a same-address BNB/MATIC/other
+ * native holding fails this exact-ticker match (no per-chain native registry
+ * exists here) and correctly falls back to a non-brand render rather than
+ * borrowing the wrong mark. Any other address, or no address at all, yields
+ * `null` — no icon, even if the symbol would otherwise match a brand key.
+ */
+function verifiedBrandTicker(
+  family: "evm" | "solana",
+  tokenAddress: string | null,
+  symbol: string,
+): string | null {
+  if (tokenAddress === null) return null;
+  const known =
+    family === "solana"
+      ? (KNOWN_SOLANA_MINTS.get(tokenAddress) ?? null)
+      : tokenAddress.toLowerCase() === NATIVE_EVM_SENTINEL
+        ? "ETH"
+        : null;
+  return known !== null && known.toLowerCase() === symbol.toLowerCase()
+    ? known
+    : null;
+}
 
 export function PositionChains({
   chains,
@@ -238,8 +289,13 @@ function ChainTotalFigure({
  * well-known asset. It is passed through the shared ASCII-allowlist
  * `sanitizeTokenSymbol` (rejects control characters, bidi controls,
  * zero-width characters, and Unicode confusables) BEFORE it reaches display
- * text or `TokenIcon`'s symbol-keyed brand-mark lookup, so a spoofed symbol
- * can render neither a deceptive label nor a borrowed brand logo.
+ * text, so a homoglyph/control-character spoof never renders at all. A
+ * PLAIN-ASCII brand impersonation (e.g. a scam token literally named "ETH")
+ * survives sanitization as text, so `TokenIcon`'s brand mark additionally
+ * requires `verifiedBrandTicker` to confirm the line's `tokenAddress` is one
+ * of the few independently-verified addresses above — an unverified address
+ * still shows the sanitized symbol as text, just with no borrowed logo (the
+ * same trade-off `MovesBlock` makes for captured symbols).
  */
 function ChainTokenList({
   chainId,
@@ -248,6 +304,7 @@ function ChainTokenList({
   readonly chainId: number;
   readonly tokens: readonly PositionChainDto["tokens"][number][];
 }): JSX.Element {
+  const family = familyForChainId(chainId);
   const displayable = tokens.filter((t) =>
     t.balanceUsd === null
       ? t.amount !== null && t.amount > 0
@@ -265,13 +322,22 @@ function ChainTokenList({
       {displayable.map((token, index) => {
         const symbol = sanitizeTokenSymbol(token.symbol);
         const quantity = formatTokenQuantity(token.amount, symbol);
+        const tokenAddress = token.tokenAddress ?? null;
+        // A brand-colliding symbol needs address verification; a non-brand
+        // symbol carries no impersonation risk and passes through as-is
+        // (TokenIcon renders its neutral monogram either way).
+        const isBrandClaim =
+          symbol !== null && BRAND_ICON_SYMBOLS.has(symbol.toLowerCase());
+        const iconSymbol = isBrandClaim
+          ? verifiedBrandTicker(family, tokenAddress, symbol)
+          : symbol;
         return (
           <li
-            key={`${chainId}:${symbol ?? "—"}:${index}`}
+            key={`${chainId}:${tokenAddress ?? "x"}:${symbol ?? "—"}:${index}`}
             className="flex items-center justify-between gap-3 border-b border-[var(--vex-line)] py-1.5 last:border-b-0"
           >
             <span className="flex min-w-0 flex-1 items-center gap-2">
-              <TokenIcon symbol={symbol} size={13} />
+              <TokenIcon symbol={iconSymbol} size={13} />
               <span className="truncate font-mono text-[11px] text-[var(--vex-text-2)]">
                 {symbol !== null && symbol.length > 0 ? symbol : "—"}
               </span>

--- a/vex-app/src/shared/schemas/__tests__/portfolio.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/portfolio.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  chainTokenDtoSchema,
   portfolioDtoSchema,
   portfolioReadInputSchema,
   positionTokenDtoSchema,
@@ -290,6 +291,74 @@ describe("portfolio dto schema", () => {
       portfolioDtoSchema.safeParse(
         dtoFixture({ chains: [chainFixture({ family: "bitcoin" })] }),
       ).success,
+    ).toBe(false);
+  });
+
+  // ── tokenAddress: address-correct aggregation (position branding) ──────
+
+  it("accepts a valid EVM tokenAddress on a flat token line", () => {
+    const parsed = positionTokenDtoSchema.safeParse({
+      chainId: 1,
+      symbol: "ETH",
+      tokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      balanceUsd: 1000,
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.tokenAddress).toBe(
+        "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      );
+    }
+  });
+
+  it("accepts a valid Solana base58 tokenAddress on a chain-breakdown token line", () => {
+    const parsed = chainTokenDtoSchema.safeParse({
+      symbol: "SOL",
+      tokenAddress: "So11111111111111111111111111111111111111112",
+      balanceUsd: 50,
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts a null tokenAddress and tolerates a missing tokenAddress key entirely (additive, defensive default)", () => {
+    expect(
+      positionTokenDtoSchema.safeParse({
+        chainId: 1,
+        symbol: "ETH",
+        tokenAddress: null,
+        balanceUsd: 1,
+      }).success,
+    ).toBe(true);
+    const withoutKey = positionTokenDtoSchema.safeParse({
+      chainId: 1,
+      symbol: "ETH",
+      balanceUsd: 1,
+    });
+    expect(withoutKey.success).toBe(true);
+    if (withoutKey.success) {
+      expect(withoutKey.data.tokenAddress).toBeUndefined();
+    }
+  });
+
+  it("rejects a malformed tokenAddress (wrong shape)", () => {
+    expect(
+      positionTokenDtoSchema.safeParse({
+        chainId: 1,
+        symbol: "ETH",
+        tokenAddress: "not-an-address",
+        balanceUsd: 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an oversized tokenAddress", () => {
+    expect(
+      positionTokenDtoSchema.safeParse({
+        chainId: 1,
+        symbol: "ETH",
+        tokenAddress: "0x" + "a".repeat(200),
+        balanceUsd: 1,
+      }).success,
     ).toBe(false);
   });
 });

--- a/vex-app/src/shared/schemas/portfolio.ts
+++ b/vex-app/src/shared/schemas/portfolio.ts
@@ -24,10 +24,43 @@
  * (no value is fabricated — `null` when absent/unparseable). Token lines keep
  * `balanceUsd: null` for UNPRICED holdings (no price source — owner decision:
  * show the funds instead of hiding them) and carry `amount`, the human token
- * quantity derived per row from `balance_raw / 10^decimals`.
+ * quantity derived per row from `balance_raw / 10^decimals`. Token lines also
+ * carry `tokenAddress` (nullable, optional/additive) — aggregation keys on
+ * `(chain, normalized address)` server-side (symbol is display metadata,
+ * never an aggregation key), so a spoofed token sharing a legitimate symbol
+ * never coalesces into that token's line;
+ * the renderer uses the address (never the self-declared symbol) to decide
+ * whether a brand icon is authorized.
  */
 
 import { z } from "zod";
+
+/**
+ * Token contract/mint address — the identity key that disambiguates two
+ * DIFFERENT on-chain tokens sharing a self-declared symbol (the whole point
+ * of this field: aggregation groups by address, never by symbol alone, so a
+ * spoofed token cannot coalesce into a legitimate one's line). Bounded to
+ * either shape addresses actually take in `proj_balances.token_address`: EVM
+ * 0x-hex (40 hex chars) or Solana base58 (32-44 chars) — mirrors
+ * `wallets/base-chain.ts`'s `evmAddressSchema`/`solanaAddressSchema` patterns
+ * without importing them (this DTO field is chain-family-agnostic, unlike
+ * those per-family wallet schemas). `null`/absent means the renderer could
+ * not resolve an address for this line (older payload shape, or a
+ * left-join miss in the per-chain breakdown) — it falls back to symbol-only
+ * display with NO brand icon, never a fabricated address.
+ */
+const TOKEN_ADDRESS_MAX_LENGTH = 64;
+const EVM_TOKEN_ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/;
+const SOLANA_TOKEN_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+const tokenAddressSchema = z
+  .string()
+  .max(TOKEN_ADDRESS_MAX_LENGTH)
+  .refine(
+    (value) =>
+      EVM_TOKEN_ADDRESS_PATTERN.test(value) ||
+      SOLANA_TOKEN_ADDRESS_PATTERN.test(value),
+    { message: "Invalid token address." },
+  );
 
 /**
  * IPC input for `vex.portfolio.read`. Discriminated on `scope`:
@@ -58,19 +91,23 @@ export const portfolioReadInputSchema = z.discriminatedUnion("scope", [
 export type PortfolioReadInput = z.infer<typeof portfolioReadInputSchema>;
 
 /**
- * One aggregated position line — a single (chain, token) bucket summed
- * across every wallet in the resolved allow-list. `chainId` is `null` when
- * the DB chain id is absent or could not be coerced to a finite JS number;
- * `symbol` is `null` for rows without a token symbol. `balanceUsd` is `null`
- * for an UNPRICED holding (no price available); `amount` is the human token
- * quantity (per-row `balance_raw / 10^decimals`, summed AFTER the division so
- * mixed-decimals buckets stay correct), `null` when no row is computable.
- * `amount` defaults to `null` so pre-amount payloads still parse.
+ * One aggregated position line — a single (chain, token, address) bucket
+ * summed across every wallet in the resolved allow-list. `chainId` is `null`
+ * when the DB chain id is absent or could not be coerced to a finite JS
+ * number; `symbol` is `null` for rows without a token symbol. `balanceUsd` is
+ * `null` for an UNPRICED holding (no price available); `amount` is the human
+ * token quantity (per-row `balance_raw / 10^decimals`, summed AFTER the
+ * division so mixed-decimals buckets stay correct), `null` when no row is
+ * computable. `amount` defaults to `null` so pre-amount payloads still parse.
+ * `tokenAddress` is additive and OPTIONAL (not defaulted): an older payload
+ * missing the key entirely still parses, and the renderer treats a missing
+ * key the same as an explicit `null` (no brand icon, symbol-only display).
  */
 export const positionTokenDtoSchema = z
   .object({
     chainId: z.number().nullable(),
     symbol: z.string().max(64).nullable(),
+    tokenAddress: tokenAddressSchema.nullable().optional(),
     balanceUsd: z.number().nullable(),
     amount: z.number().nullable().default(null),
   })
@@ -81,11 +118,13 @@ export type PositionTokenDto = z.infer<typeof positionTokenDtoSchema>;
  * One token line inside a per-chain breakdown — like `positionTokenDtoSchema`
  * but WITHOUT `chainId` (the parent chain carries it). `balanceUsd` is
  * strictly positive when priced (the breakdown query drops priced-at-zero
- * lines) and `null` for an unpriced holding; `amount` mirrors the flat line.
+ * lines) and `null` for an unpriced holding; `amount`/`tokenAddress` mirror
+ * the flat line (see `positionTokenDtoSchema`).
  */
 export const chainTokenDtoSchema = z
   .object({
     symbol: z.string().max(64).nullable(),
+    tokenAddress: tokenAddressSchema.nullable().optional(),
     balanceUsd: z.number().positive().nullable(),
     amount: z.number().nullable().default(null),
   })


### PR DESCRIPTION
Both portfolio queries now group by `(chain_id, normalized token_address)` (EVM lowercased, Solana base58 preserved) with a deterministic freshest-synced symbol — a spoof token sharing a legitimate symbol can never coalesce into that token's line/totals/top-three, and one contract never splits across casing or stale cross-wallet symbols. A validated, bounded `tokenAddress` rides both position DTO shapes (additive, nullable). `PositionChains` grants brand icons for brand-colliding symbols only via address verification; `GlobalWalletSwitcher` renders sanitized raw symbols. Extends the known-mint-only branding invariant from #18 to the positions surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)