### PR TITLE
feat(mission): explain what happened when a run ends abnormally

### DIFF
--- a/src/__tests__/vex-agent/engine/mission/mission-results-capture.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/mission-results-capture.test.ts
@@ -29,6 +29,7 @@ function deps(over: Partial<CaptureDeps> = {}): CaptureDeps {
     closeResult: vi.fn(async () => {}),
     getResult: vi.fn(async () => null),
     countTrades: vi.fn(async () => 3),
+    setStopSummaryIfAbsent: vi.fn(async () => true),
     ...over,
   };
 }

--- a/src/__tests__/vex-agent/engine/mission/system-summary-capture.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/system-summary-capture.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Mission finalisation backfills a system-generated summary when the agent
+ * never wrote one.
+ *
+ * The incident this closes: a 6-hour live mission hit a provider error,
+ * parked, and timed out without ever calling `mission_stop`. `stop_summary`
+ * stayed null, so the card fell back to raw metrics — and never mentioned
+ * the position the run had left open with nothing managing it.
+ *
+ * The load-bearing guarantee is the NEGATIVE one: a real agent-authored
+ * summary is never overwritten. That is enforced in SQL
+ * (`setStopSummaryIfAbsent`), and asserted here at the seam so a future
+ * refactor that moves the guard into JS still has to keep it.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  captureMissionFinal,
+  type CaptureDeps,
+} from "../../../../vex-agent/engine/mission/mission-results-capture.js";
+import { SYSTEM_SUMMARY_LABEL } from "../../../../vex-agent/engine/mission/system-summary.js";
+
+const MISSION = {
+  id: "mission-1",
+  goal: "grow ETH +8% in 60 min",
+  allowedChains: ["robinhood"],
+  allowedWallets: ["0x9ed25bdedceB28Adf9E3C7fCa34511e78e47C77f"],
+};
+
+const OPENED_ROW = {
+  bankrollStartEth: 0.01,
+  startedAt: "2026-01-01T00:00:00.000Z",
+};
+
+function deps(over: Partial<CaptureDeps> = {}): CaptureDeps {
+  return {
+    getMission: vi.fn(async () => MISSION as never),
+    readBankroll: vi.fn(async () => ({
+      bankrollEth: 0.0096,
+      ethPriceUsd: 1800,
+      openPositions: [{ symbol: "PEPE", address: "0xdead", amount: "1" }],
+    })) as never,
+    openResult: vi.fn(async () => {}),
+    closeResult: vi.fn(async () => {}),
+    getResult: vi.fn(async () => OPENED_ROW as never),
+    countTrades: vi.fn(async () => 1),
+    setStopSummaryIfAbsent: vi.fn(async () => true),
+    ...over,
+  };
+}
+
+const ARGS = {
+  missionId: "mission-1",
+  runId: "run-1",
+  sessionId: "s-1",
+  outcome: "failed" as const,
+  stopReason: "provider_error",
+};
+
+/** The summary text handed to the repo on this run, or null if none was. */
+function writtenSummary(d: CaptureDeps): string | null {
+  const mock = d.setStopSummaryIfAbsent as ReturnType<typeof vi.fn>;
+  if (mock.mock.calls.length === 0) return null;
+  return mock.mock.calls[0]![1] as string;
+}
+
+describe("captureMissionFinal — system summary backfill", () => {
+  it("writes a summary for a run that reached a terminal state without mission_stop", async () => {
+    const d = deps();
+
+    await captureMissionFinal(ARGS, d);
+
+    expect(d.setStopSummaryIfAbsent).toHaveBeenCalledTimes(1);
+    expect(writtenSummary(d)).toBeTruthy();
+  });
+
+  it("labels the summary as system-generated", async () => {
+    const d = deps();
+
+    await captureMissionFinal(ARGS, d);
+
+    expect(writtenSummary(d)).toContain(SYSTEM_SUMMARY_LABEL);
+  });
+
+  it("names the still-open, unmanaged position", async () => {
+    const d = deps();
+
+    await captureMissionFinal(ARGS, d);
+
+    const summary = writtenSummary(d)!;
+    expect(summary).toContain("PEPE");
+    expect(summary).toContain("STILL OPEN");
+    expect(summary).toContain("no longer being managed");
+  });
+
+  it("delegates the never-overwrite guarantee to the if-absent repo write", async () => {
+    // The repo's WHERE clause is the guard. What matters here is that
+    // finalisation calls the guarded write and NEVER a blind update — a
+    // `mission_stop` landing concurrently must always win.
+    const d = deps({ setStopSummaryIfAbsent: vi.fn(async () => false) });
+
+    await captureMissionFinal(ARGS, d);
+
+    const mock = d.setStopSummaryIfAbsent as ReturnType<typeof vi.fn>;
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock.mock.calls[0]![0]).toBe("run-1");
+    // A `false` return (agent prose already present) is a normal outcome,
+    // not an error — finalisation must complete regardless.
+    expect(d.closeResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("derives its figures from the ledger values it just wrote", async () => {
+    const d = deps();
+
+    await captureMissionFinal(ARGS, d);
+
+    // start 0.01 -> end 0.0096 = -0.0004 ETH, x $1800 = -$0.72.
+    expect(writtenSummary(d)).toContain("-$0.72");
+  });
+
+  it("stays fail-soft when the summary write throws", async () => {
+    // Bankroll accounting must never break a mission's lifecycle, and a
+    // cosmetic backfill least of all.
+    const d = deps({
+      setStopSummaryIfAbsent: vi.fn(async () => {
+        throw new Error("db down");
+      }),
+    });
+
+    await expect(captureMissionFinal(ARGS, d)).resolves.toBeUndefined();
+    expect(d.closeResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not write a summary when the ledger row was never opened", async () => {
+    const d = deps({ getResult: vi.fn(async () => null) });
+
+    await captureMissionFinal(ARGS, d);
+
+    expect(d.setStopSummaryIfAbsent).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/vex-agent/engine/mission/system-summary.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/system-summary.test.ts
@@ -1,0 +1,177 @@
+/**
+ * `buildSystemSummary` — the fallback account of a run that ended without
+ * the agent ever calling `mission_stop`.
+ *
+ * Anchored on a real incident: a 6-hour live mission hit a provider error,
+ * parked, and timed out. No `mission_stop`, so no prose, so the card showed
+ * raw metrics at the one moment an explanation mattered — and said nothing
+ * about the position the run had left open and unmanaged.
+ *
+ * The honesty constraints are what these tests actually guard. A fallback
+ * that quietly passes itself off as the agent's own account, or that
+ * invents a rationale the run never recorded, would be worse than the raw
+ * metrics it replaces.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  SYSTEM_SUMMARY_LABEL,
+  buildSystemSummary,
+  type SystemSummaryFacts,
+} from "../../../../vex-agent/engine/mission/system-summary.js";
+
+/** The incident: provider error, parked, timed out, position left open. */
+function abnormalEnd(overrides: Partial<SystemSummaryFacts> = {}): SystemSummaryFacts {
+  return {
+    outcome: "failed",
+    stopReason: "provider_error",
+    trades: 1,
+    pnlEth: -0.0004,
+    ethPriceUsd: 1800,
+    openPositionSymbols: ["PEPE"],
+    ...overrides,
+  };
+}
+
+const bullets = (s: string): string[] => s.split("\n");
+
+describe("buildSystemSummary — labelling", () => {
+  it("opens with the system-generated label", () => {
+    const summary = buildSystemSummary(abnormalEnd());
+
+    expect(bullets(summary)[0]).toBe(`- ${SYSTEM_SUMMARY_LABEL}`);
+  });
+
+  it("says plainly that no agent wrote it", () => {
+    const summary = buildSystemSummary(abnormalEnd());
+
+    expect(summary).toContain("the agent stopped without writing one");
+    expect(summary).toContain("assembled from the run record");
+  });
+
+  it("never speaks in the agent's first person", () => {
+    const summary = buildSystemSummary(abnormalEnd());
+
+    // The agent's own prose is written as "I looked at / I bought". A
+    // fallback that adopts that voice is passing itself off as the agent.
+    // Word-bounded: the summary legitimately says "your wallet", which
+    // contains a bare "our".
+    for (const firstPerson of [/\bI\b/, /\bwe\b/i, /\bmy\b/i, /\bour\b/i, /\bus\b/i]) {
+      expect(summary).not.toMatch(firstPerson);
+    }
+  });
+
+  it("does not invent a thesis or a reason the record does not carry", () => {
+    const summary = buildSystemSummary(abnormalEnd({ stopReason: null, outcome: "failed" }));
+
+    expect(summary).toContain("did not record why");
+    // No fabricated rationale for the entry.
+    for (const invented of ["because", "looked promising", "thesis", "decided", "strategy"]) {
+      expect(summary.toLowerCase()).not.toContain(invented);
+    }
+  });
+});
+
+describe("buildSystemSummary — the still-open position", () => {
+  it("says the position is still open and unmanaged", () => {
+    const summary = buildSystemSummary(abnormalEnd());
+
+    expect(summary).toContain("PEPE");
+    expect(summary).toContain("STILL OPEN");
+    expect(summary).toContain("no longer being managed");
+  });
+
+  it("ranks the open-position warning above the activity and PnL lines", () => {
+    const lines = bullets(buildSystemSummary(abnormalEnd()));
+    const openIdx = lines.findIndex((l) => l.includes("STILL OPEN"));
+    const pnlIdx = lines.findIndex((l) => l.includes("$"));
+
+    expect(openIdx).toBeGreaterThan(-1);
+    expect(openIdx).toBeLessThan(pnlIdx);
+  });
+
+  it("marks the PnL as provisional while a position is still open", () => {
+    const summary = buildSystemSummary(abnormalEnd());
+
+    // A mark-to-market number presented as a settled result is a lie of
+    // omission — the position can still move.
+    expect(summary).toContain("This is not final");
+    expect(summary).toContain("valued at its current price");
+  });
+
+  it("names every open symbol, not just the first", () => {
+    const summary = buildSystemSummary(abnormalEnd({ openPositionSymbols: ["PEPE", "DEGEN"] }));
+
+    expect(summary).toContain("PEPE");
+    expect(summary).toContain("DEGEN");
+    expect(summary).toContain("are STILL OPEN");
+  });
+
+  it("says nothing about open positions when the run closed everything", () => {
+    const summary = buildSystemSummary(abnormalEnd({ openPositionSymbols: [] }));
+
+    expect(summary).not.toContain("STILL OPEN");
+    expect(summary).toContain("Overall result:");
+  });
+});
+
+describe("buildSystemSummary — figures come from the run record", () => {
+  it("converts the ledger's ETH PnL at the ledger's ETH price", () => {
+    // -0.0004 ETH x $1800 = -$0.72.
+    const summary = buildSystemSummary(abnormalEnd({ openPositionSymbols: [] }));
+
+    expect(summary).toContain("-$0.72");
+  });
+
+  it("states no figure at all when the record cannot support one", () => {
+    const summary = buildSystemSummary(
+      abnormalEnd({ pnlEth: null, ethPriceUsd: null, openPositionSymbols: [] }),
+    );
+
+    expect(summary).toContain("could not be determined from the record");
+    expect(summary).not.toContain("$");
+  });
+
+  it("omits the figure when the ETH price is missing, rather than guessing", () => {
+    const summary = buildSystemSummary(
+      abnormalEnd({ pnlEth: -0.0004, ethPriceUsd: null, openPositionSymbols: [] }),
+    );
+
+    expect(summary).not.toContain("$");
+  });
+
+  it("reports the trade count from the record", () => {
+    expect(buildSystemSummary(abnormalEnd({ trades: 0 }))).toContain("No trades were made");
+    expect(buildSystemSummary(abnormalEnd({ trades: 1 }))).toContain("1 trade was made");
+    expect(buildSystemSummary(abnormalEnd({ trades: 4 }))).toContain("4 trades were made");
+  });
+});
+
+describe("buildSystemSummary — why it stopped", () => {
+  it.each([
+    ["provider_error", "connection to the trading service failed"],
+    ["deadline_reached", "reached its time limit"],
+    ["max_loss_hit", "maximum loss you allowed"],
+    ["capital_depleted", "ran out of funds"],
+    ["user_stopped", "You stopped this run"],
+  ])("explains %s in plain language", (reason, expected) => {
+    expect(buildSystemSummary(abnormalEnd({ stopReason: reason }))).toContain(expected);
+  });
+
+  it("falls back honestly on an unrecognised stop reason", () => {
+    const summary = buildSystemSummary(
+      abnormalEnd({ stopReason: "something_new_we_added_later", outcome: "failed" }),
+    );
+
+    expect(summary).toContain("did not record why");
+  });
+});
+
+describe("buildSystemSummary — shape", () => {
+  it("emits `- ` bullets so the card renders it like agent prose", () => {
+    for (const line of bullets(buildSystemSummary(abnormalEnd()))) {
+      expect(line.startsWith("- ")).toBe(true);
+    }
+  });
+});

--- a/src/vex-agent/db/repos/mission-runs.ts
+++ b/src/vex-agent/db/repos/mission-runs.ts
@@ -163,6 +163,29 @@ export async function updateStatus(
   }
 }
 
+/**
+ * Write a fallback `stop_summary`, but ONLY if the run has none.
+ *
+ * The `WHERE ... AND (stop_summary IS NULL OR btrim(stop_summary) = '')`
+ * guard is the whole point: agent-authored prose always wins, and it wins
+ * in SQL rather than in a caller's read-then-write, so a `mission_stop`
+ * landing concurrently with finalisation can never be overwritten.
+ *
+ * Returns whether a row was actually written, so callers can log honestly.
+ */
+export async function setStopSummaryIfAbsent(
+  id: string,
+  summary: string,
+): Promise<boolean> {
+  const written = await execute(
+    `UPDATE mission_runs SET stop_summary = $2
+      WHERE id = $1
+        AND (stop_summary IS NULL OR btrim(stop_summary) = '')`,
+    [id, summary],
+  );
+  return written > 0;
+}
+
 export async function setLastCheckpoint(id: string): Promise<void> {
   await execute(
     "UPDATE mission_runs SET last_checkpoint_at = NOW() WHERE id = $1",

--- a/src/vex-agent/engine/mission/mission-results-capture.ts
+++ b/src/vex-agent/engine/mission/mission-results-capture.ts
@@ -8,6 +8,11 @@
  * Start and finalize run in different turns, so nothing is held in memory —
  * the row is keyed on `mission_run_id` and re-addressed at close.
  *
+ * Finalize also backfills a system-generated `stop_summary` for a run that
+ * reached a terminal state without ever calling `mission_stop` (provider
+ * error, park, timeout). See `system-summary.ts` for the honesty rules;
+ * the write is guarded in SQL so agent-authored prose always wins.
+ *
  * Naming: this produces a "mission result (ETH)" — an honest, ETH-
  * denominated PnL record. Never call it "performance" here or in any
  * consumer (agent behavior is directional and carries risk; a single
@@ -28,6 +33,8 @@ import {
   getResultForRun,
   type MissionResultOutcome,
 } from "../../db/repos/mission-results.js";
+import { setStopSummaryIfAbsent } from "../../db/repos/mission-runs.js";
+import { buildSystemSummary } from "./system-summary.js";
 import logger from "@utils/logger.js";
 
 const GOAL_SNIPPET_MAX = 240;
@@ -39,6 +46,11 @@ export interface CaptureDeps {
   closeResult: typeof closeMissionResult;
   getResult: typeof getResultForRun;
   countTrades: typeof countMissionTrades;
+  /**
+   * Writes the fallback prose for a run that never called `mission_stop`.
+   * No-ops when the agent already wrote one (guarded in SQL).
+   */
+  setStopSummaryIfAbsent: typeof setStopSummaryIfAbsent;
 }
 
 // Built lazily (inside each function's try) rather than at module load: some
@@ -53,6 +65,7 @@ function productionDeps(): CaptureDeps {
     closeResult: closeMissionResult,
     getResult: getResultForRun,
     countTrades: countMissionTrades,
+    setStopSummaryIfAbsent,
   };
 }
 
@@ -136,6 +149,7 @@ export async function captureMissionFinal(
       existing.startedAt,
       new Date().toISOString(),
     );
+    const openPositions = bankroll?.openPositions ?? null;
     await deps.closeResult({
       missionRunId: args.runId,
       outcome: args.outcome,
@@ -145,8 +159,35 @@ export async function captureMissionFinal(
       pnlEth,
       pnlPct,
       trades,
-      openPositions: bankroll?.openPositions ?? null,
+      openPositions,
     });
+
+    // A run that died without calling `mission_stop` leaves no prose at
+    // all, so the card falls back to raw metrics exactly when the operator
+    // most needs an explanation — and says nothing about a position left
+    // open. Backfill an honest, clearly-labelled account from the facts we
+    // just wrote. The repo guards on `stop_summary IS NULL`, so a real
+    // agent-authored summary is never overwritten.
+    const wrote = await deps.setStopSummaryIfAbsent(
+      args.runId,
+      buildSystemSummary({
+        outcome: args.outcome,
+        stopReason: args.stopReason,
+        trades,
+        pnlEth,
+        ethPriceUsd: bankroll?.ethPriceUsd ?? null,
+        openPositionSymbols: (openPositions ?? [])
+          .map((p) => p.symbol)
+          .filter((sym): sym is string => typeof sym === "string" && sym.length > 0),
+      }),
+    );
+    if (wrote) {
+      logger.info("mission.results.system_summary_written", {
+        runId: args.runId,
+        stopReason: args.stopReason,
+        openPositions: (openPositions ?? []).length,
+      });
+    }
   } catch (err) {
     logger.warn("mission.results.capture_final_failed", {
       runId: args.runId,

--- a/src/vex-agent/engine/mission/system-summary.ts
+++ b/src/vex-agent/engine/mission/system-summary.ts
@@ -1,0 +1,135 @@
+/**
+ * System-generated mission summary — the fallback account of a run that
+ * ended without the agent ever calling `mission_stop`.
+ *
+ * WHY THIS EXISTS. A 6-hour live mission hit a provider error, parked, and
+ * then timed out. It never called `mission_stop`, so `stop_summary` stayed
+ * null and the mission card fell back to a strip of raw metrics — at
+ * exactly the moment the operator most needed to be told what had happened
+ * to their money. Worse, the run had left a position open with nothing
+ * watching it, and nothing on screen said so.
+ *
+ * WHAT THIS IS NOT. This is not a stand-in for the agent. It is assembled
+ * from the run record and says only what that record proves:
+ *
+ *   1. It is LABELLED. Every summary opens with `SYSTEM_SUMMARY_LABEL` so
+ *      the operator can tell at a glance that no agent wrote this.
+ *   2. It never speaks AS the agent, and never invents the agent's
+ *      reasoning, thesis, or intent. The agent's silence is a fact about
+ *      the run, and it is reported as one.
+ *   3. Every figure comes from the ledger record passed in — never
+ *      computed from prose, never estimated, and omitted entirely when the
+ *      record does not carry it.
+ *
+ * The highest-value line by far is the still-open-position warning: an
+ * unmanaged position after a dead run is money at risk right now.
+ */
+
+/** Opens every system-generated summary. The operator must never mistake this for the agent's own words. */
+export const SYSTEM_SUMMARY_LABEL =
+  "Automatic summary — the agent stopped without writing one, so this was assembled from the run record.";
+
+export interface SystemSummaryFacts {
+  /** Terminal ledger outcome. */
+  readonly outcome: "completed" | "cancelled" | "failed" | "stopped";
+  /** Raw engine StopReason, or null when the run died without recording one. */
+  readonly stopReason: string | null;
+  /** Trades executed during the run, from the ledger row. */
+  readonly trades: number;
+  /** Ledger PnL in ETH. Null when start/end bankroll could not be read. */
+  readonly pnlEth: number | null;
+  /** ETH price at close, for the USD conversion. Null when unavailable. */
+  readonly ethPriceUsd: number | null;
+  /** Symbols still held when the run died. Non-empty means money is unmanaged. */
+  readonly openPositionSymbols: readonly string[];
+}
+
+/**
+ * Plain-language cause of death, keyed on the raw StopReason.
+ *
+ * Deliberately describes the MECHANISM only. "A connection failed" is a
+ * fact from the record; "the agent decided the setup had broken down"
+ * would be an invention.
+ */
+const REASON_PROSE: Readonly<Record<string, string>> = {
+  goal_reached: "The run reported that it had reached its goal.",
+  deadline_reached: "The run reached its time limit and was stopped.",
+  capital_depleted: "The run ran out of funds to keep trading with.",
+  max_loss_hit: "The run hit the maximum loss you allowed and was stopped.",
+  no_viable_opportunity: "The run did not find anything it was willing to trade.",
+  emergency_stop: "The run was halted by an emergency stop.",
+  user_stopped: "You stopped this run.",
+  provider_error: "The connection to the trading service failed and the run could not continue.",
+  system_error: "A system error ended the run.",
+  waiting_for_wake: "The run was waiting to resume and never did.",
+  compact_unable_at_critical: "The run could not free up enough working memory to continue.",
+};
+
+/** Format an ETH PnL as USD, or null when the record cannot support a figure. */
+function pnlUsdText(pnlEth: number | null, ethPriceUsd: number | null): string | null {
+  if (pnlEth === null || ethPriceUsd === null) return null;
+  if (!Number.isFinite(pnlEth) || !Number.isFinite(ethPriceUsd)) return null;
+  const usd = pnlEth * ethPriceUsd;
+  const sign = usd > 0 ? "+" : usd < 0 ? "-" : "";
+  return `${sign}$${Math.abs(usd).toFixed(2)}`;
+}
+
+/** Oxford-comma join: `a`, `a and b`, `a, b and c`. */
+function joinSymbols(symbols: readonly string[]): string {
+  if (symbols.length === 1) return symbols[0]!;
+  return `${symbols.slice(0, -1).join(", ")} and ${symbols[symbols.length - 1]!}`;
+}
+
+/**
+ * Build the fallback summary as `- `-prefixed bullets, matching the shape
+ * the card already renders for agent-authored prose.
+ *
+ * Ordering is by what the operator must act on: the label, why it stopped,
+ * then the still-open warning (money at risk), then activity and PnL.
+ */
+export function buildSystemSummary(facts: SystemSummaryFacts): string {
+  const bullets: string[] = [`${SYSTEM_SUMMARY_LABEL}`];
+
+  const reason =
+    facts.stopReason === null
+      ? null
+      : (REASON_PROSE[facts.stopReason] ?? null);
+  if (reason !== null) {
+    bullets.push(reason);
+  } else if (facts.outcome === "failed") {
+    bullets.push("The run stopped unexpectedly and did not record why.");
+  } else {
+    bullets.push("The run ended without recording a reason.");
+  }
+
+  // The line that matters most: a position nobody is watching.
+  const open = facts.openPositionSymbols;
+  if (open.length > 0) {
+    const what = joinSymbols(open);
+    const isAre = open.length === 1 ? "is" : "are";
+    bullets.push(
+      `${what} ${isAre} STILL OPEN and no longer being managed — the run ended without selling, so nothing is watching this position or acting on its exit levels. Check it in your wallet.`,
+    );
+  }
+
+  bullets.push(
+    facts.trades === 0
+      ? "No trades were made during this run."
+      : `${facts.trades} ${facts.trades === 1 ? "trade was" : "trades were"} made during this run.`,
+  );
+
+  const usd = pnlUsdText(facts.pnlEth, facts.ethPriceUsd);
+  if (usd === null) {
+    bullets.push("The profit or loss for this run could not be determined from the record.");
+  } else if (open.length > 0) {
+    // An open position makes the figure a mark-to-market, not a realised
+    // result. Saying so is the difference between honest and merely accurate.
+    bullets.push(
+      `Value change so far: ${usd}. This is not final — it includes the position still open above, valued at its current price.`,
+    );
+  } else {
+    bullets.push(`Overall result: ${usd}.`);
+  }
+
+  return bullets.map((b) => `- ${b}`).join("\n");
+}


### PR DESCRIPTION
## The bug

A 6-hour live mission hit a provider error, parked, and then timed out. It **never called `mission_stop`**, so `stop_summary` stayed null and the mission card fell back to a strip of raw metrics — at exactly the moment the operator most needed to be told what had happened to their money.

Worse: the run had left a **position open with nothing managing it**. No exit levels were being watched, and nothing on screen said so.

The failure mode is precisely inverted from what you want. A clean run that stops properly gets prose; a run that dies badly — the one you actually need explained — gets nothing.

## What this does

When a run reaches a terminal state with no agent-authored summary, finalisation backfills an honest account assembled from the run record: why it stopped, how much trading happened, **whether a position is still open and unmanaged**, and the PnL.

The constraints are what make it safe to put on screen:

- **It is labelled.** Every summary opens with a system-generated marker so the operator can see at a glance that no agent wrote it.
- **It never speaks in the agent's voice.** No first person, and it never invents the agent's reasoning, thesis, or intent. Where the record carries no reason, it says *"The run stopped unexpectedly and did not record why"* rather than supplying one.
- **Figures come from the run record only.** PnL is the ledger's `pnl_eth` converted at the ledger's own close price, and is **omitted entirely** when the record cannot support a figure — never estimated, never inferred from prose. (Same ledger-truth rule as #PR1, arrived at independently.)
- **A still-open position marks the figure provisional.** A mark-to-market number presented as a settled result is a lie of omission, so the summary says the value "is not final — it includes the position still open above".
- **The still-open warning outranks everything else.** An unmanaged position after a dead run is money at risk *right now*, so it sits above the activity and PnL lines.

Example output for the incident above:

```
- Automatic summary — the agent stopped without writing one, so this was assembled from the run record.
- The connection to the trading service failed and the run could not continue.
- PEPE is STILL OPEN and no longer being managed — the run ended without selling, so
  nothing is watching this position or acting on its exit levels. Check it in your wallet.
- 1 trade was made during this run.
- Value change so far: -$0.72. This is not final — it includes the position still open
  above, valued at its current price.
```

## Never overwrites the agent

`setStopSummaryIfAbsent` guards on `stop_summary IS NULL OR btrim(stop_summary) = ''` **in SQL**, not in a caller's read-then-write — so a `mission_stop` landing concurrently with finalisation can never be clobbered. Agent prose always wins.

The backfill is fail-soft like the rest of `mission-results-capture`: a cosmetic write must never break a mission's lifecycle.

## Tests

`system-summary.test.ts` (20) — labelling; never first-person; no invented rationale; the still-open warning names every symbol and outranks the PnL line; figures derive from the record and are omitted when it can't support them; plain-language mapping per stop reason.

`system-summary-capture.test.ts` (7) — a terminal run without `mission_stop` produces a summary; it is labelled; it names the still-open position; finalisation calls the *guarded* write and never a blind update; figures match the ledger values just written; fail-soft when the write throws; no write when the ledger row was never opened.

Note: this is independent of the plain-language-summary PR and does not stack on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
