### PR TITLE
fix(docker): strip managed vault secrets from every helper spawn env

### DIFF
--- a/vex-app/src/main/docker/__tests__/cli-env.test.ts
+++ b/vex-app/src/main/docker/__tests__/cli-env.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { buildDockerPath } from "../cli-env.js";
+import { buildDockerPath, dockerSpawnEnv } from "../cli-env.js";
 
 const DARWIN_CANDIDATES = [
   "/usr/local/bin",
@@ -91,5 +91,26 @@ describe("buildDockerPath", () => {
       KEEP: "yes",
     });
     expect(dirExists).not.toHaveBeenCalled();
+  });
+});
+
+describe("dockerSpawnEnv", () => {
+  it("strips managed secrets from the real process.env (covers docker CLI + probe/daemon.ts callers)", () => {
+    const originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      PATH: originalEnv.PATH ?? "/usr/bin",
+      OPENROUTER_API_KEY: "secret",
+      VEX_KEYSTORE_PASSWORD: "master-password",
+    };
+    try {
+      const result = dockerSpawnEnv();
+
+      expect(result.OPENROUTER_API_KEY).toBeUndefined();
+      expect(result.VEX_KEYSTORE_PASSWORD).toBeUndefined();
+      expect(result.PATH).toBeDefined();
+    } finally {
+      process.env = originalEnv;
+    }
   });
 });

--- a/vex-app/src/main/docker/__tests__/env-hygiene.test.ts
+++ b/vex-app/src/main/docker/__tests__/env-hygiene.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { MANAGED_SECRET_ENV_KEYS } from "@vex-lib/secret-keys.js";
+import { withoutManagedSecrets } from "../env-hygiene.js";
+
+describe("withoutManagedSecrets", () => {
+  it("strips every catalog key at its canonical casing", () => {
+    const env: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+    for (const key of MANAGED_SECRET_ENV_KEYS) {
+      env[key] = `value-for-${key}`;
+    }
+
+    const result = withoutManagedSecrets(env);
+
+    expect(result).toEqual({ PATH: "/usr/bin" });
+    for (const key of MANAGED_SECRET_ENV_KEYS) {
+      expect(result[key]).toBeUndefined();
+    }
+  });
+
+  it("strips catalog keys regardless of case (Windows case-insensitive env names)", () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: "/usr/bin",
+      openrouter_api_key: "leaked-lower",
+      Openrouter_Api_Key: "leaked-mixed",
+      TAVILY_API_KEY: "leaked-upper",
+      vex_keystore_password: "leaked-password-lower",
+    };
+
+    const result = withoutManagedSecrets(env);
+
+    expect(result).toEqual({ PATH: "/usr/bin" });
+  });
+
+  it("keeps operational vars untouched", () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: "/usr/bin",
+      DOCKER_HOST: "unix:///var/run/docker.sock",
+      HOME: "/home/vex",
+      CUSTOM: "yes",
+    };
+
+    const result = withoutManagedSecrets(env);
+
+    expect(result).toEqual(env);
+  });
+
+  it("never mutates the input, even when the input is process.env by identity", () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: "/usr/bin",
+      OPENROUTER_API_KEY: "secret",
+    };
+    const snapshot = { ...env };
+
+    const result = withoutManagedSecrets(env);
+
+    expect(env).toEqual(snapshot);
+    expect(result).not.toBe(env);
+  });
+});

--- a/vex-app/src/main/docker/__tests__/spawn-runner-options.test.ts
+++ b/vex-app/src/main/docker/__tests__/spawn-runner-options.test.ts
@@ -56,19 +56,29 @@ describe("runSpawn environment and spawn errors", () => {
     );
   });
 
