### PR TITLE
feat(exit): venue-agnostic take-profit / stop-loss engine and position watch

### DIFF
--- a/src/__tests__/vex-agent/engine/exit/exit-rules.test.ts
+++ b/src/__tests__/vex-agent/engine/exit/exit-rules.test.ts
@@ -146,10 +146,13 @@ describe("evaluateExit — trailing stop", () => {
     expect(decisions).toEqual([]);
   });
 
+  // Price 2.5 is chosen so the two rules cannot be confused: it is at/below the
+  // trail (peak 4 − 25% = 3) but below the 3x take-profit rung, so only the
+  // trailing stop can explain a decision here.
   it("exits the remainder once armed and price falls the trail distance from peak", () => {
     const decisions = evaluateExit(
       position({ consumedRungs: [0], peakPriceUsd: 4 }),
-      3,
+      2.5,
       OPENED_AT,
       CONFIG,
     );
@@ -166,7 +169,7 @@ describe("evaluateExit — trailing stop", () => {
 
     const decisions = evaluateExit(
       position({ consumedRungs: [0], peakPriceUsd: 4 }),
-      3,
+      2.5,
       OPENED_AT,
       noTrail,
     );

--- a/src/__tests__/vex-agent/engine/exit/exit-rules.test.ts
+++ b/src/__tests__/vex-agent/engine/exit/exit-rules.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Pins the exit-rule engine's decision contract.
+ *
+ * `evaluateExit` is the pure core of the exit engine: given a position, a
+ * price, a clock reading (passed IN, never read here) and a static config, it
+ * returns the exit decisions that fire on this tick. It decides NOTHING about
+ * execution — a decision is a proposal, and every caller routes it through the
+ * app's existing approval path.
+ *
+ * Two invariants matter most and are asserted throughout:
+ *   - PURITY: same inputs → same output, no I/O, no Date.now, no randomness.
+ *   - TOTALITY: it never throws. Garbage price/entry, a malformed ladder, or a
+ *     fully-consumed position yields `[]` — a documented "do nothing" — so a
+ *     single bad price tick can never take down the watch loop that calls it.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateExit,
+  type ExitConfig,
+  type Position,
+} from "../../../../vex-agent/engine/exit/exit-rules.js";
+
+const MINUTE_MS = 60_000;
+const OPENED_AT = 1_700_000_000_000;
+
+/** Ladder: sell half at 2x, half at 3x. Stop 35%. Trail 25%. */
+const CONFIG: ExitConfig = {
+  takeProfitLadder: [
+    { multiple: 2, sellFraction: 0.5 },
+    { multiple: 3, sellFraction: 0.5 },
+  ],
+  stopLossPct: 0.35,
+  trailingStopPct: 0.25,
+  timeStopMinutes: 120,
+  timeStopFlatBandPct: 0.15,
+};
+
+function position(overrides: Partial<Position> = {}): Position {
+  return {
+    token: "0xtoken",
+    entryPriceUsd: 1,
+    amountTokens: 1_000,
+    peakPriceUsd: 1,
+    openedAtMs: OPENED_AT,
+    consumedRungs: [],
+    ...overrides,
+  };
+}
+
+describe("evaluateExit — take-profit ladder", () => {
+  it("fires the first rung when price reaches the 2x multiple", () => {
+    const decisions = evaluateExit(position(), 2, OPENED_AT, CONFIG);
+
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      kind: "take_profit",
+      rungIndex: 0,
+      sellFraction: 0.5,
+    });
+  });
+
+  it("does not re-fire a rung already recorded as consumed (idempotent)", () => {
+    const decisions = evaluateExit(
+      position({ consumedRungs: [0] }),
+      2,
+      OPENED_AT,
+      CONFIG,
+    );
+
+    expect(decisions).toEqual([]);
+  });
+
+  it("fires both rungs at once when a single tick jumps past the whole ladder", () => {
+    const decisions = evaluateExit(position(), 3.5, OPENED_AT, CONFIG);
+
+    expect(decisions.map((d) => d.rungIndex)).toEqual([0, 1]);
+    const total = decisions.reduce((sum, d) => sum + d.sellFraction, 0);
+    expect(total).toBeCloseTo(1);
+  });
+
+  it("never sells more than the position — cumulative fraction is clamped to 1", () => {
+    const greedy: ExitConfig = {
+      ...CONFIG,
+      takeProfitLadder: [
+        { multiple: 2, sellFraction: 0.8 },
+        { multiple: 3, sellFraction: 0.8 },
+      ],
+    };
+
+    const decisions = evaluateExit(position(), 5, OPENED_AT, greedy);
+    const total = decisions.reduce((sum, d) => sum + d.sellFraction, 0);
+
+    expect(total).toBeLessThanOrEqual(1);
+    expect(total).toBeCloseTo(1);
+  });
+
+  it("holds below the rung — a price just under 2x is a no-op", () => {
+    expect(evaluateExit(position(), 1.99, OPENED_AT, CONFIG)).toEqual([]);
+  });
+});
+
+describe("evaluateExit — stop-loss", () => {
+  it("exits the full remaining position once price crosses the stop", () => {
+    const decisions = evaluateExit(position(), 0.6, OPENED_AT, CONFIG);
+
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({ kind: "stop_loss", sellFraction: 1 });
+  });
+
+  it("fires exactly at the threshold price (inclusive boundary)", () => {
+    const decisions = evaluateExit(position(), 0.65, OPENED_AT, CONFIG);
+
+    expect(decisions[0]?.kind).toBe("stop_loss");
+  });
+
+  it("sells only what is left when part of the ladder is already consumed", () => {
+    const decisions = evaluateExit(
+      position({ consumedRungs: [0] }),
+      0.5,
+      OPENED_AT,
+      CONFIG,
+    );
+
+    expect(decisions[0]).toMatchObject({ kind: "stop_loss", sellFraction: 0.5 });
+  });
+
+  it("outranks take-profit — capital preservation wins a contradictory tick", () => {
+    const contradictory: ExitConfig = { ...CONFIG, stopLossPct: -1 };
+
+    const decisions = evaluateExit(position(), 2, OPENED_AT, contradictory);
+
+    expect(decisions[0]?.kind).toBe("stop_loss");
+  });
+});
+
+describe("evaluateExit — trailing stop", () => {
+  it("stays disarmed until the ladder is in profit", () => {
+    const decisions = evaluateExit(
+      position({ peakPriceUsd: 1.5 }),
+      1.1,
+      OPENED_AT,
+      CONFIG,
+    );
+
+    expect(decisions).toEqual([]);
+  });
+
+  it("exits the remainder once armed and price falls the trail distance from peak", () => {
+    const decisions = evaluateExit(
+      position({ consumedRungs: [0], peakPriceUsd: 4 }),
+      3,
+      OPENED_AT,
+      CONFIG,
+    );
+
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      kind: "trailing_stop",
+      sellFraction: 0.5,
+    });
+  });
+
+  it("is skipped entirely when trailingStopPct is not configured", () => {
+    const noTrail: ExitConfig = { ...CONFIG, trailingStopPct: undefined };
+
+    const decisions = evaluateExit(
+      position({ consumedRungs: [0], peakPriceUsd: 4 }),
+      3,
+      OPENED_AT,
+      noTrail,
+    );
+
+    expect(decisions).toEqual([]);
+  });
+});
+
+describe("evaluateExit — time stop", () => {
+  it("rotates out of a flat position once the dwell time elapses", () => {
+    const decisions = evaluateExit(
+      position(),
+      1.05,
+      OPENED_AT + 120 * MINUTE_MS,
+      CONFIG,
+    );
+
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({ kind: "time_stop", sellFraction: 1 });
+  });
+
+  it("holds a position that is old but has broken out of the flat band", () => {
+    const decisions = evaluateExit(
+      position(),
+      1.4,
+      OPENED_AT + 120 * MINUTE_MS,
+      CONFIG,
+    );
+
+    expect(decisions).toEqual([]);
+  });
+
+  it("holds a flat position that has not yet reached the dwell time", () => {
+    const decisions = evaluateExit(
+      position(),
+      1.05,
+      OPENED_AT + 10 * MINUTE_MS,
+      CONFIG,
+    );
+
+    expect(decisions).toEqual([]);
+  });
+});
+
+describe("evaluateExit — totality on bad data", () => {
+  it.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["zero", 0],
+    ["negative", -5],
+  ])("returns no decisions for a %s price rather than throwing", (_label, price) => {
+    expect(() => evaluateExit(position(), price, OPENED_AT, CONFIG)).not.toThrow();
+    expect(evaluateExit(position(), price, OPENED_AT, CONFIG)).toEqual([]);
+  });
+
+  it("returns no decisions when the entry price is missing or nonsensical", () => {
+    expect(evaluateExit(position({ entryPriceUsd: 0 }), 2, OPENED_AT, CONFIG)).toEqual([]);
+    expect(
+      evaluateExit(position({ entryPriceUsd: Number.NaN }), 2, OPENED_AT, CONFIG),
+    ).toEqual([]);
+  });
+
+  it("returns no decisions once the whole position has been sold", () => {
+    expect(evaluateExit(position({ consumedRungs: [0, 1] }), 5, OPENED_AT, CONFIG)).toEqual(
+      [],
+    );
+  });
+
+  it("ignores out-of-range, duplicate and non-integer consumed-rung indices", () => {
+    const decisions = evaluateExit(
+      position({ consumedRungs: [-1, 99, 1.5, 0, 0] }),
+      2,
+      OPENED_AT,
+      CONFIG,
+    );
+
+    // Only index 0 is a real consumed rung, so rung 0 must not re-fire and the
+    // bogus indices must not have eaten any of the remaining capacity.
+    expect(decisions).toEqual([]);
+    expect(
+      evaluateExit(position({ consumedRungs: [-1, 99, 1.5, 0, 0] }), 3, OPENED_AT, CONFIG),
+    ).toMatchObject([{ kind: "take_profit", rungIndex: 1, sellFraction: 0.5 }]);
+  });
+
+  it("survives an empty ladder and a fully malformed config", () => {
+    const empty: ExitConfig = {
+      takeProfitLadder: [],
+      stopLossPct: Number.NaN,
+      timeStopMinutes: Number.NaN,
+      timeStopFlatBandPct: Number.NaN,
+    };
+
+    expect(() => evaluateExit(position(), 2, OPENED_AT, empty)).not.toThrow();
+    expect(evaluateExit(position(), 2, OPENED_AT, empty)).toEqual([]);
+  });
+
+  it("skips ladder rungs whose multiple or fraction is not a real number", () => {
+    const malformed: ExitConfig = {
+      ...CONFIG,
+      takeProfitLadder: [
+        { multiple: Number.NaN, sellFraction: 0.5 },
+        { multiple: 2, sellFraction: Number.NaN },
+      ],
+    };
+
+    expect(evaluateExit(position(), 10, OPENED_AT, malformed)).toEqual([]);
+  });
+
+  it("is deterministic — repeated evaluation of one tick yields an identical result", () => {
+    const pos = position({ consumedRungs: [0], peakPriceUsd: 3 });
+    const first = evaluateExit(pos, 2.5, OPENED_AT + MINUTE_MS, CONFIG);
+    const second = evaluateExit(pos, 2.5, OPENED_AT + MINUTE_MS, CONFIG);
+
+    expect(first).toEqual(second);
+  });
+
+  it("does not mutate the position or config it is given", () => {
+    const pos = position({ consumedRungs: [0] });
+    const posSnapshot = structuredClone(pos);
+    const configSnapshot = structuredClone(CONFIG);
+
+    evaluateExit(pos, 3, OPENED_AT, CONFIG);
+
+    expect(pos).toEqual(posSnapshot);
+    expect(CONFIG).toEqual(configSnapshot);
+  });
+});

