### PR TITLE
fix(mission): enforce the hard deadline while a run is parked

### DIFF
--- a/src/__tests__/vex-agent/engine/wake/deadline-watchdog.test.ts
+++ b/src/__tests__/vex-agent/engine/wake/deadline-watchdog.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Deadline watchdog unit tests — the agent-INDEPENDENT hard-deadline path.
+ *
+ * The loop-boundary enforcer (turn-loop.ts) only fires while the turn loop is
+ * iterating. A PARKED run never reaches that boundary, so its box is never
+ * enforced until something resumes it (observed live: a 5-minute mission ran
+ * 1h20m). These tests pin the sweep that closes that gap.
+ *
+ * Pure `sweepMissionDeadlines(now, deps)` with injected fakes — no DB, mirroring
+ * the `wake/executor.ts` tick tests. Clock is an explicit `now` argument, so no
+ * fake timers are needed here.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  sweepMissionDeadlines,
+  type DeadlineWatchdogDeps,
+} from "../../../../vex-agent/engine/wake/deadline-watchdog.js";
+import type { MissionRun } from "../../../../vex-agent/db/repos/mission-runs.js";
+import type { MissionRunStatus } from "../../../../vex-agent/engine/types.js";
+import { PAUSED_RUN_STATUSES } from "../../../../vex-agent/engine/types.js";
+
+const START = "2026-07-19T10:00:00.000Z";
+const START_MS = Date.parse(START);
+/** 5-minute box — the live-repro mission's duration. */
+const BOX_MIN = 5;
+const DEADLINE_MS = START_MS + BOX_MIN * 60_000;
+
+function makeRun(overrides: Partial<MissionRun> = {}): MissionRun {
+  return {
+    id: "run-1",
+    missionId: "mission-1",
+    sessionId: "sess-1",
+    status: "paused_error",
+    startedAt: START,
+    endedAt: null,
+    lastCheckpointAt: null,
+    stopReason: null,
+    stopSummary: null,
+    stopEvidenceJson: null,
+    iterationCount: 3,
+    contractSnapshotJson: {
+      frozenMission: { draft: { durationMinutes: BOX_MIN } },
+    },
+    recoveredFromRunId: null,
+    errorRetryCount: 0,
+    autoRetryUnsafe: false,
+    ...overrides,
+  };
+}
+
+interface Harness {
+  deps: DeadlineWatchdogDeps;
+  casStopPastDeadline: ReturnType<typeof vi.fn>;
+  rejectPendingApprovals: ReturnType<typeof vi.fn>;
+  cancelPendingWakes: ReturnType<typeof vi.fn>;
+  setMissionFailed: ReturnType<typeof vi.fn>;
+  captureFinal: ReturnType<typeof vi.fn>;
+  emitControlState: ReturnType<typeof vi.fn>;
+  getLease: ReturnType<typeof vi.fn>;
+  /** Rows the fake DB currently holds, keyed by run id (drives CAS idempotency). */
+  statuses: Map<string, MissionRunStatus>;
+}
+
+function makeHarness(runs: MissionRun[]): Harness {
+  const statuses = new Map<string, MissionRunStatus>(
+    runs.map((r) => [r.id, r.status]),
+  );
+
+  // Fake CAS with the real contract: it only wins when the CURRENT status is in
+  // `fromStatuses`, and flipping is a one-way move to terminal. A second sweep
+  // (or a concurrent resume that already moved the row) therefore returns null.
+  const casStopPastDeadline = vi.fn(
+    async (runId: string, fromStatuses: readonly MissionRunStatus[]) => {
+      const current = statuses.get(runId);
+      if (current === undefined || !fromStatuses.includes(current)) return null;
+      statuses.set(runId, "failed");
+      return current;
+    },
+  );
+
+  const rejectPendingApprovals = vi.fn(async () => 0);
+  const cancelPendingWakes = vi.fn(async () => 0);
+  const setMissionFailed = vi.fn(async () => undefined);
+  const captureFinal = vi.fn(async () => undefined);
+  const emitControlState = vi.fn(async () => undefined);
+  const getLease = vi.fn(async () => null);
+
+  const deps: DeadlineWatchdogDeps = {
+    listCandidateRuns: async () =>
+      runs.filter((r) => {
+        const s = statuses.get(r.id)!;
+        return s === "running" || PAUSED_RUN_STATUSES.has(s);
+      }).map((r) => ({ ...r, status: statuses.get(r.id)! })),
+    resolveDeadlineMs: (run) =>
+      run.startedAt === "not-a-date" ? null : DEADLINE_MS,
+    getLease: getLease as unknown as DeadlineWatchdogDeps["getLease"],
+    casStopPastDeadline:
+      casStopPastDeadline as unknown as DeadlineWatchdogDeps["casStopPastDeadline"],
+    rejectPendingApprovals,
+    cancelPendingWakes,
+    setMissionFailed,
+    captureFinal,
+    emitControlState,
+  };
+
+  return {
+    deps,
+    casStopPastDeadline,
+    rejectPendingApprovals,
+    cancelPendingWakes,
+    setMissionFailed,
+    captureFinal,
+    emitControlState,
+    getLease,
+    statuses,
+  };
+}
+
+/** One second past the 5-minute box — the run is overdue. */
+const PAST_DUE = new Date(DEADLINE_MS + 1_000);
+/** One minute into the box — not yet due. */
+const NOT_DUE = new Date(START_MS + 60_000);
+
+describe("sweepMissionDeadlines — parked runs past the hard deadline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The core regression: EVERY parked arm must be enforced, not just the ones
+  // a resume happens to touch. `paused_error` is the live-repro state.
+  it.each(Array.from(PAUSED_RUN_STATUSES))(
+    "stops a past-deadline run parked in %s with deadline_reached",
+    async (parkedStatus) => {
+      const h = makeHarness([makeRun({ status: parkedStatus })]);
+
+      const outcomes = await sweepMissionDeadlines(PAST_DUE, h.deps);
+
+      expect(outcomes).toEqual([
+        { kind: "stopped", runId: "run-1", previousStatus: parkedStatus },
+      ]);
+      expect(h.casStopPastDeadline).toHaveBeenCalledTimes(1);
+      const [runId, fromStatuses, payload] = h.casStopPastDeadline.mock.calls[0];
+      expect(runId).toBe("run-1");
+      // Claim from the parked set only — never from `running`, so the CAS can
+      // never yank a row out from under a live loop.
+      expect([...fromStatuses].sort()).toEqual(
+        [...PAUSED_RUN_STATUSES].sort(),
+      );
+      expect(payload.stopReason).toBe("deadline_reached");
+      expect(h.statuses.get("run-1")).toBe("failed");
+    },
+  );
+
+  it("does not touch a parked run whose box has not expired yet", async () => {
+    const h = makeHarness([makeRun({ status: "paused_wake" })]);
+
+    const outcomes = await sweepMissionDeadlines(NOT_DUE, h.deps);
+
+    expect(outcomes).toEqual([{ kind: "skipped_not_due", runId: "run-1" }]);
+    expect(h.casStopPastDeadline).not.toHaveBeenCalled();
+    expect(h.setMissionFailed).not.toHaveBeenCalled();
+    expect(h.statuses.get("run-1")).toBe("paused_wake");
+  });
+
+  it("fails open when the run has no resolvable deadline", async () => {
+    const h = makeHarness([makeRun({ startedAt: "not-a-date" })]);
+
+    const outcomes = await sweepMissionDeadlines(PAST_DUE, h.deps);
+
+    expect(outcomes).toEqual([{ kind: "skipped_no_deadline", runId: "run-1" }]);
+    expect(h.casStopPastDeadline).not.toHaveBeenCalled();
+  });
+});
+
+describe("sweepMissionDeadlines — running runs and lease liveness", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips a past-deadline running run that still holds a LIVE lease", async () => {
+    // A live loop enforces its own deadline at the turn boundary — the watchdog
+    // must never race it.
+    const h = makeHarness([makeRun({ status: "running" })]);
+    h.getLease.mockResolvedValue({
+      expiresAt: new Date(PAST_DUE.getTime() + 30_000),
+    });
+
+    const outcomes = await sweepMissionDeadlines(PAST_DUE, h.deps);
+
+    expect(outcomes).toEqual([{ kind: "skipped_live_lease", runId: "run-1" }]);
+    expect(h.casStopPastDeadline).not.toHaveBeenCalled();
+    expect(h.statuses.get("run-1")).toBe("running");
+  });
+
+  it("stops a past-deadline GHOST run — status running, lease expired", async () => {
+    const h = makeHarness([makeRun({ status: "running" })]);
+    h.getLease.mockResolvedValue({
+      expiresAt: new Date(PAST_DUE.getTime() - 30_000),
+    });
+
+    const outcomes = await sweepMissionDeadlines(PAST_DUE, h.deps);
+
+    expect(outcomes).toEqual([
+      { kind: "stopped", runId: "run-1", previousStatus: "running" },
+    ]);
+    const [, fromStatuses] = h.casStopPastDeadline.mock.calls[0];
+    expect([...fromStatuses]).toEqual(["running"]);
+    expect(h.statuses.get("run-1")).toBe("failed");
+  });
+
+  it("stops a past-deadline running run with NO lease row at all", async () => {
+    const h = makeHarness([makeRun({ status: "running" })]);
+    h.getLease.mockResolvedValue(null);
+
+    const outcomes = await sweepMissionDeadlines(PAST_DUE, h.deps);
+
+    expect(outcomes).toEqual([
+      { kind: "stopped", runId: "run-1", previousStatus: "running" },
+    ]);
+  });
+});
+
+describe("sweepMissionDeadlines — idempotency and concurrency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is idempotent — a second sweep does not double-stop the same run", async () => {
+    const h = makeHarness([makeRun({ status: "paused_error" })]);
+
+    const first = await sweepMissionDeadlines(PAST_DUE, h.deps);
+    const second = await sweepMissionDeadlines(PAST_DUE, h.deps);
+
+    expect(first).toEqual([
+      { kind: "stopped", runId: "run-1", previousStatus: "paused_error" },
+    ]);
+    // The row is terminal now, so it is no longer a candidate at all.
+    expect(second).toEqual([]);
+    // Terminal side-effects fired exactly once.
+    expect(h.setMissionFailed).toHaveBeenCalledTimes(1);
+    expect(h.captureFinal).toHaveBeenCalledTimes(1);
+    expect(h.emitControlState).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops when a concurrent resume/loop-boundary stop won the CAS", async () => {
+    const h = makeHarness([makeRun({ status: "paused_error" })]);
+    // Simulate the row being claimed by another path between list and CAS.
+    h.casStopPastDeadline.mockResolvedValueOnce(null);
+
+    const outcomes = await sweepMissionDeadlines(PAST_DUE, h.deps);
+
+    expect(outcomes).toEqual([
+      { kind: "skipped_already_terminal", runId: "run-1" },
+    ]);
+    // CRITICAL: losing the CAS must skip ALL terminal side-effects, otherwise
+    // the ledger/mission row would be written twice.
+    expect(h.setMissionFailed).not.toHaveBeenCalled();
+    expect(h.captureFinal).not.toHaveBeenCalled();
+    expect(h.rejectPendingApprovals).not.toHaveBeenCalled();
+    expect(h.cancelPendingWakes).not.toHaveBeenCalled();
+  });
+
+  it("isolates a per-run failure so one bad row cannot poison the batch", async () => {
+    const h = makeHarness([
+      makeRun({ id: "run-bad", status: "paused_error" }),
+      makeRun({ id: "run-good", status: "paused_user" }),
+    ]);
+    h.casStopPastDeadline.mockImplementationOnce(async () => {
+      throw new Error("db exploded");
+    });
+
+    const outcomes = await sweepMissionDeadlines(PAST_DUE, h.deps);
+
+    expect(outcomes[0]).toEqual({
+      kind: "error",
+      runId: "run-bad",
+      message: "db exploded",
+    });
+    expect(outcomes[1]).toEqual({
+      kind: "stopped",
+      runId: "run-good",
+      previousStatus: "paused_user",
+    });
+  });
+});
+
+describe("sweepMissionDeadlines — stop side-effects", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects pending approvals and cancels pending wakes so the run cannot be resurrected", async () => {
+    // A swept `paused_approval` run leaves a pending approval_queue row; a swept
+    // `paused_error` run may have an auto-retry wake queued (upstream 28de53f6).
+    // Either would resume the now-terminal run.
+    const h = makeHarness([makeRun({ status: "paused_approval" })]);
+    h.rejectPendingApprovals.mockResolvedValue(2);
+    h.cancelPendingWakes.mockResolvedValue(1);
+
+    await sweepMissionDeadlines(PAST_DUE, h.deps);
+
+    expect(h.rejectPendingApprovals).toHaveBeenCalledWith("sess-1");
+    expect(h.cancelPendingWakes).toHaveBeenCalledWith("sess-1");
+  });
+
+  it("mirrors the loop-boundary terminal side-effects: mission failed + ledger close", async () => {
+    const h = makeHarness([makeRun({ status: "paused_wake" })]);
+
+    await sweepMissionDeadlines(PAST_DUE, h.deps);
+
+    expect(h.setMissionFailed).toHaveBeenCalledWith("mission-1");
+    expect(h.captureFinal).toHaveBeenCalledWith({
+      missionId: "mission-1",
+      runId: "run-1",
+      sessionId: "sess-1",
+      outcome: "failed",
+      stopReason: "deadline_reached",
+    });
+    expect(h.emitControlState).toHaveBeenCalledWith("sess-1", "run-1");
+  });
+
+  it("SURFACES an open position rather than closing it — auto-flatten stays deferred", async () => {
+    const h = makeHarness([makeRun({ status: "paused_error" })]);
+
+    await sweepMissionDeadlines(PAST_DUE, h.deps);
+
+    const payload = h.casStopPastDeadline.mock.calls[0][2];
+    expect(payload.evidence).toMatchObject({
+      enforcedWhileParked: true,
+      parkedStatus: "paused_error",
+      positionCloseDeferred: true,
+    });
+    // The operator-facing note must say the bag is still open.
+    expect(payload.summary).toMatch(/open/i);
+    // There is deliberately NO sell/close/liquidate dep on this surface.
+    expect(Object.keys(h.deps)).not.toContain("closePositions");
+  });
+});

