### PR TITLE
feat(provider): optional fallback model so a provider blip can't strand a run

### DIFF
--- a/src/__tests__/vex-agent/inference/failover-wiring.test.ts
+++ b/src/__tests__/vex-agent/inference/failover-wiring.test.ts
@@ -1,0 +1,126 @@
+/**
+ * ENV + registry wiring for the optional fallback provider.
+ *
+ * Contract: the fallback activates ONLY when BOTH `OPENROUTER_API_KEY_FALLBACK`
+ * and `AGENT_MODEL_FALLBACK` are set. A partial config is ignored (and warned
+ * about) rather than silently half-enabling failover, and the resulting stack
+ * stays single-provider — byte-for-byte the pre-change behaviour.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../../../vex-agent/inference/openrouter.js", () => ({
+  OpenRouterProvider: class {
+    readonly id: string;
+    readonly displayName: string;
+    readonly model: string;
+    constructor(
+      options: {
+        apiKey?: string;
+        model?: string;
+        displayName?: string;
+        id?: string;
+      } = {},
+    ) {
+      this.id = options.id ?? "openrouter";
+      this.displayName = options.displayName ?? "OpenRouter";
+      this.model = options.model ?? process.env.AGENT_MODEL ?? "";
+    }
+  },
+}));
+
+const { loadEnvConfig } = await import("../../../vex-agent/inference/config.js");
+const { resolveProvider, resetProvider } = await import(
+  "../../../vex-agent/inference/registry.js"
+);
+const { FailoverProvider } = await import(
+  "../../../vex-agent/inference/failover.js"
+);
+
+const PRIMARY_KEY = "sk-or-primary";
+const PRIMARY_MODEL = "vendor/primary";
+const FALLBACK_KEY = "sk-or-fallback";
+const FALLBACK_MODEL = "vendor/fallback";
+
+describe("fallback provider wiring", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    resetProvider();
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("AGENT_") || key.startsWith("OPENROUTER_")) {
+        delete process.env[key];
+      }
+    }
+    process.env.OPENROUTER_API_KEY = PRIMARY_KEY;
+    process.env.AGENT_MODEL = PRIMARY_MODEL;
+  });
+
+  afterEach(() => {
+    resetProvider();
+    process.env = { ...originalEnv };
+  });
+
+  describe("loadEnvConfig", () => {
+    it("reports no fallback when neither var is set", () => {
+      const cfg = loadEnvConfig();
+      expect(cfg.fallbackApiKey).toBeNull();
+      expect(cfg.fallbackModel).toBeNull();
+    });
+
+    it("reads both fallback vars when both are set", () => {
+      process.env.OPENROUTER_API_KEY_FALLBACK = FALLBACK_KEY;
+      process.env.AGENT_MODEL_FALLBACK = FALLBACK_MODEL;
+      const cfg = loadEnvConfig();
+      expect(cfg.fallbackApiKey).toBe(FALLBACK_KEY);
+      expect(cfg.fallbackModel).toBe(FALLBACK_MODEL);
+    });
+
+    it("does NOT throw on a partial fallback config — it is simply inactive", () => {
+      process.env.OPENROUTER_API_KEY_FALLBACK = FALLBACK_KEY;
+      expect(() => loadEnvConfig()).not.toThrow();
+    });
+  });
+
+  describe("resolveProvider", () => {
+    it("builds a single-provider stack when no fallback is configured", async () => {
+      const provider = await resolveProvider();
+      expect(provider).toBeInstanceOf(FailoverProvider);
+      expect((provider as InstanceType<typeof FailoverProvider>).size).toBe(1);
+      // Identity is unchanged for every existing `provider.id` call site.
+      expect(provider?.id).toBe("openrouter");
+      expect(provider?.displayName).toBe("OpenRouter");
+    });
+
+    it("builds a 2-deep stack when both fallback vars are set", async () => {
+      process.env.OPENROUTER_API_KEY_FALLBACK = FALLBACK_KEY;
+      process.env.AGENT_MODEL_FALLBACK = FALLBACK_MODEL;
+      const provider = await resolveProvider();
+      expect((provider as InstanceType<typeof FailoverProvider>).size).toBe(2);
+      expect(provider?.id).toBe("openrouter");
+    });
+
+    it("ignores a fallback with only a key (both-or-neither)", async () => {
+      process.env.OPENROUTER_API_KEY_FALLBACK = FALLBACK_KEY;
+      const provider = await resolveProvider();
+      expect((provider as InstanceType<typeof FailoverProvider>).size).toBe(1);
+    });
+
+    it("ignores a fallback with only a model (both-or-neither)", async () => {
+      process.env.AGENT_MODEL_FALLBACK = FALLBACK_MODEL;
+      const provider = await resolveProvider();
+      expect((provider as InstanceType<typeof FailoverProvider>).size).toBe(1);
+    });
+
+    it("gives the fallback instance its OWN model", async () => {
+      process.env.OPENROUTER_API_KEY_FALLBACK = FALLBACK_KEY;
+      process.env.AGENT_MODEL_FALLBACK = FALLBACK_MODEL;
+      const provider = await resolveProvider();
+      // Stack identity mirrors the primary's model, not the fallback's.
+      expect(provider?.model).toBe(PRIMARY_MODEL);
+      expect(
+        (provider as InstanceType<typeof FailoverProvider>).displayName,
+      ).toContain("fallback");
+    });
+  });
+});

--- a/src/__tests__/vex-agent/inference/failover.test.ts
+++ b/src/__tests__/vex-agent/inference/failover.test.ts
@@ -1,0 +1,392 @@
+/**
+ * FailoverProvider — bounded retry → provider failover → recoverable park.
+ *
+ * Behavioural contract under test:
+ *  - transient error retries the SAME provider, then succeeds;
+ *  - fatal (auth/4xx) fails fast — no retry, no failover;
+ *  - primary exhausting its transient budget fails over to the fallback;
+ *  - every provider failing throws a BOUNDED, RECOVERABLE error (no crash);
+ *  - a single-provider stack behaves exactly as the bare provider did;
+ *  - a delegated call targets the ACTIVE provider's OWN model (P1 regression).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  FailoverProvider,
+  AllProvidersFailedError,
+} from "@vex-agent/inference/failover.js";
+import { classifyMissionRunError } from "@vex-agent/engine/core/runner/mission-error-classifier.js";
+import type {
+  InferenceProvider,
+  InferenceConfig,
+  InferenceResponse,
+  InferenceUsage,
+  ProviderBalance,
+  RequestCost,
+  StreamChunk,
+} from "@vex-agent/inference/types.js";
+
+// ── Fixtures ─────────────────────────────────────────────────────
+
+const USAGE: InferenceUsage = {
+  promptTokens: 1,
+  completionTokens: 1,
+  totalTokens: 2,
+};
+
+function configFor(model: string): InferenceConfig {
+  return {
+    provider: "openrouter",
+    model,
+    contextLimit: 1000,
+    maxOutputTokens: 100,
+    inputPricePerM: 1,
+    outputPricePerM: 1,
+    priceCurrency: "USD",
+    cachePricePerM: null,
+    cacheWritePricePerM: null,
+    reasoningPricePerM: null,
+  };
+}
+
+/** Error carrying a lean `status` own-property, like the OpenRouter normalizer attaches. */
+function httpError(status: number, message = `request returned ${status}`): Error {
+  const err = new Error(message);
+  Object.defineProperty(err, "status", { value: status, enumerable: false });
+  return err;
+}
+
+interface StubOptions {
+  readonly id: string;
+  readonly model: string;
+  /** Queue of behaviours, consumed per call; the LAST entry repeats. */
+  readonly script: ReadonlyArray<Error | "ok">;
+}
+
+/**
+ * Minimal InferenceProvider stub. Records the `config.model` it was invoked
+ * with so the model-retargeting regression can assert on it.
+ */
+class StubProvider implements InferenceProvider {
+  readonly id: string;
+  readonly displayName: string;
+  readonly model: string;
+  readonly seenModels: string[] = [];
+  calls = 0;
+
+  private readonly script: ReadonlyArray<Error | "ok">;
+
+  constructor(opts: StubOptions) {
+    this.id = opts.id;
+    this.displayName = opts.id;
+    this.model = opts.model;
+    this.script = opts.script;
+  }
+
+  private next(): Error | "ok" {
+    const step = this.script[Math.min(this.calls, this.script.length - 1)];
+    this.calls += 1;
+    return step ?? "ok";
+  }
+
+  async loadConfig(): Promise<InferenceConfig | null> {
+    return configFor(this.model);
+  }
+
+  async chatCompletion(
+    _messages: never[],
+    _tools: never[],
+    config: InferenceConfig,
+  ): Promise<InferenceResponse> {
+    this.seenModels.push(config.model);
+    const step = this.next();
+    if (step !== "ok") throw step;
+    return { content: this.id, toolCalls: null, usage: USAGE };
+  }
+
+  async chatCompletionSimple(
+    _messages: never[],
+    config: InferenceConfig,
+  ): Promise<{ content: string; usage: InferenceUsage }> {
+    this.seenModels.push(config.model);
+    const step = this.next();
+    if (step !== "ok") throw step;
+    return { content: this.id, usage: USAGE };
+  }
+
+  async *chatCompletionStream(): AsyncGenerator<StreamChunk> {
+    yield { type: "done" };
+  }
+
+  async getBalance(): Promise<ProviderBalance | null> {
+    return null;
+  }
+
+  calculateCost(): RequestCost {
+    return {
+      totalCost: 0,
+      currency: "USD",
+      breakdown: {
+        promptCost: 0,
+        completionCost: 0,
+        cachedSavings: 0,
+        reasoningCost: 0,
+      },
+    };
+  }
+}
+
+/** Instant-backoff stack so tests never wait on real timers. */
+function stack(providers: InferenceProvider[]): FailoverProvider {
+  return new FailoverProvider(providers, {
+    maxRetriesPerProvider: 2,
+    sleep: async () => undefined,
+    jitter: false,
+  });
+}
+
+const NO_MESSAGES = [] as never[];
+const NO_TOOLS = [] as never[];
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe("FailoverProvider", () => {
+  it("retries the same provider on a transient error, then succeeds", async () => {
+    const primary = new StubProvider({
+      id: "primary",
+      model: "vendor/primary",
+      script: [httpError(429), "ok"],
+    });
+    const failover = stack([primary]);
+
+    const res = await failover.chatCompletion(
+      NO_MESSAGES,
+      NO_TOOLS,
+      configFor("vendor/primary"),
+    );
+
+    expect(res.content).toBe("primary");
+    expect(primary.calls).toBe(2);
+  });
+
+  it("fails fast on a fatal auth error — no retry, no failover", async () => {
+    const primary = new StubProvider({
+      id: "primary",
+      model: "vendor/primary",
+      script: [httpError(401)],
+    });
+    const fallback = new StubProvider({
+      id: "fallback",
+      model: "vendor/fallback",
+      script: ["ok"],
+    });
+    const failover = stack([primary, fallback]);
+
+    await expect(
+      failover.chatCompletion(NO_MESSAGES, NO_TOOLS, configFor("vendor/primary")),
+    ).rejects.toThrow(/401/);
+
+    // One attempt only, and the fallback was never consulted: a bad key fails
+    // identically everywhere and must reach the operator.
+    expect(primary.calls).toBe(1);
+    expect(fallback.calls).toBe(0);
+  });
+
+  it("fails over to the fallback once the primary exhausts its retries", async () => {
+    const primary = new StubProvider({
+      id: "primary",
+      model: "vendor/primary",
+      script: [httpError(429)],
+    });
+    const fallback = new StubProvider({
+      id: "fallback",
+      model: "vendor/fallback",
+      script: ["ok"],
+    });
+    const failover = stack([primary, fallback]);
+
+    const res = await failover.chatCompletion(
+      NO_MESSAGES,
+      NO_TOOLS,
+      configFor("vendor/primary"),
+    );
+
+    expect(res.content).toBe("fallback");
+    expect(primary.calls).toBe(3); // initial + 2 retries
+    expect(fallback.calls).toBe(1);
+  });
+
+  it("delegates to the fallback using the FALLBACK's own model, not the primary's", async () => {
+    // P1 regression: the engine builds `config` from the PRIMARY, so a naive
+    // delegation invokes the fallback provider with the primary's model id.
+    const primary = new StubProvider({
+      id: "primary",
+      model: "vendor/primary",
+      script: [httpError(503)],
+    });
+    const fallback = new StubProvider({
+      id: "fallback",
+      model: "vendor/fallback",
+      script: ["ok"],
+    });
+    const failover = stack([primary, fallback]);
+
+    await failover.chatCompletion(
+      NO_MESSAGES,
+      NO_TOOLS,
+      configFor("vendor/primary"),
+    );
+
+    expect(primary.seenModels).toEqual([
+      "vendor/primary",
+      "vendor/primary",
+      "vendor/primary",
+    ]);
+    expect(fallback.seenModels).toEqual(["vendor/fallback"]);
+  });
+
+  it("preserves caller-owned per-turn config fields when retargeting the model", async () => {
+    const primary = new StubProvider({
+      id: "primary",
+      model: "vendor/primary",
+      script: [httpError(500)],
+    });
+    const fallback = new StubProvider({
+      id: "fallback",
+      model: "vendor/fallback",
+      script: ["ok"],
+    });
+    const failover = stack([primary, fallback]);
+
+    const seen: InferenceConfig[] = [];
+    vi.spyOn(fallback, "chatCompletionSimple").mockImplementation(
+      async (_m, config) => {
+        seen.push(config);
+        return { content: "fallback", usage: USAGE };
+      },
+    );
+
+    const turnConfig: InferenceConfig = {
+      ...configFor("vendor/primary"),
+      reasoningEffort: "high",
+      temperature: 0.42,
+    };
+    await failover.chatCompletionSimple(NO_MESSAGES, turnConfig);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.model).toBe("vendor/fallback");
+    expect(seen[0]?.reasoningEffort).toBe("high");
+    expect(seen[0]?.temperature).toBe(0.42);
+    // Caller's config object must not be mutated.
+    expect(turnConfig.model).toBe("vendor/primary");
+  });
+
+  it("throws a bounded, RECOVERABLE error when every provider fails", async () => {
+    const primary = new StubProvider({
+      id: "primary",
+      model: "vendor/primary",
+      script: [httpError(429)],
+    });
+    const fallback = new StubProvider({
+      id: "fallback",
+      model: "vendor/fallback",
+      script: [httpError(503)],
+    });
+    const failover = stack([primary, fallback]);
+
+    const caught = await failover
+      .chatCompletion(NO_MESSAGES, NO_TOOLS, configFor("vendor/primary"))
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+
+    expect(caught).toBeInstanceOf(AllProvidersFailedError);
+
+    // Bounded by construction: providers × (1 + maxRetries) = 2 × 3.
+    expect(primary.calls).toBe(3);
+    expect(fallback.calls).toBe(3);
+
+    // The mission layer must still treat this as recoverable, so the run parks
+    // with an auto-retry budget instead of dying.
+    expect(classifyMissionRunError(caught)).toBe("transient");
+  });
+
+  it("prefers the primary again on the next call (stateless between calls)", async () => {
+    const primary = new StubProvider({
+      id: "primary",
+      model: "vendor/primary",
+      script: [httpError(429), httpError(429), httpError(429), "ok"],
+    });
+    const fallback = new StubProvider({
+      id: "fallback",
+      model: "vendor/fallback",
+      script: ["ok"],
+    });
+    const failover = stack([primary, fallback]);
+
+    const first = await failover.chatCompletion(
+      NO_MESSAGES,
+      NO_TOOLS,
+      configFor("vendor/primary"),
+    );
+    expect(first.content).toBe("fallback");
+
+    // Primary has recovered — the next call must go back to it, not stick.
+    const second = await failover.chatCompletion(
+      NO_MESSAGES,
+      NO_TOOLS,
+      configFor("vendor/primary"),
+    );
+    expect(second.content).toBe("primary");
+    expect(fallback.calls).toBe(1);
+  });
+
+  describe("single-provider stack (backward compatibility)", () => {
+    it("surfaces the provider's own error unchanged — never AllProvidersFailedError", async () => {
+      const only = new StubProvider({
+        id: "primary",
+        model: "vendor/primary",
+        script: [httpError(429, "rate limited")],
+      });
+      const failover = stack([only]);
+
+      const caught = await failover
+        .chatCompletion(NO_MESSAGES, NO_TOOLS, configFor("vendor/primary"))
+        .then(
+          () => null,
+          (e: unknown) => e,
+        );
+
+      expect(caught).not.toBeInstanceOf(AllProvidersFailedError);
+      expect((caught as Error).message).toBe("rate limited");
+      // Still classified transient, exactly as before this change.
+      expect(classifyMissionRunError(caught)).toBe("transient");
+    });
+
+    it("never rewrites the model and reports the primary's identity", async () => {
+      const only = new StubProvider({
+        id: "primary",
+        model: "vendor/primary",
+        script: ["ok"],
+      });
+      const failover = stack([only]);
+
+      await failover.chatCompletion(
+        NO_MESSAGES,
+        NO_TOOLS,
+        configFor("vendor/primary"),
+      );
+
+      expect(only.seenModels).toEqual(["vendor/primary"]);
+      expect(failover.id).toBe("primary");
+      expect(failover.displayName).toBe("primary");
+      expect(failover.size).toBe(1);
+    });
+  });
+
+  it("rejects an empty provider list", () => {
+    expect(() => new FailoverProvider([])).toThrow(/at least one provider/i);
+  });
+});