--- a/src/__tests__/vex-agent/engine/exit/watch-cycle.test.ts
+++ b/src/__tests__/vex-agent/engine/exit/watch-cycle.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Pins the per-tick watch orchestrator.
+ *
+ * `runWatchCycle` is the pure layer between the rule engine and any real
+ * polling loop: it refreshes each position's high-water peak, runs
+ * `evaluateExit` against it, and returns one alert per position describing
+ * what fired and which peak the caller should persist.
+ *
+ * The invariant that earns this its own module is FAULT ISOLATION: pricing is
+ * the flakiest input in the system, so a missing, garbage or *throwing* price
+ * lookup must degrade to a `price_unavailable` alert for that one token and
+ * leave every other position in the sweep untouched.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { ExitConfig } from "../../../../vex-agent/engine/exit/exit-rules.js";
+import {
+  runWatchCycle,
+  type WatchInputPosition,
+} from "../../../../vex-agent/engine/exit/watch-cycle.js";
+
+const NOW = 1_700_000_000_000;
+
+const CONFIG: ExitConfig = {
+  takeProfitLadder: [{ multiple: 2, sellFraction: 0.5 }],
+  stopLossPct: 0.35,
+  trailingStopPct: 0.25,
+  timeStopMinutes: 120,
+  timeStopFlatBandPct: 0.15,
+};
+
+function input(overrides: Partial<WatchInputPosition> = {}): WatchInputPosition {
+  return {
+    token: "0xtoken",
+    entryPriceUsd: 1,
+    amountTokens: 1_000,
+    openedAtMs: NOW,
+    consumedRungs: [],
+    priorPeakPriceUsd: 1,
+    ...overrides,
+  };
+}
+
+describe("runWatchCycle — peak tracking", () => {
+  it("ratchets the peak up when the new price exceeds the carried high-water mark", () => {
+    const [alert] = runWatchCycle([input()], () => 1.8, NOW, CONFIG);
+
+    expect(alert?.updatedPeakPriceUsd).toBe(1.8);
+    expect(alert?.currentPriceUsd).toBe(1.8);
+  });
+
+  it("keeps the carried peak when price falls back", () => {
+    const [alert] = runWatchCycle([input({ priorPeakPriceUsd: 4 })], () => 2.5, NOW, CONFIG);
+
+    expect(alert?.updatedPeakPriceUsd).toBe(4);
+  });
+});
+
+describe("runWatchCycle — decision surfacing", () => {
+  it("surfaces a take-profit decision when a rung is crossed", () => {
+    const [alert] = runWatchCycle([input()], () => 2, NOW, CONFIG);
+
+    expect(alert?.decisions).toMatchObject([{ kind: "take_profit", rungIndex: 0 }]);
+  });
+
+  it("surfaces a stop-loss decision when the stop is crossed", () => {
+    const [alert] = runWatchCycle([input()], () => 0.5, NOW, CONFIG);
+
+    expect(alert?.decisions).toMatchObject([{ kind: "stop_loss" }]);
+  });
+
+  it("reports an empty decision list when nothing fires", () => {
+    const [alert] = runWatchCycle([input()], () => 1.1, NOW, CONFIG);
+
+    expect(alert?.decisions).toEqual([]);
+    expect(alert?.note).toBeUndefined();
+  });
+
+  it("evaluates the rules against the REFRESHED peak, not the stale one", () => {
+    // Peak carried as 1, price spikes to 4, then the trailing stop is measured
+    // from 4 — so a same-tick price of 4 cannot itself trip the trail.
+    const [alert] = runWatchCycle(
+      [input({ consumedRungs: [0], priorPeakPriceUsd: 1 })],
+      () => 4,
+      NOW,
+      CONFIG,
+    );
+
+    expect(alert?.updatedPeakPriceUsd).toBe(4);
+    expect(alert?.decisions).toEqual([]);
+  });
+
+  it("returns one alert per position, in input order", () => {
+    const alerts = runWatchCycle(
+      [input({ token: "A" }), input({ token: "B" }), input({ token: "C" })],
+      () => 1.1,
+      NOW,
+      CONFIG,
+    );
+
+    expect(alerts.map((a) => a.token)).toEqual(["A", "B", "C"]);
+  });
+
+  it("returns nothing for an empty sweep", () => {
+    expect(runWatchCycle([], () => 1, NOW, CONFIG)).toEqual([]);
+  });
+});
+
+describe("runWatchCycle — price fault isolation", () => {
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["NaN", Number.NaN],
+    ["zero", 0],
+    ["negative", -1],
+  ])("degrades a %s price to a price_unavailable alert", (_label, price) => {
+    const [alert] = runWatchCycle(
+      [input({ priorPeakPriceUsd: 3 })],
+      () => price as number,
+      NOW,
+      CONFIG,
+    );
+
+    expect(alert).toMatchObject({
+      currentPriceUsd: null,
+      decisions: [],
+      note: "price_unavailable",
+      updatedPeakPriceUsd: 3,
+    });
+  });
+
+  it("does not let a throwing price lookup abort the sweep", () => {
+    const priceOf = vi.fn((token: string) => {
+      if (token === "B") throw new Error("provider down");
+      return 2;
+    });
+
+    const alerts = runWatchCycle(
+      [input({ token: "A" }), input({ token: "B" }), input({ token: "C" })],
+      priceOf,
+      NOW,
+      CONFIG,
+    );
+
+    expect(alerts).toHaveLength(3);
+    expect(alerts[1]).toMatchObject({ token: "B", note: "price_unavailable", decisions: [] });
+    // Neighbours still evaluated normally.
+    expect(alerts[0]?.decisions).toMatchObject([{ kind: "take_profit" }]);
+    expect(alerts[2]?.decisions).toMatchObject([{ kind: "take_profit" }]);
+  });
+
+  it("never proposes an exit on a stale position it could not price", () => {
+    const [alert] = runWatchCycle([input({ consumedRungs: [] })], () => null, NOW, CONFIG);
+
+    expect(alert?.decisions).toEqual([]);
+  });
+});

