### PR TITLE
fix(web): make web_research Tavily-only — remove the raw-HTTP fallback

### DIFF
--- a/src/__tests__/vex-agent/tools/internal/web.test.ts
+++ b/src/__tests__/vex-agent/tools/internal/web.test.ts
@@ -162,57 +162,61 @@ describe("web_research", () => {
       if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
     });
 
-    it("falls back to raw HTTP and surfaces failedResults when Tavily extract returns empty", async () => {
+    it("surfaces failedResults as an honest failure — there is NO raw-HTTP fallback (Tavily-only, owner decision)", async () => {
       const origKey = process.env.TAVILY_API_KEY;
       process.env.TAVILY_API_KEY = "test-key";
-      // Tavily reports the URL in failedResults — code must log it and still try
-      // the raw HTTP fallback (preserving old behavior).
       mockTavilyExtract.mockResolvedValueOnce({
         results: [],
         failedResults: [{ url: "https://blocked.example.com", error: "403 Forbidden" }],
       });
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response("<html><title>Blocked Page</title><body>fallback body</body></html>", {
-          status: 200,
-        }),
-      );
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
 
       const result = await handleWebResearch(
         { url: "https://blocked.example.com" },
         baseContext,
       );
-      expect(result.success).toBe(true);
-      const parsed = JSON.parse(result.output);
-      expect(parsed.title).toBe("Blocked Page");
-      expect(parsed.content).toContain("fallback body");
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("403 Forbidden");
+      // The privileged process must never fetch the URL itself.
+      expect(fetchSpy).not.toHaveBeenCalled();
 
       fetchSpy.mockRestore();
       if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
     });
 
-    it("falls back to raw HTTP when Tavily extract throws (timeout)", async () => {
+    it("a Tavily extract failure (timeout) is an honest failure — no raw-HTTP fallback", async () => {
       const origKey = process.env.TAVILY_API_KEY;
       process.env.TAVILY_API_KEY = "test-key";
       mockTavilyExtract.mockRejectedValueOnce(new Error("Request timed out after 25000ms"));
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-        new Response("<html><title>HTTP OK</title><body>raw body</body></html>", {
-          status: 200,
-        }),
-      );
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
 
       const result = await handleWebResearch(
         { url: "https://slow.example.com" },
         baseContext,
       );
-      expect(result.success).toBe(true);
-      const parsed = JSON.parse(result.output);
-      expect(parsed.title).toBe("HTTP OK");
-      expect(parsed.content).toContain("raw body");
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("timed out");
+      expect(fetchSpy).not.toHaveBeenCalled();
 
       fetchSpy.mockRestore();
       if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
+    });
+
+    it("fetch without TAVILY_API_KEY fails with actionable guidance — defense-in-depth: the registry (requiresEnv) already hides the tool from the LLM without the key", async () => {
+      const origKey = process.env.TAVILY_API_KEY;
+      delete process.env.TAVILY_API_KEY;
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      const result = await handleWebResearch(
+        { url: "https://example.com/article" },
+        baseContext,
+      );
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("TAVILY_API_KEY");
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      fetchSpy.mockRestore();
+      if (origKey) process.env.TAVILY_API_KEY = origKey;
     });
 
     it("rejects plain string (not a url) at Zod boundary", async () => {
@@ -415,7 +419,7 @@ describe("web_research", () => {
       if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
     });
 
-    it("whole batch failure → fallback raw HTTP per URL", async () => {
+    it("whole batch failure → every URL reported ok:false with the reason — no raw-HTTP fallback", async () => {
       const origKey = process.env.TAVILY_API_KEY;
       process.env.TAVILY_API_KEY = "test-key";
       mockTavilySearch.mockResolvedValueOnce({
@@ -425,21 +429,15 @@ describe("web_research", () => {
         ],
       });
       mockTavilyExtract.mockRejectedValueOnce(new Error("Request timed out after 25000ms"));
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValueOnce(
-          new Response("<html><title>A page</title><body>raw A</body></html>", { status: 200 }),
-        )
-        .mockResolvedValueOnce(
-          new Response("<html><title>B page</title><body>raw B</body></html>", { status: 200 }),
-        );
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
 
       const result = await handleWebResearch({ query: "foo", fetchTop: 2 }, baseContext);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(true); // search itself succeeded — snippets stand
       const parsed = JSON.parse(result.output);
       expect(parsed.fetchedPages).toHaveLength(2);
-      expect(parsed.fetchedPages.every((p: { ok: boolean }) => p.ok)).toBe(true);
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(parsed.fetchedPages.every((p: { ok: boolean }) => p.ok === false)).toBe(true);
+      expect(parsed.fetchedPages.every((p: { error?: string }) => String(p.error).includes("timed out"))).toBe(true);
+      expect(fetchSpy).not.toHaveBeenCalled();
 
       fetchSpy.mockRestore();
       if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
@@ -465,5 +463,151 @@ describe("web_research", () => {
 
       if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
     });
+  });
+
+  it("a batch result with EMPTY rawContent is reported ok:false — never silently dropped (exactly-once accounting)", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    process.env.TAVILY_API_KEY = "test-key";
+    mockTavilySearch.mockResolvedValueOnce({
+      results: [
+        { title: "A", url: "https://a.example.com", content: "snippet" },
+        { title: "B", url: "https://b.example.com", content: "snippet" },
+      ],
+    });
+    mockTavilyExtract.mockResolvedValueOnce({
+      results: [
+        { url: "https://a.example.com", rawContent: "# A\n\nbody" },
+        { url: "https://b.example.com", rawContent: "" }, // accounted for, but empty
+      ],
+      failedResults: [],
+    });
+
+    const result = await handleWebResearch({ query: "foo", fetchTop: 2 }, baseContext);
+    expect(result.success).toBe(true);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.fetchedPages).toHaveLength(2);
+    const pageB = parsed.fetchedPages.find((p: { url: string }) => p.url === "https://b.example.com");
+    expect(pageB.ok).toBe(false);
+    expect(String(pageB.error)).toContain("empty content");
+
+    if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
+  });
+
+  it("duplicate results for one URL yield exactly ONE outcome (first success wins)", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    process.env.TAVILY_API_KEY = "test-key";
+    mockTavilySearch.mockResolvedValueOnce({
+      results: [{ title: "A", url: "https://a.example.com", content: "snippet" }],
+    });
+    mockTavilyExtract.mockResolvedValueOnce({
+      results: [
+        { url: "https://a.example.com", rawContent: "# First\n\nfirst body" },
+        { url: "https://a.example.com", rawContent: "# Second\n\nsecond body" },
+      ],
+      failedResults: [],
+    });
+
+    const result = await handleWebResearch({ query: "foo", fetchTop: 1 }, baseContext);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.fetchedPages).toHaveLength(1);
+    expect(parsed.fetchedPages[0].ok).toBe(true);
+    expect(parsed.fetchedPages[0].content).toContain("first body");
+
+    if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
+  });
+
+  it("an URL listed in BOTH results and failedResults resolves to the success (deterministic precedence), once", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    process.env.TAVILY_API_KEY = "test-key";
+    mockTavilySearch.mockResolvedValueOnce({
+      results: [{ title: "A", url: "https://a.example.com", content: "snippet" }],
+    });
+    mockTavilyExtract.mockResolvedValueOnce({
+      results: [{ url: "https://a.example.com", rawContent: "# A\n\nreal body" }],
+      failedResults: [{ url: "https://a.example.com", error: "flaky report" }],
+    });
+
+    const result = await handleWebResearch({ query: "foo", fetchTop: 1 }, baseContext);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.fetchedPages).toHaveLength(1);
+    expect(parsed.fetchedPages[0].ok).toBe(true);
+
+    if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
+  });
+
+  it("an UNREQUESTED result is ignored and never cached (provider data is untrusted)", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    process.env.TAVILY_API_KEY = "test-key";
+    mockTavilySearch.mockResolvedValueOnce({
+      results: [{ title: "A", url: "https://a.example.com", content: "snippet" }],
+    });
+    mockTavilyExtract.mockResolvedValueOnce({
+      results: [
+        { url: "https://a.example.com", rawContent: "# A\n\nbody" },
+        { url: "https://evil.example.net/planted", rawContent: "# Planted\n\ninjected" },
+      ],
+      failedResults: [],
+    });
+
+    const result = await handleWebResearch({ query: "foo", fetchTop: 1 }, baseContext);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.fetchedPages).toHaveLength(1);
+    expect(parsed.fetchedPages[0].url).toBe("https://a.example.com");
+    // The planted URL must not reach the fetch cache.
+    const cachedUrls = mockCacheFetchResult.mock.calls.map((c: unknown[]) => c[0]);
+    expect(cachedUrls).not.toContain("https://evil.example.net/planted");
+
+    if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
+  });
+
+  it("duplicate search-result URLs collapse to ONE outcome even when the whole batch fails", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    process.env.TAVILY_API_KEY = "test-key";
+    mockTavilySearch.mockResolvedValueOnce({
+      results: [
+        { title: "A", url: "https://a.example.com", content: "snippet" },
+        { title: "A again", url: "https://a.example.com", content: "snippet2" },
+      ],
+    });
+    mockTavilyExtract.mockRejectedValueOnce(new Error("batch down"));
+
+    const result = await handleWebResearch({ query: "foo", fetchTop: 2 }, baseContext);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.fetchedPages).toHaveLength(1);
+    expect(parsed.fetchedPages[0].ok).toBe(false);
+
+    if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
+  });
+
+  it("URL-only fetch rejects a result for a DIFFERENT url — fails honestly, caches nothing (planted-result guard)", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    process.env.TAVILY_API_KEY = "test-key";
+    mockTavilyExtract.mockResolvedValueOnce({
+      results: [{ url: "https://evil.example.net/planted", rawContent: "# Planted\n\ninjected" }],
+      failedResults: [],
+    });
+
+    const result = await handleWebResearch({ url: "https://a.example.com/doc" }, baseContext);
+    expect(result.success).toBe(false);
+    expect(mockCacheFetchResult).not.toHaveBeenCalled();
+
+    if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
+  });
+
+  it("a cache-write failure never discards a usable extract — content is served, failure only logged", async () => {
+    const origKey = process.env.TAVILY_API_KEY;
+    process.env.TAVILY_API_KEY = "test-key";
+    mockTavilyExtract.mockResolvedValueOnce({
+      results: [{ url: "https://a.example.com/doc", rawContent: "# Doc\n\nreal body" }],
+      failedResults: [],
+    });
+    mockCacheFetchResult.mockRejectedValueOnce(new Error("disk full"));
+
+    const result = await handleWebResearch({ url: "https://a.example.com/doc" }, baseContext);
+    expect(result.success).toBe(true);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.content).toContain("real body");
+
+    if (origKey) process.env.TAVILY_API_KEY = origKey; else delete process.env.TAVILY_API_KEY;
   });
 });

