### PR TITLE
feat(mission): discoverable review-&-accept bar with honest plan-state gating

### DIFF
--- a/vex-app/src/renderer/features/appShell/MissionContractModal.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionContractModal.tsx
@@ -64,9 +64,22 @@ import { PremiumBadge, type PremiumBadgeState } from "./PremiumBadge.js";
 type PlanGate =
   | { readonly kind: "none" }
   | { readonly kind: "ready"; readonly planUpdatedAt: string }
-  | { readonly kind: "missing" };
+  | { readonly kind: "missing" }
+  | { readonly kind: "loading" }
+  | { readonly kind: "failed" };
 
-function resolvePlanGate(plan: PlanGetResult | null): PlanGate {
+type PlanReadState = "loading" | "failed" | "known";
+
+function resolvePlanGate(plan: PlanGetResult | null, readState: PlanReadState): PlanGate {
+  // Pending/failed plan read = the plan state is UNKNOWN. The engine would
+  // reject an unsafe accept anyway, but the UI must not INVITE a knowingly
+  // invalid action — both suppress acceptance (same rule as the rail badge
+  // and the MissionControls review bar). They differ in the exit: loading
+  // resolves itself; failed needs an explicit Retry (the failed Result sits
+  // in the query cache as "successful" data, so nothing refetches on its
+  // own while the modal stays mounted).
+  if (readState === "loading") return { kind: "loading" };
+  if (readState === "failed") return { kind: "failed" };
   if (plan === null || !plan.enabled || plan.accepted) return { kind: "none" };
   if (plan.planMd.length === 0) return { kind: "missing" };
   return { kind: "ready", planUpdatedAt: plan.updatedAt };
@@ -96,7 +109,16 @@ export function MissionContractModal({
   const diffQuery = useMissionDiff(sessionId, draft?.missionId ?? null);
   const diff = readDiff(diffQuery.data);
   const planQuery = useSessionPlan(sessionId);
-  const planGate = resolvePlanGate(readPlan(planQuery.data));
+  // isError FIRST: a rejected ipc invoke leaves data undefined forever —
+  // reading only `data` would render "loading" with no way out.
+  const planReadState: PlanReadState = planQuery.isError
+    ? "failed"
+    : planQuery.data === undefined
+      ? "loading"
+      : planQuery.data.ok
+        ? "known"
+        : "failed";
+  const planGate = resolvePlanGate(readPlan(planQuery.data), planReadState);
   const accept = useAcceptMissionContract();
   const autoRetry = useSetAutoRetry();
 
@@ -172,7 +194,7 @@ export function MissionContractModal({
   }, [accept.data, planRefetch]);
 
   const title = state?.draft.title?.trim() || "Mission contract";
-  const badgeState = toBadgeState(state?.kind, acceptOutcome);
+  const badgeState = toBadgeState(state?.kind, acceptOutcome, planGate);
   const badgeShimmer = badgeState === "ready";
 
   const showAutoRetry = permission === "full" && state !== null;
@@ -237,6 +259,8 @@ export function MissionContractModal({
           pending={accept.isPending}
           onAccept={onAccept}
           planGate={planGate}
+          onPlanRetry={() => void planQuery.refetch()}
+          planRetryPending={planQuery.isFetching}
           notice={acceptNotice}
         />
       </DialogContent>
@@ -249,6 +273,10 @@ interface FooterActionProps {
   readonly pending: boolean;
   readonly onAccept: (hash: string) => void;
   readonly planGate: PlanGate;
+  /** Refetches the plan read after a failed Result — see the `failed` gate. */
+  readonly onPlanRetry: () => void;
+  /** True while a refetch is in flight — the Retry button disables itself. */
+  readonly planRetryPending: boolean;
   readonly notice: string | null;
 }
 
@@ -263,6 +291,8 @@ function FooterAction({
   pending,
   onAccept,
   planGate,
+  onPlanRetry,
+  planRetryPending,
   notice,
 }: FooterActionProps): JSX.Element | null {
   if (state === null) return null;
@@ -285,6 +315,47 @@ function FooterAction({
     );
   }
   if (currentHash === null) return null;
+
+  // Plan state not yet known — block accept: the UI must never present an
+  // action the engine is known to reject right now.
+  if (planGate.kind === "loading") {
+    return (
+      <DialogFooter className="justify-start border-[var(--vex-line)]">
+        <p
+          className="text-xs text-warning"
+          role="alert"
+          data-vex-state="plan-unknown"
+        >
+          Plan status is loading. Accepting is unavailable until it is known.
+        </p>
+      </DialogFooter>
+    );
+  }
+  // Failed read: the err Result sits in the query cache as data, so nothing
+  // refetches by itself while the modal stays mounted — without an explicit
+  // Retry the user would be stranded here.
+  if (planGate.kind === "failed") {
+    return (
+      <DialogFooter className="justify-between border-[var(--vex-line)]">
+        <p
+          className="text-xs text-warning"
+          role="alert"
+          data-vex-state="plan-failed"
+        >
+          Plan status could not be read. Accepting is unavailable until it is.
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={planRetryPending}
+          onClick={() => void onPlanRetry()}
+        >
+          Retry
+        </Button>
+      </DialogFooter>
+    );
+  }
 
   // Plan-mode ON but nothing authored — block accept and prompt to write a plan
   // first (matches the engine `plan_missing`).
@@ -354,6 +425,7 @@ function FooterAction({
 function toBadgeState(
   kind: CardStateKind | undefined,
   acceptOutcome: MissionAcceptContractResult["outcome"] | null,
+  planGate: PlanGate,
 ): PremiumBadgeState {
   if (acceptOutcome === "plan_stale") return "stale";
   switch (kind) {
@@ -365,7 +437,12 @@ function toBadgeState(
     case "dirty-acceptance":
       return "stale";
     case "awaiting-acceptance":
-      return "ready";
+      // The header must never contradict the footer: while the plan is
+      // loading/failed/empty the footer blocks acceptance, so the badge says
+      // Preparing (same semantics as the Rail badge and the Controls bar).
+      return planGate.kind === "loading" || planGate.kind === "failed" || planGate.kind === "missing"
+        ? "preparing"
+        : "ready";
   }
 }
 

--- a/vex-app/src/renderer/features/appShell/MissionControls.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionControls.tsx
@@ -10,9 +10,27 @@
  *    (accent-hairline, S3) → mission.start.
  *  - NO ACTIVE RUN + a terminal accepted mission (the renew source) → a
  *    "Renew mission" button → mission.renew (clones it into a fresh draft).
+ *  - NO ACTIVE RUN + a ready, unaccepted draft (the "MISSION READY" state) →
+ *    a full-width accent-OUTLINED "Review & accept contract" bar (vs the
+ *    solid Start key above) in the same slot, opening the mission dialog via
+ *    `uiStore.reviewModal` (owned/rendered by `MissionRail`, a sibling
+ *    component in the header cluster). Previously this state surfaced only
+ *    the passive notice below with no visible control — the shimmering
+ *    MISSION READY badge was the only path to the accept dialog. Reveal is
+ *    gated on `useIsChatSubmitting` settling so the bar can't flash open
+ *    mid-turn during a tool-call gap (the draft can flip to `ready` before
+ *    the turn's final text response); a cancelled/failed turn also settles
+ *    `chatSubmitting` back to false, so the bar can never wedge shut. Only
+ *    one next-step surface shows at a time: while reviewable-and-settled,
+ *    this bar REPLACES the standing notice below, never stacks with it.
  *  - NO ACTIVE RUN + a contract pending acceptance (any non-accepted-clean
- *    draft) → a standing muted-warn notice: on-chain actions are blocked by
- *    the runtime gate until the user accepts the contract and starts the run.
+ *    draft, still in setup or mid-turn) → a standing muted-warn notice:
+ *    on-chain actions are blocked by the runtime gate until the user accepts
+ *    the contract and starts the run.
+ *
+ * `useMissionLiveSync` is mounted here (event-driven + 30s-fallback refresh
+ * of the draft/diff queries) so a dropped `transcriptAppend` event can never
+ * strand the review bar invisible for a session the user never blurs.
  *
  * The render gate keys off `runtime` ALONE — never the draft. A started
  * mission flips its row past `ready` (commit-start → `running`; terminal on
@@ -37,11 +55,13 @@ import type {
   MissionRenewResult,
 } from "@shared/schemas/mission.js";
 import type { RuntimeStateDto } from "@shared/schemas/runtime.js";
+import { useIsChatSubmitting } from "../../lib/api/chat.js";
 import {
   useEditMission,
   useMissionContinue,
   useMissionDiff,
   useMissionDraft,
+  useMissionLiveSync,
   useMissionRenew,
   useMissionRetry,
   useMissionStart,
@@ -50,6 +70,9 @@ import {
 } from "../../lib/api/mission.js";
 import { useRuntimeState } from "../../lib/api/runtime.js";
 import { cn } from "../../lib/utils.js";
+import { useUiStore } from "../../stores/uiStore.js";
+import { useSessionPlan } from "../../lib/api/sessions.js";
+import { planMissing } from "./MissionRail.js";
 
 /**
  * Primary mission action (Start/Renew) — the landing's solid cobalt CTA:
@@ -58,6 +81,18 @@ import { cn } from "../../lib/utils.js";
  */
 const PRIMARY_KEY =
   "flex h-10 w-full items-center justify-center gap-2 rounded-full bg-[var(--vex-accent)] font-mono text-[11px] font-medium uppercase tracking-[0.16em] text-[var(--vex-accent-contrast)] transition-colors hover:bg-[var(--vex-accent-hover)] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50";
+
+/**
+ * Review-&-accept bar — the pre-accept counterpart of `PRIMARY_KEY`: an
+ * accent-OUTLINED full-width pill (vs. the solid commitment key above),
+ * reusing the same `--vex-accent-border-strong`/`--vex-accent-fill-8`/
+ * `--vex-accent-text` tokens the rest of the shell already uses for an
+ * "outlined, accent-toned" affordance (`PlanSwitch`, `ReasoningSwitch`), so
+ * it re-tints correctly across themes (incl. hypervexing) alongside the
+ * solid key.
+ */
+const REVIEW_KEY =
+  "flex h-10 w-full items-center justify-center gap-2 rounded-full border border-[var(--vex-accent-border-strong)] bg-[var(--vex-accent-fill-8)] font-mono text-[11px] font-medium uppercase tracking-[0.16em] text-[var(--vex-accent-text)] transition-colors hover:bg-[var(--vex-accent-fill-12)] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50";
 
 export interface MissionControlsProps {
   readonly sessionId: string;
@@ -179,6 +214,13 @@ export function MissionControls({
   const draftQuery = useMissionDraft(sessionId);
   const draft = readDraft(draftQuery.data);
   const diffQuery = useMissionDiff(sessionId, draft?.missionId ?? null);
+  const planQuery = useSessionPlan(sessionId);
+  // Readiness requires a SUCCESSFUL plan read: while the query is pending or
+  // failed the plan state is UNKNOWN, and unknown must read as not-ready —
+  // collapsing it to null would make planMissing(null) vacuously false and
+  // let the review bar flash during loading or survive a plan.get failure.
+  const planKnown = planQuery.data?.ok === true;
+  const plan = planQuery.data?.ok === true ? planQuery.data.data : null;
   const renewableQuery = useRenewableMissionSource(sessionId);
 
   const start = useMissionStart();
@@ -187,6 +229,13 @@ export function MissionControls({
   const edit = useEditMission();
   const stop = useMissionStop();
   const renew = useMissionRenew();
+
+  // Keep the draft/diff queries fresh (event-driven + 30s fallback poll) so
+  // the review bar below can never be stranded by a dropped transcript event.
+  useMissionLiveSync(sessionId);
+  // Turn-gate for the review bar's reveal — see the file header comment.
+  const chatSubmitting = useIsChatSubmitting(sessionId);
+  const setReviewModal = useUiStore((s) => s.setReviewModal);
 
   const [notice, setNotice] = useState<ControlNotice>(null);
 
@@ -301,6 +350,33 @@ export function MissionControls({
           Start mission
         </button>
         {notice !== null ? <ControlNoticeLine text={notice.text} /> : null}
+      </div>
+    );
+  }
+
+  // Reviewable: a ready draft awaiting acceptance — the "MISSION READY" state.
+  // Gated on the turn settling (never on the draft/diff data alone) so the
+  // bar can't flash open mid-turn during a tool-call gap; a cancelled/failed
+  // turn also settles `chatSubmitting` back to false, so a stuck turn can
+  // never wedge the bar shut. When not yet settled (or not reviewable), fall
+  // through to the pre-existing affordances below unchanged — the standing
+  // notice already covers this state, so nothing regresses mid-turn.
+  // `planMissing` is MissionRail's exported readiness gate: with plan-mode on
+  // and no plan body, the rail says Preparing — the bar must agree, not lead.
+  const reviewable =
+    draft !== null && draft.status === "ready" && diff !== null && !diff.isAccepted &&
+    planKnown && !planMissing(plan);
+  if (reviewable && !chatSubmitting) {
+    return (
+      <div data-vex-area="mission-controls" className="mt-3">
+        <button
+          type="button"
+          onClick={() => setReviewModal("mission")}
+          aria-label="Review & accept contract"
+          className={REVIEW_KEY}
+        >
+          Review &amp; accept contract
+        </button>
       </div>
     );
   }

--- a/vex-app/src/renderer/features/appShell/MissionRail.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionRail.tsx
@@ -26,8 +26,12 @@
  *     pending acceptance / accepted), and surfaces an "awaiting resume" stale
  *     marker when an accepted plan's run is parked.
  *
- * Modal open-state is local `useState` with MUTUAL EXCLUSION — opening one
- * closes the other so two dialogs never stack. The state is UI-ephemeral (never
+ * Modal open-state lives in `uiStore` (`reviewModal`), NOT local `useState`:
+ * `MissionControls`' "Review & accept contract" bar (mounted in the session
+ * body, a different tree branch than this header cluster) needs to open the
+ * SAME dialog this component owns, so the state has to be shared, not local.
+ * MUTUAL EXCLUSION is still free — `reviewModal` is a single enum value, so
+ * opening one dialog closes the other. The state is UI-ephemeral (never
  * persisted, never crosses IPC).
  *
  * Trust boundary: 100% renderer presentation over existing hooks. No new IPC,
@@ -35,7 +39,7 @@
  * cluster only derives badge states; the modals own the content render.
  */
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { JSX } from "react";
 import type { Result } from "@shared/ipc/result.js";
 import type {
@@ -52,12 +56,10 @@ import {
 } from "../../lib/api/mission.js";
 import { useRuntimeState } from "../../lib/api/runtime.js";
 import { useSession, useSessionPlan } from "../../lib/api/sessions.js";
+import { useUiStore } from "../../stores/uiStore.js";
 import { MissionContractModal } from "./MissionContractModal.js";
 import { PlanDisplayModal } from "./PlanDisplayModal.js";
 import { PremiumBadge, type PremiumBadgeState } from "./PremiumBadge.js";
-
-/** Which review dialog (if any) is open. Mutually exclusive. */
-type OpenModal = "none" | "mission" | "plan";
 
 export interface MissionRailProps {
   readonly activeSessionId: string | null;
@@ -76,6 +78,9 @@ export function MissionRail({
   const diff = readDiff(diffQuery.data);
   const planQuery = useSessionPlan(activeSessionId);
   const plan = readPlan(planQuery.data);
+  // Pending/failed plan read = UNKNOWN plan state; the READY badge below must
+  // treat unknown as still-preparing (same rule as MissionControls' bar).
+  const planKnown = planQuery.data?.ok === true;
 
   const isMission = session?.mode === "mission";
   const planEnabled = plan?.enabled === true;
@@ -106,7 +111,8 @@ export function MissionRail({
   const hasRenewable =
     renewableQuery.data?.ok === true && renewableQuery.data.data !== null;
 
-  const [open, setOpen] = useState<OpenModal>("none");
+  const open = useUiStore((s) => s.reviewModal);
+  const setReviewModal = useUiStore((s) => s.setReviewModal);
 
   const mission = useMemo(
     () =>
@@ -115,11 +121,12 @@ export function MissionRail({
         draft,
         diff,
         plan,
+        planKnown,
         hasActiveRun,
         hasRenewable,
         runtimeStatus,
       ),
-    [isMission, draft, diff, plan, hasActiveRun, hasRenewable, runtimeStatus],
+    [isMission, draft, diff, plan, planKnown, hasActiveRun, hasRenewable, runtimeStatus],
   );
   const planBadge = useMemo(
     () => derivePlanBadge(plan, session?.missionStatus ?? null),
@@ -148,7 +155,9 @@ export function MissionRail({
           state={mission.state}
           shimmer={mission.shimmer}
           expanded={open === "mission"}
-          onClick={() => setOpen((cur) => (cur === "mission" ? "none" : "mission"))}
+          onClick={() =>
+            setReviewModal(open === "mission" ? "none" : "mission")
+          }
         />
       ) : null}
 
@@ -159,7 +168,7 @@ export function MissionRail({
           state={planBadge.state}
           shimmer={planBadge.shimmer}
           expanded={open === "plan"}
-          onClick={() => setOpen((cur) => (cur === "plan" ? "none" : "plan"))}
+          onClick={() => setReviewModal(open === "plan" ? "none" : "plan")}
         />
       ) : null}
 
@@ -171,7 +180,7 @@ export function MissionRail({
           sessionId={sessionId}
           permission={session.permission}
           open={open === "mission"}
-          onOpenChange={(next) => setOpen(next ? "mission" : "none")}
+          onOpenChange={(next) => setReviewModal(next ? "mission" : "none")}
         />
       ) : null}
       {planEnabled ? (
@@ -180,7 +189,7 @@ export function MissionRail({
           missionStatus={session?.missionStatus ?? null}
           suppressAccept={suppressPlanAccept}
           open={open === "plan"}
-          onOpenChange={(next) => setOpen(next ? "plan" : "none")}
+          onOpenChange={(next) => setReviewModal(next ? "plan" : "none")}
         />
       ) : null}
     </div>
@@ -206,6 +215,7 @@ function deriveMissionBadge(
   draft: MissionDraftDto | null,
   diff: ReadyDiff | null,
   plan: PlanGetResult | null,
+  planKnown: boolean,
   hasActiveRun: boolean,
   hasRenewable: boolean,
   runtimeStatus: RuntimeStateDto["status"],
@@ -254,7 +264,9 @@ function deriveMissionBadge(
   }
   // awaiting-acceptance. Gate "ready" on the plan when plan-mode is on:
   // plan_missing → keep preparing; otherwise ready (shimmer).
-  if (planMissing(plan)) {
+  if (!planKnown || planMissing(plan)) {
+    // Unknown (pending/failed read) counts as missing — never flash READY
+    // on a plan state we have not actually seen.
     return { state: "preparing", shimmer: false };
   }
   return { state: "ready", shimmer: true };
@@ -281,8 +293,12 @@ function derivePlanBadge(
   return { state: "accepted", shimmer: false };
 }
 
-/** Plan-mode on with an empty body → the engine's `plan_missing` block. */
-function planMissing(plan: PlanGetResult | null): boolean {
+/**
+ * Plan-mode on with an empty body → the engine's `plan_missing` block.
+ * Exported as THE shared mission-readiness gate: MissionControls' review bar
+ * must never claim "ready" while this rail still (correctly) says Preparing.
+ */
+export function planMissing(plan: PlanGetResult | null): boolean {
   return plan !== null && plan.enabled && !plan.accepted && plan.planMd.length === 0;
 }
 

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionContractModal.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionContractModal.test.tsx
@@ -398,4 +398,80 @@ describe("MissionContractModal", () => {
     });
     expect(screen.queryByRole("button", { name: /Accept/i })).toBeNull();
   });
+
+  it("suppresses acceptance while the plan read is PENDING and the header badge stays Preparing", async () => {
+    mockBridge.getDraft.mockResolvedValue({ ok: true, data: SAMPLE_DRAFT });
+    mockBridge.getDiff.mockResolvedValue({ ok: true, data: READY_DIFF });
+    mockPlanGet.mockImplementation(() => new Promise(() => {})); // never settles
+    renderModal();
+
+    await waitFor(() => {
+      const alert = screen.getByRole("alert");
+      expect(alert.getAttribute("data-vex-state")).toBe("plan-unknown");
+    });
+    expect(screen.queryByRole("button", { name: /Accept contract/i })).toBeNull();
+    // The header must not contradict the blocked footer.
+    expect(screen.queryByText(/Mission ready/i)).toBeNull();
+    expect(screen.getByText(/Preparing/i)).not.toBeNull();
+  });
+
+  it("a FAILED plan read shows the Retry action, keeps the badge Preparing, and recovery re-enables acceptance", async () => {
+    mockBridge.getDraft.mockResolvedValue({ ok: true, data: SAMPLE_DRAFT });
+    mockBridge.getDiff.mockResolvedValue({ ok: true, data: READY_DIFF });
+    mockPlanGet.mockResolvedValueOnce({
+      ok: false as const,
+      error: { code: "session.plan_read_failed", message: "boom", correlationId: "t" },
+    });
+    // The retry resolves a healthy plan-mode-off read.
+    mockPlanGet.mockResolvedValue({ ok: true, data: null });
+    renderModal();
+
+    await waitFor(() => {
+      const alert = screen.getByRole("alert");
+      expect(alert.getAttribute("data-vex-state")).toBe("plan-failed");
+    });
+    expect(screen.queryByRole("button", { name: /Accept contract/i })).toBeNull();
+    expect(screen.queryByText(/Mission ready/i)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Retry/i }));
+
+    // Recovery: the read succeeds, acceptance becomes available again.
+    expect(
+      await screen.findByRole("button", { name: /Accept contract/i }),
+    ).not.toBeNull();
+  });
+
+  it("a REJECTED plan.get promise (ipc failure) shows the Retry path — never an infinite Loading", async () => {
+    mockBridge.getDraft.mockResolvedValue({ ok: true, data: SAMPLE_DRAFT });
+    mockBridge.getDiff.mockResolvedValue({ ok: true, data: READY_DIFF });
+    mockPlanGet.mockRejectedValueOnce(new Error("ipc channel died"));
+    mockPlanGet.mockResolvedValue({ ok: true, data: null }); // retry succeeds
+    renderModal();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.getAttribute("data-vex-state")).toBe("plan-failed");
+    expect(screen.queryByRole("button", { name: /Accept contract/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Retry/i }));
+    expect(
+      await screen.findByRole("button", { name: /Accept contract/i }),
+    ).not.toBeNull();
+  });
+
+  it("an EMPTY enabled plan keeps the header badge Preparing (matches the blocked footer)", async () => {
+    mockBridge.getDraft.mockResolvedValue({ ok: true, data: SAMPLE_DRAFT });
+    mockBridge.getDiff.mockResolvedValue({ ok: true, data: READY_DIFF });
+    mockPlanGet.mockResolvedValue({
+      ok: true,
+      data: { enabled: true, accepted: false, planMd: "", updatedAt: PLAN_UPDATED_AT },
+    });
+    renderModal();
+
+    await waitFor(() => {
+      const alert = screen.getByRole("alert");
+      expect(alert.getAttribute("data-vex-state")).toBe("plan-missing");
+    });
+    expect(screen.queryByText(/Mission ready/i)).toBeNull();
+    expect(screen.getByText(/Preparing/i)).not.toBeNull();
+  });
 });

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
@@ -1,15 +1,25 @@
 /**
  * MissionControls — runtime-gated mission control surface (Phase 4b-2).
  * Verifies Start gating, the status-gated toolbar (Continue/Recover/Edit/Stop),
- * dispatch wiring to the mission IPC, the in-flight/pending disable, and that
- * refusal outcomes (ok:true non-success) surface a notice.
+ * dispatch wiring to the mission IPC, the in-flight/pending disable, refusal
+ * outcomes (ok:true non-success) surfacing a notice, the review-&-accept bar
+ * (ready-unaccepted state, store wiring), and its turn-gated reveal.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
 
+import { useSubmitChat } from "../../../lib/api/chat.js";
+import { useUiStore } from "../../../stores/uiStore.js";
 import { MissionControls } from "../MissionControls.js";
 
 const SESSION = "00000000-0000-4000-8000-0000000000d1";
@@ -29,6 +39,9 @@ const retryMock = vi.fn();
 const editMock = vi.fn();
 const stopMock = vi.fn();
 const renewMock = vi.fn();
+const chatSubmitMock = vi.fn();
+const getPlanMock = vi.fn();
+const onTranscriptAppendMock = vi.fn(() => vi.fn());
 
 function setVex(): void {
   Object.defineProperty(window, "vex", {
@@ -36,6 +49,7 @@ function setVex(): void {
     writable: true,
     value: {
       runtime: { getState: getStateMock },
+      sessions: { plan: { get: getPlanMock } },
       mission: {
         getDraft: getDraftMock,
         getDiff: getDiffMock,
@@ -47,6 +61,8 @@ function setVex(): void {
         stop: stopMock,
         renew: renewMock,
       },
+      chat: { submit: chatSubmitMock },
+      engine: { onTranscriptAppend: onTranscriptAppendMock },
     },
   });
 }
@@ -101,14 +117,33 @@ function renderControls() {
   });
 }
 
+/**
+ * Renders MissionControls against a CALLER-SUPPLIED client (instead of the
+ * one-off client `Wrapper` creates internally) so a `useSubmitChat` hook
+ * driven separately in the same test can share the mutation cache
+ * `useIsChatSubmitting` reads — used by the turn-gated reveal test.
+ */
+function renderControlsOnClient(client: QueryClient) {
+  setVex();
+  function SharedWrapper({ children }: { readonly children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  }
+  return render(createElement(MissionControls, { sessionId: SESSION }), {
+    wrapper: SharedWrapper,
+  });
+}
+
 beforeEach(() => {
   // Default: no renewable source. The hook fires for every render (active or
   // not), so give it a safe value; renew-specific tests override it.
   getRenewableMock.mockResolvedValue(ok(null));
+  getPlanMock.mockResolvedValue(ok({ enabled: false, accepted: false, planMd: "" }));
+  useUiStore.setState({ reviewModal: "none" });
 });
 
 afterEach(() => {
   vi.clearAllMocks();
+  useUiStore.setState({ reviewModal: "none" });
   // @ts-expect-error — test cleanup
   delete window.vex;
 });
@@ -124,26 +159,79 @@ describe("MissionControls", () => {
     renderControls();
 
     const startBtn = await screen.findByRole("button", { name: "Start mission" });
-    // Accepted-clean contract → the acceptance-pending notice must be gone
-    // (the Start CTA is the deterministic signal from here).
+    // Accepted-clean contract → the acceptance-pending notice AND the review
+    // bar must be gone (the Start CTA is the deterministic signal from here).
     expect(screen.queryByText(/Mission contract not accepted/i)).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Review & accept contract" }),
+    ).toBeNull();
     fireEvent.click(startBtn);
     await waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
     expect(startMock).toHaveBeenCalledWith({ sessionId: SESSION, missionId: MISSION });
   });
 
-  it("does not show Start when the contract is not accepted", async () => {
+  it("shows the Review & accept contract bar (not Start, not the notice) for a ready, unaccepted contract — the MISSION READY state", async () => {
     getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
     getDraftMock.mockResolvedValue(draftReady());
     getDiffMock.mockResolvedValue(diffAccepted(false));
     renderControls();
 
-    await waitFor(() => expect(getDiffMock).toHaveBeenCalled());
-    await new Promise((r) => setTimeout(r, 0));
+    // One next-step surface at a time: the bar replaces the standing notice.
+    const reviewBtn = await screen.findByRole("button", {
+      name: "Review & accept contract",
+    });
+    expect(screen.queryByText(/Mission contract not accepted/i)).toBeNull();
     expect(screen.queryByRole("button", { name: "Start mission" })).toBeNull();
-    // Standing acceptance-pending notice: the runtime gate blocks every
-    // on-chain broadcast pre-acceptance, and the user must SEE that.
-    await screen.findByText(/on-chain actions .* are blocked until you accept/i);
+    // Store wiring: clicking the bar opens the mission dialog via uiStore.
+    expect(useUiStore.getState().reviewModal).toBe("none");
+    fireEvent.click(reviewBtn);
+    expect(useUiStore.getState().reviewModal).toBe("mission");
+  });
+
+  it("keeps the bar hidden while the plan read is still PENDING — unknown plan state is not readiness", async () => {
+    getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(false));
+    getPlanMock.mockImplementation(() => new Promise(() => {})); // never settles
+    renderControls();
+
+    await screen.findByText(/Mission contract not accepted/i);
+    expect(
+      screen.queryByRole("button", { name: "Review & accept contract" }),
+    ).toBeNull();
+  });
+
+  it("keeps the bar hidden after a FAILED plan read — a failed read must not unlock readiness", async () => {
+    getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(false));
+    getPlanMock.mockResolvedValue({
+      ok: false as const,
+      error: { code: "session.plan_read_failed", message: "boom", correlationId: "t" },
+    });
+    renderControls();
+
+    await screen.findByText(/Mission contract not accepted/i);
+    expect(
+      screen.queryByRole("button", { name: "Review & accept contract" }),
+    ).toBeNull();
+  });
+
+  it("keeps the bar hidden while an enabled plan is still missing — MissionRail's Preparing state must win", async () => {
+    // Shared readiness predicate (planMissing, exported by MissionRail): a
+    // ready draft with plan-mode ON but an empty plan body is NOT the
+    // MISSION READY state — the rail says Preparing, and the bar must agree.
+    getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(false));
+    getPlanMock.mockResolvedValue(ok({ enabled: true, accepted: false, planMd: "" }));
+    renderControls();
+
+    // The standing notice (the pre-existing affordance) stays instead.
+    await screen.findByText(/Mission contract not accepted/i);
+    expect(
+      screen.queryByRole("button", { name: "Review & accept contract" }),
+    ).toBeNull();
   });
 
   it("shows the standing acceptance-pending notice while the draft is still in setup", async () => {
@@ -154,6 +242,54 @@ describe("MissionControls", () => {
 
     await screen.findByText(/Mission contract not accepted/i);
     expect(screen.queryByRole("button", { name: "Start mission" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Review & accept contract" }),
+    ).toBeNull();
+  });
+
+  it("holds the review bar until the chat turn settles, revealing it only once chatSubmitting goes false (no mid-turn flash)", async () => {
+    getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(false));
+    let settleSubmit!: (r: { ok: true; data: { text: null } }) => void;
+    chatSubmitMock.mockReturnValue({
+      promise: new Promise((resolve) => {
+        settleSubmit = resolve;
+      }),
+      cancel: vi.fn(),
+    });
+    setVex();
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    function SharedWrapper({ children }: { readonly children: ReactNode }) {
+      return createElement(QueryClientProvider, { client }, children);
+    }
+    const submitHook = renderHook(() => useSubmitChat(), {
+      wrapper: SharedWrapper,
+    });
+    void submitHook.result.current.mutate({ sessionId: SESSION, message: "hi" });
+    await waitFor(() => expect(chatSubmitMock).toHaveBeenCalledTimes(1));
+
+    renderControlsOnClient(client);
+
+    // Turn still in flight → the bar is HELD; the pre-existing standing
+    // notice covers this state instead (never both at once).
+    await screen.findByText(/Mission contract not accepted/i);
+    expect(
+      screen.queryByRole("button", { name: "Review & accept contract" }),
+    ).toBeNull();
+
+    await act(async () => {
+      settleSubmit({ ok: true, data: { text: null } });
+      await Promise.resolve();
+    });
+
+    // Settled → the bar reveals.
+    await screen.findByRole("button", { name: "Review & accept contract" });
   });
 
   it("running: Stop + Edit enabled, Continue + Recover disabled", async () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionRail.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionRail.test.tsx
@@ -19,7 +19,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { Result } from "@shared/ipc/result.js";
 import type {
   MissionDraftDto,
@@ -65,6 +65,7 @@ vi.mock("../PlanDisplayModal.js", () => ({
 }));
 
 const { MissionRail } = await import("../MissionRail.js");
+const { useUiStore } = await import("../../../stores/uiStore.js");
 
 const SESSION = "00000000-0000-4000-8000-00000000dd01";
 const MISSION = "mission-1";
@@ -165,6 +166,10 @@ function renewable(missionId: string | null = null) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The open-dialog state now lives in uiStore (`reviewModal`), shared across
+  // components — reset it so no test leaks its open/closed dialog into the
+  // next one.
+  useUiStore.setState({ reviewModal: "none" });
   // Sensible defaults: no draft/diff/plan; tests override per case.
   mockUseSession.mockReturnValue({ data: ok(sessionRow()) });
   mockUseMissionDraft.mockReturnValue({ data: ok(null) });
@@ -240,6 +245,28 @@ describe("MissionRail badge derivation", () => {
     expect(screen.getByText("Ready")).not.toBeNull();
     const btn = screen.getByRole("button", { name: /Mission ready/i });
     expect(btn.classList.contains("vex-badge--shimmer")).toBe(true);
+  });
+
+  it("Mission badge stays Preparing while the plan read is PENDING — unknown plan state never flashes Ready", () => {
+    mockUseSession.mockReturnValue({ data: ok(sessionRow({ mode: "mission" })) });
+    mockUseMissionDraft.mockReturnValue({ data: ok(READY_DRAFT) });
+    mockUseMissionDiff.mockReturnValue({ data: ok(diff()) });
+    mockUseSessionPlan.mockReturnValue({ data: undefined }); // query still pending
+    rail();
+    expect(screen.getByText("Preparing")).not.toBeNull();
+    expect(screen.queryByText("Ready")).toBeNull();
+  });
+
+  it("Mission badge stays Preparing after a FAILED plan read", () => {
+    mockUseSession.mockReturnValue({ data: ok(sessionRow({ mode: "mission" })) });
+    mockUseMissionDraft.mockReturnValue({ data: ok(READY_DRAFT) });
+    mockUseMissionDiff.mockReturnValue({ data: ok(diff()) });
+    mockUseSessionPlan.mockReturnValue({
+      data: { ok: false as const, error: { code: "session.plan_read_failed", message: "boom", correlationId: "t" } },
+    });
+    rail();
+    expect(screen.getByText("Preparing")).not.toBeNull();
+    expect(screen.queryByText("Ready")).toBeNull();
   });
 
   it("Mission badge stays Preparing when plan-mode on but plan is missing", () => {
@@ -408,5 +435,21 @@ describe("MissionRail single-modal mutual exclusion", () => {
     // Clicking Plan again toggles it closed.
     fireEvent.click(screen.getByRole("button", { name: /Plan/i }));
     expect(screen.queryByTestId("plan-modal-open")).toBeNull();
+  });
+
+  it("opens the mission dialog from an EXTERNAL uiStore write (MissionControls' review bar), not just its own badge click", () => {
+    // MissionControls lives in a different tree branch and can only reach
+    // this dialog through uiStore.reviewModal — pin that the rail reacts to
+    // the store regardless of who wrote it.
+    mockUseSession.mockReturnValue({ data: ok(sessionRow({ mode: "mission" })) });
+    mockUseMissionDraft.mockReturnValue({ data: ok(READY_DRAFT) });
+    mockUseMissionDiff.mockReturnValue({ data: ok(diff()) });
+    rail();
+
+    expect(screen.queryByTestId("mission-modal-open")).toBeNull();
+    act(() => {
+      useUiStore.getState().setReviewModal("mission");
+    });
+    expect(screen.getByTestId("mission-modal-open")).not.toBeNull();
   });
 });

--- a/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingCopilotDock.test.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingCopilotDock.test.tsx
@@ -71,11 +71,11 @@ const SESSION = "00000000-0000-4000-8000-00000000dc01";
 const MISSION = "mission-1";
 const HASH = "a".repeat(64);
 
-let activeSessionId: string | null = SESSION;
-vi.mock("../../../../stores/uiStore.js", () => ({
-  useUiStore: (selector: (s: { activeSessionId: string | null }) => unknown) =>
-    selector({ activeSessionId }),
-}));
+// REAL uiStore (no static mock): MissionRail's dialog state moved to
+// uiStore.reviewModal, so the rail's reads/writes are reactive store state —
+// a fixed-selector mock would swallow the badge click. Tests drive
+// activeSessionId/reviewModal via useUiStore.setState (reset in beforeEach).
+const { useUiStore } = await import("../../../../stores/uiStore.js");
 
 const { HypervexingCopilotDock } = await import("../HypervexingCopilotDock.js");
 
@@ -166,7 +166,7 @@ function runtime(hasActiveRun = false) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  activeSessionId = SESSION;
+  useUiStore.setState({ activeSessionId: SESSION, reviewModal: "none" });
   mockUseSession.mockReturnValue({ data: ok(sessionRow()) });
   mockUseMissionDraft.mockReturnValue({ data: ok(null) });
   mockUseMissionDiff.mockReturnValue({ data: undefined });
@@ -223,7 +223,7 @@ describe("HypervexingCopilotDock mission rail", () => {
   });
 
   it("passes a null active session straight through (rail render-gates off)", () => {
-    activeSessionId = null;
+    useUiStore.setState({ activeSessionId: null });
     mockUseSession.mockReturnValue({ data: undefined });
 
     const { container } = render(<HypervexingCopilotDock />);

--- a/vex-app/src/renderer/lib/api/__tests__/mission.test.ts
+++ b/vex-app/src/renderer/lib/api/__tests__/mission.test.ts
@@ -9,6 +9,11 @@
  *   - continue/stop  → runtimeKeys.state
  *   - renew          → missionKeys.all
  *   - setAutoRetry   → missionKeys.draft
+ *
+ * `useMissionLiveSync` (review-&-accept bar) mirrors
+ * `useTranscriptLiveSync`/`useUsageLiveSync`: subscribes/unsubscribes,
+ * ignores foreign-session events, invalidates draft + diff on a matching
+ * transcript append, and runs a 30s fallback poll.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -21,6 +26,7 @@ import {
   useAcceptMissionContract,
   useEditMission,
   useMissionContinue,
+  useMissionLiveSync,
   useMissionRecover,
   useMissionRenew,
   useMissionRetry,
@@ -28,6 +34,7 @@ import {
   useMissionStop,
   useRenewableMissionSource,
   useSetAutoRetry,
+  MISSION_LIVE_FALLBACK_POLL_MS,
 } from "../mission.js";
 import {
   missionKeys,
@@ -53,18 +60,51 @@ const mockMissionBridge = {
   setAutoRetry: vi.fn(),
 };
 
+type TranscriptListener = (event: {
+  type: string;
+  sessionId: string;
+  messageId: number;
+  role: string;
+  createdAt: string;
+  messageType: string | null;
+  correlationId: string | null;
+}) => void;
+
+let lastSubscribedListener: TranscriptListener | null = null;
+const unsubscribeMock = vi.fn();
+const onTranscriptAppendMock = vi.fn((cb: TranscriptListener) => {
+  lastSubscribedListener = cb;
+  return unsubscribeMock;
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
+  lastSubscribedListener = null;
   Object.defineProperty(window, "vex", {
     configurable: true,
     writable: true,
-    value: { mission: mockMissionBridge },
+    value: {
+      mission: mockMissionBridge,
+      engine: { onTranscriptAppend: onTranscriptAppendMock },
+    },
   });
 });
 
 afterEach(() => {
   Reflect.deleteProperty(window, "vex");
 });
+
+function sampleTranscriptEvent(sessionId: string) {
+  return {
+    type: "engine.transcript.append",
+    sessionId,
+    messageId: 1,
+    role: "assistant",
+    createdAt: "2026-05-21T10:00:00.000Z",
+    messageType: null,
+    correlationId: null,
+  };
+}
 
 function makeWrapper(client: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -360,5 +400,101 @@ describe("mission hook invalidations", () => {
     });
     expect(result.current.fetchStatus).toBe("idle");
     expect(mockMissionBridge.getRenewableSource).not.toHaveBeenCalled();
+  });
+});
+
+describe("useMissionLiveSync", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const SESSION_B = "00000000-0000-4000-8000-000000000002";
+
+  it("subscribes on mount and unsubscribes on unmount", () => {
+    const { client } = makeClient();
+    const { unmount } = renderHook(() => useMissionLiveSync(SESSION), {
+      wrapper: makeWrapper(client),
+    });
+    expect(lastSubscribedListener).not.toBeNull();
+    unmount();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops on null sessionId (no subscribe)", () => {
+    const { client } = makeClient();
+    renderHook(() => useMissionLiveSync(null), { wrapper: makeWrapper(client) });
+    expect(lastSubscribedListener).toBeNull();
+    expect(onTranscriptAppendMock).not.toHaveBeenCalled();
+  });
+
+  it("invalidates draft + diff for the session on a matching transcript-append event", () => {
+    const { client, invalidateSpy } = makeClient();
+    renderHook(() => useMissionLiveSync(SESSION), {
+      wrapper: makeWrapper(client),
+    });
+
+    lastSubscribedListener!(sampleTranscriptEvent(SESSION));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: missionKeys.draft(SESSION),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: missionKeys.diffsForSession(SESSION),
+    });
+  });
+
+  it("ignores events for a different session", () => {
+    const { client, invalidateSpy } = makeClient();
+    renderHook(() => useMissionLiveSync(SESSION), {
+      wrapper: makeWrapper(client),
+    });
+
+    lastSubscribedListener!(sampleTranscriptEvent(SESSION_B));
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("runs the 30s fallback poll while mounted (draft + diff, repeated ticks), stops after unmount", () => {
+    const { client, invalidateSpy } = makeClient();
+    const { unmount } = renderHook(() => useMissionLiveSync(SESSION), {
+      wrapper: makeWrapper(client),
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(MISSION_LIVE_FALLBACK_POLL_MS);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: missionKeys.draft(SESSION),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: missionKeys.diffsForSession(SESSION),
+    });
+    const callsAfterFirstTick = invalidateSpy.mock.calls.length;
+
+    act(() => {
+      vi.advanceTimersByTime(MISSION_LIVE_FALLBACK_POLL_MS);
+    });
+    expect(invalidateSpy.mock.calls.length).toBeGreaterThan(callsAfterFirstTick);
+
+    const callsAfterSecondTick = invalidateSpy.mock.calls.length;
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(MISSION_LIVE_FALLBACK_POLL_MS);
+    });
+    expect(invalidateSpy.mock.calls.length).toBe(callsAfterSecondTick);
+  });
+
+  it("mounts no interval handle for a null session (no leaked timer)", () => {
+    const { client, invalidateSpy } = makeClient();
+    renderHook(() => useMissionLiveSync(null), { wrapper: makeWrapper(client) });
+    act(() => {
+      vi.advanceTimersByTime(MISSION_LIVE_FALLBACK_POLL_MS * 2);
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
   });
 });

--- a/vex-app/src/renderer/lib/api/mission.ts
+++ b/vex-app/src/renderer/lib/api/mission.ts
@@ -12,8 +12,14 @@
  *
  * `useMissionDiff` query reader follows the same staleTime as
  * `useMissionDraft`.
+ *
+ * `useMissionLiveSync` (mission review-&-accept bar) keeps the draft + diff
+ * queries fresh the same way `useTranscriptLiveSync`/`useUsageLiveSync` do:
+ * event-driven invalidation on `engine.transcriptAppend` plus a 30s fallback
+ * poll, so a dropped IPC event can never strand the review bar invisible.
  */
 
+import { useEffect } from "react";
 import {
   queryOptions,
   useMutation,
@@ -155,6 +161,50 @@ export function useMissionResultForRun(
   walletAddress: string | null,
 ): UseQueryResult<Result<MissionGetResultForRunResult>> {
   return useQuery(missionResultForRunOptions(missionRunId ?? "", walletAddress ?? ""));
+}
+
+/**
+ * 30s fallback invalidation cadence for the mission draft/diff queries —
+ * mirrors `TRANSCRIPT_LIVE_FALLBACK_POLL_MS`/`USAGE_LIVE_FALLBACK_POLL_MS`.
+ * Exported for tests.
+ */
+export const MISSION_LIVE_FALLBACK_POLL_MS = 30_000;
+
+/**
+ * Keep a mission session's draft + diff queries fresh so the review-&-accept
+ * bar (and the MISSION badge) can never be stranded by a dropped
+ * `transcriptAppend` event: the agent's draft patches land via the same
+ * transcript writes the transcript/usage live-sync hooks already key off, so
+ * this mounts the identical two-layer refresh — event-driven invalidation +
+ * a 30s fallback poll. Pure side effect — mount once per active mission
+ * session (in `MissionControls`).
+ */
+export function useMissionLiveSync(sessionId: string | null): void {
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (sessionId === null || sessionId.length === 0) return;
+
+    const invalidate = (): void => {
+      void queryClient.invalidateQueries({
+        queryKey: missionKeys.draft(sessionId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: missionKeys.diffsForSession(sessionId),
+      });
+    };
+
+    const off = window.vex.engine.onTranscriptAppend((event) => {
+      if (event.sessionId !== sessionId) return;
+      invalidate();
+    });
+
+    const intervalId = window.setInterval(invalidate, MISSION_LIVE_FALLBACK_POLL_MS);
+
+    return () => {
+      off();
+      window.clearInterval(intervalId);
+    };
+  }, [sessionId, queryClient]);
 }
 
 // ── Mutations ───────────────────────────────────────────────────

--- a/vex-app/src/renderer/lib/api/queryKeys.ts
+++ b/vex-app/src/renderer/lib/api/queryKeys.ts
@@ -139,6 +139,14 @@ export const missionKeys = {
   diff: (sessionId: string, missionId: string) =>
     ["mission", "diff", sessionId, missionId] as const,
   /**
+   * Session-wide diff-invalidation prefix — matches every `diff(sessionId,
+   * missionId)` entry for a session regardless of which mission id is
+   * current (TanStack's default fuzzy `invalidateQueries` matching), so
+   * `useMissionLiveSync` can refresh the diff without knowing the active
+   * mission id. Mirrors `messagesKeys.forSession`.
+   */
+  diffsForSession: (sessionId: string) => ["mission", "diff", sessionId] as const,
+  /**
    * Puzzle 04 phase 7 — latest terminal accepted mission for
    * `/mission-renew`. Returns `{ missionId }` or null. Invalidated on
    * any mutation that may flip a mission to terminal (start, stop,

--- a/vex-app/src/renderer/stores/__tests__/uiStore.test.ts
+++ b/vex-app/src/renderer/stores/__tests__/uiStore.test.ts
@@ -30,6 +30,7 @@ function resetStoreToDefaults(): void {
     createSessionOpen: false,
     createSessionInitialMessage: null,
     pendingFirstMessage: null,
+    reviewModal: "none",
   });
 }
 
@@ -59,6 +60,23 @@ describe("uiStore", () => {
     expect(state.createSessionOpen).toBe(false);
     expect(state.createSessionInitialMessage).toBeNull();
     expect(state.pendingFirstMessage).toBeNull();
+    expect(state.reviewModal).toBe("none");
+  });
+
+  it("setReviewModal mutates and reflects new value, without persisting it", () => {
+    useUiStore.getState().setReviewModal("mission");
+    expect(useUiStore.getState().reviewModal).toBe("mission");
+    useUiStore.getState().setReviewModal("plan");
+    expect(useUiStore.getState().reviewModal).toBe("plan");
+    useUiStore.getState().setReviewModal("none");
+    expect(useUiStore.getState().reviewModal).toBe("none");
+    // UI-ephemeral — never in the persist whitelist (a relaunch always starts
+    // with no dialog open).
+    useUiStore.getState().setReviewModal("mission");
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.state.reviewModal).toBeUndefined();
   });
 
   it("setTheme + toggleTheme flip the persisted Robinhood-mode theme", () => {

--- a/vex-app/src/renderer/stores/uiStore.ts
+++ b/vex-app/src/renderer/stores/uiStore.ts
@@ -41,6 +41,17 @@ export type VexTheme = "vex" | "robinhood";
  */
 export type WorkspaceMode = "normal" | "hypervexing";
 
+/**
+ * Which mission/plan review dialog (if any) the DESK RULE header cluster
+ * (`MissionRail`) should show. Lifted out of `MissionRail`'s local state so a
+ * DIFFERENT component in a different tree branch — `MissionControls`' "Review
+ * & accept contract" bar, mounted in the session body, not the header — can
+ * open the same dialog `MissionRail` owns. UI-ephemeral, NOT persisted: a
+ * relaunch always starts with no dialog open. The single enum value keeps
+ * mission/plan mutual exclusion for free (setting one closes the other).
+ */
+export type ReviewModal = "none" | "mission" | "plan";
+
 export type View =
   | "splash"
   | "systemCheck"
@@ -146,6 +157,8 @@ interface UiState {
    * Pure UI preference: rows come from the markets query, this only stars.
    */
   readonly hlFavorites: readonly string[];
+  /** See `ReviewModal`. NOT persisted — see partialize. */
+  readonly reviewModal: ReviewModal;
   readonly setTheme: (value: VexTheme) => void;
   readonly toggleTheme: () => void;
   readonly setWorkspaceMode: (value: WorkspaceMode) => void;
@@ -170,6 +183,7 @@ interface UiState {
   ) => void;
   readonly setSigningState: (value: "idle" | "signing" | "signed") => void;
   readonly toggleHlFavorite: (coin: string) => void;
+  readonly setReviewModal: (value: ReviewModal) => void;
   readonly appendLog: (entry: UiLogEntry) => void;
   readonly clearLogs: () => void;
 }
@@ -194,6 +208,7 @@ export const useUiStore = create<UiState>()(
       signingState: "idle",
       reasoningEffortBySession: {},
       hlFavorites: [],
+      reviewModal: "none",
       setTheme: (theme) => set({ theme }),
       toggleTheme: () =>
         set((state) => ({ theme: state.theme === "vex" ? "robinhood" : "vex" })),
@@ -236,6 +251,7 @@ export const useUiStore = create<UiState>()(
             ? state.hlFavorites.filter((c) => c !== coin)
             : [...state.hlFavorites, coin],
         })),
+      setReviewModal: (reviewModal) => set({ reviewModal }),
       appendLog: (entry) =>
         set((state) => ({
           logBuffer: [...state.logBuffer, entry].slice(-MAX_RENDER_LOGS),


### PR DESCRIPTION
Accent-outlined 'Review & accept contract' bar in MissionControls (uiStore `reviewModal` enum opens the rail-owned dialog); `useMissionLiveSync` invalidates on transcript appends + a 30s fallback poll per repo convention. Unknown plan state is never readiness: rail badge and bar stay Preparing on pending/failed reads, the contract modal's header matches its blocked footer, and a failed/rejected plan read gets an explicit Retry. Reimplements the intent of #38 (mandatedisrael) with fallback-poll and unknown-state hardening — credit to the author for the discoverability diagnosis and the one-slot lifecycle design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)