--- a/src/__tests__/vex-agent/engine/exit/watch-worker.test.ts
+++ b/src/__tests__/vex-agent/engine/exit/watch-worker.test.ts
@@ -192,6 +192,9 @@ describe("setupExitWatchWorker", () => {
     await vi.advanceTimersByTimeAsync(1_000);
     expect(getOpenPositions).toHaveBeenCalledTimes(2);
 
+    // Release tick 2 as well: teardown awaits the in-flight tick, so leaving it
+    // pending would hang stop() forever.
+    release?.();
     await stop();
   });
 

--- a/src/__tests__/vex-agent/engine/exit/watch-worker.test.ts
+++ b/src/__tests__/vex-agent/engine/exit/watch-worker.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Pins the exit-watch poll loop's sequencing and failure behaviour.
+ *
+ * The worker owns no business logic: every side effect (loading positions,
+ * pricing, emitting alerts, persisting peaks) is injected, and the wrapper only
+ * sequences them. It deliberately does NOT execute anything — `emitAlert` is
+ * the seam, and surfacing an alert is where this subsystem's responsibility
+ * ends.
+ *
+ * Loop discipline mirrors the existing regime worker: a non-reentrant
+ * `setTimeout` chain (never an overlapping `setInterval`), an immediate first
+ * tick, a tick that throws being routed to `onError` rather than killing the
+ * loop, and an idempotent teardown that awaits an in-flight tick.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ExitConfig } from "../../../../vex-agent/engine/exit/exit-rules.js";
+import type { WatchInputPosition } from "../../../../vex-agent/engine/exit/watch-cycle.js";
+import {
+  runExitWatchTick,
+  setupExitWatchWorker,
+  type ExitWatchWorkerDeps,
+} from "../../../../vex-agent/engine/exit/watch-worker.js";
+
+const NOW = 1_700_000_000_000;
+
+const CONFIG: ExitConfig = {
+  takeProfitLadder: [{ multiple: 2, sellFraction: 0.5 }],
+  stopLossPct: 0.35,
+  trailingStopPct: 0.25,
+  timeStopMinutes: 120,
+  timeStopFlatBandPct: 0.15,
+};
+
+const POSITION: WatchInputPosition = {
+  token: "0xtoken",
+  entryPriceUsd: 1,
+  amountTokens: 1_000,
+  openedAtMs: NOW,
+  consumedRungs: [],
+  priorPeakPriceUsd: 1,
+};
+
+function deps(overrides: Partial<ExitWatchWorkerDeps> = {}): ExitWatchWorkerDeps {
+  return {
+    getOpenPositions: vi.fn().mockResolvedValue([POSITION]),
+    priceOf: vi.fn().mockReturnValue(2),
+    emitAlert: vi.fn(),
+    savePeak: vi.fn(),
+    config: CONFIG,
+    now: () => NOW,
+    ...overrides,
+  };
+}
+
+describe("runExitWatchTick", () => {
+  it("loads positions, evaluates them, then emits and persists per position", async () => {
+    const d = deps();
+
+    const alerts = await runExitWatchTick(d);
+
+    expect(d.getOpenPositions).toHaveBeenCalledTimes(1);
+    expect(alerts).toHaveLength(1);
+    expect(d.emitAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "0xtoken",
+        decisions: [expect.objectContaining({ kind: "take_profit" })],
+      }),
+    );
+    expect(d.savePeak).toHaveBeenCalledWith("0xtoken", 2);
+  });
+
+  it("emits an alert carrying no decisions when nothing fires", async () => {
+    const d = deps({ priceOf: vi.fn().mockReturnValue(1.1) });
+
+    await runExitWatchTick(d);
+
+    expect(d.emitAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ decisions: [] }),
+    );
+  });
+
+  it("uses the injected clock rather than the ambient wall clock", async () => {
+    const now = vi.fn().mockReturnValue(NOW);
+    await runExitWatchTick(deps({ now }));
+
+    expect(now).toHaveBeenCalled();
+  });
+
+  it("keeps sweeping when one savePeak fails, routing the error to onError", async () => {
+    const savePeak = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("db down"))
+      .mockResolvedValue(undefined);
+    const onError = vi.fn();
+    const emitAlert = vi.fn();
+
+    await runExitWatchTick(
+      deps({
+        getOpenPositions: vi
+          .fn()
+          .mockResolvedValue([
+            { ...POSITION, token: "A" },
+            { ...POSITION, token: "B" },
+          ]),
+        savePeak,
+        onError,
+        emitAlert,
+      }),
+    );
+
+    expect(emitAlert).toHaveBeenCalledTimes(2);
+    expect(savePeak).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing but return when there are no open positions", async () => {
+    const d = deps({ getOpenPositions: vi.fn().mockResolvedValue([]) });
+
+    await expect(runExitWatchTick(d)).resolves.toEqual([]);
+    expect(d.emitAlert).not.toHaveBeenCalled();
+    expect(d.savePeak).not.toHaveBeenCalled();
+  });
+});
+
+describe("setupExitWatchWorker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs a first tick immediately without waiting for the interval", async () => {
+    const d = deps();
+    const stop = setupExitWatchWorker(d);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(d.getOpenPositions).toHaveBeenCalledTimes(1);
+    await stop();
+  });
+
+  it("keeps ticking on the configured cadence", async () => {
+    const d = deps({ pollMs: 1_000 });
+    const stop = setupExitWatchWorker(d);
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(d.getOpenPositions).toHaveBeenCalledTimes(3);
+    await stop();
+  });
+
+  it("survives a throwing tick and reports it to onError", async () => {
+    const onError = vi.fn();
+    const getOpenPositions = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("load failed"))
+      .mockResolvedValue([POSITION]);
+
+    const stop = setupExitWatchWorker(deps({ pollMs: 1_000, getOpenPositions, onError }));
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(getOpenPositions).toHaveBeenCalledTimes(2);
+
+    await stop();
+  });
+
+  it("never overlaps ticks — a slow tick delays the next one", async () => {
+    let release: (() => void) | undefined;
+    const getOpenPositions = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve([]);
+        }),
+    );
+
+    const stop = setupExitWatchWorker(deps({ pollMs: 1_000, getOpenPositions }));
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Tick 1 is still in flight; advancing well past the interval must not
+    // start a second one.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(getOpenPositions).toHaveBeenCalledTimes(1);
+
+    release?.();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(getOpenPositions).toHaveBeenCalledTimes(2);
+
+    await stop();
+  });
+
+  it("stops cleanly and is safe to call twice", async () => {
+    const d = deps({ pollMs: 1_000 });
+    const stop = setupExitWatchWorker(d);
+    await vi.advanceTimersByTimeAsync(0);
+
+    await stop();
+    await stop();
+
+    const callsAfterStop = (d.getOpenPositions as ReturnType<typeof vi.fn>).mock.calls.length;
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(d.getOpenPositions).toHaveBeenCalledTimes(callsAfterStop);
+  });
+});

