### PR TITLE
fix(hypervexing): smooth exit drain, focus handoff, earn-card clipping

### DIFF
--- a/vex-app/src/renderer/features/appShell/AppShell.tsx
+++ b/vex-app/src/renderer/features/appShell/AppShell.tsx
@@ -32,11 +32,13 @@
  * custom).
  */
 
-import type { JSX } from "react";
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { AnimatePresence } from "motion/react";
 import type { SkyTheme } from "./signalSkyShaders.js";
-import type { AppShellView } from "../../stores/uiStore.js";
+import type { AppShellView, WorkspaceMode } from "../../stores/uiStore.js";
 import { useUiStore } from "../../stores/uiStore.js";
 import { BookPanel } from "./BookPanel.js";
+import { shouldFocusComposerAfterWorkspaceExit } from "./composer-focus-handoff.js";
 import { DeskRuleTapeState } from "./DeskRuleTapeState.js";
 import { MissionRail } from "./MissionRail.js";
 import { useAutoCollapseBook } from "./useAutoCollapseBook.js";
@@ -72,12 +74,23 @@ export function AppShell(): JSX.Element {
   // first entry, always-available exit. The controller owns the ack-dialog gate
   // and turns each agent request into the right store transition.
   const workspace = useHypervexingWorkspace();
+  // Two distinct signals, deliberately not collapsed into one "inWorkspace"
+  // flag: `workspaceMode` (logical) gates whether the room is the child
+  // `AnimatePresence` is asked to keep present/exit; `visualWorkspaceMode`
+  // (lagged on exit until the drain finishes) gates everything the user
+  // SEES while that exit plays — theme, sky dimming, and whether the normal
+  // shell is allowed to mount (never alongside a still-draining room).
   const inWorkspace = workspace.workspaceMode === "hypervexing";
+  const visuallyInWorkspace = workspace.visualWorkspaceMode === "hypervexing";
 
-  // `data-vex-theme` is DERIVED: while the mode is active it reads
-  // "hypervexing"; otherwise it is the user's own persisted theme, so EXIT
-  // restores navy vs lime exactly. The mode never overwrites `theme`.
-  const derivedTheme: SkyTheme = deriveShellTheme(workspace.workspaceMode, theme);
+  // `data-vex-theme` is DERIVED: while the mode is visually active (including
+  // through the exit drain) it reads "hypervexing"; otherwise it is the
+  // user's own persisted theme, so EXIT restores navy vs lime exactly once
+  // the drain completes. The mode never overwrites `theme`.
+  const derivedTheme: SkyTheme = deriveShellTheme(
+    workspace.visualWorkspaceMode,
+    theme,
+  );
 
   // Stage F responsive: below ~1360px the three columns (sidebar + chat +
   // BOOK) no longer fit, so auto-collapse BOOK on the narrowing edge. One-way on
@@ -87,12 +100,39 @@ export function AppShell(): JSX.Element {
 
   // Sky intensity is derived from state AppShell already subscribes to —
   // full on welcome/idle (no active session, or a non-session sub-view),
-  // dimmed behind an active session transcript OR the Hypervexing chart. The
+  // dimmed behind an active session transcript OR the Hypervexing chart
+  // (including through its exit drain, alongside the theme above). The
   // uniform itself eases inside SignalSky, so this can flip freely.
   const skyIntensity =
-    inWorkspace || (activeSessionId !== null && appShellView === "session")
+    visuallyInWorkspace || (activeSessionId !== null && appShellView === "session")
       ? SKY_DIM_INTENSITY
       : 1;
+
+  // Focus handoff BACK to the normal chat composer once the exit drain
+  // completes (see SessionComposer's `focusRequest` doc). Detected as the one
+  // visual transition hypervexing → normal; reset the moment the composer
+  // reports it consumed the request, so an unrelated later composer mount
+  // never inherits a stale "focus me".
+  const previousVisualModeRef = useRef<WorkspaceMode>(
+    workspace.visualWorkspaceMode,
+  );
+  const [focusComposerOnReturn, setFocusComposerOnReturn] = useState(false);
+
+  useEffect(() => {
+    if (
+      shouldFocusComposerAfterWorkspaceExit(
+        previousVisualModeRef.current,
+        workspace.visualWorkspaceMode,
+      )
+    ) {
+      setFocusComposerOnReturn(true);
+    }
+    previousVisualModeRef.current = workspace.visualWorkspaceMode;
+  }, [workspace.visualWorkspaceMode]);
+
+  const handleComposerFocusHandled = useCallback((): void => {
+    setFocusComposerOnReturn(false);
+  }, []);
 
   return (
     // `relative isolate`: anchors the absolutely-positioned Signal Sky and
@@ -105,18 +145,33 @@ export function AppShell(): JSX.Element {
     >
       <SignalSky intensity={skyIntensity} theme={derivedTheme} />
 
-      {inWorkspace ? (
-        // The 5-zone trading room replaces the normal columns while active. It
-        // reuses the SAME SessionPanel (docked), so chat context is preserved
-        // and only ONE chat surface is ever mounted.
-        <HypervexingWorkspace onExit={workspace.exit} />
-      ) : (
+      {/* The 5-zone trading room replaces the normal columns while active. It
+       * reuses the SAME SessionPanel (docked), so chat context is preserved
+       * and only ONE chat surface is ever mounted. `AnimatePresence` lets the
+       * room's own declared exit animation actually play instead of the hard
+       * conditional unmounting it mid-drain (the #40 defect); `onExitComplete`
+       * releases `visualWorkspaceMode`, which is what gates the normal shell
+       * below — so it can never mount a second chat surface underneath a
+       * room still contracting away. */}
+      <AnimatePresence onExitComplete={workspace.onExitAnimationComplete}>
+        {inWorkspace ? (
+          <HypervexingWorkspace key="hypervexing-workspace" onExit={workspace.exit} />
+        ) : null}
+      </AnimatePresence>
+
+      {/* Hidden while EITHER signal says hypervexing: `inWorkspace` covers
+       * the instant of entry, `visuallyInWorkspace` covers the exit drain —
+       * the `||` is what guarantees this never mounts a second chat surface
+       * alongside a still-present (entering or still-exiting) room. */}
+      {inWorkspace || visuallyInWorkspace ? null : (
         <NormalShell
           appShellView={appShellView}
           activeSessionId={activeSessionId}
           bookOpen={bookOpen}
           toggleBook={toggleBook}
           onCreate={() => openCreateSession()}
+          focusComposerOnReturn={focusComposerOnReturn}
+          onComposerFocusHandled={handleComposerFocusHandled}
         />
       )}
 
@@ -148,12 +203,16 @@ function NormalShell({
   bookOpen,
   toggleBook,
   onCreate,
+  focusComposerOnReturn,
+  onComposerFocusHandled,
 }: {
   readonly appShellView: AppShellView;
   readonly activeSessionId: string | null;
   readonly bookOpen: boolean;
   readonly toggleBook: () => void;
   readonly onCreate: () => void;
+  readonly focusComposerOnReturn: boolean;
+  readonly onComposerFocusHandled: () => void;
 }): JSX.Element {
   return (
     <>
@@ -202,7 +261,10 @@ function NormalShell({
           ) : appShellView === "missionHistory" ? (
             <MissionHistory />
           ) : (
-            <SessionPanel />
+            <SessionPanel
+              focusRequest={focusComposerOnReturn}
+              onFocusRequestHandled={onComposerFocusHandled}
+            />
           )}
         </div>
       </section>

--- a/vex-app/src/renderer/features/appShell/SessionComposer.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionComposer.tsx
@@ -109,12 +109,24 @@ export interface SessionComposerProps {
    * and gating are identical in both variants.
    */
   readonly stage?: boolean;
+  /**
+   * Focus handoff BACK from Hypervexing: true for the render immediately
+   * after the shell's exit drain completes and this composer is the return
+   * target. The parent owns the "why" (an exit just happened); this
+   * component only reacts to the transition and reports it consumed via
+   * `onFocusRequestHandled` so the parent can reset it — otherwise a later,
+   * unrelated mount of this composer would inherit a stale "focus me" flag.
+   */
+  readonly focusRequest?: boolean;
+  readonly onFocusRequestHandled?: () => void;
 }
 
 export function SessionComposer({
   activeSession,
   activeSessionId,
   stage = false,
+  focusRequest = false,
+  onFocusRequestHandled,
 }: SessionComposerProps): JSX.Element {
   // Submit/enable gate on the canonical selected id (uiStore), NOT the
   // detail-query object: the engine ingress loads its own session context,
@@ -196,6 +208,15 @@ export function SessionComposer({
   useEffect(() => {
     setNotice(null);
   }, [sessionId]);
+
+  // Focus handoff back from Hypervexing (see the prop doc): react to the
+  // transition rather than mount, since this same instance can receive the
+  // request without remounting.
+  useEffect(() => {
+    if (!focusRequest) return;
+    textareaRef.current?.focus();
+    onFocusRequestHandled?.();
+  }, [focusRequest, onFocusRequestHandled]);
 
   // Reset the stop acknowledgment when the turn settles (success, error, or
   // the retry path re-arming) so the next turn starts from a clean Stop key.

--- a/vex-app/src/renderer/features/appShell/SessionPanel.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionPanel.tsx
@@ -60,10 +60,19 @@ export interface SessionPanelProps {
    * dock passes the mission badge cluster here so the panel stays mode-unaware.
    */
   readonly headerTrailing?: ReactNode;
+  /**
+   * Forwarded to the composer unchanged — see `SessionComposer`'s
+   * `focusRequest` doc. This panel stays agnostic to WHY a focus handoff is
+   * requested (e.g. returning from Hypervexing); it only threads the signal.
+   */
+  readonly focusRequest?: boolean;
+  readonly onFocusRequestHandled?: () => void;
 }
 
 export function SessionPanel({
   headerTrailing,
+  focusRequest,
+  onFocusRequestHandled,
 }: SessionPanelProps = {}): JSX.Element {
   const activeSessionId = useUiStore((s) => s.activeSessionId);
   // In the Hypervexing dock the composer is ALWAYS bottom-pinned (user
@@ -135,7 +144,13 @@ export function SessionPanel({
             live $VEX widget used to sit below the composer here; it moved to
             the sessions rail (SessionsList) to keep the welcome stage clean. */}
         <div className="vex-rise vex-rise-d2 relative z-10 mx-auto w-[min(680px,92%)] shrink-0">
-          <SessionComposer activeSession={null} activeSessionId={null} stage />
+          <SessionComposer
+            activeSession={null}
+            activeSessionId={null}
+            stage
+            focusRequest={focusRequest}
+            onFocusRequestHandled={onFocusRequestHandled}
+          />
         </div>
         {/* Trailing spacer — balances the hero zone above (vertical
             centering) and reserves the band the hero's absolute bottom row
@@ -221,6 +236,8 @@ export function SessionPanel({
             activeSession={activeSession}
             activeSessionId={activeSessionId}
             stage={isIdleSession}
+            focusRequest={focusRequest}
+            onFocusRequestHandled={onFocusRequestHandled}
           />
         </div>
         {/* Idle-stage trailing spacer — appears AFTER the composer wrapper so

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-focus-handoff.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-focus-handoff.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Focus handoff BACK to the composer after leaving Hypervexing
+ * (fix/hypervexing-exit-focus, item b). Same isolated `lib/api` mocking
+ * harness as composer-console.test.tsx.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useUiStore } from "../../../../stores/uiStore.js";
+
+vi.mock("@hugeicons/react", () => ({
+  HugeiconsIcon: () => null,
+}));
+
+vi.mock("@hugeicons/core-free-icons", () => ({
+  Add01Icon: "Add01Icon",
+  CheckmarkCircle02Icon: "CheckmarkCircle02Icon",
+  Download01Icon: "Download01Icon",
+  ArrowDown01Icon: "ArrowDown01Icon",
+  ArrowUp01Icon: "ArrowUp01Icon",
+  MapPinIcon: "MapPinIcon",
+  AiBrain05Icon: "AiBrain05Icon",
+  StopCircleIcon: "StopCircleIcon",
+  FireIcon: "FireIcon",
+  ChartLineData01Icon: "ChartLineData01Icon",
+  PercentSquareIcon: "PercentSquareIcon",
+}));
+
+const mockSubmitChat = {
+  isPending: false as boolean,
+  mutateAsync: vi.fn(),
+  stop: vi.fn(),
+};
+vi.mock("../../../../lib/api/chat.js", () => ({
+  useSubmitChat: () => mockSubmitChat,
+}));
+vi.mock("../../../../lib/api/messages.js", () => ({
+  useTranscriptInfinite: () => ({ data: undefined, isSuccess: false }),
+  flattenTranscriptPages: () => [],
+}));
+vi.mock("../../../../lib/api/runtime.js", () => ({
+  useRuntimeState: () => ({ data: { ok: true, data: { status: null } } }),
+}));
+vi.mock("../../../../lib/api/sessions.js", () => ({
+  useSessionPlan: () => ({
+    data: { ok: true, data: { enabled: false, planMd: "", accepted: false } },
+  }),
+  useSetPlanMode: () => ({ mutate: vi.fn(), isPending: false }),
+  useSessionModel: () => ({ data: undefined }),
+}));
+
+const { SessionComposer } = await import("../../SessionComposer.js");
+
+const SESSION = "00000000-0000-4000-8000-00000000cc02";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useUiStore.setState({
+    pendingFirstMessage: null,
+    createSessionInitialMessage: null,
+  });
+});
+
+describe("SessionComposer focusRequest", () => {
+  it("focuses the draft field and reports the request handled when focusRequest turns true", () => {
+    const onFocusRequestHandled = vi.fn();
+    const { rerender } = render(
+      <SessionComposer
+        activeSession={null}
+        activeSessionId={SESSION}
+        focusRequest={false}
+        onFocusRequestHandled={onFocusRequestHandled}
+      />,
+    );
+    const draft = screen.getByLabelText("Session draft");
+    expect(document.activeElement).not.toBe(draft);
+    expect(onFocusRequestHandled).not.toHaveBeenCalled();
+
+    rerender(
+      <SessionComposer
+        activeSession={null}
+        activeSessionId={SESSION}
+        focusRequest
+        onFocusRequestHandled={onFocusRequestHandled}
+      />,
+    );
+    expect(document.activeElement).toBe(draft);
+    expect(onFocusRequestHandled).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not steal focus or call the handler when focusRequest is absent", () => {
+    const onFocusRequestHandled = vi.fn();
+    render(
+      <SessionComposer
+        activeSession={null}
+        activeSessionId={SESSION}
+        onFocusRequestHandled={onFocusRequestHandled}
+      />,
+    );
+    const draft = screen.getByLabelText("Session draft");
+    fireEvent.blur(draft);
+    expect(document.activeElement).not.toBe(draft);
+    expect(onFocusRequestHandled).not.toHaveBeenCalled();
+  });
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionPanel-focus-handoff.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionPanel-focus-handoff.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * SessionPanel forwards the composer focus handoff unchanged
+ * (fix/hypervexing-exit-focus, item b) — to BOTH SessionComposer mount sites
+ * (welcome/no-session stage and the active-session tape), since either can be
+ * the render the shell returns to. SessionPanel itself stays agnostic to WHY
+ * a handoff was requested; this only protects the wiring.
+ *
+ * Heavy children are stubbed (same rationale as SessionPanel-approval.test.tsx)
+ * so this stays a focused wiring test.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Result } from "@shared/ipc/result.js";
+import type { SessionListItem } from "@shared/schemas/sessions.js";
+
+vi.mock("../../../lib/api/messages.js", () => ({
+  useTranscriptLiveSync: () => undefined,
+  useTranscriptInfinite: () => ({ data: undefined, isLoading: false }),
+  flattenTranscriptPages: () => [],
+}));
+vi.mock("../../../lib/api/usage.js", () => ({
+  useUsageLiveSync: () => undefined,
+}));
+vi.mock("../../../lib/api/streams.js", () => ({
+  useStreamPreviewSync: () => undefined,
+}));
+vi.mock("../../../lib/api/runtime.js", async (importActual) => {
+  const actual = await importActual<
+    typeof import("../../../lib/api/runtime.js")
+  >();
+  return {
+    ...actual,
+    useControlStateLiveSync: () => undefined,
+  };
+});
+vi.mock("../../../lib/api/sessions.js", async (importActual) => {
+  const actual = await importActual<
+    typeof import("../../../lib/api/sessions.js")
+  >();
+  return {
+    ...actual,
+    useSession: () => ({
+      data: {
+        ok: true,
+        data: {
+          id: SESSION,
+          mode: "agent",
+        } as unknown as SessionListItem, // test-local cast — render only checks wiring
+      } satisfies Result<SessionListItem>,
+      isLoading: false,
+    }),
+  };
+});
+vi.mock("../../../lib/api/approvals.js", () => ({
+  usePendingApprovals: () => ({ data: { ok: true, data: [] } }),
+  useApprove: () => ({ mutate: vi.fn(), isPending: false }),
+  useReject: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("../SessionContext.js", () => ({ SessionContext: () => null }));
+vi.mock("../SessionTranscript.js", () => ({ SessionTranscript: () => null }));
+vi.mock("../SessionWelcomeHero.js", () => ({ SessionWelcomeHero: () => null }));
+
+const composerProps = vi.fn();
+vi.mock("../SessionComposer.js", () => ({
+  SessionComposer: (props: unknown) => {
+    composerProps(props);
+    return null;
+  },
+}));
+
+const { SessionPanel } = await import("../SessionPanel.js");
+const { useUiStore } = await import("../../../stores/uiStore.js");
+
+const SESSION = "00000000-0000-4000-8000-00000000aa02";
+
+afterEach(() => {
+  useUiStore.setState({ activeSessionId: null });
+  vi.clearAllMocks();
+});
+
+function renderPanel(): void {
+  composerProps.mockClear();
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const onFocusRequestHandled = vi.fn();
+  render(
+    <QueryClientProvider client={qc}>
+      <SessionPanel
+        focusRequest
+        onFocusRequestHandled={onFocusRequestHandled}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+function lastComposerProps(): {
+  focusRequest?: boolean;
+  onFocusRequestHandled?: () => void;
+} {
+  expect(composerProps).toHaveBeenCalled();
+  return composerProps.mock.calls.at(-1)?.[0] as {
+    focusRequest?: boolean;
+    onFocusRequestHandled?: () => void;
+  };
+}
+
+describe("SessionPanel — composer focus handoff wiring", () => {
+  it("forwards focusRequest/onFocusRequestHandled unchanged to the active-session composer", () => {
+    useUiStore.setState({ activeSessionId: SESSION });
+    renderPanel();
+    const props = lastComposerProps();
+    expect(props.focusRequest).toBe(true);
+    expect(typeof props.onFocusRequestHandled).toBe("function");
+  });
+
+  it("forwards focusRequest/onFocusRequestHandled unchanged to the welcome-stage composer", () => {
+    useUiStore.setState({ activeSessionId: null });
+    renderPanel();
+    const props = lastComposerProps();
+    expect(props.focusRequest).toBe(true);
+    expect(typeof props.onFocusRequestHandled).toBe("function");
+  });
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/composer-focus-handoff.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/composer-focus-handoff.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure transition rule behind the composer focus handoff (fix/hypervexing-exit-focus,
+ * item b): the shell must hand focus back to the normal chat composer on the
+ * ONE visual transition where the Hypervexing exit drain just finished, and
+ * on no other render. Tested in isolation, no component mount required.
+ */
+
+import { describe, expect, it } from "vitest";
+import { shouldFocusComposerAfterWorkspaceExit } from "../composer-focus-handoff.js";
+
+describe("shouldFocusComposerAfterWorkspaceExit", () => {
+  it("requests focus exactly on the hypervexing → normal visual transition", () => {
+    expect(shouldFocusComposerAfterWorkspaceExit("hypervexing", "normal")).toBe(
+      true,
+    );
+  });
+
+  it("does not request focus while entering (normal → hypervexing)", () => {
+    expect(
+      shouldFocusComposerAfterWorkspaceExit("normal", "hypervexing"),
+    ).toBe(false);
+  });
+
+  it("does not request focus on a no-op re-render while normal", () => {
+    expect(shouldFocusComposerAfterWorkspaceExit("normal", "normal")).toBe(
+      false,
+    );
+  });
+
+  it("does not request focus while still draining (hypervexing → hypervexing)", () => {
+    expect(
+      shouldFocusComposerAfterWorkspaceExit("hypervexing", "hypervexing"),
+    ).toBe(false);
+  });
+});

--- a/vex-app/src/renderer/features/appShell/composer-focus-handoff.ts
+++ b/vex-app/src/renderer/features/appShell/composer-focus-handoff.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure transition rule for `AppShell`'s composer focus handoff
+ * (fix/hypervexing-exit-focus, item b): true exactly on the ONE visual
+ * transition that means "the Hypervexing exit drain just finished" — the
+ * moment the shell should hand focus back to the normal chat composer.
+ *
+ * Pulled out of `AppShell.tsx` (same reason as `composer-helpers.ts`): no
+ * React, no hooks, so the rule is unit-testable without mounting the shell's
+ * heavy import graph (SignalSky, the workspace panes, session lists, …).
+ */
+
+import type { WorkspaceMode } from "../../stores/uiStore.js";
+
+export function shouldFocusComposerAfterWorkspaceExit(
+  previousVisualMode: WorkspaceMode,
+  nextVisualMode: WorkspaceMode,
+): boolean {
+  return previousVisualMode === "hypervexing" && nextVisualMode === "normal";
+}

--- a/vex-app/src/renderer/features/appShell/workspace/HypervexingLeftColumn.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/HypervexingLeftColumn.tsx
@@ -71,7 +71,11 @@ function EarnCard({
 }): JSX.Element {
   const submit = useSubmitChat();
   return (
-    <div className="relative mx-3 mb-2 overflow-hidden rounded-lg bg-[var(--vex-surface-2)] p-3 transition-colors duration-150 hover:bg-[var(--vex-surface-2-up,var(--vex-surface-2))]">
+    // `shrink-0`: without it, this flex-col column's default flex-shrink
+    // compresses the card below its content height once the room's height is
+    // constrained — clipping the "Ask Vex" action instead of letting the
+    // column scroll to it (the aside below is already `overflow-y-auto`).
+    <div className="relative mx-3 mb-2 shrink-0 overflow-hidden rounded-lg bg-[var(--vex-surface-2)] p-3 transition-colors duration-150 hover:bg-[var(--vex-surface-2-up,var(--vex-surface-2))]">
       <HlLiquidVeil />
       <p className="relative text-[13px] font-semibold tracking-[0.01em] text-[var(--vex-text)]">
         {title}

--- a/vex-app/src/renderer/features/appShell/workspace/HypervexingTopBar.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/HypervexingTopBar.tsx
@@ -88,7 +88,11 @@ export function HypervexingTopBar({
   };
 
   return (
-    <header className="relative flex h-full items-center gap-4 px-4">
+    <header
+      aria-label="Hypervexing top bar"
+      aria-busy={exitPending}
+      className="relative flex h-full items-center gap-4 px-4"
+    >
       {/* The desk-rule accent tick, recolored to mint by token. */}
       <span
         aria-hidden

--- a/vex-app/src/renderer/features/appShell/workspace/HypervexingWorkspace.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/HypervexingWorkspace.tsx
@@ -14,6 +14,12 @@
  * (framer `useReducedMotion` here + the global keyframe-collapse rule for the
  * CSS `vex-rise` stagger). Only clip-path / opacity / transform animate — no
  * layout props, no blur (guard-compliant).
+ *
+ * Focus handoff (in): this component only ever mounts while the mode is
+ * active, so "on mount" IS "on enter" — the root lands an explicit `region`
+ * landmark (`tabIndex={-1}`, focused on mount) so a keyboard/screen-reader
+ * user is placed inside the room instead of stranded on whatever the shell
+ * unmounted underneath it.
  */
 
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type JSX } from "react";
@@ -142,9 +148,21 @@ export function HypervexingWorkspace({
   const motionProps = buildWorkspaceTransition(useReducedMotion() ?? false);
   const wideRoom = useWideRoom();
 
+  // Explicit focus handoff INTO the room on enter (a11y). This component
+  // mounts exactly when the mode activates, so a mount-only effect IS the
+  // "on enter" moment.
+  const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
   return (
     <motion.div
+      ref={containerRef}
       data-vex-hypervexing-workspace
+      role="region"
+      aria-label="Hypervexing trading room"
+      tabIndex={-1}
       className="absolute inset-0 z-10 grid gap-2.5 overflow-hidden p-2.5"
       style={wideRoom ? WIDE_GRID_STYLE : NARROW_GRID_STYLE}
       initial={motionProps.initial}

--- a/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingLeftColumn.test.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingLeftColumn.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Earn-card non-clip regression (fix/hypervexing-exit-focus, item c): jsdom
+ * does not lay out flexbox, so the CSS mechanism itself (`shrink-0` on the
+ * HLP vault / Staking cards, `overflow-y-auto` on the scrolling column) is
+ * the only testable proxy for "the Ask Vex action never clips, the column
+ * scrolls instead" — without it, the cards silently absorb flex-shrink and
+ * compress below their content height in a constrained room.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../lib/api/chat.js", () => ({
+  useSubmitChat: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("../../../../lib/api/usage.js", () => ({
+  useSessionUsageTotals: () => ({ data: undefined }),
+}));
+vi.mock("../../book/HyperliquidRiskBlock.js", () => ({
+  HyperliquidRiskProposalPanel: () => null,
+}));
+vi.mock("../HypervexingRiskSetup.js", () => ({
+  HypervexingRiskSetup: () => null,
+}));
+
+const { HypervexingLeftColumn } = await import("../HypervexingLeftColumn.js");
+
+const SESSION = "00000000-0000-4000-8000-000000000001";
+
+describe("HypervexingLeftColumn earn cards", () => {
+  it("keeps the HLP vault and Staking cards from flex-shrinking, and the column scrollable", () => {
+    render(
+      <HypervexingLeftColumn
+        account={null}
+        upnl={null}
+        sessionId={SESSION}
+        selectedCoin="BTC"
+      />,
+    );
+    const hlpCard = screen
+      .getByRole("button", { name: "Ask Vex about HLP" })
+      .closest("div");
+    const stakingCard = screen
+      .getByRole("button", { name: "Ask Vex about staking" })
+      .closest("div");
+    expect(hlpCard?.className).toContain("shrink-0");
+    expect(stakingCard?.className).toContain("shrink-0");
+
+    const column = screen.getByText("Account").closest("aside");
+    expect(column?.className).toContain("overflow-y-auto");
+  });
+});

--- a/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingTopBar.test.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingTopBar.test.tsx
@@ -16,3 +16,26 @@ describe("HypervexingTopBar exit authority", () => {
     await waitFor(() => expect(onExit).toHaveBeenCalledTimes(2));
   });
 });
+
+describe("HypervexingTopBar a11y", () => {
+  it("carries an accessible name and marks itself busy only while an exit is in flight", async () => {
+    // A mutable holder (not a reassigned `let`) — passing the closure that
+    // reassigns a bare `let` as a call argument confuses TS's control-flow
+    // narrowing into `never` at the later read (a known compiler quirk).
+    const pendingExit: { resolve: ((accepted: boolean) => void) | null } = {
+      resolve: null,
+    };
+    const onExit = vi.fn(
+      () => new Promise<boolean>((resolve) => { pendingExit.resolve = resolve; }),
+    );
+    render(<HypervexingTopBar positions={[]} account={null} onExit={onExit} />);
+    const header = screen.getByRole("banner", { name: "Hypervexing top bar" });
+    expect(header.getAttribute("aria-busy")).toBe("false");
+
+    fireEvent.click(screen.getByRole("button", { name: "Exit Hypervexing" }));
+    expect(header.getAttribute("aria-busy")).toBe("true");
+
+    pendingExit.resolve?.(true);
+    await waitFor(() => expect(header.getAttribute("aria-busy")).toBe("false"));
+  });
+});

--- a/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingWorkspace.a11y.test.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/__tests__/HypervexingWorkspace.a11y.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * Focus handoff INTO the room on enter (fix/hypervexing-exit-focus, item b):
+ * the root carries an explicit `region` landmark and grabs focus on mount —
+ * this component only ever mounts while the mode is active, so "on mount" IS
+ * "on enter". Heavy children are stubbed (same rationale as
+ * HypervexingWorkspace.selection.test.ts): this is an a11y/focus mount test,
+ * not a full room render.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("motion/react", () => ({ motion: { div: "div" }, useReducedMotion: () => true }));
+vi.mock("../../../../lib/api/hyperliquid.js", () => ({ useHyperliquidPositions: () => ({ data: undefined }) }));
+vi.mock("../../../../stores/uiStore.js", () => ({ useUiStore: () => null }));
+vi.mock("../HvZone.js", () => ({ HvZone: () => null }));
+vi.mock("../HypervexingBookPane.js", () => ({ HypervexingBookPane: () => null }));
+vi.mock("../HypervexingChartPane.js", () => ({ HypervexingChartPane: () => null }));
+vi.mock("../HypervexingCopilotDock.js", () => ({ HypervexingCopilotDock: () => null }));
+vi.mock("../HypervexingLeftColumn.js", () => ({ HypervexingLeftColumn: () => null }));
+vi.mock("../HypervexingTabs.js", () => ({ HypervexingTabs: () => null }));
+vi.mock("../HypervexingTopBar.js", () => ({ HypervexingTopBar: () => null }));
+
+const { HypervexingWorkspace } = await import("../HypervexingWorkspace.js");
+
+describe("HypervexingWorkspace focus handoff (enter)", () => {
+  it("declares a focusable landmark region and focuses it on mount", () => {
+    render(<HypervexingWorkspace onExit={vi.fn().mockResolvedValue(true)} />);
+    const region = screen.getByRole("region", { name: "Hypervexing trading room" });
+    expect(region.tabIndex).toBe(-1);
+    expect(document.activeElement).toBe(region);
+  });
+});

--- a/vex-app/src/renderer/features/appShell/workspace/__tests__/useHypervexingWorkspace.test.tsx
+++ b/vex-app/src/renderer/features/appShell/workspace/__tests__/useHypervexingWorkspace.test.tsx
@@ -154,6 +154,43 @@ describe("useHypervexingWorkspace", () => {
     await waitFor(() => expect(result.current.workspaceMode).toBe("hypervexing"));
   });
 
+  it("visualWorkspaceMode mirrors entry immediately", () => {
+    const { result } = renderHook(() => useHypervexingWorkspace(), { wrapper });
+    expect(result.current.visualWorkspaceMode).toBe("normal");
+    emit("hypervexing", true);
+    expect(result.current.workspaceMode).toBe("hypervexing");
+    expect(result.current.visualWorkspaceMode).toBe("hypervexing");
+  });
+
+  it("visualWorkspaceMode LAGS at hypervexing after exit until onExitAnimationComplete releases it", () => {
+    const { result } = renderHook(() => useHypervexingWorkspace(), { wrapper });
+    emit("hypervexing", true);
+    emit("normal", true);
+    // The logical flag already flipped (the store is exact truth for the
+    // AnimatePresence gate)...
+    expect(result.current.workspaceMode).toBe("normal");
+    // ...but the visual authority holds "hypervexing" until the shell reports
+    // the drain animation finished — this is what keeps the theme (and the
+    // single mounted chat surface) intact through the whole exit.
+    expect(result.current.visualWorkspaceMode).toBe("hypervexing");
+    act(() => {
+      result.current.onExitAnimationComplete();
+    });
+    expect(result.current.visualWorkspaceMode).toBe("normal");
+  });
+
+  it("re-entering before the drain completes cancels the lag immediately", () => {
+    const { result } = renderHook(() => useHypervexingWorkspace(), { wrapper });
+    emit("hypervexing", true);
+    emit("normal", true);
+    expect(result.current.visualWorkspaceMode).toBe("hypervexing");
+    // The agent asks back in before the previous exit's onExitAnimationComplete
+    // ever fires — visual stays (was already) hypervexing, no flicker.
+    emit("hypervexing", true);
+    expect(result.current.workspaceMode).toBe("hypervexing");
+    expect(result.current.visualWorkspaceMode).toBe("hypervexing");
+  });
+
   it("a late 'normal' mount read never overrides a fresher live push", async () => {
     let resolveRead: ((value: unknown) => void) | null = null;
     getWorkspaceMode.mockImplementation(

--- a/vex-app/src/renderer/features/appShell/workspace/useHypervexingWorkspace.ts
+++ b/vex-app/src/renderer/features/appShell/workspace/useHypervexingWorkspace.ts
@@ -11,6 +11,22 @@
  *
  * Exit is always available in-mode. Main remains the authority: `exit()` asks
  * main to change the active session and waits for its pushed `normal` event.
+ *
+ * `visualWorkspaceMode` is the shell's VISUAL authority, distinct from the
+ * store's logical `workspaceMode`: entering mirrors it on the next effect
+ * tick (one commit — imperceptible), but on exit it LAGS at "hypervexing"
+ * until the shell reports the drain animation finished
+ * (`onExitAnimationComplete`, wired to `AnimatePresence`'s `onExitComplete`).
+ * Without this lag the shell's hard render conditional unmounts the trading
+ * room — and flips its theme back — before the room's own declared exit
+ * animation ever gets to play (the #40 defect). The lag applies uniformly
+ * regardless of `prefers-reduced-motion`: that preference already shortens
+ * the drain itself (`workspaceTransition.ts`), so waiting for its completion
+ * reads as an instant swap. The normal shell never double-mounts alongside a
+ * still-present room on EITHER edge: the shell hides it on
+ * `workspaceMode === "hypervexing" || visualWorkspaceMode === "hypervexing"`
+ * (`AppShell.tsx`), so the one-tick entry lag on the visual flag is covered
+ * by the always-instant logical one.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -28,7 +44,13 @@ import {
 } from "./workspaceBridge.js";
 
 export interface HypervexingWorkspaceController {
+  /** Logical mode (the store's transient flag) — gates whether the trading
+   * room is the child AnimatePresence is asked to keep present/exit. */
   readonly workspaceMode: WorkspaceMode;
+  /** Visual mode — lags `workspaceMode` on exit until the drain animation
+   * completes. Gates theme, sky dimming, and the normal shell's mount so it
+   * never doubles up with the still-draining room. */
+  readonly visualWorkspaceMode: WorkspaceMode;
   /** The first-entry risk dialog is open (agent asked to enter, not yet acked). */
   readonly ackPending: boolean;
   /** The acknowledgment write is in flight. */
@@ -39,6 +61,9 @@ export interface HypervexingWorkspaceController {
   readonly cancelAck: () => void;
   /** In-mode EXIT: leave the mode (local flip + tell main). */
   readonly exit: () => Promise<boolean>;
+  /** Call once the shell's `AnimatePresence` reports the exit drain finished
+   * (its `onExitComplete`) — releases `visualWorkspaceMode` back to normal. */
+  readonly onExitAnimationComplete: () => void;
 }
 
 export function useHypervexingWorkspace(): HypervexingWorkspaceController {
@@ -48,6 +73,22 @@ export function useHypervexingWorkspace(): HypervexingWorkspaceController {
   const [ackPending, setAckPending] = useState(false);
   const acknowledge = useAcknowledgeHyperliquidRisk();
   const modeRead = useHyperliquidWorkspaceModeRead(activeSessionId);
+
+  // Visual mode: mirrors `workspaceMode` on enter (one effect tick); on exit
+  // it holds "hypervexing" until `onExitAnimationComplete` releases it (see
+  // the file docblock for why the lag exists, why it stays uniform across
+  // `prefers-reduced-motion`, and why the shell's OR-gate keeps either edge
+  // double-mount-safe).
+  const [visualWorkspaceMode, setVisualWorkspaceMode] =
+    useState<WorkspaceMode>(workspaceMode);
+
+  useEffect(() => {
+    if (workspaceMode === "hypervexing") setVisualWorkspaceMode("hypervexing");
+  }, [workspaceMode]);
+
+  const onExitAnimationComplete = useCallback((): void => {
+    setVisualWorkspaceMode("normal");
+  }, []);
 
   const applyAction = useCallback(
     (action: WorkspaceModeAction): void => {
@@ -118,10 +159,12 @@ export function useHypervexingWorkspace(): HypervexingWorkspaceController {
 
   return {
     workspaceMode,
+    visualWorkspaceMode,
     ackPending,
     ackSaving: acknowledge.isPending,
     confirmAck,
     cancelAck,
     exit,
+    onExitAnimationComplete,
   };
 }


### PR DESCRIPTION
AnimatePresence with a lagging `visualWorkspaceMode` lets the declared exit animation actually play, holding the trading-room theme through the drain (uniform onExitComplete wait incl. reduced motion) while preserving the single-chat-surface invariant; focus moves into the room on enter and back to the composer on exit; HLP vault/Staking cards no longer flex-shrink below content height. Salvages parts (a)+(b)+(c) of #40 (alexastro01) — credit to the author; the direct-entry feature remains rejected (entry stays agent-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)