### PR TITLE
feat(provider): explain free vs paid inference tradeoffs in the wizard

### DIFF
--- a/vex-app/src/renderer/features/wizard/steps/ProviderStep.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/ProviderStep.tsx
@@ -57,6 +57,7 @@ import {
 import { WIZARD_STEP_META } from "../wizard-icons.js";
 import { WizardStepPanel } from "../WizardStepPanel.js";
 import { CAUSE_HINTS, uiCopyFor, type ServerError } from "./provider/error-ui.js";
+import { InferenceTierNote } from "./provider/InferenceTierNote.js";
 import { ModelBrandIcon } from "./provider/ModelBrandIcon.js";
 import { ModelPicker } from "./provider/ModelPicker.js";
 
@@ -359,6 +360,7 @@ export function ProviderStep({
             </a>
             .
           </p>
+          <InferenceTierNote />
         </div>
 
         {clientError ? (

--- a/vex-app/src/renderer/features/wizard/steps/__tests__/ProviderStep.test.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/__tests__/ProviderStep.test.tsx
@@ -441,6 +441,65 @@ describe("ProviderStep", () => {
     expect(models?.getAttribute("rel")).toContain("noreferrer");
   });
 
+  it("free-vs-paid note starts collapsed and expands on click", () => {
+    mockUseEnvState.mockReturnValue(makeQueryResult(envState()));
+    const { container } = renderWithQuery(
+      <ProviderStep
+        completedSteps={["keystore", "wallets", "apiKeys", "embedding", "agentCore"]}
+        onAdvance={mockOnAdvance}
+        flowMode="first-pass"
+      />,
+    );
+
+    // Collapsed by default so the common path stays light.
+    const trigger = container.querySelector(
+      '[data-vex-provider-tier-note="collapsed"]',
+    );
+    expect(trigger).toBeTruthy();
+    expect(
+      container.querySelector('[data-vex-provider-tier-note="open"]'),
+    ).toBeNull();
+
+    fireEvent.click(trigger as Element);
+
+    const panel = container.querySelector(
+      '[data-vex-provider-tier-note="open"]',
+    );
+    expect(panel).toBeTruthy();
+    // Links out to the LIVE catalogue and guardrail pages rather than
+    // restating anything volatile in-app.
+    const hrefs = Array.from(panel!.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href"),
+    );
+    expect(hrefs).toContain("https://openrouter.ai/settings/privacy");
+    expect(hrefs).toContain("https://openrouter.ai/models");
+  });
+
+  it("free-vs-paid note hardcodes no prices and no model names", () => {
+    mockUseEnvState.mockReturnValue(makeQueryResult(envState()));
+    const { container } = renderWithQuery(
+      <ProviderStep
+        completedSteps={["keystore", "wallets", "apiKeys", "embedding", "agentCore"]}
+        onAdvance={mockOnAdvance}
+        flowMode="first-pass"
+      />,
+    );
+    fireEvent.click(
+      container.querySelector(
+        '[data-vex-provider-tier-note="collapsed"]',
+      ) as Element,
+    );
+    const text =
+      container.querySelector('[data-vex-provider-tier-note="open"]')
+        ?.textContent ?? "";
+
+    // Prices and model names go stale fast, and stale onboarding copy reads as
+    // authoritative long after it stopped being true. Keep it qualitative.
+    expect(text).not.toMatch(/\$\s?\d/);
+    expect(text).not.toMatch(/\d+\s*(tokens?|requests?)\s*(per|\/)\s*(day|min)/i);
+    expect(text).not.toMatch(/gpt-|claude-|llama-|deepseek-|gemini-/i);
+  });
+
   it("Skip-card 'Continue' button advances to review without calling persistProvider", async () => {
     mockUseEnvState.mockReturnValue(
       makeQueryResult(

--- a/vex-app/src/renderer/features/wizard/steps/provider/InferenceTierNote.tsx
+++ b/vex-app/src/renderer/features/wizard/steps/provider/InferenceTierNote.tsx
@@ -1,0 +1,106 @@
+/**
+ * Free-vs-paid inference guidance for the wizard's Provider step.
+ *
+ * OpenRouter lists free and paid variants of many models side by side, and
+ * from the picker they look interchangeable. For a long unattended agentic run
+ * they are not, and the difference only shows up hours in — when the mission
+ * parks. This note states the tradeoff before the user picks, rather than
+ * leaving them to discover it from a stalled run.
+ *
+ * Deliberately collapsed and deliberately qualitative:
+ *
+ *  - Collapsed, because the default single-model path should stay light. The
+ *    trigger names the tradeoff so it is skippable without being invisible.
+ *  - NO prices and NO model names in the copy. Both change constantly, and a
+ *    stale hardcoded number in onboarding is worse than no number — it reads
+ *    as authoritative long after it stopped being true. Anything volatile is
+ *    delegated to OpenRouter's live pages via the links below.
+ *  - Balanced, not a paid upsell. Free models are genuinely fine for light
+ *    experimentation and as a failover target; the frontier tier is NOT
+ *    required for good agent behaviour. The honest recommendation is a
+ *    capable mid-tier paid model, and the copy says exactly that.
+ */
+
+import { useState, type JSX } from "react";
+
+const ACCENT_LINK =
+  "text-[var(--vex-onboarding-accent)] underline-offset-2 hover:underline";
+
+export function InferenceTierNote(): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        data-vex-provider-tier-note="collapsed"
+        className={`self-start text-xs ${ACCENT_LINK}`}
+      >
+        Free or paid model — what to expect
+      </button>
+    );
+  }
+
+  return (
+    <div
+      data-vex-provider-tier-note="open"
+      className="flex flex-col gap-2 rounded-lg border border-white/[0.08] bg-white/[0.02] p-3 text-xs text-[var(--color-text-muted)]"
+    >
+      <p>
+        <strong className="font-semibold text-[var(--color-text-primary)]">
+          Free models cost nothing but are rate limited.
+        </strong>{" "}
+        A single agent run makes many sequential requests as it calls tools and
+        reads results, so it can hit the limit partway through and park the
+        mission mid-run. Free tiers also cap how much you can use per day.
+      </p>
+      <p>
+        <strong className="font-semibold text-[var(--color-text-primary)]">
+          Free endpoints usually keep your prompts.
+        </strong>{" "}
+        Providers serving free traffic commonly retain it and may train on it.
+        If that matters, you can restrict routing to providers that do not
+        train on your inputs in{" "}
+        <a
+          href="https://openrouter.ai/settings/privacy"
+          target="_blank"
+          rel="noreferrer"
+          className={ACCENT_LINK}
+        >
+          OpenRouter&rsquo;s privacy settings
+        </a>
+        .
+      </p>
+      <p>
+        <strong className="font-semibold text-[var(--color-text-primary)]">
+          Paid is typically cents per run
+        </strong>{" "}
+        and far steadier over a long session, which is what an unattended agent
+        needs most.
+      </p>
+      <p>
+        You do not need a frontier model — a capable mid-tier paid model is the
+        sweet spot for agent work. A free model is a reasonable choice for
+        light experimentation, or as a fallback. Current pricing and rate
+        limits for every model are listed at{" "}
+        <a
+          href="https://openrouter.ai/models"
+          target="_blank"
+          rel="noreferrer"
+          className={ACCENT_LINK}
+        >
+          openrouter.ai/models
+        </a>
+        .
+      </p>
+      <button
+        type="button"
+        onClick={() => setOpen(false)}
+        className={`self-start ${ACCENT_LINK}`}
+      >
+        Hide
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

OpenRouter lists free and paid variants of many models side by side, and from the wizard's model picker they look interchangeable. For a long unattended agentic run they are not — and the difference only surfaces hours in, when the mission parks. Nothing in the wizard said so.

The three things that actually bite:

- **Rate limits.** A single agent run makes many sequential requests as it calls tools and reads results. A free model can throttle partway through and park the mission mid-run. Free tiers also cap daily usage.
- **Privacy.** Providers serving free traffic commonly retain prompts and may train on them. Routing can be restricted to non-training providers, but only if you know the setting exists.
- **Cost vs reliability.** Paid is typically cents per run and far steadier over a long session.

None of this is obscure, but a new operator has no reason to know it before their first run fails.

## What this adds

A collapsed **"Free or paid model — what to expect"** note under the model picker in the Provider step, covering those three points.

Collapsed by default so the default single-model path stays light, with the tradeoff named in the trigger so it is skippable without being invisible. Reuses the step's existing copy and accent-link styles. No new dependencies.

## Deliberately balanced, not a paid upsell

The copy says plainly that a frontier model is **not** required, that a capable mid-tier paid model is the sweet spot for agent work, and that a free model is a reasonable choice for light experimentation or as a fallback. The goal is an operator who picks knowingly, not one who is upsold.

## No hardcoded prices or model names

Prices and model names change constantly, and stale onboarding copy reads as authoritative long after it stopped being true — which is worse than saying nothing. So the note stays qualitative and delegates everything volatile to OpenRouter's live pages:

- `openrouter.ai/models` for current pricing and rate limits
- `openrouter.ai/settings/privacy` for the model & provider access guardrails

A regression test asserts the rendered copy contains no price, no quantified rate limit, and no model name, so the constraint survives future edits rather than relying on reviewer memory.

## Testing

Two tests added to `ProviderStep.test.tsx`: the note starts collapsed and expands on click with both live links present, and the rendered copy contains no prices, quantified limits, or model names.

**Not verified:** I could not screenshot the Electron wizard in this environment, so the note's appearance is verified by component tests and code review only, not visually. The copy and layout are worth a look from someone who can run the app.

## Scope

Independent of my provider-failover PR — this branches off `main` directly and does not stack. If both land, the failover PR's optional-fallback section sits alongside this note in the same step; they do not touch the same lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