--- a/src/vex-agent/engine/exit/exit-rules.ts
+++ b/src/vex-agent/engine/exit/exit-rules.ts
@@ -1,0 +1,278 @@
+/**
+ * Exit rules — pure, deterministic take-profit / stop-loss decision engine.
+ *
+ * Given an open position, the current price, the current wall-clock (passed
+ * IN — never read here) and a static exit config, `evaluateExit` returns the
+ * exit decisions that fire on this tick.
+ *
+ * SCOPE. This module proposes; it does not act. A decision is a *description*
+ * of an exit that the configured rules say is now due. Turning one into an
+ * order is the caller's job, and every such caller is expected to route it
+ * through the app's existing approval path rather than acting on it directly.
+ * Nothing here touches a wallet, a signer, a venue or the database.
+ *
+ * WHY LOCAL RULES. Venue-native bracket orders already cover Hyperliquid perps
+ * (`src/tools/hyperliquid/exchange.ts` attaches reduce-only `tpsl` children at
+ * entry). Spot/AMM holdings have no such venue-side trigger: once a swap
+ * settles, nothing is watching it. This engine is the venue-agnostic half —
+ * it works off a price and a cost basis, so it applies anywhere a position can
+ * be priced.
+ *
+ * Design constraints, each asserted by tests:
+ *   - PURE: no I/O, no Date.now(), no randomness. Same inputs → same output,
+ *     and neither the position nor the config is mutated.
+ *   - TOTAL: it never throws. A non-finite or non-positive price or entry, a
+ *     malformed ladder, or a fully-consumed position all yield `[]` — a
+ *     documented "do nothing" rather than a crash — so one bad price tick can
+ *     never take down the loop that calls it.
+ *
+ * Rule priority (capital preservation first):
+ *   1. stop_loss     — decisive full exit of the remaining position.
+ *   2. trailing_stop — full exit, but only once the ladder is in profit
+ *                      (at least one take-profit rung consumed).
+ *   3. take_profit   — partial exits per crossed ladder rung; several rungs
+ *                      may fire on one tick; the cumulative sold fraction is
+ *                      clamped so it can never exceed the whole position.
+ *   4. time_stop     — flat-and-dead rotation, only if nothing above fired.
+ *
+ * Fractions are always expressed relative to the ORIGINAL position size, so a
+ * caller holding a cost-basis ledger (see `proj_pnl_lots`) can mark rungs
+ * consumed and subtract fractions without re-deriving token amounts.
+ */
+
+export interface Position {
+  /** Token address or symbol — an opaque id, never parsed here. */
+  readonly token: string;
+  /** Cost basis per token, USD. Must be > 0 for any rule to fire. */
+  readonly entryPriceUsd: number;
+  /** Current holding size in tokens. */
+  readonly amountTokens: number;
+  /** Running high-water price seen since entry (>= entryPriceUsd). */
+  readonly peakPriceUsd: number;
+  /** Epoch ms when the position opened. */
+  readonly openedAtMs: number;
+  /** Indices of ladder rungs already sold — this is what makes exits idempotent. */
+  readonly consumedRungs: readonly number[];
+}
+
+export interface TakeProfitRung {
+  /** Price multiple vs entry that arms this rung (e.g. 2 = +100%). */
+  readonly multiple: number;
+  /** Fraction (0..1) of the ORIGINAL position to sell at this rung. */
+  readonly sellFraction: number;
+}
+
+export interface ExitConfig {
+  /** Take-profit ladder, ascending by `multiple`. */
+  readonly takeProfitLadder: readonly TakeProfitRung[];
+  /** Fractional drawdown from entry that triggers a full stop (e.g. 0.35). */
+  readonly stopLossPct: number;
+  /**
+   * Fractional drawdown from peak that trails out the remainder once the
+   * ladder is in profit. Omitted / undefined disables trailing entirely.
+   */
+  readonly trailingStopPct?: number;
+  /** Minutes of flat-and-dead price action before a time-stop rotation. */
+  readonly timeStopMinutes: number;
+  /** Half-width of the "flat" band around entry (e.g. 0.15 = ±15%). */
+  readonly timeStopFlatBandPct: number;
+}
+
+export type ExitReasonKind = "stop_loss" | "trailing_stop" | "take_profit" | "time_stop";
+
+export interface ExitDecision {
+  readonly kind: ExitReasonKind;
+  /** Fraction of the ORIGINAL position this rule says to sell now, in (0..1]. */
+  readonly sellFraction: number;
+  /** Set for take_profit so the caller can mark the rung consumed. */
+  readonly rungIndex?: number;
+  /** Human-readable explanation, e.g. "Hit +100% take-profit rung (2x)". */
+  readonly reason: string;
+}
+
+/** True for a real, strictly-positive number. */
+function isPositiveFinite(n: number): boolean {
+  return Number.isFinite(n) && n > 0;
+}
+
+/**
+ * The ladder as a safe array. Types are compile-time only and this module is
+ * load-bearing for a background loop, so a config that arrives malformed at
+ * runtime degrades to "no ladder" instead of throwing on iteration.
+ */
+function ladderOf(config: ExitConfig): readonly TakeProfitRung[] {
+  return Array.isArray(config.takeProfitLadder) ? config.takeProfitLadder : [];
+}
+
+/** The consumed-rung indices as a safe array, for the same reason. */
+function consumedRungsOf(position: Position): readonly number[] {
+  return Array.isArray(position.consumedRungs) ? position.consumedRungs : [];
+}
+
+/**
+ * Fraction of the ORIGINAL position already sold, summed from the ladder
+ * sellFractions at the consumed rung indices. Out-of-range, duplicate and
+ * non-integer indices are ignored so a malformed `consumedRungs` cannot
+ * corrupt the remaining-capacity math.
+ */
+function consumedFraction(position: Position, config: ExitConfig): number {
+  const ladder = ladderOf(config);
+  const seen = new Set<number>();
+  let total = 0;
+
+  for (const idx of consumedRungsOf(position)) {
+    if (!Number.isInteger(idx) || idx < 0 || idx >= ladder.length || seen.has(idx)) {
+      continue;
+    }
+    const rung = ladder[idx];
+    if (rung === undefined) {
+      continue;
+    }
+    seen.add(idx);
+    if (Number.isFinite(rung.sellFraction) && rung.sellFraction > 0) {
+      total += rung.sellFraction;
+    }
+  }
+
+  return total;
+}
+
+/** Remaining sellable fraction of the original position, clamped to [0, 1]. */
+function remainingFraction(position: Position, config: ExitConfig): number {
+  const remaining = 1 - consumedFraction(position, config);
+  if (!Number.isFinite(remaining)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, remaining));
+}
+
+/**
+ * Decide which exits are due for `position` at `currentPriceUsd` and `nowMs`.
+ *
+ * Returns `[]` when nothing fires and when the inputs are unusable. Callers
+ * should treat a non-empty result as a proposal to be surfaced for approval,
+ * never as an instruction already authorised.
+ */
+export function evaluateExit(
+  position: Position,
+  currentPriceUsd: number,
+  nowMs: number,
+  config: ExitConfig,
+): ExitDecision[] {
+  // --- Defensive totality: a bad tick must never throw or over-sell. ---
+  if (!isPositiveFinite(currentPriceUsd) || !isPositiveFinite(position.entryPriceUsd)) {
+    return [];
+  }
+
+  const { entryPriceUsd } = position;
+  const remaining = remainingFraction(position, config);
+
+  // Nothing left to sell → no exit is meaningful.
+  if (remaining <= 0) {
+    return [];
+  }
+
+  // --- 1. stop_loss (highest priority: capital preservation). ---
+  if (Number.isFinite(config.stopLossPct)) {
+    const stopPrice = entryPriceUsd * (1 - config.stopLossPct);
+    if (currentPriceUsd <= stopPrice) {
+      const lossPct = (1 - currentPriceUsd / entryPriceUsd) * 100;
+      return [
+        {
+          kind: "stop_loss",
+          sellFraction: remaining,
+          reason: `Stop-loss hit: ${lossPct.toFixed(1)}% below entry (threshold ${(
+            config.stopLossPct * 100
+          ).toFixed(1)}%)`,
+        },
+      ];
+    }
+  }
+
+  // --- 2. trailing_stop: armed only once at least one rung is consumed. ---
+  if (
+    consumedRungsOf(position).length > 0 &&
+    config.trailingStopPct !== undefined &&
+    Number.isFinite(config.trailingStopPct) &&
+    isPositiveFinite(position.peakPriceUsd)
+  ) {
+    const trailPrice = position.peakPriceUsd * (1 - config.trailingStopPct);
+    if (currentPriceUsd <= trailPrice) {
+      const dropPct = (1 - currentPriceUsd / position.peakPriceUsd) * 100;
+      return [
+        {
+          kind: "trailing_stop",
+          sellFraction: remaining,
+          reason: `Trailing stop hit: ${dropPct.toFixed(1)}% below peak (threshold ${(
+            config.trailingStopPct * 100
+          ).toFixed(1)}%)`,
+        },
+      ];
+    }
+  }
+
+  // --- 3. take_profit: emit every newly-crossed rung, ascending, clamped. ---
+  const takeProfits: ExitDecision[] = [];
+  const consumed = new Set<number>(consumedRungsOf(position));
+  let cumulative = consumedFraction(position, config);
+
+  ladderOf(config).forEach((rung, index) => {
+    if (consumed.has(index)) {
+      return;
+    }
+    if (!Number.isFinite(rung.multiple) || !Number.isFinite(rung.sellFraction)) {
+      return;
+    }
+    if (currentPriceUsd < entryPriceUsd * rung.multiple) {
+      return;
+    }
+    const capacity = 1 - cumulative;
+    if (capacity <= 0) {
+      return; // Fully allocated — nothing left for this or any later rung.
+    }
+    const sellFraction = Math.min(rung.sellFraction, capacity);
+    if (sellFraction <= 0) {
+      return;
+    }
+    cumulative += sellFraction;
+    const gainPct = (rung.multiple - 1) * 100;
+    takeProfits.push({
+      kind: "take_profit",
+      sellFraction,
+      rungIndex: index,
+      reason: `Hit +${gainPct.toFixed(0)}% take-profit rung (${rung.multiple}x)`,
+    });
+  });
+
+  if (takeProfits.length > 0) {
+    return takeProfits;
+  }
+
+  // --- 4. time_stop: flat-and-dead rotation, only if nothing above fired. ---
+  if (
+    Number.isFinite(config.timeStopMinutes) &&
+    Number.isFinite(config.timeStopFlatBandPct) &&
+    Number.isFinite(nowMs) &&
+    Number.isFinite(position.openedAtMs)
+  ) {
+    const elapsedMs = nowMs - position.openedAtMs;
+    const bandDistance = Math.abs(currentPriceUsd / entryPriceUsd - 1);
+    if (
+      elapsedMs >= config.timeStopMinutes * 60_000 &&
+      bandDistance <= config.timeStopFlatBandPct
+    ) {
+      const driftPct = (currentPriceUsd / entryPriceUsd - 1) * 100;
+      return [
+        {
+          kind: "time_stop",
+          sellFraction: remaining,
+          reason: `Time-stop: flat ${driftPct.toFixed(
+            1,
+          )}% from entry after ${config.timeStopMinutes}m`,
+        },
+      ];
+    }
+  }
+
+  return [];
+}

