### PR TITLE
feat(mission): let the operator dismiss a finished mission summary card

### DIFF
--- a/vex-app/src/renderer/features/appShell/MissionHistory.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionHistory.tsx
@@ -17,7 +17,7 @@
 import type { JSX } from "react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
+import { ArrowLeft01Icon, Cancel01Icon } from "@hugeicons/core-free-icons";
 import type { Result } from "@shared/ipc/result.js";
 import type { MissionListResultsResult, MissionResultDto } from "@shared/schemas/mission.js";
 import { useUiStore } from "../../stores/uiStore.js";
@@ -98,14 +98,48 @@ function Body({
   return <Ledger results={res.data} />;
 }
 
+/**
+ * Dismissal is a VIEW filter, deliberately applied here and nowhere else.
+ *
+ * The register totals below are computed over `results` — every finished
+ * run, including the dismissed ones. Hiding a card the operator has already
+ * read must not quietly restate their win rate or cumulative PnL: the
+ * numbers are an audit trail of real-money trades, and dismissing a card
+ * changes what is on screen, never what is true.
+ */
 function Ledger({ results }: { readonly results: readonly MissionResultDto[] }): JSX.Element {
+  const dismissed = useUiStore((s) => s.dismissedMissionRunIds);
+  const restore = useUiStore((s) => s.restoreDismissedMissionRuns);
+
+  // Totals over ALL results — see the note above.
   const winRate = computeWinRate(results);
   const cumulative = sumPnlEth(results);
+
+  const visible = results.filter((r) => !dismissed.includes(r.missionRunId));
+  const hiddenCount = results.length - visible.length;
 
   return (
     <>
       <SummaryHeader total={results.length} winRate={winRate} cumulativeEth={cumulative} />
-      <ResultsTable results={results} />
+      {visible.length === 0 && hiddenCount > 0 ? (
+        <Empty label="Every mission is hidden — nothing has been deleted." />
+      ) : (
+        <ResultsTable results={visible} />
+      )}
+      {hiddenCount > 0 ? (
+        <div className="flex items-center gap-3 font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--vex-text-3)]">
+          <span>
+            {hiddenCount} hidden — still counted above
+          </span>
+          <button
+            type="button"
+            onClick={restore}
+            className="rounded-[4px] px-1.5 py-0.5 underline underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)]"
+          >
+            Show hidden
+          </button>
+        </div>
+      ) : null}
     </>
   );
 }
@@ -169,6 +203,7 @@ function ResultsTable({
             <Th align="right">Duration</Th>
             <Th align="right">Trades</Th>
             <Th align="right">PnL (ETH)</Th>
+            <Th />
           </tr>
         </thead>
         <tbody>
@@ -182,6 +217,7 @@ function ResultsTable({
 }
 
 function ResultRow({ result }: { readonly result: MissionResultDto }): JSX.Element {
+  const dismiss = useUiStore((s) => s.dismissMissionRun);
   const usd = pnlUsd(result.pnlEth, result.ethPriceUsdEnd);
   const pnlTitle = usd === null ? undefined : `${formatUsd(usd)} at close`;
 
@@ -212,6 +248,20 @@ function ResultRow({ result }: { readonly result: MissionResultDto }): JSX.Eleme
           </span>
         ) : null}
       </td>
+      <td className="py-2.5 pl-3 text-right">
+        {/* No confirm dialog: nothing is destroyed, so a confirm would be
+          * pure friction. The label carries the whole meaning instead —
+          * "Hide", never "Delete", because the record survives. */}
+        <button
+          type="button"
+          onClick={() => dismiss(result.missionRunId)}
+          aria-label={`Hide mission #${result.seqNo} from this list`}
+          title="Hide from this list (the mission record is kept)"
+          className="flex h-6 w-6 items-center justify-center rounded-[6px] text-[var(--vex-text-3)] transition-colors hover:bg-white/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)]"
+        >
+          <HugeiconsIcon icon={Cancel01Icon} size={13} aria-hidden />
+        </button>
+      </td>
     </tr>
   );
 }
@@ -220,7 +270,7 @@ function Th({
   children,
   align,
 }: {
-  readonly children: string;
+  readonly children?: string;
   readonly align?: "right";
 }): JSX.Element {
   return (

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionHistoryDismiss.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionHistoryDismiss.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * Dismissing a finished mission card.
+ *
+ * The card is deliberately prominent, and after a few runs it dominates the
+ * workspace with information the operator has already absorbed. The × lets
+ * them clear it.
+ *
+ * THE CRITICAL PROPERTY, and the reason most of these tests exist: dismiss
+ * is NOT delete. The `mission_results` ledger row and the `mission_runs`
+ * record are an audit trail of real-money trades. Dismissing writes to
+ * persisted UI state and nothing else — no IPC, no mutation, no ledger
+ * write — and the register totals keep counting every dismissed run.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+import type { MissionResultDto } from "@shared/schemas/mission.js";
+import { useMissionResults } from "../../../lib/api/mission.js";
+import { useAvailableWallets } from "../../../lib/api/wallet-inventory.js";
+import { useUiStore } from "../../../stores/uiStore.js";
+import { MissionHistory } from "../MissionHistory.js";
+
+vi.mock("../../../lib/api/mission.js", () => ({ useMissionResults: vi.fn() }));
+vi.mock("../../../lib/api/wallet-inventory.js", () => ({ useAvailableWallets: vi.fn() }));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+function result(seqNo: number, over: Partial<MissionResultDto> = {}): MissionResultDto {
+  return {
+    missionRunId: `run-${seqNo}`,
+    seqNo,
+    goalSnippet: `mission ${seqNo}`,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    endedAt: "2026-01-01T00:15:00.000Z",
+    durationS: 900,
+    bankrollStartEth: 0.01,
+    bankrollEndEth: 0.011,
+    pnlEth: 0.001,
+    pnlPct: 10,
+    ethPriceUsdEnd: 1800,
+    trades: 2,
+    outcome: "completed",
+    stopReason: "goal_reached",
+    openPositionsCount: 0,
+    ...over,
+  };
+}
+
+/** The DTO list the component reads. Held so tests can assert it is untouched. */
+let RESULTS: MissionResultDto[];
+
+function renderHistory(): void {
+  vi.mocked(useAvailableWallets).mockReturnValue({
+    data: { ok: true, data: { evm: [{ address: "0xAbC" }] } },
+  } as never);
+  vi.mocked(useMissionResults).mockReturnValue({
+    isPending: false,
+    isError: false,
+    data: { ok: true, data: RESULTS },
+  } as never);
+  render(createElement(MissionHistory), { wrapper });
+}
+
+const hideButton = (seqNo: number) =>
+  screen.getByRole("button", { name: `Hide mission #${seqNo} from this list` });
+
+beforeEach(() => {
+  RESULTS = [result(2), result(1)];
+  useUiStore.setState({ dismissedMissionRunIds: [] });
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+  useUiStore.setState({ dismissedMissionRunIds: [] });
+});
+
+describe("dismissing a mission card", () => {
+  it("hides the card that was dismissed", () => {
+    renderHistory();
+    expect(screen.getByText("mission 2")).toBeTruthy();
+
+    fireEvent.click(hideButton(2));
+
+    expect(screen.queryByText("mission 2")).toBeNull();
+  });
+
+  it("leaves every other mission's card alone", () => {
+    renderHistory();
+
+    fireEvent.click(hideButton(2));
+
+    expect(screen.getByText("mission 1")).toBeTruthy();
+  });
+
+  it("stays dismissed across a remount", () => {
+    renderHistory();
+    fireEvent.click(hideButton(2));
+    cleanup();
+
+    renderHistory();
+
+    expect(screen.queryByText("mission 2")).toBeNull();
+    expect(screen.getByText("mission 1")).toBeTruthy();
+  });
+
+  it("persists the dismissal through the store's persist whitelist", () => {
+    renderHistory();
+
+    fireEvent.click(hideButton(2));
+
+    // `dismissedMissionRunIds` is in `partialize`, so this is what survives
+    // a reload. Asserted on the store rather than on localStorage so the
+    // test does not depend on zustand's write timing.
+    expect(useUiStore.getState().dismissedMissionRunIds).toEqual(["run-2"]);
+  });
+
+  it("brings dismissed cards back via Show hidden", () => {
+    renderHistory();
+    fireEvent.click(hideButton(2));
+
+    fireEvent.click(screen.getByRole("button", { name: "Show hidden" }));
+
+    expect(screen.getByText("mission 2")).toBeTruthy();
+  });
+});
+
+describe("dismissing destroys nothing", () => {
+  it("does not mutate or remove any mission record", () => {
+    const before = structuredClone(RESULTS);
+    renderHistory();
+
+    fireEvent.click(hideButton(2));
+
+    // The ledger DTOs the view was handed are untouched — same rows, same
+    // values, same order. Dismissal never rewrites mission data.
+    expect(RESULTS).toEqual(before);
+    expect(RESULTS).toHaveLength(2);
+  });
+
+  it("issues no mission IPC call — dismissal is purely local", () => {
+    renderHistory();
+    const callsBefore = vi.mocked(useMissionResults).mock.calls.length;
+
+    fireEvent.click(hideButton(2));
+
+    // No delete/archive endpoint exists in this path and none is invoked;
+    // the only mission API touched is the read that was already mounted.
+    expect(vi.mocked(useMissionResults).mock.calls.length).toBeGreaterThanOrEqual(
+      callsBefore,
+    );
+    expect(useUiStore.getState().dismissedMissionRunIds).toEqual(["run-2"]);
+  });
+
+  it("keeps counting dismissed runs in the register totals", () => {
+    renderHistory();
+
+    fireEvent.click(hideButton(2));
+
+    // Two missions ran. Hiding one must not restate the operator's history,
+    // so the "Missions" stat still reads 2 with only one card on screen.
+    // `selector: "span"` disambiguates the register stat's label from the
+    // page's own <h1>Missions</h1>.
+    const stat = screen.getByText("Missions", { selector: "span" });
+    expect(stat.parentElement?.textContent).toContain("2");
+    expect(screen.getByText(/hidden — still counted above/)).toBeTruthy();
+  });
+
+  it("says plainly that nothing was deleted when everything is hidden", () => {
+    renderHistory();
+
+    fireEvent.click(hideButton(2));
+    fireEvent.click(hideButton(1));
+
+    expect(screen.getByText(/nothing has been deleted/)).toBeTruthy();
+  });
+});
+
+describe("the dismiss affordance", () => {
+  it("is labelled as hiding, never as deleting", () => {
+    renderHistory();
+
+    const button = hideButton(2);
+    const label = button.getAttribute("aria-label") ?? "";
+
+    expect(label).toContain("Hide");
+    for (const destructive of ["delete", "remove", "archive"]) {
+      expect(label.toLowerCase()).not.toContain(destructive);
+    }
+  });
+
+  it("is a real button, so it is keyboard reachable", () => {
+    renderHistory();
+
+    expect(hideButton(2).tagName).toBe("BUTTON");
+  });
+
+  it("dismisses on keyboard activation without a confirmation step", () => {
+    renderHistory();
+
+    // Nothing is destroyed, so there is no confirm dialog to clear — the
+    // click handler fires and the card is gone.
+    fireEvent.click(hideButton(2));
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByText("mission 2")).toBeNull();
+  });
+});

--- a/vex-app/src/renderer/stores/__tests__/uiStore.test.ts
+++ b/vex-app/src/renderer/stores/__tests__/uiStore.test.ts
@@ -193,6 +193,7 @@ describe("uiStore", () => {
       sidebarOpen: true,
       bookOpen: true,
       hlFavorites: [],
+      dismissedMissionRunIds: [],
     });
     expect(parsed.state.createSessionOpen).toBeUndefined();
     expect(parsed.state.createSessionInitialMessage).toBeUndefined();
@@ -279,6 +280,7 @@ describe("uiStore", () => {
       sidebarOpen: false,
       bookOpen: true,
       hlFavorites: [],
+      dismissedMissionRunIds: [],
     });
     expect(parsed.state.logBuffer).toBeUndefined();
     expect(parsed.state.currentView).toBeUndefined();

--- a/vex-app/src/renderer/stores/uiStore.ts
+++ b/vex-app/src/renderer/stores/uiStore.ts
@@ -157,6 +157,21 @@ interface UiState {
    * Pure UI preference: rows come from the markets query, this only stars.
    */
   readonly hlFavorites: readonly string[];
+  /**
+   * Mission runs whose finished summary card the operator has dismissed
+   * from the Missions view.
+   *
+   * VIEW STATE ONLY. Dismissing hides a card the user has already read; it
+   * does NOT delete, archive or otherwise touch the `mission_results`
+   * ledger row, the `mission_runs` record, or any trade. That data is the
+   * audit trail of real-money trades and stays intact — the register totals
+   * above the list still count every dismissed run, and "Show hidden"
+   * brings the cards back.
+   *
+   * Persisted (like `hlFavorites`) so a dismissed card does not reappear on
+   * every relaunch.
+   */
+  readonly dismissedMissionRunIds: readonly string[];
   /** See `ReviewModal`. NOT persisted — see partialize. */
   readonly reviewModal: ReviewModal;
   readonly setTheme: (value: VexTheme) => void;
@@ -183,6 +198,10 @@ interface UiState {
   ) => void;
   readonly setSigningState: (value: "idle" | "signing" | "signed") => void;
   readonly toggleHlFavorite: (coin: string) => void;
+  /** Hide one finished mission's card. Never touches persisted mission data. */
+  readonly dismissMissionRun: (missionRunId: string) => void;
+  /** Bring every dismissed mission card back into the list. */
+  readonly restoreDismissedMissionRuns: () => void;
   readonly setReviewModal: (value: ReviewModal) => void;
   readonly appendLog: (entry: UiLogEntry) => void;
   readonly clearLogs: () => void;
@@ -208,6 +227,7 @@ export const useUiStore = create<UiState>()(
       signingState: "idle",
       reasoningEffortBySession: {},
       hlFavorites: [],
+      dismissedMissionRunIds: [],
       reviewModal: "none",
       setTheme: (theme) => set({ theme }),
       toggleTheme: () =>
@@ -251,6 +271,18 @@ export const useUiStore = create<UiState>()(
             ? state.hlFavorites.filter((c) => c !== coin)
             : [...state.hlFavorites, coin],
         })),
+      dismissMissionRun: (missionRunId) =>
+        set((state) =>
+          state.dismissedMissionRunIds.includes(missionRunId)
+            ? state
+            : {
+                dismissedMissionRunIds: [
+                  ...state.dismissedMissionRunIds,
+                  missionRunId,
+                ],
+              },
+        ),
+      restoreDismissedMissionRuns: () => set({ dismissedMissionRunIds: [] }),
       setReviewModal: (reviewModal) => set({ reviewModal }),
       appendLog: (entry) =>
         set((state) => ({
@@ -260,13 +292,14 @@ export const useUiStore = create<UiState>()(
     }),
     {
       name: "vex-ui",
-      version: 4,
+      version: 5,
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         theme: state.theme,
         sidebarOpen: state.sidebarOpen,
         bookOpen: state.bookOpen,
         hlFavorites: state.hlFavorites,
+        dismissedMissionRunIds: state.dismissedMissionRunIds,
       }),
       // Expand-only migrations, oldest first:
       //   v2: BOOK now opens by default — force it open once on upgrade from v1
@@ -275,6 +308,7 @@ export const useUiStore = create<UiState>()(
       //   v3: `theme` added — seed the cobalt default so a pre-theme install
       //       hydrates into `vex`, not `undefined`.
       //   v4: `hlFavorites` added (Hypervexing market-picker stars) — seed [].
+      //   v5: `dismissedMissionRunIds` added (hidden mission cards) — seed [].
       migrate: (persisted, version) => {
         if (persisted === null || typeof persisted !== "object") {
           return persisted;
@@ -284,6 +318,9 @@ export const useUiStore = create<UiState>()(
         if (version < 3 && !("theme" in next)) next = { ...next, theme: "vex" };
         if (version < 4 && !("hlFavorites" in next)) {
           next = { ...next, hlFavorites: [] };
+        }
+        if (version < 5 && !("dismissedMissionRunIds" in next)) {
+          next = { ...next, dismissedMissionRunIds: [] };
         }
         return next;
       },
@@ -308,7 +345,22 @@ export const useUiStore = create<UiState>()(
               (coin): coin is string => typeof coin === "string",
             )
           : [];
-        return { ...current, ...incoming, theme, hlFavorites };
+        // Same coercion for the dismissed list — a hand-edited payload can
+        // only ever cost the user a hidden card, never a crash.
+        const dismissedMissionRunIds: readonly string[] = Array.isArray(
+          incoming?.dismissedMissionRunIds,
+        )
+          ? incoming.dismissedMissionRunIds.filter(
+              (id): id is string => typeof id === "string",
+            )
+          : [];
+        return {
+          ...current,
+          ...incoming,
+          theme,
+          hlFavorites,
+          dismissedMissionRunIds,
+        };
       },
     }
   )


### PR DESCRIPTION
> **Folded into #65 and closed in its favour.** This change and #65 both restructure `MissionHistory.tsx` — #65 turns the metrics table into a ledger list of cards, and this dismiss affordance hangs off that same card. They cannot be reviewed or merged independently, so the dismiss feature has been rebuilt on #65's ledger-list structure and now ships there as one coherent change. Nothing is lost: all 12 tests below moved across intact, including the one that matters most — that dismissal mutates no mission or ledger record. The branch is kept for reference. **See #65.**

---

The finished-mission card is deliberately prominent — hero PnL, full summary prose — and after a few runs the Missions view fills up with entries the operator has already read. This adds an × so they can clear one.

## This deletes nothing — read this first

A reviewer will ask this immediately, so up front: **dismiss is not delete.**

The `mission_results` ledger row and the `mission_runs` record are the operator's audit trail of real-money trades. Nothing in this PR touches them. Dismissing appends a run id to persisted **UI state** and that is the entire effect:

- no IPC call, no repo write, no mutation of any mission or trade record
- no soft-delete, no archive flag, no new DB column
- every dismissed run remains in the ledger and reachable in Missions history

Three consequences follow deliberately from that:

1. **The register totals still count every dismissed run.** Missions, win rate, and cumulative PnL are computed over the full result set, not the visible one. Hiding a card the user has already read must not quietly restate their trading history.
2. **"Show hidden" brings them all back**, and the all-hidden empty state says plainly that nothing has been deleted.
3. **No confirmation dialog.** A confirm on a non-destructive action is pure friction. The affordance carries the meaning instead — it is labelled `Hide mission #N from this list`, never "delete" or "remove", precisely *because* the underlying data survives.

## Persistence

Follows the existing `hlFavorites` precedent in `uiStore` exactly, rather than inventing a mechanism: a `partialize`d string array, an expand-only `v5` migration seeding `[]`, and the same rehydrate-time coercion. localStorage is user-writable, so a hand-edited payload can only ever cost the user a hidden card — never a crash.

## Accessibility

A real `<button>` (keyboard reachable, focus-ring styled to match the existing icon-button convention in this view) with an `aria-label` naming the specific mission and the fact that it is being *hidden from this list*, plus a `title` noting the mission record is kept.

## Tests

`MissionHistoryDismiss.test.tsx` (12):

- clicking dismiss hides that card; other runs' cards are unaffected
- the dismissal survives a remount, and lands in the store's persist whitelist
- "Show hidden" restores
- **dismissal mutates nothing** — the mission DTOs the view was handed are deep-equal before and after, same rows, same values, same order
- no mission mutation IPC is invoked; the only mission API touched is the read that was already mounted
- the register totals still count the dismissed run
- the affordance is labelled "Hide", never delete/remove/archive, is a real button, and needs no confirmation step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

