### PR TITLE
fix(updates): keep toast actions inside the card (layout only)

### DIFF
--- a/vex-app/src/renderer/features/updates/UpdateToast.tsx
+++ b/vex-app/src/renderer/features/updates/UpdateToast.tsx
@@ -142,7 +142,7 @@ export function UpdateToast({
           </button>
         ) : null}
       </div>
-      <div className="mt-3 flex items-center justify-end gap-2">
+      <div className="mt-3 flex flex-wrap items-center justify-end gap-x-2 gap-y-1">
         {renderActions(status, {
           busy,
           onLater,
@@ -175,11 +175,21 @@ function renderActions(
     case "available":
       return (
         <>
-          <Button variant="link" size="sm" onClick={a.onReleaseNotes}>
+          <Button
+            variant="link"
+            size="sm"
+            className="mr-auto px-0"
+            onClick={a.onReleaseNotes}
+          >
             Release notes
           </Button>
           {!isCritical(status) ? (
-            <Button variant="ghost" size="sm" onClick={a.onLater}>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="px-2"
+              onClick={a.onLater}
+            >
               Later
             </Button>
           ) : null}
@@ -219,7 +229,12 @@ function renderActions(
     case "error":
       return (
         <>
-          <Button variant="link" size="sm" onClick={a.onReleaseNotes}>
+          <Button
+            variant="link"
+            size="sm"
+            className="mr-auto px-0"
+            onClick={a.onReleaseNotes}
+          >
             Open download page
           </Button>
           <Button size="sm" onClick={a.onTryAgain} disabled={a.busy}>

--- a/vex-app/src/renderer/features/updates/__tests__/UpdateToast.test.tsx
+++ b/vex-app/src/renderer/features/updates/__tests__/UpdateToast.test.tsx
@@ -88,6 +88,29 @@ describe("UpdateToast — available", () => {
     expect(screen.getByText("Release notes")).toBeTruthy();
   });
 
+  it("anchors Release notes left and strips its inherited horizontal padding", () => {
+    renderToast(AVAILABLE as ToastableUpdateStatus);
+    const releaseNotes = screen.getByText("Release notes");
+    expect(releaseNotes.className).toContain("mr-auto");
+    expect(releaseNotes.className).toContain("px-0");
+  });
+
+  it("compacts the Later secondary action's horizontal padding", () => {
+    renderToast(AVAILABLE as ToastableUpdateStatus);
+    const later = screen.getByText("Later");
+    expect(later.className).toContain("px-2");
+    expect(later.className).not.toContain("px-4");
+  });
+
+  it("keeps the action row on one line at standard toast width and wraps safely if narrower", () => {
+    renderToast(AVAILABLE as ToastableUpdateStatus);
+    const actionsRow = screen.getByText("Update now").parentElement;
+    expect(actionsRow).not.toBeNull();
+    expect(actionsRow?.className).toContain("flex-wrap");
+    expect(actionsRow?.className).toContain("gap-x-2");
+    expect(actionsRow?.className).toContain("gap-y-1");
+  });
+
   it("fires onUpdateNow / onLater / onReleaseNotes from their buttons", () => {
     const props = renderToast(AVAILABLE as ToastableUpdateStatus);
     fireEvent.click(screen.getByText("Update now"));
@@ -210,5 +233,12 @@ describe("UpdateToast — error", () => {
     expect(props.onTryAgain).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByText("Open download page"));
     expect(props.onReleaseNotes).toHaveBeenCalledTimes(1);
+  });
+
+  it("anchors Open download page left and strips its inherited horizontal padding", () => {
+    renderToast(ERROR as ToastableUpdateStatus);
+    const releaseLink = screen.getByText("Open download page");
+    expect(releaseLink.className).toContain("mr-auto");
+    expect(releaseLink.className).toContain("px-0");
   });
 });


### PR DESCRIPTION
Links anchor left with inherited padding stripped, compact secondary spacing holds one row at standard width, safe wrap below. Copy byte-identical — #36's wording change stays a separate product decision. Reimplements the layout portion of #36 (alexastro01) — credit to the author for the root-cause diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)