--- a/src/vex-agent/engine/exit/watch-cycle.ts
+++ b/src/vex-agent/engine/exit/watch-cycle.ts
@@ -1,0 +1,127 @@
+/**
+ * Watch cycle — pure, deterministic per-tick orchestrator for the exit engine.
+ *
+ * Given the open positions, a price lookup, the current wall-clock (passed IN)
+ * and the static exit config, `runWatchCycle` produces one `WatchAlert` per
+ * position:
+ *   - refreshes the high-water peak (max of the carried peak and the new price);
+ *   - runs the pure `evaluateExit` rule engine against that refreshed peak;
+ *   - reports the decisions plus the peak the caller should persist.
+ *
+ * PURE and TOTAL by construction: no I/O, no Date.now, no randomness, and a
+ * missing or garbage price — or a `priceOf` that throws — degrades to a
+ * `price_unavailable` alert rather than an exception, so one bad token lookup
+ * can never abort the rest of the sweep. Pricing is the flakiest input in the
+ * system, which is why that isolation lives here rather than in the caller.
+ *
+ * This module decides NOTHING about money or execution. It surfaces alerts;
+ * what a caller does with one is out of scope, and is expected to go through
+ * the app's existing approval path.
+ */
+
+import {
+  evaluateExit,
+  type ExitConfig,
+  type ExitDecision,
+  type Position,
+} from "./exit-rules.js";
+
+export interface WatchInputPosition {
+  readonly token: string;
+  readonly entryPriceUsd: number;
+  readonly amountTokens: number;
+  readonly openedAtMs: number;
+  readonly consumedRungs: readonly number[];
+  /** High-water price carried from the last cycle (>= entry). */
+  readonly priorPeakPriceUsd: number;
+}
+
+export interface WatchAlert {
+  readonly token: string;
+  /** Peak the caller should persist for the next cycle. */
+  readonly updatedPeakPriceUsd: number;
+  /** Null when the price lookup missed or returned garbage. */
+  readonly currentPriceUsd: number | null;
+  /** Exit decisions that fired this tick; [] when nothing fires or price is missing. */
+  readonly decisions: ExitDecision[];
+  /** Diagnostic note, e.g. "price_unavailable". */
+  readonly note?: string;
+}
+
+/** True for a real, strictly-positive number. */
+function isPositiveFinite(n: number): boolean {
+  return Number.isFinite(n) && n > 0;
+}
+
+/**
+ * Resolve a price via `priceOf`, degrading EVERY failure mode to `null`: a
+ * thrown lookup, `null` / `undefined`, or a non-finite / non-positive number
+ * are all "unavailable".
+ */
+function safePrice(
+  priceOf: (token: string) => number | null | undefined,
+  token: string,
+): number | null {
+  let raw: number | null | undefined;
+  try {
+    raw = priceOf(token);
+  } catch {
+    return null;
+  }
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+  return isPositiveFinite(raw) ? raw : null;
+}
+
+/**
+ * Evaluate every open position once. Returns one alert per input position, in
+ * input order — including for positions that could not be priced, so a caller
+ * can distinguish "nothing fired" from "we did not look".
+ */
+export function runWatchCycle(
+  positions: readonly WatchInputPosition[],
+  priceOf: (token: string) => number | null | undefined,
+  nowMs: number,
+  config: ExitConfig,
+): WatchAlert[] {
+  const alerts: WatchAlert[] = [];
+
+  for (const input of positions) {
+    const price = safePrice(priceOf, input.token);
+
+    // Price missing or garbage → carry the peak unchanged, surface no decisions.
+    // Proposing an exit off a stale price is worse than proposing nothing.
+    if (price === null) {
+      alerts.push({
+        token: input.token,
+        updatedPeakPriceUsd: input.priorPeakPriceUsd,
+        currentPriceUsd: null,
+        decisions: [],
+        note: "price_unavailable",
+      });
+      continue;
+    }
+
+    // High-water refresh: the peak only ever ratchets up.
+    const updatedPeakPriceUsd = Math.max(input.priorPeakPriceUsd, price);
+
+    const position: Position = {
+      token: input.token,
+      entryPriceUsd: input.entryPriceUsd,
+      amountTokens: input.amountTokens,
+      peakPriceUsd: updatedPeakPriceUsd,
+      openedAtMs: input.openedAtMs,
+      consumedRungs: input.consumedRungs,
+    };
+
+    alerts.push({
+      token: input.token,
+      updatedPeakPriceUsd,
+      currentPriceUsd: price,
+      decisions: evaluateExit(position, price, nowMs, config),
+    });
+  }
+
+  return alerts;
+}