--- a/src/vex-agent/tools/internal/web.ts
+++ b/src/vex-agent/tools/internal/web.ts
@@ -26,7 +26,6 @@ import logger from "@utils/logger.js";
 const DEFAULT_SEARCH_LIMIT = 10;   // search returns up to N results
 const DEFAULT_FETCH_TOP = 5;       // auto-scrape top N when fetchTop is omitted
 const MAX_FETCH_TOP = 10;          // hard cap per call (Tavily allows up to 20)
-const FETCH_TIMEOUT_MS = 15_000;
 const SEARCH_TIMEOUT_S = 30;
 const EXTRACT_TIMEOUT_S = 25;
 
@@ -99,6 +98,22 @@ export async function handleWebResearch(
 
 // ── Single-page fetch (Tavily extract → raw HTTP fallback) ─────
 
+/**
+ * Cache writes are BEST-EFFORT: a failed local write must never discard a
+ * usable provider result or masquerade as a Tavily failure — the content is
+ * already in hand; only future cache hits are lost.
+ */
+async function cacheFetchBestEffort(url: string, markdown: string, title: string | null): Promise<void> {
+  try {
+    await searchRepo.cacheFetchResult(url, markdown, title);
+  } catch (err) {
+    logger.warn("web.fetch.cache_write_failed", {
+      url: url.slice(0, 60),
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 type FetchedPage = {
   url: string;
   title: string | null;
@@ -116,62 +131,58 @@ async function fetchUrl(url: string): Promise<ToolResult> {
   }
 
   const client = getTavilyClient();
-  if (client) {
+  if (!client) {
+    // Defense-in-depth: the registry hides web_research without the key
+    // (requiresEnv), so this branch is unreachable via visible tools.
+    logger.warn("web.fetch.no_api_key", { hint: "Set TAVILY_API_KEY for web fetch" });
+    return fail(
+      "Web fetch unavailable — TAVILY_API_KEY not configured. The key is free (tavily.com); add it in Settings to enable web research.",
+    );
+  }
+  {
     try {
       // Tavily's default extract timeout is 10s (basic) / 30s (advanced).
       // We pin 25s so basic depth still has runway before the SDK fires.
       const response = await client.extract([url], { timeout: EXTRACT_TIMEOUT_S });
-      const extracted = response.results?.[0];
+      // Provider data is untrusted: accept ONLY a result for the URL we
+      // requested — a planted result for a different URL must never be
+      // served (nor cached under the requested key). Tavily's server-side
+      // URL echo is undocumented (SDK verified as byte-verbatim passthrough,
+      // 2026-07-19), so a mismatch here is at least as likely benign
+      // normalization as an attack — the fail-safe response is an honest
+      // fetch failure, never acceptance.
+      const extracted = (response.results ?? []).find((r) => r.url === url);
+      const mismatched = !extracted && (response.results?.length ?? 0) > 0;
+      if (mismatched) {
+        logger.warn("web.fetch.unrequested_result", { url: String(response.results?.[0]?.url ?? "").slice(0, 60) });
+      }
       if (extracted?.rawContent) {
         const titleMatch = extracted.rawContent.match(/^#\s+(.+)$/m);
         const title = titleMatch?.[1] ?? null;
-        await searchRepo.cacheFetchResult(url, extracted.rawContent, title);
+        await cacheFetchBestEffort(url, extracted.rawContent, title);
         const content = `# ${title ?? "Fetched page"}\n\nSource: ${url}\n\n${extracted.rawContent}`;
         return ok({ title, url, content });
       }
-      // Tavily returned no usable content. If it explicitly listed this URL in
-      // failedResults, surface the reason before falling back to raw HTTP.
+      // Tavily returned no usable content. Surface the explicit failure
+      // reason when present. There is deliberately NO raw-HTTP fallback:
+      // owner decision (2026-07-19) removed direct fetching from the
+      // privileged process entirely — Tavily's infrastructure does the
+      // fetching, which also removes the local SSRF surface (the concern
+      // that briefly lived here as a destination policy).
       const failedResult = response.failedResults?.find((f) => f.url === url);
+      const reason = failedResult ? failedResult.error : "no usable content returned";
       if (failedResult) {
         logger.warn("web.fetch.tavily_failed_explicit", {
           url: url.slice(0, 60),
           error: failedResult.error,
         });
       }
+      return fail(`Fetch failed: ${reason}`);
     } catch (err) {
-      logger.debug("web.fetch.tavily_failed", { error: err instanceof Error ? err.message : String(err) });
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.debug("web.fetch.tavily_failed", { error: msg });
+      return fail(`Fetch failed: ${msg}`);
     }
-  }
-
-  // Raw HTTP fallback — used when Tavily extract returned empty/errored or no API key.
-  const fallback = await fetchUrlRawHttp(url);
-  if (fallback.ok) {
-    return ok({ title: fallback.title, url: fallback.url, content: fallback.content });
-  }
-  return fail(`Fetch failed: ${fallback.error ?? "unknown error"}`);
-}
-
-// Raw HTTP fetch + parse <title> + slice. Returns FetchedPage shape so it can
-// be reused in the batch path's failure recovery without a wrapper.
-async function fetchUrlRawHttp(url: string): Promise<FetchedPage> {
-  try {
-    const res = await fetch(url, {
-      headers: { "User-Agent": "Vex/2.0" },
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-    if (!res.ok) {
-      return { url, title: null, content: "", ok: false, error: `HTTP ${res.status}` };
-    }
-    const text = await res.text();
-    const titleMatch = text.match(/<title[^>]*>([^<]+)<\/title>/i);
-    const title = titleMatch?.[1]?.trim() ?? null;
-    const markdown = text.slice(0, 50_000);
-    await searchRepo.cacheFetchResult(url, markdown, title);
-    const content = `# ${title ?? "Fetched page"}\n\nSource: ${url}\n\n${markdown}`;
-    return { url, title, content, ok: true };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { url, title: null, content: "", ok: false, error: msg };
   }
 }
 
@@ -209,7 +220,15 @@ export async function searchAndOptionallyFetch(
         url: r.url ?? "",
         content: r.content ?? "",
       }));
-      await searchRepo.cacheResult(query, results);
+      try {
+        await searchRepo.cacheResult(query, results);
+      } catch (cacheErr) {
+        // Best-effort: a failed cache write must not turn a successful
+        // search into web.search.failed — the results are already in hand.
+        logger.warn("web.search.cache_write_failed", {
+          error: cacheErr instanceof Error ? cacheErr.message : String(cacheErr),
+        });
+      }
       logger.debug("web.search.completed", { count: results.length, query: query.slice(0, 50) });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -229,9 +248,15 @@ export async function searchAndOptionallyFetch(
   const targets = results.slice(0, Math.min(fetchTop, MAX_FETCH_TOP, results.length));
   const fetchedPages: FetchedPage[] = [];
   const uncachedUrls: string[] = [];
+  // Dedup up front: search results can repeat an URL, and every consumer
+  // below (extract call, batch-failure loop, no-key loop, outcome emission)
+  // must see each URL exactly once.
+  const seenTargets = new Set<string>();
 
   for (const target of targets) {
     if (!target.url) continue;
+    if (seenTargets.has(target.url)) continue;
+    seenTargets.add(target.url);
     if (!isHttpUrl(target.url)) {
       fetchedPages.push({
         url: target.url,
@@ -266,46 +291,66 @@ export async function searchAndOptionallyFetch(
           query,
         });
 
-        // Successful results — cache + push.
+        // EXACTLY-ONCE accounting, keyed by what WE requested. The response
+        // is provider data (untrusted until validated): duplicate entries,
+        // an URL listed in both results and failedResults, or an URL we
+        // never asked for must not multiply/poison outcomes or the cache.
+        // Precedence is deterministic: a usable success beats any failure
+        // report for the same URL; among duplicate successes the first wins.
+        const requested = new Set(uncachedUrls); // already unique (deduped at collection)
+        const outcomes = new Map<string, FetchedPage>();
         for (const r of response.results ?? []) {
-          if (!r.rawContent) continue;
+          if (!requested.has(r.url)) {
+            logger.warn("web.fetch.unrequested_result", { url: r.url.slice(0, 60) });
+            continue; // never accept — and never cache — what we did not ask for
+          }
+          if (outcomes.get(r.url)?.ok) continue; // first success wins
+          if (!r.rawContent) {
+            // Still "accounted for" by Tavily — must not vanish: ok:false,
+            // unless a duplicate already produced a real outcome.
+            if (!outcomes.has(r.url)) {
+              outcomes.set(r.url, { url: r.url, title: null, content: "", ok: false, error: "empty content from Tavily extract" });
+            }
+            continue;
+          }
           const titleMatch = r.rawContent.match(/^#\s+(.+)$/m);
           const title = r.title ?? titleMatch?.[1] ?? null;
-          await searchRepo.cacheFetchResult(r.url, r.rawContent, title);
+          await cacheFetchBestEffort(r.url, r.rawContent, title);
           const content = `# ${title ?? "Fetched page"}\n\nSource: ${r.url}\n\n${r.rawContent}`;
-          fetchedPages.push({ url: r.url, title, content, ok: true });
+          outcomes.set(r.url, { url: r.url, title, content, ok: true }); // success overrides an earlier failure entry
         }
-
-        // Explicit failures — log + push as ok:false.
         for (const f of response.failedResults ?? []) {
+          if (!requested.has(f.url)) {
+            logger.warn("web.fetch.unrequested_failure", { url: f.url.slice(0, 60) });
+            continue;
+          }
           logger.warn("web.fetch.tavily_failed_explicit", {
             url: f.url.slice(0, 60),
             error: f.error,
           });
-          fetchedPages.push({ url: f.url, title: null, content: "", ok: false, error: f.error });
+          if (outcomes.has(f.url)) continue; // success (or first report) wins
+          outcomes.set(f.url, { url: f.url, title: null, content: "", ok: false, error: f.error });
         }
-
-        // Orphans (URLs neither in results nor failedResults) — fallback raw HTTP.
-        const accountedFor = new Set([
-          ...(response.results ?? []).map((r) => r.url),
-          ...(response.failedResults ?? []).map((f) => f.url),
-        ]);
-        const orphans = uncachedUrls.filter((u) => !accountedFor.has(u));
-        for (const url of orphans) {
-          fetchedPages.push(await fetchUrlRawHttp(url));
+        // One outcome per requested URL, in request order; anything Tavily
+        // left unmentioned is an honest failure (no raw-HTTP fallback exists
+        // — owner decision: fetching happens only through Tavily).
+        for (const url of [...requested]) {
+          fetchedPages.push(
+            outcomes.get(url) ?? { url, title: null, content: "", ok: false, error: "not returned by Tavily extract" },
+          );
         }
       } catch (err) {
-        // Whole batch failed (timeout, auth) — fallback raw HTTP per URL.
+        // Whole batch failed (timeout, auth) — every URL reported as failed.
         const msg = err instanceof Error ? err.message : String(err);
         logger.warn("web.fetch.tavily_batch_failed", { error: msg, count: uncachedUrls.length });
         for (const url of uncachedUrls) {
-          fetchedPages.push(await fetchUrlRawHttp(url));
+          fetchedPages.push({ url, title: null, content: "", ok: false, error: msg });
         }
       }
     } else {
-      // No API key — raw HTTP per URL.
+      // No API key — fetching is unavailable (free key: tavily.com).
       for (const url of uncachedUrls) {
-        fetchedPages.push(await fetchUrlRawHttp(url));
+        fetchedPages.push({ url, title: null, content: "", ok: false, error: "TAVILY_API_KEY not configured" });
       }
     }
   }


### PR DESCRIPTION
Owner decision: fetching happens exclusively through Tavily's infrastructure (the tool is already hidden without `TAVILY_API_KEY` via `requiresEnv`), removing the local SSRF surface outright instead of hardening it. Tavily miss/error paths fail honestly with the reason; batch outcomes are exactly-once per requested URL with deterministic precedence — duplicate/conflicting/unrequested/empty provider entries can no longer multiply, poison the cache, or vanish; cache writes are best-effort. Resolves the concern behind #44 (darahub) by deleting the attack surface — credit to the author for surfacing the SSRF class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)