-  it("does not augment a non-docker command environment", async () => {
-    await runSpawn("open", ["-a", "Docker"]);
+  it("does not augment a non-docker command environment, but still strips managed secrets", async () => {
+    const originalEnv = process.env;
+    process.env = { ...originalEnv, PATH: "/system/path", OPENROUTER_API_KEY: "secret" };
+    try {
+      await runSpawn("open", ["-a", "Docker"]);
 
-    expect(mocks.dockerSpawnEnv).not.toHaveBeenCalled();
-    expect(mocks.spawn).toHaveBeenCalledWith(
-      "open",
-      ["-a", "Docker"],
-      expect.objectContaining({ env: undefined }),
-    );
+      expect(mocks.dockerSpawnEnv).not.toHaveBeenCalled();
+      const call = mocks.spawn.mock.calls[0];
+      const passedEnv = (call?.[2] as { env?: NodeJS.ProcessEnv } | undefined)?.env;
+      expect(passedEnv).not.toBeUndefined();
+      expect(passedEnv?.PATH).toBe("/system/path");
+      expect(passedEnv?.OPENROUTER_API_KEY).toBeUndefined();
+    } finally {
+      process.env = originalEnv;
+    }
   });
 
-  it("keeps a caller-supplied docker environment", async () => {
-    const env = { PATH: "/caller/path", CUSTOM: "yes" };
+  it("strips managed secrets from a caller-supplied docker environment", async () => {
+    const env = {
+      PATH: "/caller/path",
+      CUSTOM: "yes",
+      OPENROUTER_API_KEY: "secret",
+    };
 
     await runSpawn("docker", ["info"], { env });
 
@@ -76,7 +86,9 @@ describe("runSpawn environment and spawn errors", () => {
     expect(mocks.spawn).toHaveBeenCalledWith(
       "docker",
       ["info"],
-      expect.objectContaining({ env }),
+      expect.objectContaining({
+        env: { PATH: "/caller/path", CUSTOM: "yes" },
+      }),
     );
   });
 

--- a/vex-app/src/main/docker/cli-env.ts
+++ b/vex-app/src/main/docker/cli-env.ts
@@ -1,6 +1,7 @@
 import { statSync } from "node:fs";
 import { homedir as getHomedir } from "node:os";
 import { posix } from "node:path";
+import { withoutManagedSecrets } from "./env-hygiene.js";
 
 export interface BuildDockerPathOptions {
   readonly platform: NodeJS.Platform;
@@ -65,12 +66,18 @@ function directoryExists(path: string): boolean {
   }
 }
 
-/** Recomputes Docker CLI candidates per spawn so Recheck sees new installs. */
+/**
+ * Recomputes Docker CLI candidates per spawn so Recheck sees new installs,
+ * and strips managed secrets so the Docker CLI/compose child never inherits
+ * the master password or vault-managed API keys.
+ */
 export function dockerSpawnEnv(): NodeJS.ProcessEnv {
-  return buildDockerPath({
-    platform: process.platform,
-    homedir: getHomedir(),
-    env: process.env,
-    dirExists: directoryExists,
-  });
+  return withoutManagedSecrets(
+    buildDockerPath({
+      platform: process.platform,
+      homedir: getHomedir(),
+      env: process.env,
+      dirExists: directoryExists,
+    }),
+  );
 }

--- a/vex-app/src/main/docker/env-hygiene.ts
+++ b/vex-app/src/main/docker/env-hygiene.ts
@@ -1,0 +1,31 @@
+/**
+ * Strips managed secrets out of an environment before it is handed to a
+ * spawned Docker/child process. Docker CLI/probe/compose helpers only need
+ * operational vars (PATH, DOCKER_HOST, HOME, …); they must never inherit the
+ * master password or vault-managed API secrets that happen to live in
+ * `process.env` for the lifetime of the app.
+ */
+
+import { MANAGED_SECRET_ENV_KEYS } from "@vex-lib/secret-keys.js";
+
+// Windows env var names are case-insensitive and preserve first-set casing,
+// so a mixed-case duplicate of a managed key must be stripped too.
+const MANAGED_SECRET_ENV_KEYS_LOWER = new Set(
+  MANAGED_SECRET_ENV_KEYS.map((key) => key.toLowerCase()),
+);
+
+/**
+ * Returns a new env object with every `MANAGED_SECRET_ENV_KEYS` entry
+ * removed (case-insensitive). Never mutates `env`, even when `env` is
+ * `process.env` itself.
+ */
+export function withoutManagedSecrets(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const stripped: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (MANAGED_SECRET_ENV_KEYS_LOWER.has(key.toLowerCase())) continue;
+    stripped[key] = value;
+  }
+  return stripped;
+}

--- a/vex-app/src/main/docker/spawn-runner.ts
+++ b/vex-app/src/main/docker/spawn-runner.ts
@@ -12,6 +12,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { redact } from "../logger/redact.js";
 import { dockerSpawnEnv } from "./cli-env.js";
+import { withoutManagedSecrets } from "./env-hygiene.js";
 
 export interface SpawnRunnerOptions {
   readonly cwd?: string;
@@ -91,7 +92,15 @@ export async function runSpawn(
     onStdoutLine,
     onStderrLine,
   } = options;
-  const spawnEnv = env ?? (command === "docker" ? dockerSpawnEnv() : undefined);
+  // Every branch strips managed secrets: a caller-supplied env is not
+  // trusted to have done so already, `dockerSpawnEnv()` handles the Docker
+  // CLI case, and any other helper (open/systemctl/powershell, …) still
+  // gets a stripped clone of `process.env` rather than a full inherit.
+  const spawnEnv = env
+    ? withoutManagedSecrets(env)
+    : command === "docker"
+      ? dockerSpawnEnv()
+      : withoutManagedSecrets(process.env);
 
   return new Promise((resolve) => {
     let aborted = false;


### PR DESCRIPTION
`withoutManagedSecrets()` (new `env-hygiene.ts`) clones and strips the `MANAGED_SECRET_ENV_KEYS` catalog case-insensitively (Windows env semantics), never mutating the input; wired into `dockerSpawnEnv()` and every `runSpawn()` branch, so docker CLI/probe/compose and non-docker start helpers stop inheriting unlocked vault secrets. Reimplements the intent of #46 (darahub) with case-insensitivity hardening — credit to the author for the finding and the centralized-chokepoint approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)