--- a/src/vex-agent/engine/exit/watch-worker.ts
+++ b/src/vex-agent/engine/exit/watch-worker.ts
@@ -1,0 +1,129 @@
+/**
+ * Exit-watch worker — thin polling wrapper around the pure `runWatchCycle`.
+ *
+ * This module owns NO business logic and does NO direct I/O: every side effect
+ * (loading open positions, pricing, alert emission, peak persistence) is
+ * supplied by the caller as an injected dependency. The wrapper only sequences
+ * them on a timer:
+ *
+ *   each tick →  getOpenPositions()
+ *             →  runWatchCycle(positions, priceOf, now, config)   [pure]
+ *             →  emitAlert(alert)              for each alert
+ *             →  savePeak(token, updatedPeak)  for each alert
+ *
+ * `emitAlert` is where this subsystem's responsibility ENDS. It is a
+ * notification seam, not an execution seam: the worker never places an order,
+ * signs anything, or touches a wallet. A caller that wants an alert to become
+ * a trade is expected to route it through the app's existing approval path,
+ * exactly as any other user-authorised trade — this module deliberately opens
+ * no second route.
+ *
+ * Loop discipline mirrors the engine's other workers (see
+ * `engine/regime/regime-worker.ts`): a non-reentrant `setTimeout` chain rather
+ * than an overlapping `setInterval`, an immediate first tick, and an
+ * idempotent teardown that awaits an in-flight tick. A tick that throws is
+ * swallowed and routed to the injected `onError`, so a single bad poll can
+ * never kill the loop. Peak persistence is best-effort per token: one failed
+ * `savePeak` does not skip the rest of the sweep.
+ *
+ * Not wired into app boot. Construction of the real dependencies — and the
+ * decision to run this at all — is left to whoever owns the product story for
+ * acting on an exit.
+ */
+
+import { runWatchCycle, type WatchAlert, type WatchInputPosition } from "./watch-cycle.js";
+import { type ExitConfig } from "./exit-rules.js";
+
+/** Default poll cadence — one exit sweep per 15s. */
+export const EXIT_WATCH_POLL_MS = 15_000;
+
+export interface ExitWatchWorkerDeps {
+  /** Load the currently-open positions to evaluate this tick. */
+  getOpenPositions: () => Promise<readonly WatchInputPosition[]>;
+  /** Current USD price for a token (sync); any failure degrades to unavailable. */
+  priceOf: (token: string) => number | null | undefined;
+  /** Surface one exit alert. Notification only — never execution. */
+  emitAlert: (alert: WatchAlert) => void | Promise<void>;
+  /** Persist the refreshed high-water peak for the next cycle. */
+  savePeak: (token: string, peakPriceUsd: number) => void | Promise<void>;
+  /** Static exit configuration (ladder, stops, time-stop). */
+  config: ExitConfig;
+  /** Poll interval in ms. Defaults to EXIT_WATCH_POLL_MS. */
+  pollMs?: number;
+  /** Wall-clock source, injectable for tests. Defaults to Date.now. */
+  now?: () => number;
+  /** Optional error sink; a throwing tick is swallowed and reported here. */
+  onError?: (err: unknown) => void;
+}
+
+/** Teardown handle — idempotent, awaits any in-flight tick. */
+export type ExitWatchTeardown = () => Promise<void>;
+
+/**
+ * Run ONE watch tick against the injected deps. Exported so the sequencing
+ * (load → cycle → emit → persist) can be asserted without timers. Errors from
+ * `getOpenPositions` / `emitAlert` propagate to the caller;
+ * `setupExitWatchWorker` is what turns them into `onError` calls.
+ */
+export async function runExitWatchTick(deps: ExitWatchWorkerDeps): Promise<WatchAlert[]> {
+  const now = deps.now ?? Date.now;
+  const positions = await deps.getOpenPositions();
+  const alerts = runWatchCycle(positions, deps.priceOf, now(), deps.config);
+
+  for (const alert of alerts) {
+    await deps.emitAlert(alert);
+    // Peak persistence is best-effort per token: never let one failure abort
+    // the rest of the sweep. A dropped peak self-heals on the next tick.
+    try {
+      await deps.savePeak(alert.token, alert.updatedPeakPriceUsd);
+    } catch (err: unknown) {
+      deps.onError?.(err);
+    }
+  }
+
+  return alerts;
+}
+
+/**
+ * Start the exit-watch poll loop and return an idempotent teardown fn.
+ *
+ * Non-reentrant `setTimeout` chain (never overlapping): the next tick is armed
+ * only after the current one settles, so a slow poll delays the next rather
+ * than stacking. Ticks that throw are caught and routed to `onError` so the
+ * loop survives transient failures. Teardown clears the timer and awaits any
+ * in-flight tick.
+ */
+export function setupExitWatchWorker(deps: ExitWatchWorkerDeps): ExitWatchTeardown {
+  const pollMs = deps.pollMs ?? EXIT_WATCH_POLL_MS;
+
+  let stopped = false;
+  let inFlight: Promise<unknown> | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const tick = async (): Promise<void> => {
+    try {
+      await runExitWatchTick(deps);
+    } catch (err: unknown) {
+      deps.onError?.(err);
+    }
+  };
+
+  const schedule = (): void => {
+    if (stopped) return;
+    inFlight = tick().finally(() => {
+      inFlight = null;
+      if (!stopped) timer = setTimeout(schedule, pollMs);
+    });
+  };
+
+  schedule();
+
+  return async function teardown(): Promise<void> {
+    stopped = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (inFlight) await inFlight;
+  };
+}