--- a/src/__tests__/vex-agent/engine/wake/executor-surface.test.ts
+++ b/src/__tests__/vex-agent/engine/wake/executor-surface.test.ts
@@ -32,6 +32,7 @@ import type {
   WakeExecutorHandle,
   StartOptions,
 } from "../../../../vex-agent/engine/wake/executor.js";
+import type { DeadlineWatchdogDeps } from "../../../../vex-agent/engine/wake/deadline-watchdog.js";
 
 // Reference the type-only imports so the bindings are not elided as unused; the
 // assignment compiles only if the exported types are structurally as expected.
@@ -51,6 +52,27 @@ function makeDeps(overrides: Partial<WakeDeps> = {}): WakeDeps {
     injectWakeBanner: vi.fn().mockResolvedValue(undefined),
     resumeMissionRun: vi.fn().mockResolvedValue(undefined),
     isProviderReady: vi.fn(() => true),
+    ...overrides,
+  };
+}
+
+/**
+ * Deadline-watchdog deps for the sweep the executor now hosts. ALWAYS injected
+ * in these tests — the production factory would reach the real DB.
+ */
+function makeDeadlineDeps(
+  overrides: Partial<DeadlineWatchdogDeps> = {},
+): DeadlineWatchdogDeps {
+  return {
+    listCandidateRuns: vi.fn().mockResolvedValue([]),
+    resolveDeadlineMs: vi.fn(() => null),
+    getLease: vi.fn().mockResolvedValue(null),
+    casStopPastDeadline: vi.fn().mockResolvedValue(null),
+    rejectPendingApprovals: vi.fn().mockResolvedValue(0),
+    cancelPendingWakes: vi.fn().mockResolvedValue(0),
+    setMissionFailed: vi.fn().mockResolvedValue(undefined),
+    captureFinal: vi.fn().mockResolvedValue(undefined),
+    emitControlState: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -97,7 +119,12 @@ describe("startWakeExecutor — self-scheduling lifecycle (fake timers)", () => 
     const claimDue = vi.fn().mockReturnValueOnce(claimGate).mockResolvedValue([]);
     const deps = makeDeps({ claimDue });
 
-    const handle = startWakeExecutor({ intervalMs: 2000, batchSize: 5, deps });
+    const handle = startWakeExecutor({
+      intervalMs: 2000,
+      batchSize: 5,
+      deps,
+      deadlineDeps: makeDeadlineDeps(),
+    });
 
     // Nothing runs until the initial timeout fires.
     expect(claimDue).not.toHaveBeenCalled();
@@ -132,5 +159,79 @@ describe("startWakeExecutor — self-scheduling lifecycle (fake timers)", () => 
     // if a timer had been armed, advancing time triggers no further ticks.
     await vi.advanceTimersByTimeAsync(10_000);
     expect(claimDue).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The hard-deadline sweep rides this executor's existing timer rather than
+ * standing up a second subsystem. These pin the hosting contract.
+ */
+describe("startWakeExecutor — hosted deadline sweep (fake timers)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sweeps on the executor's timer, throttled to its own interval", async () => {
+    vi.useFakeTimers();
+    const deadlineDeps = makeDeadlineDeps();
+    const handle = startWakeExecutor({
+      intervalMs: 1000,
+      deps: makeDeps(),
+      deadlineDeps,
+      deadlineSweepIntervalMs: 5000,
+    });
+
+    // First executor tick sweeps immediately.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(deadlineDeps.listCandidateRuns).toHaveBeenCalledTimes(1);
+
+    // Three more 1s ticks fall inside the 5s sweep window — no extra sweeps.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(deadlineDeps.listCandidateRuns).toHaveBeenCalledTimes(1);
+
+    // Past the window → sweeps again.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(deadlineDeps.listCandidateRuns).toHaveBeenCalledTimes(2);
+
+    await handle.stop();
+  });
+
+  it("sweeps even when the inference provider is NOT ready", async () => {
+    // `tick` is provider-gated because resuming needs inference. Stopping does
+    // not — and an absent provider key is exactly what parks runs in
+    // paused_error, so gating the sweep would disable enforcement precisely
+    // when it matters.
+    vi.useFakeTimers();
+    const deadlineDeps = makeDeadlineDeps();
+    const claimDue = vi.fn().mockResolvedValue([]);
+    const handle = startWakeExecutor({
+      intervalMs: 1000,
+      deps: makeDeps({ claimDue, isProviderReady: vi.fn(() => false) }),
+      deadlineDeps,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(deadlineDeps.listCandidateRuns).toHaveBeenCalledTimes(1);
+    expect(claimDue).not.toHaveBeenCalled();
+
+    await handle.stop();
+  });
+
+  it("a sweep failure does not stop the wake tick from running", async () => {
+    vi.useFakeTimers();
+    const claimDue = vi.fn().mockResolvedValue([]);
+    const handle = startWakeExecutor({
+      intervalMs: 1000,
+      deps: makeDeps({ claimDue }),
+      deadlineDeps: makeDeadlineDeps({
+        listCandidateRuns: vi.fn().mockRejectedValue(new Error("db down")),
+      }),
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(claimDue).toHaveBeenCalledTimes(1);
+
+    await handle.stop();
   });
 });

--- a/src/vex-agent/db/repos/mission-runs.ts
+++ b/src/vex-agent/db/repos/mission-runs.ts
@@ -353,11 +353,14 @@ export async function casStopPastDeadline(
       "SELECT status FROM mission_runs WHERE id = $1 FOR UPDATE",
       [runId],
     );
-    if (lockRow.rowCount === 0) {
+    // Destructure rather than index — `rows[0]` is `T | undefined` under the
+    // app's stricter `noUncheckedIndexedAccess` tsconfig.
+    const locked = lockRow.rows[0];
+    if (locked === undefined) {
       await client.query("ROLLBACK");
       return null;
     }
-    const prev = coerceStatus(lockRow.rows[0].status, runId);
+    const prev = coerceStatus(locked.status, runId);
     if (!fromStatuses.includes(prev)) {
       await client.query("ROLLBACK");
       return null;

--- a/src/vex-agent/db/repos/mission-runs.ts
+++ b/src/vex-agent/db/repos/mission-runs.ts
@@ -14,7 +14,7 @@ import {
 } from "../../engine/types.js";
 import type { PoolClient } from "pg";
 
-import { queryOne, queryOneWith, execute, getPool } from "../client.js";
+import { query, queryOne, queryOneWith, execute, getPool } from "../client.js";
 import { nullableJsonb } from "../params.js";
 import logger from "@utils/logger.js";
 
@@ -289,6 +289,93 @@ export async function casFlipToRunning(
            ended_at = NULL
        WHERE id = $1`,
       [runId],
+    );
+    await client.query("COMMIT");
+    return prev;
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {
+      // ROLLBACK failures are non-actionable; the original error is what matters.
+    });
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Every run that is still `running` or parked in a `paused_*` state — the
+ * candidate set for the agent-independent deadline sweep
+ * (`engine/wake/deadline-watchdog.ts`). Unbounded on purpose: the active set is
+ * a handful of rows (one active run per mission), and a LIMIT could starve an
+ * overdue run behind newer ones. Ordered oldest-first so the most overdue rows
+ * are enforced first.
+ */
+export async function listActiveOrPausedRuns(): Promise<MissionRun[]> {
+  const rows = await query<Record<string, unknown>>(
+    `SELECT * FROM mission_runs
+     WHERE status IN (${ACTIVE_OR_PAUSED_SQL_IN})
+     ORDER BY started_at ASC`,
+  );
+  return rows.map(mapRow);
+}
+
+/**
+ * Atomic compare-and-set from any of `fromStatuses` to the terminal
+ * `failed` / `deadline_reached` pair — the deadline watchdog's claim.
+ *
+ * The mirror image of `casFlipToRunning`: SELECT … FOR UPDATE locks the row,
+ * the UPDATE only fires when the LOCKED status is still in the allowed set, and
+ * the previous status is returned on success or `null` when someone else
+ * already moved the row. That `null` is what makes the sweep idempotent and
+ * safe against a concurrent resume or the loop-boundary enforcer — only one
+ * caller can ever win the flip, so the terminal side-effects (mission row,
+ * ledger close, approvals cleanup) run exactly once.
+ *
+ * Unlike `updateStatus`, stop fields are written unconditionally (no COALESCE):
+ * a parked run carries stale `paused_error` evidence that must NOT survive into
+ * the deadline record.
+ */
+export async function casStopPastDeadline(
+  runId: string,
+  fromStatuses: readonly MissionRunStatus[],
+  payload: {
+    stopReason: "deadline_reached";
+    summary?: string;
+    evidence?: Record<string, unknown>;
+  },
+): Promise<MissionRunStatus | null> {
+  if (fromStatuses.length === 0) return null;
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const lockRow = await client.query<{ status: string }>(
+      "SELECT status FROM mission_runs WHERE id = $1 FOR UPDATE",
+      [runId],
+    );
+    if (lockRow.rowCount === 0) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+    const prev = coerceStatus(lockRow.rows[0].status, runId);
+    if (!fromStatuses.includes(prev)) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+    await client.query(
+      `UPDATE mission_runs
+       SET status = 'failed',
+           stop_reason = $2,
+           stop_summary = $3,
+           stop_evidence_json = $4::jsonb,
+           ended_at = NOW()
+       WHERE id = $1`,
+      [
+        runId,
+        payload.stopReason,
+        payload.summary ?? null,
+        nullableJsonb(payload.evidence ?? null),
+      ],
     );
     await client.query("COMMIT");
     return prev;

--- a/src/vex-agent/engine/wake/deadline-watchdog-deps.ts
+++ b/src/vex-agent/engine/wake/deadline-watchdog-deps.ts
@@ -1,0 +1,70 @@
+/**
+ * Production wiring for the deadline watchdog.
+ *
+ * Split out of `deadline-watchdog.ts` (which stays a pure, DB-free unit) so the
+ * sweep can be unit-tested with injected fakes while production builds its deps
+ * from the real repos + engine surfaces here — the same split as
+ * `wake/executor.ts` vs `wake/executor/deps.ts`.
+ *
+ * `emitControlState` mirrors `runner/mission-finalize.ts`'s post-finalize
+ * broadcast so a watchdog-stopped run reaches the renderer with the canonical
+ * terminal status and a cleared lease, exactly like the loop-boundary path. It
+ * re-reads canonical state and is fully fail-soft.
+ */
+
+import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
+import * as missionsRepo from "@vex-agent/db/repos/missions.js";
+import * as runnerLeasesRepo from "@vex-agent/db/repos/runner-leases.js";
+import * as loopWakeRepo from "@vex-agent/db/repos/loop-wake.js";
+
+import { captureMissionFinal } from "../mission/mission-results-capture.js";
+import { resolveFrozenDeadlineMs } from "../mission/mission-deadline.js";
+import { rejectPendingApprovalsForSession } from "../core/runner/approvals-cleanup.js";
+import type { DeadlineWatchdogDeps } from "./deadline-watchdog.js";
+
+async function emitControlState(sessionId: string, runId: string): Promise<void> {
+  try {
+    const { controlStateBus, CONTROL_STATE_EVENT_TYPE } = await import(
+      "../runtime/control-bus.js"
+    );
+    const run = await missionRunsRepo.getRun(runId);
+    if (run === null) return;
+    const lease = await runnerLeasesRepo.getLease(sessionId);
+    const leaseActive = lease !== null && lease.expiresAt >= new Date();
+    controlStateBus.emit({
+      type: CONTROL_STATE_EVENT_TYPE,
+      sessionId,
+      missionRunId: runId,
+      runStatus: run.status,
+      stopReason: run.stopReason ?? null,
+      pendingControlKind: null,
+      leaseActive,
+      leaseExpiresAt: leaseActive ? lease!.expiresAt.toISOString() : null,
+      correlationId: null,
+    });
+  } catch {
+    // Fail-soft — a bus error must never break the sweep.
+  }
+}
+
+export function buildProductionDeadlineWatchdogDeps(): DeadlineWatchdogDeps {
+  return {
+    listCandidateRuns: () => missionRunsRepo.listActiveOrPausedRuns(),
+    // Same resolver the loop-boundary enforcer uses — immutable started_at +
+    // the durationMinutes frozen in the run's contract snapshot.
+    resolveDeadlineMs: (run) =>
+      resolveFrozenDeadlineMs(run.startedAt, run.contractSnapshotJson),
+    getLease: (sessionId) => runnerLeasesRepo.getLease(sessionId),
+    casStopPastDeadline: (runId, fromStatuses, payload) =>
+      missionRunsRepo.casStopPastDeadline(runId, fromStatuses, payload),
+    rejectPendingApprovals: (sessionId) =>
+      rejectPendingApprovalsForSession(sessionId),
+    cancelPendingWakes: (sessionId) =>
+      loopWakeRepo.cancelForSession(sessionId, "deadline_reached"),
+    setMissionFailed: (missionId) => missionsRepo.setStatus(missionId, "failed"),
+    // Closes the ledger row — `openPositions` in that snapshot is how an open
+    // bag is SURFACED at the deadline. Nothing here sells it.
+    captureFinal: (args) => captureMissionFinal(args),
+    emitControlState,
+  };
+}

--- a/src/vex-agent/engine/wake/deadline-watchdog.ts
+++ b/src/vex-agent/engine/wake/deadline-watchdog.ts
@@ -1,0 +1,238 @@
+/**
+ * Deadline watchdog — the agent-INDEPENDENT hard-deadline enforcement path.
+ *
+ * The loop-boundary enforcer in `core/turn-loop.ts` is correct but reachable
+ * only while the turn loop is actually iterating: it compares
+ * `loopConfig.missionDeadlineMs` at the TOP of each iteration, before
+ * inference. A run parked in any `paused_*` state has no loop iterating, so it
+ * never reaches that check until something resumes it. Observed live: a
+ * 5-minute box sat in `paused_error` and ran 1h20m wall-clock, with
+ * `engine.mission.deadline_enforced` finally firing ~1h15m late on resume.
+ *
+ * This module closes that gap with a wall-clock sweep hosted on the wake
+ * executor's existing timer (`wake/executor.ts`), independent of any inference:
+ *
+ *   - PARKED runs (`paused_approval` / `paused_wake` / `paused_error` /
+ *     `paused_user` / `paused_plan_acceptance`) past their frozen deadline are
+ *     stopped outright. No loop is running, so there is nothing to race.
+ *   - RUNNING runs are stopped ONLY when the runner lease is dead — a ghost row
+ *     whose process died mid-run. A running run with a LIVE lease is left
+ *     alone; its own loop boundary is the authority, and yanking the row would
+ *     race a live loop.
+ *
+ * Deadline source: the run's IMMUTABLE `started_at` plus the `durationMinutes`
+ * frozen into `contract_snapshot_json` — i.e. `resolveFrozenDeadlineMs` from
+ * `mission/mission-deadline.ts`, the SAME resolver the loop-boundary enforcer
+ * uses. The two paths cannot disagree about when the box ends, and a live
+ * mission edit cannot move an in-flight deadline.
+ *
+ * Concurrency + idempotency: the stop is one atomic CAS (`casStopPastDeadline`
+ * — SELECT … FOR UPDATE, re-check, flip, all in a single tx). Exactly one
+ * caller wins. A second sweep pass, a concurrent `/retry` resume, a wake
+ * executor claim, or the loop-boundary enforcer all see `null` and become
+ * no-ops, so the terminal side-effects below run exactly once per run.
+ *
+ * Composes with the auto-retry work in 28de53f6: a `paused_error` run may have
+ * an auto-retry wake queued. Stopping it without cancelling that wake would let
+ * the executor resume a terminal run, so `cancelPendingWakes` +
+ * `rejectPendingApprovals` are part of the stop — the same resurrection
+ * hygiene `abort.ts` performs.
+ *
+ * POSITION CLOSING IS OUT OF SCOPE. This watchdog never sells, flattens, or
+ * liquidates anything. Deadline-aware position closing is deliberately deferred
+ * to a designed prepared-close flow with its own approval story; until that
+ * lands, an open bag is SURFACED — flagged in the stop summary and evidence,
+ * and snapshotted by `captureMissionFinal`'s `openPositions` capture — so an
+ * operator can act on it. Do not add a close/sell dependency to this surface.
+ *
+ * Pure `sweepMissionDeadlines(now, deps)` with injected deps so tests exercise
+ * filtering + stop orchestration with no DB, mirroring `wake/executor.ts`.
+ */
+
+import logger from "@utils/logger.js";
+
+import { PAUSED_RUN_STATUSES, type MissionRunStatus } from "../types.js";
+import type { MissionRun } from "@vex-agent/db/repos/mission-runs.js";
+
+// ── Deps (injected) ─────────────────────────────────────────────────
+
+export interface DeadlineWatchdogDeps {
+  /** Every `running` / `paused_*` run — the sweep's candidate set. */
+  listCandidateRuns(): Promise<MissionRun[]>;
+  /**
+   * The run's frozen hard-deadline epoch (ms), or `null` for "no resolvable
+   * box" — fail-open, so a bad `started_at` never manufactures an early stop.
+   */
+  resolveDeadlineMs(run: MissionRun): number | null;
+  /** The session's runner lease (live = `expiresAt` in the future), or null. */
+  getLease(sessionId: string): Promise<{ expiresAt: Date } | null>;
+  /** Atomic, idempotent claim → terminal `failed` / `deadline_reached`. */
+  casStopPastDeadline(
+    runId: string,
+    fromStatuses: readonly MissionRunStatus[],
+    payload: {
+      stopReason: "deadline_reached";
+      summary?: string;
+      evidence?: Record<string, unknown>;
+    },
+  ): Promise<MissionRunStatus | null>;
+  /** Reject the session's still-pending approvals. Returns the count. */
+  rejectPendingApprovals(sessionId: string): Promise<number>;
+  /** Cancel the session's pending wakes (incl. auto-retry). Returns the count. */
+  cancelPendingWakes(sessionId: string): Promise<number>;
+  /** Move the parent mission row to `failed` (mirrors finalize). */
+  setMissionFailed(missionId: string): Promise<void>;
+  /** Close the ledger row — also snapshots the still-open position bag. */
+  captureFinal(args: {
+    missionId: string;
+    runId: string;
+    sessionId: string;
+    outcome: "failed";
+    stopReason: "deadline_reached";
+  }): Promise<void>;
+  /** Broadcast the post-finalize control state to the renderer. */
+  emitControlState(sessionId: string, runId: string): Promise<void>;
+}
+
+// ── Outcomes (observable for tests / logs / health) ─────────────────
+
+export type DeadlineSweepOutcome =
+  | { kind: "stopped"; runId: string; previousStatus: MissionRunStatus }
+  | { kind: "skipped_already_terminal"; runId: string }
+  | { kind: "skipped_not_due"; runId: string }
+  | { kind: "skipped_no_deadline"; runId: string }
+  | { kind: "skipped_live_lease"; runId: string }
+  | { kind: "error"; runId: string; message: string };
+
+/** Frozen once — the parked arms the CAS may claim from. */
+const PARKED_FROM_STATUSES: readonly MissionRunStatus[] = Array.from(
+  PAUSED_RUN_STATUSES,
+);
+const RUNNING_FROM_STATUSES: readonly MissionRunStatus[] = ["running"];
+
+// ── Sweep ───────────────────────────────────────────────────────────
+
+/**
+ * One watchdog pass. Returns a per-run outcome so the scheduler, tests, and
+ * operators can see exactly what the sweep did. Per-run failures are isolated —
+ * one bad row never poisons the rest of the batch.
+ */
+export async function sweepMissionDeadlines(
+  now: Date,
+  deps: DeadlineWatchdogDeps,
+): Promise<DeadlineSweepOutcome[]> {
+  const runs = await deps.listCandidateRuns();
+  const outcomes: DeadlineSweepOutcome[] = [];
+  for (const run of runs) {
+    try {
+      outcomes.push(await evaluateRun(run, now, deps));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error("engine.mission.deadline_watchdog.run_failed", {
+        missionRunId: run.id,
+        sessionId: run.sessionId,
+        error: message,
+      });
+      outcomes.push({ kind: "error", runId: run.id, message });
+    }
+  }
+  return outcomes;
+}
+
+async function evaluateRun(
+  run: MissionRun,
+  now: Date,
+  deps: DeadlineWatchdogDeps,
+): Promise<DeadlineSweepOutcome> {
+  const deadlineMs = deps.resolveDeadlineMs(run);
+  if (deadlineMs === null) return { kind: "skipped_no_deadline", runId: run.id };
+  if (now.getTime() < deadlineMs) return { kind: "skipped_not_due", runId: run.id };
+
+  // A live loop enforces its own deadline at the turn boundary — only reap a
+  // RUNNING row when its lease is dead (a ghost: status says running, the
+  // process is gone). Parked rows have no live loop and are always eligible.
+  if (run.status === "running") {
+    const lease = await deps.getLease(run.sessionId);
+    if (lease !== null && lease.expiresAt.getTime() >= now.getTime()) {
+      return { kind: "skipped_live_lease", runId: run.id };
+    }
+  }
+
+  return stopPastDeadline(run, now, deadlineMs, deps);
+}
+
+async function stopPastDeadline(
+  run: MissionRun,
+  now: Date,
+  deadlineMs: number,
+  deps: DeadlineWatchdogDeps,
+): Promise<DeadlineSweepOutcome> {
+  const parked = run.status !== "running";
+  const fromStatuses = parked ? PARKED_FROM_STATUSES : RUNNING_FROM_STATUSES;
+
+  const openBagNote =
+    "Any position this mission opened remains OPEN — it was NOT auto-sold. " +
+    "Automatic deadline-time closing is deferred to the prepared-close flow.";
+  const summary = parked
+    ? `Hard mission deadline reached while parked (${run.status}); stopped by the deadline watchdog. ${openBagNote}`
+    : `Hard mission deadline reached on a ghost run (running, lease dead); stopped by the deadline watchdog. ${openBagNote}`;
+
+  // Claim atomically. `null` means another path (a concurrent resume, another
+  // sweep, or the loop-boundary enforcer) already moved the row → this pass is
+  // a no-op. Do NOT run the terminal side-effects; the winner owns them.
+  const previousStatus = await deps.casStopPastDeadline(run.id, fromStatuses, {
+    stopReason: "deadline_reached",
+    summary,
+    evidence: {
+      enforcedWhileParked: parked,
+      parkedStatus: run.status,
+      deadlineMs,
+      sweptAt: now.toISOString(),
+      overdueMs: now.getTime() - deadlineMs,
+      // The bag is SURFACED here, never sold — see the module docstring.
+      positionCloseDeferred: true,
+      path: "watchdog",
+    },
+  });
+  if (previousStatus === null) {
+    return { kind: "skipped_already_terminal", runId: run.id };
+  }
+
+  // Resurrection hygiene FIRST, exactly as `abort.ts` does it. A swept
+  // `paused_approval` run leaves a pending `approval_queue` row that the UI
+  // keeps listing and a later approve would try to resume; a swept
+  // `paused_error` run may have an auto-retry wake queued (28de53f6) that the
+  // wake executor would otherwise claim. Both would resume a terminal run.
+  const rejectedApprovals = await deps.rejectPendingApprovals(run.sessionId);
+  const cancelledWakes = await deps.cancelPendingWakes(run.sessionId);
+
+  // Terminal side-effects — mirror `finalizeMissionRunStatus`'s terminate
+  // branch for `deadline_reached` (mission row → failed, ledger close, control
+  // broadcast). Sequential like finalize; the CAS above is the concurrency gate
+  // that guarantees only one sweeper ever reaches here.
+  await deps.setMissionFailed(run.missionId);
+  await deps.captureFinal({
+    missionId: run.missionId,
+    runId: run.id,
+    sessionId: run.sessionId,
+    outcome: "failed",
+    stopReason: "deadline_reached",
+  });
+  await deps.emitControlState(run.sessionId, run.id);
+
+  // Same event name the loop-boundary enforcer logs, with `path` to tell the
+  // two apart in the field — which is how the 1h20m overrun was diagnosed.
+  logger.info("engine.mission.deadline_enforced", {
+    missionRunId: run.id,
+    sessionId: run.sessionId,
+    deadlineMs,
+    previousStatus,
+    enforcedWhileParked: parked,
+    overdueMs: now.getTime() - deadlineMs,
+    rejectedApprovals,
+    cancelledWakes,
+    path: "watchdog",
+  });
+
+  return { kind: "stopped", runId: run.id, previousStatus };
+}

--- a/src/vex-agent/engine/wake/executor.ts
+++ b/src/vex-agent/engine/wake/executor.ts
@@ -44,11 +44,28 @@ import logger from "@utils/logger.js";
 
 import { tick } from "./executor/tick.js";
 import { buildProductionDeps, type WakeDeps } from "./executor/deps.js";
+import {
+  sweepMissionDeadlines,
+  type DeadlineWatchdogDeps,
+} from "./deadline-watchdog.js";
+import { buildProductionDeadlineWatchdogDeps } from "./deadline-watchdog-deps.js";
 
 export type { ClaimedWakeOutcome, ClaimedWake } from "./executor/tick.js";
 export { tick } from "./executor/tick.js";
 export type { WakeDeps } from "./executor/deps.js";
 export { isWakeProviderConfigured } from "./executor/provider.js";
+// NOTE: `sweepMissionDeadlines` is deliberately NOT re-exported here. This
+// façade's runtime export set is pinned by `executor-surface.test.ts`; the
+// sweep is a peer module, imported directly by its own tests and by the
+// lifecycle owner below.
+
+/**
+ * Default gap between deadline sweeps. Deliberately coarser than the 2s wake
+ * interval: the sweep reads every active-or-parked run, and a mission box is
+ * measured in minutes, so 30s of enforcement latency is immaterial next to the
+ * 1h20m overrun this closes.
+ */
+const DEFAULT_DEADLINE_SWEEP_INTERVAL_MS = 30_000;
 
 // ── Scheduler ──────────────────────────────────────────────────────
 
@@ -62,6 +79,10 @@ export interface StartOptions {
   batchSize?: number;
   deps?: WakeDeps;
   now?: () => Date;
+  /** Injected fakes for the deadline sweep (tests). */
+  deadlineDeps?: DeadlineWatchdogDeps;
+  /** Gap between deadline sweeps. Default 30s. */
+  deadlineSweepIntervalMs?: number;
 }
 
 /**
@@ -78,14 +99,51 @@ export function startWakeExecutor(options: StartOptions = {}): WakeExecutorHandl
   const limit = options.batchSize ?? 10;
   const now = options.now ?? (() => new Date());
   const deps = options.deps ?? buildProductionDeps();
+  const deadlineDeps = options.deadlineDeps ?? buildProductionDeadlineWatchdogDeps();
+  const deadlineSweepInterval =
+    options.deadlineSweepIntervalMs ?? DEFAULT_DEADLINE_SWEEP_INTERVAL_MS;
 
   let stopped = false;
   let inFlight: Promise<void> | null = null;
   let timer: NodeJS.Timeout | null = null;
+  let lastDeadlineSweepMs: number | null = null;
+
+  /**
+   * The hard-deadline sweep, throttled onto this executor's existing timer
+   * rather than a second subsystem. Two properties matter here:
+   *
+   *   1. It runs BEFORE `tick`, so an overdue parked run is stopped rather
+   *      than resumed by a wake claimed in the same pass.
+   *   2. It is NOT gated on `isProviderReady`. `tick` is, because resuming a
+   *      run needs inference — but STOPPING one does not, and a missing
+   *      provider key is precisely the condition that parks runs in
+   *      `paused_error`. Gating the sweep would disable enforcement exactly
+   *      when it is needed most.
+   */
+  const runDeadlineSweep = async (at: Date): Promise<void> => {
+    if (
+      lastDeadlineSweepMs !== null &&
+      at.getTime() - lastDeadlineSweepMs < deadlineSweepInterval
+    ) {
+      return;
+    }
+    lastDeadlineSweepMs = at.getTime();
+    try {
+      await sweepMissionDeadlines(at, deadlineDeps);
+    } catch (err) {
+      logger.error("wake.executor.deadline_sweep_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
 
   const runOne = async (): Promise<void> => {
+    const at = now();
+    // Isolated from the wake tick — a sweep failure must not skip wake work,
+    // and vice versa.
+    await runDeadlineSweep(at);
     try {
-      await tick(now(), limit, deps);
+      await tick(at, limit, deps);
     } catch (err) {
       logger.error("wake.executor.tick_failed", {
         error: err instanceof Error ? err.message : String(err),
@@ -104,7 +162,11 @@ export function startWakeExecutor(options: StartOptions = {}): WakeExecutorHandl
   };
 
   timer = setTimeout(schedule, interval);
-  logger.info("wake.executor.started", { intervalMs: interval, batchSize: limit });
+  logger.info("wake.executor.started", {
+    intervalMs: interval,
+    batchSize: limit,
+    deadlineSweepIntervalMs: deadlineSweepInterval,
+  });
 
   return {
     async stop(): Promise<void> {


### PR DESCRIPTION
## The bug

The hard mission deadline is not enforced while a run is **parked**. A mission that stalls in any `paused_*` state overruns its time box indefinitely — the box is only honoured once something happens to resume the run.

Two live repros:

- A **5-minute** mission ran **1h20m** wall-clock. It sat in `paused_error`; `engine.mission.deadline_enforced` finally fired **~1h15m late**, at the moment of resume.
- A **6h** mission ran **7h07m**, same shape.

## Why the loop-boundary check misses it

The enforcer added in #30 is correct, but it lives at the **top of the turn loop**, compared just before inference. That check is only reachable while the loop is actually iterating. A run parked in `paused_error` / `paused_wake` / `paused_approval` / `paused_user` / `paused_plan_acceptance` has **no loop iterating**, so it never reaches the boundary — the deadline is evaluated only when something eventually resumes the run, which is exactly why the log line arrives an hour and a quarter late rather than on time. The time box is therefore advisory precisely when a run is most likely to be stuck.

The same hole covers a **ghost**: a row whose `status` is still `running` but whose runner lease is dead because the process died mid-run. No loop, no boundary check, no enforcement.

## The fix

A wall-clock sweep **independent of the inference loop**, hosted on the **wake executor's existing timer** rather than introduced as a new subsystem (`src/vex-agent/engine/wake/deadline-watchdog.ts`, wired in `wake/executor.ts`).

- Runs **before** `tick`, so an overdue parked run is stopped rather than resumed by a wake claimed in the same pass.
- Deliberately **not** gated on `isProviderReady`. `tick` is gated because resuming needs inference — but *stopping* does not, and a missing or failing provider is exactly the condition that parks runs in `paused_error`. Gating the sweep would disable enforcement when it matters most.
- Default cadence 30s — coarser than the 2s wake interval, and immaterial next to a 1h20m overrun.

### Builds on #30, does not duplicate it

The deadline is resolved with **your existing helpers** — `resolveFrozenDeadlineMs` (`computeHardDeadlineMs` / `resolveDurationMinutes` over the frozen `contract_snapshot_json` duration plus the immutable `started_at`). The watchdog and the loop-boundary enforcer therefore *cannot disagree* about when the box ends, and a live mission edit still cannot move an in-flight deadline. This is a complementary follow-up closing the parked gap, not a second implementation.

### Composes with `28de53f6`

`28de53f6` rewrote the transient-error classifier and added provider auto-retry for parked missions, so a `paused_error` run may have an auto-retry wake queued. Stopping such a run without cancelling that wake would let the executor resume a terminal run, so cancelling pending wakes is part of the stop. Auto-retry keeps healing blips *inside* the box; the watchdog ends the box.

## States covered

| State | Behaviour |
|---|---|
| `paused_approval`, `paused_wake`, `paused_error`, `paused_user`, `paused_plan_acceptance` | Stopped when past deadline |
| `running`, lease **dead** (ghost) | Stopped |
| `running`, lease **live** | **Skipped** — the loop's own boundary check is the authority; yanking the row would race a live loop |
| Not yet due | Untouched |
| No resolvable deadline | Untouched — fail-open, so a bad `started_at` never manufactures an early stop |

## Concurrency + idempotency

The stop is a single atomic CAS (`casStopPastDeadline`): `SELECT … FOR UPDATE`, re-check the **locked** status against the allowed set, flip — all in one transaction. Exactly one caller can win. A second sweep pass, a concurrent resume, a wake-executor claim, and the loop-boundary enforcer all observe `null` and become no-ops, so the terminal side-effects (mission row → `failed`, ledger close, control broadcast) run **exactly once** per run. Per-run failures are isolated so one bad row never poisons the batch.

## No orphaned pending approvals

A swept run must not leave state that could resurrect it. A `paused_approval` run stopped naively leaves a pending `approval_queue` row that the UI keeps listing and that a later approve would try to resume. The stop therefore rejects the session's pending approvals and cancels its pending wakes — the same resurrection hygiene `abort.ts` already performs.

## Deferred: position closing is explicitly OUT OF SCOPE

**This watchdog never sells, flattens, or liquidates anything.** Deadline-aware position closing is deliberately left to a designed prepared-close flow with its own approval story, per your earlier call. Until that lands, an open bag is **surfaced, not closed**:

- the stop summary states plainly that any position remains **open** and was **not** auto-sold;
- stop evidence carries `positionCloseDeferred: true`, alongside `enforcedWhileParked` / `parkedStatus` / `overdueMs` and `path: "watchdog"` — the `path` tag is how the two enforcement paths are told apart in the field, which is how the 1h20m overrun was diagnosed;
- `captureMissionFinal`'s `openPositions` snapshot records the bag for an operator.

A code comment in the module points at the deferred flow so nobody bolts a close/sell dependency onto this surface later.

## Tests

Written fail-first (red `425a12ac`, green `4995a5ff`). `src/__tests__/vex-agent/engine/wake/deadline-watchdog.test.ts` pins: a past-deadline parked run is stopped with `deadline_reached` for **each** relevant `paused_*` state; the sweep is idempotent (two passes never double-stop); a not-yet-due parked run is untouched; a live-lease running run is skipped; a dead-lease ghost is stopped; approvals and wakes are cleared on stop; a failing row does not poison the batch.

## Verification

- `cd vex-app && pnpm run lint` → **pass** — tsc clean, type ratchet green at 432 known errors (at/below baseline), process-boundary check passed
- `pnpm run build` (root: `tsc` + `tsc-alias`) → **pass**, exit 0
- `vitest run` over `engine/wake`, `engine/mission`, `engine/core`, `abort-mission-run` → **70 files, 676 tests passed**
- `vitest run` over `db`, `engine/repos`, `engine/runtime` → **40 files, 356 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