--- a/src/lib/secret-keys.ts
+++ b/src/lib/secret-keys.ts
@@ -2,6 +2,11 @@ export const MASTER_PASSWORD_ENV_KEY = "VEX_KEYSTORE_PASSWORD" as const;
 
 export const VAULT_SECRET_KEYS = [
   "OPENROUTER_API_KEY",
+  // Optional second inference key used only after the primary exhausts its
+  // transient retries (see inference/failover.ts). Managed exactly like the
+  // primary key: encrypted in the vault, mirrored to process.env at unlock,
+  // and stripped from .env.
+  "OPENROUTER_API_KEY_FALLBACK",
   "JUPITER_API_KEY",
   "TAVILY_API_KEY",
   "RETTIWT_API_KEY",

--- a/src/vex-agent/inference/config.ts
+++ b/src/vex-agent/inference/config.ts
@@ -37,6 +37,14 @@ export interface EnvConfig {
   openrouterApiKey: string | null;
   /** Model ID — required for OpenRouter */
   agentModel: string | null;
+  /**
+   * OPTIONAL second OpenRouter key used only after the primary exhausts its
+   * transient retries. Activates ONLY together with {@link fallbackModel} —
+   * see `registry.ts`. Absent (the default) ⇒ single-provider behaviour.
+   */
+  fallbackApiKey: string | null;
+  /** Model id for the optional fallback provider. Both-or-neither with {@link fallbackApiKey}. */
+  fallbackModel: string | null;
   /** Sampling temperature — OpenRouter only */
   temperature: number | null;
   /** Max output tokens per response */
@@ -69,6 +77,23 @@ export function loadEnvConfig(): EnvConfig {
   const openrouterApiKey = process.env.OPENROUTER_API_KEY?.trim() ?? null;
   const agentModel = process.env.AGENT_MODEL?.trim() ?? null;
 
+  // Optional fallback provider. Deliberately NOT a validation error when only
+  // one half is present: failover is an opt-in convenience, and refusing to
+  // start the agent over a half-filled optional field would be a worse failure
+  // than running without it. `registry.ts` requires both to activate; the warn
+  // below is what makes a partial config visible.
+  const fallbackApiKey = process.env.OPENROUTER_API_KEY_FALLBACK?.trim() || null;
+  const fallbackModel = process.env.AGENT_MODEL_FALLBACK?.trim() || null;
+  if ((fallbackApiKey === null) !== (fallbackModel === null)) {
+    logger.warn("inference.config.fallback_partial", {
+      hint:
+        "Fallback provider ignored — set BOTH OPENROUTER_API_KEY_FALLBACK and " +
+        "AGENT_MODEL_FALLBACK to enable it",
+      hasKey: fallbackApiKey !== null,
+      hasModel: fallbackModel !== null,
+    });
+  }
+
   // AGENT_CONTEXT_LIMIT / AGENT_MAX_OUTPUT_TOKENS / AGENT_TEMPERATURE —
   // delegated to shared parser (returns collected ParseErrors so we
   // preserve the "throw all at once" engine contract).
@@ -95,6 +120,8 @@ export function loadEnvConfig(): EnvConfig {
     contextLimit: agentParse.value.contextLimit,
     openrouterApiKey,
     agentModel,
+    fallbackApiKey,
+    fallbackModel,
     temperature: agentParse.value.temperature,
     maxOutputTokens: agentParse.value.maxOutputTokens,
   };

--- a/src/vex-agent/inference/failover.ts
+++ b/src/vex-agent/inference/failover.ts
@@ -1,0 +1,379 @@
+/**
+ * FailoverProvider — bounded retry → provider failover → recoverable park.
+ *
+ * Wraps an ORDERED list of {@link InferenceProvider}s (primary first, then an
+ * optional fallback) so that a provider blip on one endpoint cannot strand a
+ * long unattended run. Every call drives the same state machine:
+ *
+ *   for each provider, in preference order:
+ *     retry the call with exponential backoff + jitter while the error is
+ *     TRANSIENT, up to `maxRetriesPerProvider` extra attempts;
+ *     ├─ success                 → return immediately;
+ *     ├─ PERMANENT error         → throw immediately (fail fast, NO failover:
+ *     │                             a bad key or malformed request fails
+ *     │                             identically everywhere and must reach the
+ *     │                             operator rather than burn a second key);
+ *     └─ transient budget spent  → switch to the next provider (logged).
+ *   all providers exhausted      → throw {@link AllProvidersFailedError}.
+ *
+ * ── Relationship to the mission auto-retry classifier ───────────────────────
+ *
+ * This module deliberately does NOT define its own transient/permanent rules.
+ * It delegates to `classifyMissionRunError` — the single, conservative,
+ * own-property-based classifier the mission layer already uses (validated
+ * `causeCode` via `mission-error-signal.ts`, a closed transient allow-list, and
+ * hard exclusions for operator-abort / DNS / TLS / 4xx). A second, competing
+ * classifier here would be the exact drift hazard that classifier exists to
+ * remove: an error could be "retryable" to the inference layer and "permanent"
+ * to the mission layer, or vice versa.
+ *
+ * Layering note: `mission-error-classifier.ts` and `mission-error-signal.ts`
+ * are dependency-free leaf modules (no DB, no engine state, no transport), so
+ * importing them here introduces no cycle. If maintainers would rather keep the
+ * inference layer strictly free of `engine/` imports, both leaves can move to
+ * `src/lib/` unchanged — this module only needs the function.
+ *
+ * That reuse also gives the terminal error its key property: this layer retries
+ * and fails over, and when the whole stack is down it throws an error the
+ * SAME classifier still reads as transient, so the mission parks with an
+ * auto-retry budget instead of dying.
+ *
+ * The stack is STATELESS between calls: every call restarts at the primary, so
+ * a one-off failover does not stick — the primary is preferred again as soon as
+ * it recovers.
+ *
+ * Bounded by construction: total attempts = providers.length × (1 +
+ * maxRetriesPerProvider). No unbounded loop and no uncaught throw, so a
+ * recovery pass that re-enters this client backs off and fails over rather than
+ * hot-looping.
+ */
+
+import type {
+  InferenceProvider,
+  InferenceConfig,
+  InferenceResponse,
+  InferenceUsage,
+  StreamChunk,
+  ProviderBalance,
+  ProviderMessage,
+  ToolDefinition,
+  RequestCost,
+} from "./types.js";
+import { classifyMissionRunError } from "../engine/core/runner/mission-error-classifier.js";
+import { readMissionErrorSignal } from "../engine/core/runner/mission-error-signal.js";
+import logger from "@utils/logger.js";
+
+// ── Tuning defaults (technical constants, not ENV) ───────────────
+
+const DEFAULT_MAX_RETRIES_PER_PROVIDER = 2;
+const DEFAULT_BASE_DELAY_MS = 2000;
+const DEFAULT_MAX_DELAY_MS = 15_000;
+
+export interface FailoverOptions {
+  /** Extra retry attempts per provider on a TRANSIENT error (initial attempt not counted). */
+  maxRetriesPerProvider: number;
+  /** Initial backoff delay. */
+  baseDelayMs: number;
+  /** Upper bound on a single backoff delay. */
+  maxDelayMs: number;
+  /** Add up to +baseDelay jitter to spread retries (default true). */
+  jitter: boolean;
+  /** Injectable clock — tests pass a no-op to make backoff instant. */
+  sleep: (ms: number) => Promise<void>;
+  /**
+   * Injectable classifier seam. Defaults to the shared mission classifier;
+   * overridden only in tests. Production code must not pass this.
+   */
+  isTransient: (err: Error) => boolean;
+}
+
+/** Read the HTTP status off an error's validated own-properties (never a message regex). */
+function statusOf(err: Error): number | null {
+  return readMissionErrorSignal(err).status;
+}
+
+function isTransientByMissionClassifier(err: Error): boolean {
+  return classifyMissionRunError(err) === "transient";
+}
+
+// ── Terminal error ───────────────────────────────────────────────
+
+export interface ProviderFailure {
+  readonly providerId: string;
+  readonly message: string;
+  readonly status: number | null;
+}
+
+/**
+ * Thrown when EVERY provider in the stack exhausted its transient retries.
+ *
+ * Deliberately shaped so `classifyMissionRunError` reads it as TRANSIENT — it
+ * carries `retryable: true` plus, when known, the last transient HTTP status as
+ * lean `status`/`statusCode` own-properties. That keeps a total-outage run
+ * RECOVERABLE (parked with an auto-retry budget) instead of permanently halted.
+ *
+ * Carries only per-provider ids and already-normalized/scrubbed messages —
+ * never raw error objects, and never a key or request body.
+ */
+export class AllProvidersFailedError extends Error {
+  override readonly name = "AllProvidersFailedError";
+  /** Read by the mission classifier's `retryable` fallback to stay recoverable. */
+  readonly retryable = true;
+  readonly failures: readonly ProviderFailure[];
+
+  constructor(failures: readonly ProviderFailure[]) {
+    const summary = failures
+      .map((f) => `${f.providerId}${f.status !== null ? ` (status=${f.status})` : ""}`)
+      .join(", ");
+    super(`All inference providers failed after retries: ${summary}`);
+    this.failures = failures;
+
+    // Surface the last known transient status as a lean own-property so the
+    // classifier decides on status (authoritative) rather than the `retryable`
+    // marker. Non-enumerable to keep it out of incidental serialization.
+    const lastStatus =
+      [...failures].reverse().find((f) => f.status !== null)?.status ?? null;
+    if (lastStatus !== null) {
+      Object.defineProperty(this, "statusCode", { value: lastStatus, enumerable: false });
+      Object.defineProperty(this, "status", { value: lastStatus, enumerable: false });
+    }
+  }
+}
+
+// ── FailoverProvider ─────────────────────────────────────────────
+
+export class FailoverProvider implements InferenceProvider {
+  readonly id: string;
+  readonly displayName: string;
+  readonly model: string | undefined;
+
+  private readonly providers: readonly InferenceProvider[];
+  private readonly primary: InferenceProvider;
+  private readonly opts: FailoverOptions;
+
+  constructor(providers: InferenceProvider[], options: Partial<FailoverOptions> = {}) {
+    const [primary, ...rest] = providers;
+    if (primary === undefined) {
+      throw new Error("FailoverProvider requires at least one provider");
+    }
+    this.providers = [primary, ...rest];
+    this.primary = primary;
+
+    // Identity mirrors the PRIMARY so existing call sites reading `provider.id`
+    // see the same value whether or not a fallback is configured.
+    this.id = primary.id;
+    this.model = primary.model;
+    this.displayName =
+      rest.length === 0
+        ? primary.displayName
+        : `${primary.displayName} (+${rest.length} fallback)`;
+
+    this.opts = {
+      maxRetriesPerProvider:
+        options.maxRetriesPerProvider ?? DEFAULT_MAX_RETRIES_PER_PROVIDER,
+      baseDelayMs: options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
+      maxDelayMs: options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
+      jitter: options.jitter ?? true,
+      sleep: options.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms))),
+      isTransient: options.isTransient ?? isTransientByMissionClassifier,
+    };
+  }
+
+  /** Number of providers in the stack (1 = single provider, no failover target). */
+  get size(): number {
+    return this.providers.length;
+  }
+
+  // ── Central driver ──────────────────────────────────────────────
+
+  private async run<T>(
+    label: string,
+    op: (p: InferenceProvider) => Promise<T>,
+  ): Promise<T> {
+    const failures: ProviderFailure[] = [];
+    const single = this.providers.length === 1;
+
+    for (const [pIdx, provider] of this.providers.entries()) {
+      let lastErr: Error | undefined;
+
+      for (let attempt = 0; attempt <= this.opts.maxRetriesPerProvider; attempt++) {
+        try {
+          return await op(provider);
+        } catch (raw) {
+          const error = raw instanceof Error ? raw : new Error(String(raw));
+          lastErr = error;
+
+          // Permanent → fail fast. No retry, no failover.
+          if (!this.opts.isTransient(error)) {
+            logger.warn("inference.failover.permanent", {
+              label,
+              providerId: provider.id,
+              status: statusOf(error),
+            });
+            throw error;
+          }
+
+          // Transient with budget left → back off and retry the SAME provider.
+          if (attempt < this.opts.maxRetriesPerProvider) {
+            const delayMs = this.backoffDelay(attempt);
+            logger.debug("inference.failover.retry", {
+              label,
+              providerId: provider.id,
+              attempt: attempt + 1,
+              delayMs: Math.round(delayMs),
+              status: statusOf(error),
+            });
+            await this.opts.sleep(delayMs);
+          }
+        }
+      }
+
+      // Provider exhausted its transient budget.
+      failures.push({
+        providerId: provider.id,
+        message: lastErr?.message ?? "unknown error",
+        status: lastErr ? statusOf(lastErr) : null,
+      });
+
+      const nextProvider = this.providers[pIdx + 1];
+      if (nextProvider !== undefined) {
+        logger.warn("inference.failover.switch", {
+          label,
+          from: provider.id,
+          to: nextProvider.id,
+          status: lastErr ? statusOf(lastErr) : null,
+        });
+      } else if (single) {
+        // Single-provider stack: nothing to fail over to. Surface the
+        // provider's own (already-normalized) error unchanged so a
+        // no-fallback install behaves exactly as it did before this change.
+        throw lastErr!;
+      }
+    }
+
+    logger.error("inference.failover.exhausted", {
+      label,
+      providers: failures.map((f) => f.providerId),
+    });
+    throw new AllProvidersFailedError(failures);
+  }
+
+  /**
+   * Retarget the per-turn `config` to the ACTIVE provider's OWN model.
+   *
+   * The engine builds `config` once per turn from `loadConfig()`, which returns
+   * the PRIMARY's config. Delegating that object verbatim to a fallback would
+   * request the PRIMARY's model id against the FALLBACK's endpoint/key — a real
+   * P1: the failover appears to work, then fails or silently bills the wrong
+   * model. Only `model` is swapped, and only when the active provider
+   * advertises a different one; every caller-owned per-turn field
+   * (reasoningEffort, temperature, limits) is preserved, and the caller's
+   * object is never mutated.
+   */
+  private configFor(
+    provider: InferenceProvider,
+    config: InferenceConfig,
+  ): InferenceConfig {
+    if (provider.model !== undefined && provider.model !== config.model) {
+      return { ...config, model: provider.model };
+    }
+    return config;
+  }
+
+  private backoffDelay(attempt: number): number {
+    const base = this.opts.baseDelayMs * Math.pow(2, attempt);
+    const jitter = this.opts.jitter ? Math.random() * this.opts.baseDelayMs : 0;
+    return Math.min(base + jitter, this.opts.maxDelayMs);
+  }
+
+  // ── InferenceProvider surface ───────────────────────────────────
+
+  /**
+   * Load config from the first provider that returns a non-null config.
+   * `loadConfig` is null-on-failure (not throw) and each provider serves its
+   * own last-good/stale copy, so a first-non-null walk is the correct failover.
+   */
+  async loadConfig(): Promise<InferenceConfig | null> {
+    for (const provider of this.providers) {
+      try {
+        const config = await provider.loadConfig();
+        if (config) return config;
+      } catch (err) {
+        logger.warn("inference.failover.load_config_failed", {
+          providerId: provider.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    return null;
+  }
+
+  chatCompletion(
+    messages: ProviderMessage[],
+    tools: ToolDefinition[],
+    config: InferenceConfig,
+  ): Promise<InferenceResponse> {
+    return this.run("chatCompletion", (p) =>
+      p.chatCompletion(messages, tools, this.configFor(p, config)),
+    );
+  }
+
+  chatCompletionSimple(
+    messages: ProviderMessage[],
+    config: InferenceConfig,
+  ): Promise<{ content: string; usage: InferenceUsage }> {
+    return this.run("chatCompletionSimple", (p) =>
+      p.chatCompletionSimple(messages, this.configFor(p, config)),
+    );
+  }
+
+  /**
+   * Streaming failover is CONNECTION-LEVEL only: a provider is retried (with
+   * transient backoff) until it yields its FIRST chunk, so a connect-time blip
+   * fails over. Once bytes have flowed we cannot silently switch providers
+   * mid-stream, so a mid-stream error propagates to the caller. Missions use
+   * the non-streaming path; this method backs the interactive UI chat.
+   */
+  async *chatCompletionStream(
+    messages: ProviderMessage[],
+    tools: ToolDefinition[],
+    config: InferenceConfig,
+    signal?: AbortSignal,
+  ): AsyncGenerator<StreamChunk> {
+    const opened = await this.run("chatCompletionStream.open", async (p) => {
+      const gen = p.chatCompletionStream(
+        messages,
+        tools,
+        this.configFor(p, config),
+        signal,
+      );
+      // Pull the first chunk INSIDE the retry/failover scope so a connect-time
+      // transient error triggers backoff/failover instead of surfacing raw.
+      const first = await gen.next();
+      return { gen, first };
+    });
+
+    if (!opened.first.done) {
+      yield opened.first.value;
+      yield* opened.gen;
+    }
+  }
+
+  /** Balance is best-effort: the first provider that reports a value wins. */
+  async getBalance(): Promise<ProviderBalance | null> {
+    for (const provider of this.providers) {
+      try {
+        const balance = await provider.getBalance();
+        if (balance) return balance;
+      } catch {
+        // Best-effort surface — try the next provider.
+      }
+    }
+    return null;
+  }
+
+  /** Cost is a pure local computation over the passed config — delegate to the primary. */
+  calculateCost(usage: InferenceUsage, config: InferenceConfig): RequestCost {
+    return this.primary.calculateCost(usage, config);
+  }
+}

--- a/src/vex-agent/inference/openrouter.ts
+++ b/src/vex-agent/inference/openrouter.ts
@@ -96,12 +96,32 @@ function apiUnreachableHint(causeCode: string | null): string {
 
 // ── Provider ─────────────────────────────────────────────────────
 
+/**
+ * Optional per-instance overrides. Omitted fields fall back to ENV, so
+ * zero-arg construction (`new OpenRouterProvider()`) is unchanged. Used to
+ * build a SECOND instance for the failover stack without disturbing the
+ * primary's ENV-derived config.
+ */
+export interface OpenRouterProviderOptions {
+  readonly apiKey?: string;
+  readonly model?: string;
+  /** Distinguishes the instance in logs, e.g. "OpenRouter (fallback)". */
+  readonly displayName?: string;
+  /** Stable id used in failover logs; defaults to "openrouter". */
+  readonly id?: string;
+}
+
 export class OpenRouterProvider implements InferenceProvider {
-  readonly id = "openrouter";
-  readonly displayName = "OpenRouter";
+  readonly id: string;
+  readonly displayName: string;
 
   private readonly apiKey: string;
-  private readonly model: string;
+  /**
+   * Public (read-only) so the failover stack can retarget a delegated call at
+   * THIS instance's model instead of the primary's — see `configFor` in
+   * `failover.ts`.
+   */
+  readonly model: string;
   private readonly contextLimit: number;
   private readonly temperature: number | undefined;
   private readonly maxOutputTokens: number;
@@ -119,18 +139,23 @@ export class OpenRouterProvider implements InferenceProvider {
   private staleServeUntil = 0;
   private inFlight: Promise<InferenceConfig | null> | null = null;
 
-  constructor() {
+  constructor(options: OpenRouterProviderOptions = {}) {
     const env = loadEnvConfig();
 
-    if (!env.openrouterApiKey) {
+    const apiKey = options.apiKey ?? env.openrouterApiKey;
+    const model = options.model ?? env.agentModel;
+
+    if (!apiKey) {
       throw new Error("OPENROUTER_API_KEY is required for OpenRouter provider");
     }
-    if (!env.agentModel) {
+    if (!model) {
       throw new Error("AGENT_MODEL is required for OpenRouter provider");
     }
 
-    this.apiKey = env.openrouterApiKey;
-    this.model = env.agentModel;
+    this.id = options.id ?? "openrouter";
+    this.displayName = options.displayName ?? "OpenRouter";
+    this.apiKey = apiKey;
+    this.model = model;
     this.contextLimit = env.contextLimit;
     this.temperature = env.temperature ?? undefined;
     this.maxOutputTokens = env.maxOutputTokens;

--- a/src/vex-agent/inference/registry.ts
+++ b/src/vex-agent/inference/registry.ts
@@ -9,6 +9,7 @@
 
 import type { InferenceProvider } from "./types.js";
 import { loadEnvConfig } from "./config.js";
+import { FailoverProvider } from "./failover.js";
 import logger from "@utils/logger.js";
 
 // ── Lazy imports (avoid loading unused provider dependencies) ────
@@ -16,6 +17,46 @@ import logger from "@utils/logger.js";
 async function createOpenRouterProvider(): Promise<InferenceProvider> {
   const { OpenRouterProvider } = await import("./openrouter.js");
   return new OpenRouterProvider();
+}
+
+/**
+ * Wrap the resolved primary in a failover stack, adding the optional fallback
+ * provider when BOTH `OPENROUTER_API_KEY_FALLBACK` and `AGENT_MODEL_FALLBACK`
+ * are configured.
+ *
+ * The wrap is UNCONDITIONAL so there is exactly one code path in production.
+ * A 1-deep stack is a pass-through: it re-throws the provider's own error
+ * untouched and mirrors the primary's `id`/`displayName`/`model`, so an
+ * install without a fallback behaves exactly as it did before this change.
+ *
+ * Constructing the fallback must never take down a working primary — a bad
+ * fallback config is logged and dropped, not thrown.
+ */
+async function withFallback(primary: InferenceProvider): Promise<InferenceProvider> {
+  const { fallbackApiKey, fallbackModel } = loadEnvConfig();
+  if (fallbackApiKey === null || fallbackModel === null) {
+    return new FailoverProvider([primary]);
+  }
+
+  try {
+    const { OpenRouterProvider } = await import("./openrouter.js");
+    const fallback = new OpenRouterProvider({
+      apiKey: fallbackApiKey,
+      model: fallbackModel,
+      id: "openrouter-fallback",
+      displayName: "OpenRouter (fallback)",
+    });
+    logger.info("inference.registry.fallback_enabled", {
+      primaryId: primary.id,
+      fallbackId: fallback.id,
+    });
+    return new FailoverProvider([primary, fallback]);
+  } catch (err) {
+    logger.warn("inference.registry.fallback_init_failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return new FailoverProvider([primary]);
+  }
 }
 
 const PROVIDER_FACTORIES: Record<string, () => Promise<InferenceProvider>> = {
@@ -57,7 +98,7 @@ async function doResolve(): Promise<InferenceProvider | null> {
         provider: envConfig.agentProvider,
         source: "AGENT_PROVIDER",
       });
-      return provider;
+      return withFallback(provider);
     } catch (err) {
       logger.error("inference.registry.init_failed", {
         provider: envConfig.agentProvider,
@@ -75,7 +116,7 @@ async function doResolve(): Promise<InferenceProvider | null> {
         provider: "openrouter",
         source: "OPENROUTER_API_KEY",
       });
-      return provider;
+      return withFallback(provider);
     } catch (err) {
       logger.warn("inference.registry.openrouter_failed", {
         error: err instanceof Error ? err.message : String(err),

--- a/src/vex-agent/inference/types.ts
+++ b/src/vex-agent/inference/types.ts
@@ -247,6 +247,18 @@ export interface InferenceProvider {
   readonly displayName: string;
 
   /**
+   * The model id this provider instance is configured to call, when it is
+   * fixed at construction. Optional so existing implementations stay
+   * source-compatible.
+   *
+   * Read by the failover stack to retarget a delegated call at the ACTIVE
+   * provider's own model: the engine builds `InferenceConfig` once per turn
+   * from the PRIMARY, so a fallback with a different model must not be invoked
+   * with the primary's `config.model`.
+   */
+  readonly model?: string;
+
+  /**
    * Load inference configuration (model, pricing, context limit).
    *
    * Called per turn but expected to cache: a successful fetch is reused for a

--- a/vex-app/src/main/ipc/onboarding/__tests__/provider.test.ts
+++ b/vex-app/src/main/ipc/onboarding/__tests__/provider.test.ts
@@ -131,6 +131,99 @@ describe("providerPersist handler", () => {
     expect(mockWriter).toHaveBeenCalledTimes(1);
   });
 
+  it("verifies BOTH providers before persisting when a fallback is configured", async () => {
+    mockVerify.mockResolvedValue({ ok: true, data: { latencyMs: 120 } });
+    mockWriter.mockResolvedValue({
+      ok: true,
+      data: {
+        fieldsWritten: [
+          "OPENROUTER_API_KEY",
+          "AGENT_MODEL",
+          "AGENT_PROVIDER",
+          "OPENROUTER_API_KEY_FALLBACK",
+          "AGENT_MODEL_FALLBACK",
+        ],
+      },
+    });
+    registerProviderHandler();
+    const fn = handlers.get(CH.onboarding.providerPersist)!;
+    const result = (await fn(trustedSender, {
+      requestId: "req-fb",
+      payload: {
+        ...VALID_PAYLOAD,
+        fallbackApiKey: "sk-or-fallback-SECRET",
+        fallbackModel: "deepseek/deepseek-chat",
+      },
+    })) as { ok: boolean };
+
+    expect(result.ok).toBe(true);
+    expect(mockVerify).toHaveBeenCalledTimes(2);
+    // Each provider must be verified with its OWN model — verifying the
+    // fallback key against the primary's model is the P1 this guards.
+    expect(mockVerify.mock.calls[1]?.[0]).toMatchObject({
+      apiKey: "sk-or-fallback-SECRET",
+      model: "deepseek/deepseek-chat",
+    });
+    expect(mockWriter).toHaveBeenCalledTimes(1);
+  });
+
+  it("a bad fallback blocks the save entirely — writer NEVER called", async () => {
+    mockVerify
+      .mockResolvedValueOnce({ ok: true, data: { latencyMs: 90 } })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          code: "provider.invalid_api_key",
+          domain: "onboarding",
+          message: "API key rejected",
+          retryable: false,
+          userActionable: true,
+          redacted: true,
+          correlationId: "req-fb-bad",
+        },
+      });
+    registerProviderHandler();
+    const fn = handlers.get(CH.onboarding.providerPersist)!;
+    const result = (await fn(trustedSender, {
+      requestId: "req-fb-bad",
+      payload: {
+        ...VALID_PAYLOAD,
+        fallbackApiKey: "sk-or-bad",
+        fallbackModel: "deepseek/deepseek-chat",
+      },
+    })) as {
+      ok: boolean;
+      error?: { code: string; details?: { scope?: string } };
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("provider.invalid_api_key");
+    // scope lets the renderer point the error at the fallback fields.
+    expect(result.error?.details?.scope).toBe("fallback");
+    // Atomic: a half-good pair persists nothing, not even the good primary.
+    expect(mockWriter).not.toHaveBeenCalled();
+  });
+
+  it("never logs either API key", async () => {
+    mockVerify.mockResolvedValue({ ok: true, data: { latencyMs: 120 } });
+    mockWriter.mockResolvedValue({ ok: true, data: { fieldsWritten: [] } });
+    registerProviderHandler();
+    const fn = handlers.get(CH.onboarding.providerPersist)!;
+    await fn(trustedSender, {
+      requestId: "req-log",
+      payload: {
+        ...VALID_PAYLOAD,
+        fallbackApiKey: "sk-or-fallback-SECRET",
+        fallbackModel: "deepseek/deepseek-chat",
+      },
+    });
+
+    const logged = logInfo.mock.calls.flat().join("\n");
+    expect(logged).not.toContain("sk-or-secret-VALUE-XYZ");
+    expect(logged).not.toContain("sk-or-fallback-SECRET");
+    expect(logged).toContain("fallbackSet=true");
+  });
+
   it("verify failure short-circuits — writer NEVER called", async () => {
     mockVerify.mockResolvedValue({
       ok: false,

--- a/vex-app/src/main/ipc/onboarding/provider.ts
+++ b/vex-app/src/main/ipc/onboarding/provider.ts
@@ -57,6 +57,36 @@ export function registerProviderHandler(): () => void {
 
       const latencyMs = verifyResult.data.latencyMs;
 
+      // Step 1b: verify the OPTIONAL fallback the same way, still BEFORE any
+      // disk write, so the atomic guarantee covers both providers. A fallback
+      // that only fails at 3am mid-mission — exactly when it is needed — is
+      // worse than no fallback, so an unverifiable one blocks the save rather
+      // than being persisted with a warning.
+      if (input.fallbackApiKey !== undefined && input.fallbackModel !== undefined) {
+        const fallbackVerify = await verifyOpenRouterConnection(
+          { apiKey: input.fallbackApiKey, model: input.fallbackModel },
+          { correlationId: ctx.requestId },
+        );
+        if (!fallbackVerify.ok) {
+          log.info(
+            `[ipc:vex:onboarding:providerPersist] fallback ` +
+              `errCode=${fallbackVerify.error.code} correlationId=${ctx.requestId}`,
+          );
+          return {
+            ok: false,
+            error: {
+              ...fallbackVerify.error,
+              details: {
+                ...(fallbackVerify.error.details ?? {}),
+                // Lets the renderer point the error at the fallback fields
+                // instead of the primary ones.
+                scope: "fallback",
+              },
+            },
+          };
+        }
+      }
+
       // Step 2: persist vault secret + non-secret env values inside the env-write mutex.
       // On success, reload the non-secret .env into process.env (overwrite — the
       // user just rewrote it) and reset the engine's cached inference provider so
@@ -85,6 +115,7 @@ export function registerProviderHandler(): () => void {
       log.info(
         `[ipc:vex:onboarding:providerPersist] ` +
           `provider=openrouter modelSet=true latencyMs=${latencyMs} ` +
+          `fallbackSet=${input.fallbackApiKey !== undefined} ` +
           `correlationId=${ctx.requestId}`,
       );
 

--- a/vex-app/src/main/onboarding/__tests__/provider-writer.test.ts
+++ b/vex-app/src/main/onboarding/__tests__/provider-writer.test.ts
@@ -52,14 +52,90 @@ describe("writeProvider", () => {
         "AGENT_PROVIDER",
       ]);
     }
+    // The fallback slot is explicitly CLEARED (null) rather than omitted: a
+    // save with no fallback must remove any previously stored one, otherwise a
+    // stale key would keep serving as the failover target after the operator
+    // dropped it.
     expect(sessionMocks.writeUnlockedSecrets).toHaveBeenCalledWith({
       OPENROUTER_API_KEY: "sk-or-test-123",
+      OPENROUTER_API_KEY_FALLBACK: null,
     });
     expect(readDotenvFileValue("OPENROUTER_API_KEY", envFile)).toBeNull();
     expect(readDotenvFileValue("AGENT_MODEL", envFile)).toBe(
       "anthropic/claude-sonnet-4.5",
     );
     expect(readDotenvFileValue("AGENT_PROVIDER", envFile)).toBe("openrouter");
+  });
+
+  it("vaults the fallback key and writes the fallback model when one is configured", async () => {
+    const result = await writeProvider(
+      {
+        provider: "openrouter",
+        apiKey: "sk-or-primary",
+        model: "anthropic/claude-sonnet-4.5",
+        fallbackApiKey: "sk-or-fallback",
+        fallbackModel: "deepseek/deepseek-chat",
+      },
+      { envFile },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.fieldsWritten).toEqual([
+        "OPENROUTER_API_KEY",
+        "AGENT_MODEL",
+        "AGENT_PROVIDER",
+        "OPENROUTER_API_KEY_FALLBACK",
+        "AGENT_MODEL_FALLBACK",
+      ]);
+    }
+    expect(sessionMocks.writeUnlockedSecrets).toHaveBeenCalledWith({
+      OPENROUTER_API_KEY: "sk-or-primary",
+      OPENROUTER_API_KEY_FALLBACK: "sk-or-fallback",
+    });
+    // Both keys are vault-only; neither may land in .env as plaintext.
+    expect(readDotenvFileValue("OPENROUTER_API_KEY", envFile)).toBeNull();
+    expect(readDotenvFileValue("OPENROUTER_API_KEY_FALLBACK", envFile)).toBeNull();
+    expect(readFileSync(envFile, "utf8")).not.toContain("sk-or-fallback");
+    // The model id is NOT a secret and must be readable by the agent.
+    expect(readDotenvFileValue("AGENT_MODEL_FALLBACK", envFile)).toBe(
+      "deepseek/deepseek-chat",
+    );
+  });
+
+  it("clears a previously configured fallback when the operator drops it", async () => {
+    await writeProvider(
+      {
+        provider: "openrouter",
+        apiKey: "sk-or-primary",
+        model: "anthropic/claude-sonnet-4.5",
+        fallbackApiKey: "sk-or-fallback",
+        fallbackModel: "deepseek/deepseek-chat",
+      },
+      { envFile },
+    );
+    sessionMocks.writeUnlockedSecrets.mockClear();
+
+    // Re-save with no fallback: the stale pair must not survive, or the agent
+    // would keep failing over to a provider the operator deliberately removed.
+    const result = await writeProvider(
+      {
+        provider: "openrouter",
+        apiKey: "sk-or-primary",
+        model: "anthropic/claude-sonnet-4.5",
+      },
+      { envFile },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.fieldsWritten).not.toContain("AGENT_MODEL_FALLBACK");
+    }
+    expect(sessionMocks.writeUnlockedSecrets).toHaveBeenCalledWith({
+      OPENROUTER_API_KEY: "sk-or-primary",
+      OPENROUTER_API_KEY_FALLBACK: null,
+    });
+    expect(readDotenvFileValue("AGENT_MODEL_FALLBACK", envFile)).toBeNull();
   });
 
   it("strips stale plaintext OpenRouter keys while preserving unrelated non-secret values", async () => {

--- a/vex-app/src/main/onboarding/provider-writer.ts
+++ b/vex-app/src/main/onboarding/provider-writer.ts
@@ -19,7 +19,9 @@
 import { appendMultipleToDotenvFile } from "@vex-lib/dotenv.js";
 import { err, ok, type Result } from "@shared/ipc/result.js";
 import {
+  PROVIDER_PERSIST_BASE_FIELDS,
   PROVIDER_PERSIST_CANONICAL_ORDER,
+  PROVIDER_PERSIST_FALLBACK_FIELDS,
   type ProviderPersistInput,
 } from "@shared/schemas/provider.js";
 import { ENV_FILE } from "../paths/config-dir.js";
@@ -51,23 +53,29 @@ export async function writeProvider(
 ): Promise<Result<ProviderWriteResult>> {
   const targetFile = options.envFile ?? ENV_FILE;
 
-  const updates: Record<CanonicalKey, string> = {
-    OPENROUTER_API_KEY: input.apiKey,
-    AGENT_MODEL: input.model,
-    AGENT_PROVIDER: PROVIDER_AGENT_VALUE,
-  };
+  // Both-or-neither is enforced by the input schema; read as a single unit.
+  const fallback =
+    input.fallbackApiKey !== undefined && input.fallbackModel !== undefined
+      ? { apiKey: input.fallbackApiKey, model: input.fallbackModel }
+      : null;
 
   try {
+    // `null` CLEARS. A reconfigure that omits the fallback must remove any
+    // previously stored one — otherwise a stale key/model pair would keep
+    // silently serving as the failover target after the operator dropped it.
     const secretWrite = writeUnlockedSecrets({
       OPENROUTER_API_KEY: input.apiKey,
+      OPENROUTER_API_KEY_FALLBACK: fallback?.apiKey ?? null,
     });
     if (!secretWrite.ok) return secretWrite;
     stripManagedSecretsFromDotenvFile(targetFile);
     appendMultipleToDotenvFile(
       {
         OPENROUTER_API_KEY: null,
-        AGENT_MODEL: updates.AGENT_MODEL,
-        AGENT_PROVIDER: updates.AGENT_PROVIDER,
+        AGENT_MODEL: input.model,
+        AGENT_PROVIDER: PROVIDER_AGENT_VALUE,
+        OPENROUTER_API_KEY_FALLBACK: null,
+        AGENT_MODEL_FALLBACK: fallback?.model ?? null,
       },
       targetFile,
     );
@@ -88,8 +96,13 @@ export async function writeProvider(
     });
   }
 
-  log.info(`[provider-writer] persisted provider keys to ${targetFile}`);
+  log.info(
+    `[provider-writer] persisted provider keys to ${targetFile} ` +
+      `fallbackConfigured=${fallback !== null}`,
+  );
   return ok({
-    fieldsWritten: [...PROVIDER_PERSIST_CANONICAL_ORDER] as ReadonlyArray<CanonicalKey>,
+    fieldsWritten: (fallback !== null
+      ? [...PROVIDER_PERSIST_BASE_FIELDS, ...PROVIDER_PERSIST_FALLBACK_FIELDS]
+      : [...PROVIDER_PERSIST_BASE_FIELDS]) as ReadonlyArray<CanonicalKey>,
   });
 }

--- a/vex-app/src/renderer/features/wizard/steps/ProviderStep.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/ProviderStep.tsx
@@ -25,8 +25,17 @@
  * "Reconfigure" reveals the form.
  *
  * AGENT_MODEL is NOT a secret — model ids are public catalogue
- * entries — so it stays in React state. The OPENROUTER_API_KEY input
- * is the ONLY secret in this step.
+ * entries — so it stays in React state. The API key inputs (primary +
+ * optional fallback) are the ONLY secrets in this step, and both are
+ * uncontrolled refs cleared synchronously before the await.
+ *
+ * Optional fallback provider: a collapsed "+ Add a fallback provider"
+ * section adds a second key + model id. Validated both-or-neither in
+ * the renderer AND at the IPC boundary, and BOTH providers are verified
+ * before anything is persisted — a fallback that only fails mid-mission
+ * (exactly when it is needed) is worse than no fallback at all. The
+ * engine retries the primary first and switches over only once those
+ * retries are exhausted (`src/vex-agent/inference/failover.ts`).
  *
  * PR6 — `ModelBrandIcon` parses the `<provider>/<model>` prefix and
  * shows a matching brand SVG from `@thesvg/react` (DeepSeek, Anthropic,
@@ -84,6 +93,14 @@ export function ProviderStep({
   const [successLatencyMs, setSuccessLatencyMs] = useState<number | null>(null);
   const [showOverride, setShowOverride] = useState(false);
   const apiKeyRef = useRef<HTMLInputElement | null>(null);
+
+  // ── Optional fallback provider ───────────────────────────────────
+  // Collapsed by default: it is genuinely optional, and expanding the step
+  // by two more required-looking fields would make the common single-provider
+  // path feel heavier than it is.
+  const [showFallback, setShowFallback] = useState(false);
+  const [fallbackModel, setFallbackModel] = useState<string>("");
+  const fallbackApiKeyRef = useRef<HTMLInputElement | null>(null);
 
   const providerState =
     envQuery.data?.ok === true ? envQuery.data.data.provider : null;
@@ -143,14 +160,44 @@ export function ProviderStep({
         return;
       }
 
-      // Snapshot, clear ref SYNCHRONOUSLY before await (skill §14).
+      // Optional fallback — both-or-neither, validated before we touch the
+      // network so the user fixes it inline rather than via a server error.
+      const fallbackApiKeyRaw = showFallback
+        ? (fallbackApiKeyRef.current?.value ?? "")
+        : "";
+      const fallbackApiKey = fallbackApiKeyRaw.trim();
+      const fallbackModelTrim = showFallback ? fallbackModel.trim() : "";
+      const hasFallbackKey = fallbackApiKey.length > 0;
+      const hasFallbackModel = fallbackModelTrim.length > 0;
+
+      if (hasFallbackKey !== hasFallbackModel) {
+        setClientError(
+          "The fallback provider needs both an API key and a model id — fill both, or clear both.",
+        );
+        return;
+      }
+      if (fallbackApiKey.length > 200 || fallbackModelTrim.length > 200) {
+        setClientError(
+          "API key and model id must each be shorter than 200 characters.",
+        );
+        return;
+      }
+
+      // Snapshot, clear refs SYNCHRONOUSLY before await (skill §14) — both
+      // secrets, so neither is parked in a DOM node across the await.
       const payload: ProviderPersistInput = {
         provider: "openrouter",
         apiKey,
         model: modelTrim,
+        ...(hasFallbackKey && hasFallbackModel
+          ? { fallbackApiKey, fallbackModel: fallbackModelTrim }
+          : {}),
       };
       if (apiKeyRef.current) {
         apiKeyRef.current.value = "";
+      }
+      if (fallbackApiKeyRef.current) {
+        fallbackApiKeyRef.current.value = "";
       }
       setSubmitting(true);
       try {
@@ -163,11 +210,13 @@ export function ProviderStep({
           // main (mapSdkError) — narrow defensively like AgentCoreStep's
           // `details.violation`.
           const causeCodeRaw = result.error.details?.causeCode;
+          const scopeRaw = result.error.details?.scope;
           setServerError({
             code: result.error.code,
             correlationId: result.error.correlationId ?? null,
             causeCode:
               typeof causeCodeRaw === "string" ? causeCodeRaw : null,
+            scope: scopeRaw === "fallback" ? "fallback" : "primary",
           });
           return;
         }
@@ -178,7 +227,7 @@ export function ProviderStep({
         setSubmitting(false);
       }
     },
-    [advanceToReview, invalidateEnvState, model],
+    [advanceToReview, invalidateEnvState, model, showFallback, fallbackModel],
   );
 
   const meta = WIZARD_STEP_META.provider;
@@ -361,6 +410,82 @@ export function ProviderStep({
           </p>
         </div>
 
+        {/* Optional fallback provider — collapsed by default. */}
+        {showFallback ? (
+          <div
+            className="flex flex-col gap-4 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4"
+            data-vex-provider-fallback="open"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-xs text-[var(--color-text-muted)]">
+                Used only if the model above keeps failing — the agent retries
+                the primary first and switches over only after those retries
+                are exhausted. A different key or model here is what makes it
+                useful.
+              </p>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  // Clear both fields on collapse so a hidden half-filled
+                  // fallback can never be submitted.
+                  if (fallbackApiKeyRef.current) {
+                    fallbackApiKeyRef.current.value = "";
+                  }
+                  setFallbackModel("");
+                  setShowFallback(false);
+                }}
+                disabled={submitting || stepAdvance.isPending}
+              >
+                Remove
+              </Button>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="vex-provider-fallback-key">
+                Fallback API key
+              </Label>
+              <PasswordField
+                id="vex-provider-fallback-key"
+                ref={fallbackApiKeyRef}
+                placeholder="sk-or-..."
+              />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label
+                htmlFor="vex-provider-fallback-model"
+                className="flex items-center gap-2"
+              >
+                <ModelBrandIcon modelId={fallbackModel} size={16} />
+                Fallback model id
+              </Label>
+              <ModelPicker
+                id="vex-provider-fallback-model"
+                value={fallbackModel}
+                models={catalogueModels}
+                loading={providerModels.isLoading}
+                failed={catalogueFailed}
+                disabled={submitting || stepAdvance.isPending}
+                onChange={setFallbackModel}
+                onRetry={() => {
+                  void providerModels.refetch();
+                }}
+              />
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setShowFallback(true)}
+            disabled={submitting || stepAdvance.isPending}
+            data-vex-provider-fallback="collapsed"
+            className="self-start text-sm text-[var(--vex-onboarding-accent)] underline-offset-2 hover:underline disabled:opacity-50"
+          >
+            + Add a fallback provider (optional)
+          </button>
+        )}
+
         {clientError ? (
           <p className="text-sm text-[var(--color-danger)]" role="alert">
             {clientError}
@@ -374,8 +499,16 @@ export function ProviderStep({
             className="rounded-md border border-[color-mix(in_oklab,var(--color-danger)_40%,transparent)] bg-[color-mix(in_oklab,var(--color-danger)_10%,transparent)] p-4 text-sm text-[var(--color-danger)]"
           >
             <strong className="block font-semibold">
-              {uiCopyFor(String(serverError.code)).title}
+              {serverError.scope === "fallback"
+                ? `Fallback provider — ${uiCopyFor(String(serverError.code)).title}`
+                : uiCopyFor(String(serverError.code)).title}
             </strong>
+            {serverError.scope === "fallback" ? (
+              <p className="mt-1 text-xs text-[var(--color-text-muted)]">
+                Your primary provider verified fine. Fix or remove the fallback
+                to continue — nothing was saved.
+              </p>
+            ) : null}
             <p className="mt-1">
               {uiCopyFor(String(serverError.code)).body}
             </p>

--- a/vex-app/src/renderer/features/wizard/steps/provider/error-ui.ts
+++ b/vex-app/src/renderer/features/wizard/steps/provider/error-ui.ts
@@ -21,6 +21,13 @@ export interface ServerError {
    * errno string extracted main-side — never raw SDK message text.
    */
   readonly causeCode: string | null;
+  /**
+   * Which provider the verify failed on. `"fallback"` only when the optional
+   * fallback was the one that failed — the primary having already verified.
+   * Closed set stamped main-side (`ipc/onboarding/provider.ts`); anything else
+   * is treated as the primary.
+   */
+  readonly scope?: "primary" | "fallback";
 }
 
 export interface ErrorCopy {

--- a/vex-app/src/shared/schemas/__tests__/provider.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/provider.test.ts
@@ -3,6 +3,7 @@ import {
   PROVIDER_MODEL_CATALOG_MAX,
   providerListModelsResultSchema,
   providerModelOptionSchema,
+  providerPersistInputSchema,
 } from "../provider.js";
 
 const validModel = {
@@ -13,6 +14,45 @@ const validModel = {
   pricingInputPerMillion: 3,
   pricingOutputPerMillion: 15,
 };
+
+describe("providerPersistInputSchema fallback pair", () => {
+  const base = {
+    provider: "openrouter" as const,
+    apiKey: "sk-or-primary",
+    model: "anthropic/claude-sonnet-4.5",
+  };
+
+  it("accepts no fallback at all (single-provider config stays valid)", () => {
+    expect(providerPersistInputSchema.safeParse(base).success).toBe(true);
+  });
+
+  it("accepts a complete fallback pair", () => {
+    expect(
+      providerPersistInputSchema.safeParse({
+        ...base,
+        fallbackApiKey: "sk-or-fallback",
+        fallbackModel: "deepseek/deepseek-chat",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects a half-filled fallback in BOTH directions", () => {
+    // Silently dropping half a pair would leave the user believing failover is
+    // on when the engine never activates it.
+    expect(
+      providerPersistInputSchema.safeParse({
+        ...base,
+        fallbackApiKey: "sk-or-fallback",
+      }).success,
+    ).toBe(false);
+    expect(
+      providerPersistInputSchema.safeParse({
+        ...base,
+        fallbackModel: "deepseek/deepseek-chat",
+      }).success,
+    ).toBe(false);
+  });
+});
 
 describe("provider model catalogue schemas", () => {
   it("accepts renderer-safe metadata", () => {

--- a/vex-app/src/shared/schemas/provider.ts
+++ b/vex-app/src/shared/schemas/provider.ts
@@ -27,13 +27,32 @@ export type ProviderName = z.infer<typeof providerNameSchema>;
 
 const trimmedSecret = z.string().trim().min(1).max(200);
 
+/**
+ * Optional fallback provider (both-or-neither).
+ *
+ * `.refine` rather than two optional fields so a half-filled fallback is
+ * rejected at the IPC boundary instead of being silently dropped — the engine
+ * (`inference/registry.ts`) only activates failover when BOTH the key and the
+ * model are present, and a user who filled one field expects failover to work.
+ */
 export const providerPersistInputSchema = z
   .object({
     provider: z.literal("openrouter"),
     apiKey: trimmedSecret,
     model: trimmedSecret,
+    fallbackApiKey: trimmedSecret.optional(),
+    fallbackModel: trimmedSecret.optional(),
   })
-  .strict();
+  .strict()
+  .refine(
+    (v) =>
+      (v.fallbackApiKey === undefined) === (v.fallbackModel === undefined),
+    {
+      message:
+        "Fallback provider needs both an API key and a model id, or neither.",
+      path: ["fallbackModel"],
+    },
+  );
 
 export type ProviderPersistInput = z.infer<typeof providerPersistInputSchema>;
 
@@ -51,6 +70,22 @@ export const PROVIDER_PERSIST_CANONICAL_ORDER = [
   "OPENROUTER_API_KEY",
   "AGENT_MODEL",
   "AGENT_PROVIDER",
+  // Fallback pair — reported only when the operator configured one.
+  "OPENROUTER_API_KEY_FALLBACK",
+  "AGENT_MODEL_FALLBACK",
+] as const;
+
+/** Canonical fields always written by a provider persist (no fallback configured). */
+export const PROVIDER_PERSIST_BASE_FIELDS = [
+  "OPENROUTER_API_KEY",
+  "AGENT_MODEL",
+  "AGENT_PROVIDER",
+] as const;
+
+/** Extra fields written when the operator configured a fallback provider. */
+export const PROVIDER_PERSIST_FALLBACK_FIELDS = [
+  "OPENROUTER_API_KEY_FALLBACK",
+  "AGENT_MODEL_FALLBACK",
 ] as const;
 
 export const providerPersistFieldNameSchema = z.enum(


### PR DESCRIPTION
## Problem

A single provider blip currently ends a long unattended run.

`28de53f6` made the mission layer auto-retry transient errors, which handles a brief hiccup well. But every retry goes back to the **same endpoint**. If that endpoint is rate-limited or degraded for longer than the retry budget, the budget drains and the mission parks — even when the operator has a perfectly good second key sitting unused. For an agent meant to run unattended for hours, that is the difference between riding out a provider incident and losing the run.

## What this adds

Failover to a **second configured provider** once the primary's retries are exhausted, plus the config and wizard UI to set one up.

`FailoverProvider` wraps an ordered provider list (primary first, optional fallback) and drives one state machine per call:

```
for each provider, in preference order:
  retry with exponential backoff + jitter while the error is TRANSIENT
  ├─ success                → return immediately
  ├─ PERMANENT error        → throw immediately (no retry, no failover)
  └─ transient budget spent → switch to next provider (logged)
all providers exhausted     → throw AllProvidersFailedError
```

## How this composes with `28de53f6` rather than duplicating it

This was the main design constraint, so it is worth being explicit.

This module deliberately **does not define its own transient/permanent rules**. It delegates to `classifyMissionRunError` — the same conservative, own-property-based classifier that commit introduced — inheriting the validated `causeCode` handling via `mission-error-signal.ts`, the closed `TRANSIENT_CAUSE_CODES` allow-list, and the hard exclusions for operator-abort / DNS / TLS / 4xx.

A second, competing classifier here would be exactly the drift hazard that classifier exists to remove: an error could be "retryable" to the inference layer and "permanent" to the mission layer, or vice versa.

That reuse also gives the terminal error its key property. When the whole stack is down, `AllProvidersFailedError` is **shaped so the same classifier still reads it as transient** (`retryable: true`, plus the last known transient HTTP status as lean own-properties). So a total outage parks the run **recoverably** with an auto-retry budget instead of killing it. The two layers stack: this one absorbs a single-provider outage, and the mission layer still absorbs a total one.

**Layering note:** `mission-error-classifier.ts` and `mission-error-signal.ts` are dependency-free leaf modules (no DB, no engine state, no transport), so importing them here introduces no cycle. If you would rather keep the inference layer strictly free of `engine/` imports, both leaves can move to `src/lib/` unchanged — this module only needs the function. Happy to do that in this PR if you prefer.

## Properties

- **Backward compatible.** A single-provider stack is a pass-through: it re-throws the provider's own error (never `AllProvidersFailedError`), never rewrites the model, and mirrors the provider's `id` / `displayName` / `model`. Installs with no fallback configured behave exactly as today. `registry.ts` always wraps the primary so production has exactly one code path rather than two divergent ones.
- **Fail fast on permanent errors.** A bad key or malformed request fails identically everywhere, so it throws immediately — it must reach the operator rather than burn a second key.
- **Stateless between calls.** Every call restarts at the primary, so a one-off failover does not stick; the primary is preferred again as soon as it recovers.
- **Bounded by construction.** Total attempts = `providers.length × (1 + maxRetriesPerProvider)`. No unbounded loop, no uncaught throw.
- **A broken optional fallback can never take down a working primary.** A fallback that fails to construct is logged and dropped. A partial ENV config is a warning, not a startup error — refusing to boot the agent over a half-filled *optional* field is a worse failure than running without it.
- **Secrets.** `OPENROUTER_API_KEY_FALLBACK` joins `VAULT_SECRET_KEYS`, so it is encrypted at rest and stripped from `.env` like the primary. Logs carry provider ids and statuses only.

## Regression test for a real P1

Worth calling out because it is subtle and we shipped it broken first.

The engine builds `config` once per turn from `loadConfig()`, which returns the **primary's** config. Delegating that object verbatim to the fallback requests the **primary's model id against the fallback's endpoint and key** — the failover appears to work, then fails or silently bills the wrong model.

`configFor()` retargets `config.model` to the active provider's own model, swapping only `model` and only when the active provider advertises a different one. Every caller-owned per-turn field (`reasoningEffort`, `temperature`, limits) is preserved and the caller's object is never mutated. Two tests lock this: one that the fallback is invoked with its own model, one that per-turn fields survive the retarget.

## Wizard UI

A collapsed **"+ Add a fallback provider (optional)"** section in the Provider step adds a second key + model id. Collapsed by default because it is genuinely optional and two more required-looking fields would make the common single-provider path feel heavier than it is.

- Both-or-neither enforced twice — inline in the renderer, and at the IPC boundary via a schema `.refine`. The engine only activates failover when both values are present, so a silently-dropped half would leave the user believing failover is on when it is not.
- **Both providers verified before the atomic persist.** A fallback that only fails at 3am mid-mission — exactly when it is needed — is worse than no fallback, so an unverifiable one blocks the save. A bad fallback writes nothing, not even the good primary.
- Verify failures carry a `scope` stamped main-side from a closed set, so the renderer points the error at the fallback fields and says plainly that the primary was fine and nothing was saved.
- Both key inputs are uncontrolled refs cleared **synchronously before the await**, matching the existing primary-key convention. Collapsing the section clears both fields so a hidden half-filled fallback cannot be submitted.
- Dropping a configured fallback **clears** it — the writer sends an explicit `null`, so a stale pair cannot keep serving as the failover target after the operator removed it.

## Testing

Covered: retry-then-succeed on transient; fail fast on auth/4xx; primary exhausted → fallback succeeds; all-fail → bounded, recoverable, no crash; single-provider unchanged; fallback uses its own model; per-turn config preserved; both-or-neither in both directions; bad fallback blocks the whole save; stale fallback cleared on re-save; neither key ever logged.

One existing assertion in `provider-writer.test.ts` was updated: the secret write now sends an explicit `OPENROUTER_API_KEY_FALLBACK: null` to clear a dropped fallback, which changed the expected call shape. The comment explains why.

**Not verified:** I could not screenshot the Electron wizard in this environment, so the fallback section is verified by component tests and code review only, not visually.

## Notes for review

Tuning constants (2 retries per provider, 2s base delay, 15s cap) are technical defaults rather than ENV knobs — happy to expose them if you would rather they be configurable. The provider list is an ordered list internally, so extending beyond primary + one fallback is a config change rather than a rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