### PR DESCRIPTION
## The gap

Vex has no take-profit or stop-loss layer for spot/AMM positions today.

Hyperliquid perps are covered venue-side — `src/tools/hyperliquid/exchange.ts` attaches reduce-only `tpsl` children at entry, so the venue itself watches the position. A spot/AMM holding has no equivalent. Once a swap settles, **nothing is watching it**. There is no code path anywhere in the repo that re-examines an open spot position against a price.

The motivation is concrete rather than theoretical. In testing, a long unattended run halted on a provider error while holding an open position. The configured stop never fired, because no component existed whose job was to notice. The position was not mismanaged — it was *unmanaged*, and the architecture had no seam where management could have happened.

This PR adds that seam.

## Design

Three files under `src/vex-agent/engine/exit/`, layered so the decision logic is pure and every side effect is injected:

**`exit-rules.ts`** — `evaluateExit(position, price, nowMs, config)`, pure and total. Rule priority is capital-preservation first:

1. `stop_loss` — decisive full exit of the remaining position
2. `trailing_stop` — full exit, but armed only once the ladder is in profit (≥1 rung consumed)
3. `take_profit` — partial exits per crossed ladder rung; several rungs may fire on one tick, with the cumulative sold fraction clamped so it can never exceed the whole position
4. `time_stop` — flat-and-dead rotation, only if nothing above fired

Fractions are always relative to the **original** position size, so a caller holding a cost-basis ledger can mark rungs consumed and subtract fractions without re-deriving token amounts. Consumed-rung tracking is what makes repeated evaluation idempotent.

**`watch-cycle.ts`** — pure per-tick orchestrator. Refreshes the high-water peak (ratchets up only), evaluates, returns one alert per position in input order. A missing, garbage, or *throwing* price lookup degrades to a `price_unavailable` alert for that one token without aborting the sweep. Pricing is the flakiest input in the system, so that isolation lives here rather than being every caller's problem. Returning an alert even for unpriced positions lets a caller distinguish "nothing fired" from "we did not look."

**`watch-worker.ts`** — dependency-injected poll loop mirroring the conventions in `engine/regime/regime-worker.ts`: immediate first tick, non-reentrant `setTimeout` chain rather than an overlapping `setInterval`, ticks that throw routed to `onError` so one bad poll cannot kill the loop, and idempotent teardown that awaits any in-flight tick. It owns no business logic and does no direct I/O — positions, pricing, alert emission, and peak persistence are all injected.

## On the approval path — this proposes, it does not act

This is the part I most want reviewed, because it is a deliberate constraint rather than an unfinished edge.

You've previously deferred autonomous deadline-driven position closing, on the grounds that it belongs in a designed prepared-close flow with its own approval story. I agree, and this PR is built to respect that rather than route around it:

- **`emitAlert` is a notification seam, not an execution seam.** Nothing in these three files signs, orders, or touches a wallet, a venue, or the database.
- **No new autonomous liquidation path is introduced.** An `ExitDecision` is a *description* of an exit the configured rules say is now due. Turning one into a trade is the caller's job, and every such caller is expected to route it through the same approval path any user-authorized trade already uses.
- **The worker is deliberately not wired into boot.** Constructing the real dependencies — and deciding to run this at all — is left to whoever owns the product story for acting on an exit.

The intent is to land the measurement half now, so that when the prepared-close flow is designed, the rules and the watch loop already exist, are tested, and have no opinion about how approval works. If you'd prefer the worker omitted entirely and only the pure rules landed, that's a straightforward trim — say the word.

## Why it's generic

Written against stock upstream. No dependency on any fork-specific concept: no signal providers, no particular token, no chain- or venue-specific assumptions, no strategy-discipline config. The engine works off a price and a cost basis, so it applies anywhere a position can be priced. Token ids are opaque strings, never parsed.

The whole subsystem imports nothing outside itself except `vitest` in the tests — **no new dependencies**.

## Test coverage

51 cases across three files, written fail-first before the implementation existed.

`exit-rules.test.ts` — take-profit ladder (rung firing, idempotency on already-consumed rungs, multi-rung ticks, cumulative-fraction clamping), stop-loss priority and boundary conditions, trailing-stop arming, the flat-band time stop, and totality on garbage input: non-finite and non-positive prices, malformed ladders, out-of-range and non-integer consumed indices, fully-consumed positions. Each of these yields a documented no-op rather than a crash — a background loop must not be killable by one bad price tick.

`watch-cycle.test.ts` — fault isolation: missing, garbage, and throwing price lookups each degrade to `price_unavailable` for that token alone while the rest of the sweep completes. Peak-ratchet behavior.

`watch-worker.test.ts` — loop discipline only: immediate first tick, non-reentrancy, errors routed to `onError`, best-effort peak persistence, idempotent teardown. Never execution, because there is none.

## Verification

- `pnpm exec vitest run src/__tests__/vex-agent/engine/exit/` → **3 files, 51 tests, all passing**
- `pnpm run build` (root: `tsc` + `tsc-alias`) → **exit 0, clean**

`vex-app` lint was not run: this branch touches **zero** files under `vex-app/`, and that workspace's dependencies aren't installed in my worktree. Root build and tests both pass. CI will cover the rest.

---

Happy to split this differently, rename anything to match house conventions, or drop the worker and land only the pure rule engine — whichever fits your direction best.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

