### PR TITLE
fix(mission): enforce ownership and dispatch boundaries

### DIFF
--- a/src/__tests__/vex-agent/engine/core/prepared-action-follow-up.test.ts
+++ b/src/__tests__/vex-agent/engine/core/prepared-action-follow-up.test.ts
@@ -36,7 +36,15 @@ vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/results.js", () => ({
         toolCallsExecuted: args.toolCallsExecuted,
         lastText: args.lastText,
       }
-    : {
+    : args.batchStopReason
+      ? {
+          kind: "engine_stop",
+          stopReason: args.batchStopReason,
+          text: args.lastText,
+          toolCallsExecuted: args.toolCallsExecuted,
+          lastText: args.lastText,
+        }
+      : {
         kind: "normal_complete",
         toolCallsExecuted: args.toolCallsExecuted,
         lastText: args.lastText,
@@ -89,7 +97,10 @@ function context(permission: "restricted" | "full") {
   } as any;
 }
 
-async function run(permission: "restricted" | "full") {
+async function run(
+  permission: "restricted" | "full",
+  controls: { abortSignal?: AbortSignal } = {},
+) {
   return processTurnToolBatch({
     context: context(permission),
     turnResult: {
@@ -110,6 +121,7 @@ async function run(permission: "restricted" | "full") {
     currentTokenCount: 0,
     contextLimit: 128_000,
     lastTextSoFar: null,
+    ...controls,
   });
 }
 
@@ -181,6 +193,29 @@ describe("prepared-action follow-up handoff", () => {
       ],
       systemOriginated: true,
     });
+  });
+
+  it("does not synthesize confirm after operator Stop wins the handoff boundary", async () => {
+    const controller = new AbortController();
+    dispatchTool.mockImplementationOnce(async () => {
+      controller.abort();
+      return prepareResult();
+    });
+
+    const outcome = await run("full", { abortSignal: controller.signal });
+
+    expect(dispatchTool).toHaveBeenCalledOnce();
+    expect(outcome).toMatchObject({
+      kind: "engine_stop",
+      stopReason: "user_stopped",
+      toolCallsExecuted: 1,
+    });
+    expect(persistBatchTranscript).toHaveBeenCalledOnce();
+    expect(persistBatchTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executedCalls: [expect.objectContaining({ name: "wallet_send_prepare" })],
+      }),
+    );
   });
 
   it.each(["restricted", "full"] as const)(

--- a/src/__tests__/vex-agent/engine/core/runner/resume-mission-run.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/resume-mission-run.test.ts
@@ -159,6 +159,9 @@ vi.mock("@vex-agent/tools/protocols/catalog.js", () => ({
 const runnerModule = await import("../../../../../vex-agent/engine/core/runner.js");
 const { processAgentTurn, processMissionSetupTurn, startMission, resumeMissionRun } = runnerModule;
 const { MissionRunPausedError } = await import("../../../../../vex-agent/engine/types.js");
+const { RunnerLeaseLostError } = await import(
+  "../../../../../vex-agent/engine/runtime/lease-loss.js"
+);
 const { ITERATION_LIMIT_REPLY } = await import("../../../../../vex-agent/engine/core/runner/shared.js");
 
 function makeProvider() {
@@ -409,6 +412,30 @@ describe("runner", () => {
         }),
         expect.anything(),
       );
+    });
+
+    it("exits a stale runner without finalizing state after lease loss", async () => {
+      const leaseController = new AbortController();
+      const leaseLost = new RunnerLeaseLostError("session-1");
+      leaseController.abort(leaseLost);
+      mockGetRun.mockResolvedValueOnce({
+        id: "run-1", missionId: "mission-1", sessionId: "session-1",
+        status: "running", iterationCount: 5,
+      });
+      mockGetMission.mockResolvedValueOnce(makeReadyMission({ status: "running" }));
+      mockHydrate.mockResolvedValueOnce(makeHydratedSession({
+        sessionKind: "mission", missionId: "mission-1", missionRunId: "run-1",
+      }));
+      mockRunTurnLoop.mockRejectedValueOnce(leaseLost);
+
+      await expect(
+        resumeMissionRun("run-1", leaseController.signal),
+      ).rejects.toBe(leaseLost);
+
+      expect(mockRunTurnLoop.mock.calls[0]?.[11]).toBe(leaseController.signal);
+      expect(mockUpdateRunStatus).toHaveBeenCalledTimes(1);
+      expect(mockUpdateRunStatus).toHaveBeenCalledWith("run-1", "running");
+      expect(mockSetMissionStatus).not.toHaveBeenCalled();
     });
 
     it("throws if run not found", async () => {

--- a/src/__tests__/vex-agent/engine/core/runner/retry.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/retry.test.ts
@@ -41,7 +41,7 @@ vi.mock("@vex-agent/engine/runtime/lease-handle.js", () => ({
     },
     ownerId: "test-owner",
     release: vi.fn().mockResolvedValue(undefined),
-    onLeaseLost: vi.fn(),
+    signal: new AbortController().signal,
   }),
 }));
 
@@ -138,7 +138,10 @@ describe("retryActiveMissionRun", () => {
   it("flips paused_error → running and resumes the run", async () => {
     mockGetActiveRunBySession.mockResolvedValue(activeRun("paused_error"));
     const result = await retryActiveMissionRun("s-1");
-    expect(mockResumeMissionRun).toHaveBeenCalledWith("run-1");
+    expect(mockResumeMissionRun).toHaveBeenCalledWith(
+      "run-1",
+      expect.any(AbortSignal),
+    );
     expect(result).toEqual(okTurnResult);
     // Phase 4d: a human Recover cancels any pending error_retry wake first.
     expect(mockCancelForSession).toHaveBeenCalledWith(
@@ -159,7 +162,10 @@ describe("retryActiveMissionRun", () => {
       wakeCancelledCount: 1,
     });
     const result = await retryActiveMissionRun("s-1");
-    expect(mockResumeMissionRun).toHaveBeenCalledWith("run-1");
+    expect(mockResumeMissionRun).toHaveBeenCalledWith(
+      "run-1",
+      expect.any(AbortSignal),
+    );
     expect(result).toEqual(okTurnResult);
   });
 

--- a/src/__tests__/vex-agent/engine/core/turn-loop-dispatch-boundaries.test.ts
+++ b/src/__tests__/vex-agent/engine/core/turn-loop-dispatch-boundaries.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RunnerLeaseLostError } from "../../../../vex-agent/engine/runtime/lease-loss.js";
+
+const dispatchTool = vi.fn();
+const persistBatchTranscript = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@vex-agent/tools/dispatcher.js", () => ({
+  dispatchTool: (...args: unknown[]) => dispatchTool(...args),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/execute.js", () => ({
+  buildToolContext: (context: Record<string, unknown>) => ({
+    ...context,
+    approved: false,
+    contextUsageBand: "normal",
+  }),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/approval-stop.js", () => ({
+  assertApprovalActionKind: vi.fn(),
+  enqueueApprovalIntent: vi.fn(),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/results.js", () => ({
+  BATCH_ABORTED_BY_COMPACT_OUTPUT: "aborted",
+  persistBatchTranscript: (...args: unknown[]) => persistBatchTranscript(...args),
+  mapBatchOutcome: (args: {
+    batchStopReason: string | null;
+    toolCallsExecuted: number;
+    lastText: string | null;
+  }) => args.batchStopReason
+    ? {
+        kind: "engine_stop",
+        stopReason: args.batchStopReason,
+        text: args.lastText,
+        toolCallsExecuted: args.toolCallsExecuted,
+        lastText: args.lastText,
+      }
+    : {
+        kind: "normal_complete",
+        toolCallsExecuted: args.toolCallsExecuted,
+        lastText: args.lastText,
+      },
+}));
+
+const { processTurnToolBatch } = await import(
+  "../../../../vex-agent/engine/core/turn-loop-tool-batch.js"
+);
+
+const toolCalls = [
+  { id: "call-1", name: "first_tool", arguments: {} },
+  { id: "call-2", name: "second_tool", arguments: {} },
+];
+
+function run(controls: {
+  abortSignal?: AbortSignal;
+  leaseSignal?: AbortSignal;
+  missionDeadlineMs?: number;
+} = {}) {
+  return processTurnToolBatch({
+    context: {
+      sessionId: "session-1",
+      sessionKind: "mission",
+      sessionPermission: "full",
+      missionId: "mission-1",
+      missionRunId: "run-1",
+      isSubagent: false,
+      loadedDocuments: new Map(),
+      walletPolicy: { kind: "none" },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    turnResult: { content: null, toolCalls },
+    liveMessages: [],
+    currentTokenCount: 0,
+    contextLimit: 128_000,
+    lastTextSoFar: null,
+    ...controls,
+  });
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  persistBatchTranscript.mockResolvedValue(undefined);
+});
+
+describe("tool dispatch control boundaries", () => {
+  it("does not dispatch later calls after operator Stop", async () => {
+    const controller = new AbortController();
+    dispatchTool.mockImplementationOnce(async () => {
+      controller.abort();
+      return { success: true, output: "first completed" };
+    });
+
+    const outcome = await run({ abortSignal: controller.signal });
+
+    expect(dispatchTool).toHaveBeenCalledOnce();
+    expect(outcome).toMatchObject({
+      kind: "engine_stop",
+      stopReason: "user_stopped",
+      toolCallsExecuted: 1,
+    });
+    expect(persistBatchTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executedCalls: [expect.objectContaining({ id: "call-1" })],
+        executedResults: [expect.objectContaining({ output: "first completed" })],
+      }),
+    );
+  });
+
+  it("does not dispatch later calls after the hard deadline", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-07-21T10:00:00.000Z");
+    vi.setSystemTime(startedAt);
+    const deadline = startedAt.getTime() + 1_000;
+    dispatchTool.mockImplementationOnce(async () => {
+      vi.setSystemTime(deadline);
+      return { success: true, output: "first completed" };
+    });
+
+    const outcome = await run({ missionDeadlineMs: deadline });
+
+    expect(dispatchTool).toHaveBeenCalledOnce();
+    expect(outcome).toMatchObject({
+      kind: "engine_stop",
+      stopReason: "deadline_reached",
+      toolCallsExecuted: 1,
+    });
+  });
+
+  it("persists completed calls then exits without finalizing when the lease is lost", async () => {
+    const leaseController = new AbortController();
+    dispatchTool.mockImplementationOnce(async () => {
+      leaseController.abort(new RunnerLeaseLostError("session-1"));
+      return { success: true, output: "first completed" };
+    });
+
+    await expect(run({ leaseSignal: leaseController.signal })).rejects.toBeInstanceOf(
+      RunnerLeaseLostError,
+    );
+
+    expect(dispatchTool).toHaveBeenCalledOnce();
+    expect(persistBatchTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executedCalls: [expect.objectContaining({ id: "call-1" })],
+        executedResults: [expect.objectContaining({ output: "first completed" })],
+      }),
+    );
+  });
+
+  it("discards a model batch when ownership was already lost", async () => {
+    const leaseController = new AbortController();
+    leaseController.abort(new RunnerLeaseLostError("session-1"));
+
+    await expect(run({ leaseSignal: leaseController.signal })).rejects.toBeInstanceOf(
+      RunnerLeaseLostError,
+    );
+
+    expect(dispatchTool).not.toHaveBeenCalled();
+    expect(persistBatchTranscript).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/turn-loop/mission-mode.test.ts
+++ b/src/__tests__/vex-agent/engine/core/turn-loop/mission-mode.test.ts
@@ -358,6 +358,42 @@ describe("turn-loop", () => {
       expect(provider.chatCompletion).toHaveBeenCalled();
     });
 
+    it("does not dispatch tool calls returned by inference after the deadline", async () => {
+      vi.useFakeTimers();
+      const startedAt = new Date("2026-07-21T10:00:00.000Z");
+      vi.setSystemTime(startedAt);
+      const deadline = startedAt.getTime() + 1_000;
+      const provider = makeProvider([{
+        toolCalls: [{ id: "late-call", name: "wallet_balances", arguments: {} }],
+      }]);
+      provider.chatCompletion.mockImplementationOnce(async () => {
+        vi.setSystemTime(deadline);
+        return {
+          content: null,
+          toolCalls: [{ id: "late-call", name: "wallet_balances", arguments: {} }],
+          usage: {
+            promptTokens: 1_000,
+            completionTokens: 200,
+            cachedTokens: 0,
+            reasoningTokens: 0,
+          },
+        };
+      });
+
+      try {
+        const result = await runTurnLoop(
+          makeContext({ sessionKind: "mission", missionRunId: "run-1" }),
+          [], null, 0, provider as any, makeConfig() as any, [],
+          { ...defaultLoopConfig, maxIterations: 1, missionDeadlineMs: deadline },
+        );
+
+        expect(result.stopReason).toBe("deadline_reached");
+        expect(mockDispatchTool).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does not stop early when missionDeadlineMs is null/undefined (no box)", async () => {
       const provider = makeProvider([{ content: "Working..." }]);
 

--- a/src/__tests__/vex-agent/engine/ingress.test.ts
+++ b/src/__tests__/vex-agent/engine/ingress.test.ts
@@ -111,7 +111,7 @@ vi.mock("@vex-agent/engine/runtime/lease-handle.js", () => ({
     lease: { sessionId: "s1", missionRunId: null, ownerId: "test-owner", processKind: "electron_main", acquiredAt: new Date(), heartbeatAt: new Date(), expiresAt: new Date() },
     ownerId: "test-owner",
     release: vi.fn().mockResolvedValue(undefined),
-    onLeaseLost: vi.fn(),
+    signal: new AbortController().signal,
   }),
 }));
 
@@ -184,7 +184,10 @@ describe("ingress.routeUserMessage", () => {
       }),
     );
     expect(mockAddOperatorCue).toHaveBeenCalled();
-    expect(mockResumeMissionRun).toHaveBeenCalledWith("run-1");
+    expect(mockResumeMissionRun).toHaveBeenCalledWith(
+      "run-1",
+      expect.any(AbortSignal),
+    );
     expect(mockProcessAgentTurn).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/vex-agent/engine/runtime/lease-handle.test.ts
+++ b/src/__tests__/vex-agent/engine/runtime/lease-handle.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createLeaseHandle } from "../../../../vex-agent/engine/runtime/lease-handle.js";
+import {
+  createLeaseHandle,
+  RunnerLeaseLostError,
+  throwIfRunnerLeaseLost,
+} from "../../../../vex-agent/engine/runtime/lease-handle.js";
 import type { RunnerLease } from "../../../../vex-agent/db/repos/runner-leases.js";
 
 const SAMPLE_LEASE: RunnerLease = {
@@ -81,12 +85,10 @@ describe("LeaseHandle", () => {
     await handle.release();
   });
 
-  it("calls onLeaseLost when renew returns null + stops the interval", async () => {
+  it("aborts the ownership signal when renew returns null + stops the interval", async () => {
     const timer = makeFakeTimer();
     const renewFn = vi.fn().mockResolvedValue(null);
     const releaseFn = vi.fn().mockResolvedValue(0);
-    const onLeaseLost = vi.fn();
-
     const handle = createLeaseHandle({
       lease: SAMPLE_LEASE,
       ownerId: "owner-1",
@@ -94,12 +96,15 @@ describe("LeaseHandle", () => {
       timer,
       renewFn,
       releaseFn,
-      onLeaseLost,
     });
 
+    expect(handle.signal.aborted).toBe(false);
     await timer.trigger();
-    expect(onLeaseLost).toHaveBeenCalledTimes(1);
-    expect(onLeaseLost).toHaveBeenCalledWith(expect.stringContaining("stolen"));
+    expect(handle.signal.aborted).toBe(true);
+    expect(handle.signal.reason).toBeInstanceOf(RunnerLeaseLostError);
+    expect(() => throwIfRunnerLeaseLost(handle.signal)).toThrow(
+      RunnerLeaseLostError,
+    );
     expect(timer.clearInterval).toHaveBeenCalledTimes(1);
     await handle.release();
     // Already released by the lease-stolen path — second release is a no-op.

--- a/src/__tests__/vex-agent/engine/wake/executor.test.ts
+++ b/src/__tests__/vex-agent/engine/wake/executor.test.ts
@@ -118,7 +118,7 @@ describe("wake.executor.tick", () => {
       lease: makeStubLease(),
       ownerId: "test-owner",
       release: vi.fn().mockResolvedValue(undefined),
-      onLeaseLost: vi.fn(),
+      signal: new AbortController().signal,
     });
     mockReleaseLease.mockReset();
     mockReleaseLease.mockResolvedValue(undefined);
@@ -146,7 +146,10 @@ describe("wake.executor.tick", () => {
         expect.objectContaining({ missionRunId: "run-1", expectedAttempt: 2 }),
       );
       expect(mockClaimRunLeaseAndFlipToRunning).not.toHaveBeenCalled();
-      expect(deps.resumeMissionRun).toHaveBeenCalledWith("run-1");
+      expect(deps.resumeMissionRun).toHaveBeenCalledWith(
+        "run-1",
+        expect.any(AbortSignal),
+      );
     });
 
     it("CONSUMED-WAKE RACE: a human Recover stamped unsafe → claim ineligible → skip, no resume", async () => {
@@ -211,7 +214,10 @@ describe("wake.executor.tick", () => {
       "continue monitoring",
       "2026-04-20T12:00:00.000Z",
     );
-    expect(deps.resumeMissionRun).toHaveBeenCalledWith("run-1");
+    expect(deps.resumeMissionRun).toHaveBeenCalledWith(
+      "run-1",
+      expect.any(AbortSignal),
+    );
   });
 
   it("skips when the run is no longer paused_wake (user preempt won the race)", async () => {

--- a/src/vex-agent/engine/core/approval-runtime/continuation.ts
+++ b/src/vex-agent/engine/core/approval-runtime/continuation.ts
@@ -70,7 +70,7 @@ export async function runResumeAfterDecision(
 ): Promise<TurnResult> {
   try {
     const { resumeMissionRun } = await import("../runner/mission.js");
-    return await resumeMissionRun(cont.missionRunId);
+    return await resumeMissionRun(cont.missionRunId, cont.leaseHandle.signal);
   } finally {
     const { releaseLeaseAndEmitControlState } = await import(
       "../../runtime/release-and-emit.js"

--- a/src/vex-agent/engine/core/runner/abort.ts
+++ b/src/vex-agent/engine/core/runner/abort.ts
@@ -125,10 +125,9 @@ export async function abortMissionRun(runId: string): Promise<AbortMissionRunRes
     });
   }
 
-  // (a) `running` with live in-process loop → fire AbortSignal. Loop checks
-  // `abortSignal?.aborted` at the top of each iteration (turn-loop.ts:138),
-  // sets `stopReason = "user_stopped"`, breaks, and `finalizeMissionRunStatus`
-  // (mission.ts:329) maps that to `cancelled`.
+  // (a) `running` with live in-process loop → fire AbortSignal. The loop checks
+  // it at iteration and dispatch boundaries, then maps `user_stopped` to the
+  // terminal `cancelled` status.
   if (run.status === "running" && controllers.has(runId)) {
     controllers.get(runId)!.abort();
     logger.info("engine.mission.abort_signaled", {

--- a/src/vex-agent/engine/core/runner/agent.ts
+++ b/src/vex-agent/engine/core/runner/agent.ts
@@ -156,6 +156,7 @@ export async function processAgentTurn(
     { personaSetupHint }, // promptOptions
     undefined, // abortSignal — chat turns have no mission-boundary controller
     signal, // inferenceAbortSignal (9-5a) — chat-turn "stop generating"
+    sessionLease.signal,
   );
 
     // Graceful cap-hit reply: when the loop exhausted maxIterations WITHOUT the

--- a/src/vex-agent/engine/core/runner/mission-run.ts
+++ b/src/vex-agent/engine/core/runner/mission-run.ts
@@ -62,6 +62,11 @@ import { toToolDefinitions, DEFAULT_LOOP_CONFIG } from "./shared.js";
 import type { PreparedMissionStart } from "./mission-prepare.js";
 import { releaseLeaseAndEmitControlState } from "../../runtime/release-and-emit.js";
 import type { Permission } from "../../types.js";
+import logger from "@utils/logger.js";
+import {
+  isRunnerLeaseLostError,
+  throwIfRunnerLeaseLost,
+} from "../../runtime/lease-loss.js";
 
 type Provider = NonNullable<Awaited<ReturnType<typeof resolveProvider>>>;
 type ProviderConfig = NonNullable<
@@ -180,7 +185,11 @@ export async function runPreparedMissionStart(
       loopConfig,
       promptOptions,
       controller.signal,
+      undefined,
+      prepared.sessionLease.signal,
     );
+
+    throwIfRunnerLeaseLost(prepared.sessionLease.signal);
 
     const missionStatus = await finalizeMissionRunStatus(
       prepared.missionId,
@@ -198,6 +207,13 @@ export async function runPreparedMissionStart(
       missionStatus,
     };
   } catch (err: unknown) {
+    if (isRunnerLeaseLostError(err)) {
+      logger.info("engine.mission.stale_runner_exited", {
+        runId: prepared.runId,
+        sessionId: prepared.sessionId,
+      });
+      throw err;
+    }
     await finalizeMissionRunError(
       prepared.missionId,
       prepared.runId,
@@ -228,6 +244,7 @@ export interface PreparedResumeRun {
   readonly mission: Mission;
   readonly provider: Provider;
   readonly config: ProviderConfig;
+  readonly leaseSignal?: AbortSignal;
 }
 
 export async function resumePreparedMissionRun(
@@ -307,7 +324,11 @@ export async function resumePreparedMissionRun(
       loopConfig,
       promptOptions,
       controller.signal,
+      undefined,
+      prepared.leaseSignal,
     );
+
+    throwIfRunnerLeaseLost(prepared.leaseSignal);
 
     const missionStatus = await finalizeMissionRunStatus(
       prepared.run.missionId,
@@ -325,6 +346,13 @@ export async function resumePreparedMissionRun(
       missionStatus,
     };
   } catch (err: unknown) {
+    if (isRunnerLeaseLostError(err)) {
+      logger.info("engine.mission.stale_runner_exited", {
+        runId: prepared.runId,
+        sessionId: prepared.run.sessionId,
+      });
+      throw err;
+    }
     await finalizeMissionRunError(
       prepared.run.missionId,
       prepared.runId,

--- a/src/vex-agent/engine/core/runner/mission.ts
+++ b/src/vex-agent/engine/core/runner/mission.ts
@@ -26,6 +26,7 @@ import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
 import * as missionsRepo from "@vex-agent/db/repos/missions.js";
 import logger from "@utils/logger.js";
 import { finalizeMissionRunError } from "./mission-finalize.js";
+import { isRunnerLeaseLostError } from "../../runtime/lease-loss.js";
 
 import {
   prepareMissionStart,
@@ -116,7 +117,10 @@ export async function startMission(missionId: string): Promise<TurnResult> {
  * the IPC layer's resume path goes through the shared runtime
  * dispatcher (`request-resume.ts` / `_shared/runtime-resume-dispatch`).
  */
-export async function resumeMissionRun(runId: string): Promise<TurnResult> {
+export async function resumeMissionRun(
+  runId: string,
+  leaseSignal?: AbortSignal,
+): Promise<TurnResult> {
   logger.info("engine.mission.resume", { runId });
 
   // Read run + check terminal status OUTSIDE the finalize-on-error try.
@@ -147,8 +151,12 @@ export async function resumeMissionRun(runId: string): Promise<TurnResult> {
       mission,
       provider,
       config,
+      leaseSignal,
     });
   } catch (err) {
+    // Another runner owns the session now. Never let this stale invocation
+    // rewrite the shared row to paused_error after the new owner took over.
+    if (isRunnerLeaseLostError(err)) throw err;
     // Skip double-finalize: `resumePreparedMissionRun` already wraps
     // its internal turn loop in a try/catch that calls
     // `finalizeMissionRunError` and throws `MissionRunPausedError`.

--- a/src/vex-agent/engine/core/runner/recover-run.ts
+++ b/src/vex-agent/engine/core/runner/recover-run.ts
@@ -55,6 +55,7 @@ export async function runPreparedMissionRecover(
       mission: prepared.mission,
       provider: prepared.provider,
       config: prepared.config,
+      leaseSignal: prepared.sessionLease.signal,
     });
   } finally {
     await releaseLeaseAndEmitControlState(

--- a/src/vex-agent/engine/core/runner/retry.ts
+++ b/src/vex-agent/engine/core/runner/retry.ts
@@ -117,7 +117,7 @@ export async function retryActiveMissionRun(sessionId: string): Promise<TurnResu
   try {
     // Lazy import to break the runner ↔ retry circular dependency.
     const { resumeMissionRun } = await import("./mission.js");
-    return await resumeMissionRun(run.id);
+    return await resumeMissionRun(run.id, handle.signal);
   } finally {
     const { releaseLeaseAndEmitControlState } = await import(
       "@vex-agent/engine/runtime/release-and-emit.js"

--- a/src/vex-agent/engine/core/runner/setup-turn.ts
+++ b/src/vex-agent/engine/core/runner/setup-turn.ts
@@ -162,6 +162,7 @@ export async function processMissionSetupTurn(
     // intentionally broader than agent.ts (which threads only pos 11).
     signal, // abortSignal
     signal, // inferenceAbortSignal
+    sessionLease.signal,
   );
 
   // Graceful cap-hit reply (setup): when the loop exhausted maxIterations

--- a/src/vex-agent/engine/core/turn-loop-tool-batch.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch.ts
@@ -65,6 +65,10 @@ import {
   dispatchPreparedActionFollowUp,
   resolvePreparedActionFollowUp,
 } from "./turn-loop-tool-batch/prepared-follow-up.js";
+import {
+  getRunnerLeaseLostError,
+  type RunnerLeaseLostError,
+} from "../runtime/lease-loss.js";
 
 export type { StopPayload, ToolBatchOutcome } from "./turn-loop-tool-batch/outcome.js";
 
@@ -76,6 +80,9 @@ export async function processTurnToolBatch(args: {
   readonly currentTokenCount: number;
   readonly contextLimit: number;
   readonly lastTextSoFar: string | null;
+  readonly abortSignal?: AbortSignal;
+  readonly leaseSignal?: AbortSignal;
+  readonly missionDeadlineMs?: number | null;
 }): Promise<ToolBatchOutcome> {
   const { context, turnResult, liveMessages } = args;
   const executedCalls: ParsedToolCall[] = [];
@@ -93,10 +100,29 @@ export async function processTurnToolBatch(args: {
   let batchStopPayload: StopPayload | undefined;
   let compactCommittedThisBatch = false;
   let approvalId: string | null = null;
+  let leaseLostError: RunnerLeaseLostError | null = null;
 
   const dispatchBand = computeBand(args.currentTokenCount, args.contextLimit);
 
+  function stopAtDispatchBoundary(): boolean {
+    leaseLostError = getRunnerLeaseLostError(args.leaseSignal);
+    if (leaseLostError !== null) return true;
+    if (
+      args.missionDeadlineMs != null
+      && Date.now() >= args.missionDeadlineMs
+    ) {
+      batchStopReason = "deadline_reached";
+      return true;
+    }
+    if (args.abortSignal?.aborted) {
+      batchStopReason = "user_stopped";
+      return true;
+    }
+    return false;
+  }
+
   for (let i = 0; i < turnResult.toolCalls.length; i++) {
+    if (stopAtDispatchBoundary()) break;
     const toolCall = turnResult.toolCalls[i];
     // `i < turnResult.toolCalls.length` guarantees this index is populated;
     // the guard exists only to satisfy `noUncheckedIndexedAccess` (vex-app's
@@ -167,6 +193,10 @@ export async function processTurnToolBatch(args: {
     // execute confirm immediately). Remaining calls in THIS batch are never
     // reached — the model only ever emitted one call when it called prepare.
     if (followUp !== null) {
+      // The synthesized confirm is a second dispatch even though it was not
+      // model-emitted. Re-check ownership, deadline, and operator Stop before
+      // crossing that trusted handoff boundary.
+      if (stopAtDispatchBoundary()) break;
       return dispatchPreparedActionFollowUp({
         context,
         toolContext,
@@ -246,13 +276,20 @@ export async function processTurnToolBatch(args: {
     }
   }
 
-  await persistBatchTranscript({
-    sessionId: context.sessionId,
-    content: turnResult.content,
-    executedCalls,
-    executedResults,
-    liveMessages,
-  });
+  // If ownership was already gone before the first call, discard the model's
+  // unexecuted batch. If some calls completed before loss was observed, keep
+  // their canonical call/result pairs for audit before exiting stale work.
+  if (leaseLostError === null || executedCalls.length > 0) {
+    await persistBatchTranscript({
+      sessionId: context.sessionId,
+      content: turnResult.content,
+      executedCalls,
+      executedResults,
+      liveMessages,
+    });
+  }
+
+  if (leaseLostError !== null) throw leaseLostError;
 
   // Update lastText from current turn (assistant may have content alongside toolCalls)
   const lastText = turnResult.content ?? args.lastTextSoFar;

--- a/src/vex-agent/engine/core/turn-loop.ts
+++ b/src/vex-agent/engine/core/turn-loop.ts
@@ -52,6 +52,7 @@ import {
   armPostCompactBridge,
   createBandObserverWithLog,
 } from "./turn-loop-state-init.js";
+import { throwIfRunnerLeaseLost } from "../runtime/lease-loss.js";
 
 /**
  * Run the turn loop.
@@ -74,6 +75,10 @@ export async function runTurnLoop(
   // mission/subagent boundary stop) — only the chat ingress passes this, so
   // mission/subagent callers are behaviour-preserving.
   inferenceAbortSignal?: AbortSignal,
+  // Lease ownership is independent of operator Stop. Losing it throws a
+  // dedicated error so the stale runner exits without finalizing shared
+  // mission state now owned by another process.
+  leaseSignal?: AbortSignal,
 ): Promise<TurnLoopResult> {
   let lastText: string | null = null;
   let totalToolCalls = 0;
@@ -130,6 +135,7 @@ export async function runTurnLoop(
   }
 
   for (let iteration = 0; iteration < loopConfig.maxIterations; iteration++) {
+    throwIfRunnerLeaseLost(leaseSignal);
     // Hard mission deadline — the agent-independent time-box. Checked FIRST
     // each iteration, before any other guard or inference call, so an
     // expired run stops with `deadline_reached` no matter what the agent is
@@ -258,6 +264,18 @@ export async function runTurnLoop(
     currentTokenCount = turnResult.promptTokens;
     observeBand(currentTokenCount, "post_turn_text");
 
+    // Inference can finish after ownership, deadline, or Stop changed. Never
+    // let the already-generated tool batch cross a stale control boundary.
+    throwIfRunnerLeaseLost(leaseSignal);
+
+    if (
+      loopConfig.missionDeadlineMs != null
+      && Date.now() >= loopConfig.missionDeadlineMs
+    ) {
+      stopReason = "deadline_reached";
+      break;
+    }
+
     if (abortSignal?.aborted) {
       stopReason = "user_stopped";
       break;
@@ -287,7 +305,14 @@ export async function runTurnLoop(
         currentTokenCount,
         contextLimit: loopConfig.contextLimit,
         lastTextSoFar: lastText,
+        abortSignal,
+        leaseSignal,
+        missionDeadlineMs: loopConfig.missionDeadlineMs,
       });
+      // Prepared follow-ups and stop-like tool outcomes can return directly
+      // from the batch processor. Revoke stale ownership before handling any
+      // outcome or allowing mission finalization.
+      throwIfRunnerLeaseLost(leaseSignal);
       totalToolCalls += batchOutcome.toolCallsExecuted;
       lastText = batchOutcome.lastText;
 
@@ -341,16 +366,19 @@ export async function runTurnLoop(
         };
       }
       if (batchOutcome.kind === "compact_committed") {
+        throwIfRunnerLeaseLost(leaseSignal);
         await handlePostCompactBookkeeping();
         continue;
       }
 
       // Normal batch complete
+      throwIfRunnerLeaseLost(leaseSignal);
       await mergeOperatorInstructions();
       continue;
     }
 
     if (turnResult.content) {
+      throwIfRunnerLeaseLost(leaseSignal);
       lastText = turnResult.content;
       const textOutcome = await handleTextResponse({
         context,

--- a/src/vex-agent/engine/ingress.ts
+++ b/src/vex-agent/engine/ingress.ts
@@ -190,7 +190,7 @@ async function resumeMissionRunWithPreempt(
     });
     // `resumeMissionRun` refreshes tool_output_blob TTLs internally (PR-13
     // S-2), so we don't double-call here.
-    return await resumeMissionRun(runId);
+    return await resumeMissionRun(runId, handle.signal);
   } finally {
     const { releaseLeaseAndEmitControlState } = await import(
       "./runtime/release-and-emit.js"

--- a/src/vex-agent/engine/runtime/lease-handle.ts
+++ b/src/vex-agent/engine/runtime/lease-handle.ts
@@ -4,9 +4,9 @@
  * Wraps a successfully-claimed `runner_leases` row and owns:
  *   - the heartbeat interval (renews `expires_at` every `ttlMs / 3`);
  *   - the release callback (DELETE on terminal/paused/exception);
- *   - the `onLeaseLost` notification when a renewal returns null
- *     (someone else stole the lease after expiry — runner should
- *     treat this as a forced terminal).
+ *   - an abort signal that fires when a renewal returns null (someone else
+ *     stole the lease after expiry). Every runner threads this signal to its
+ *     dispatch boundary so stale owners cannot start more work.
  *
  * Heartbeat ownership lives on the runner that successfully claimed,
  * not on the IPC request that initiated the claim. An IPC handler kicks
@@ -26,10 +26,19 @@ import {
   type RunnerLease,
 } from "../../db/repos/runner-leases.js";
 import logger from "@utils/logger.js";
+import { RunnerLeaseLostError } from "./lease-loss.js";
+export {
+  RunnerLeaseLostError,
+  getRunnerLeaseLostError,
+  isRunnerLeaseLostError,
+  throwIfRunnerLeaseLost,
+} from "./lease-loss.js";
 
 export interface LeaseHandle {
   readonly lease: RunnerLease;
   readonly ownerId: string;
+  /** Aborted exactly once when heartbeat renewal proves ownership was lost. */
+  readonly signal: AbortSignal;
   /** Idempotent. Safe to call multiple times. */
   release(): Promise<void>;
 }
@@ -38,12 +47,6 @@ export interface CreateLeaseHandleOptions {
   readonly lease: RunnerLease;
   readonly ownerId: string;
   readonly ttlMs: number;
-  /**
-   * Fired when a heartbeat renewal returns null (lease stolen because
-   * the previous owner missed too many heartbeats and `expires_at`
-   * lapsed). Runner should treat this as forced pause / stop.
-   */
-  readonly onLeaseLost?: (reason: string) => void;
   /**
    * Override for tests — defaults to `globalThis.setInterval` /
    * `clearInterval`. The injectable timer makes vitest fake-timer tests
@@ -74,6 +77,7 @@ export function createLeaseHandle(opts: CreateLeaseHandleOptions): LeaseHandle {
 
   let released = false;
   let intervalHandle: ReturnType<typeof setInterval> | null = null;
+  const leaseLostController = new AbortController();
 
   function stopHeartbeat(): void {
     if (intervalHandle !== null) {
@@ -87,21 +91,12 @@ export function createLeaseHandle(opts: CreateLeaseHandleOptions): LeaseHandle {
     try {
       const renewed = await renew(opts.lease.sessionId, opts.ownerId, opts.ttlMs);
       if (renewed === null) {
-        // Lease stolen — somebody else claimed after our expiry. Stop
-        // the heartbeat and notify the runner; the runner is expected
-        // to terminate its work promptly.
+        // Lease stolen — somebody else claimed after our expiry. Stop the
+        // heartbeat and synchronously revoke this runner at its next guarded
+        // dispatch/persistence boundary.
         released = true;
         stopHeartbeat();
-        if (opts.onLeaseLost) {
-          try {
-            opts.onLeaseLost("lease_stolen_after_expiry");
-          } catch (cbErr) {
-            logger.warn("runner_lease.handle.on_lost_callback_threw", {
-              sessionId: opts.lease.sessionId,
-              error: cbErr instanceof Error ? cbErr.message : String(cbErr),
-            });
-          }
-        }
+        leaseLostController.abort(new RunnerLeaseLostError(opts.lease.sessionId));
       }
     } catch (err) {
       // Transient DB issue — log + keep the interval armed. If renewal
@@ -121,6 +116,7 @@ export function createLeaseHandle(opts: CreateLeaseHandleOptions): LeaseHandle {
   return {
     lease: opts.lease,
     ownerId: opts.ownerId,
+    signal: leaseLostController.signal,
     async release(): Promise<void> {
       if (released) return;
       released = true;

--- a/src/vex-agent/engine/runtime/lease-loss.ts
+++ b/src/vex-agent/engine/runtime/lease-loss.ts
@@ -1,0 +1,36 @@
+/**
+ * Ownership loss is not a mission failure: another runner is authoritative
+ * now, so the stale runner must exit without finalizing shared run state.
+ */
+export class RunnerLeaseLostError extends Error {
+  readonly code = "RUNNER_LEASE_LOST";
+
+  constructor(readonly sessionId: string) {
+    super(`Runner lease lost for session ${sessionId}`);
+    this.name = "RunnerLeaseLostError";
+  }
+}
+
+export function isRunnerLeaseLostError(value: unknown): value is RunnerLeaseLostError {
+  return value instanceof RunnerLeaseLostError
+    || (
+      typeof value === "object"
+      && value !== null
+      && "code" in value
+      && value.code === "RUNNER_LEASE_LOST"
+    );
+}
+
+export function getRunnerLeaseLostError(
+  signal: AbortSignal | undefined,
+): RunnerLeaseLostError | null {
+  if (!signal?.aborted) return null;
+  return isRunnerLeaseLostError(signal.reason)
+    ? signal.reason
+    : new RunnerLeaseLostError("unknown");
+}
+
+export function throwIfRunnerLeaseLost(signal: AbortSignal | undefined): void {
+  const error = getRunnerLeaseLostError(signal);
+  if (error !== null) throw error;
+}

--- a/src/vex-agent/engine/wake/executor/auto-retry.ts
+++ b/src/vex-agent/engine/wake/executor/auto-retry.ts
@@ -66,7 +66,7 @@ export async function handleAutoRetryClaimed(
   });
   try {
     await deps.injectWakeBanner(wake.sessionId, wake.reason, wake.dueAt);
-    await deps.resumeMissionRun(run.id);
+    await deps.resumeMissionRun(run.id, handle.signal);
     return { kind: "resumed", runId: run.id };
   } finally {
     const { releaseLeaseAndEmitControlState } = await import(

--- a/src/vex-agent/engine/wake/executor/claimed.ts
+++ b/src/vex-agent/engine/wake/executor/claimed.ts
@@ -75,7 +75,7 @@ export async function handleClaimed(
   });
   try {
     await deps.injectWakeBanner(wake.sessionId, wake.reason, wake.dueAt);
-    await deps.resumeMissionRun(run.id);
+    await deps.resumeMissionRun(run.id, handle.signal);
     return { kind: "resumed", runId: run.id };
   } finally {
     const { releaseLeaseAndEmitControlState } = await import(

--- a/src/vex-agent/engine/wake/executor/deps.ts
+++ b/src/vex-agent/engine/wake/executor/deps.ts
@@ -21,7 +21,7 @@ export interface WakeDeps {
   /** Persist a `wake_due` banner for the resume path to pick up. */
   injectWakeBanner(sessionId: string, reason: string | null, dueAt: string): Promise<void>;
   /** Resume a mission run. */
-  resumeMissionRun(runId: string): Promise<void>;
+  resumeMissionRun(runId: string, leaseSignal?: AbortSignal): Promise<void>;
   /**
    * Pre-claim provider/config gate. `claimDue` is destructive
    * (pending→consumed) and the subsequent resume runs the agent turn loop,
@@ -61,7 +61,7 @@ export function buildProductionDeps(): WakeDeps {
         },
       );
     },
-    resumeMissionRun: async (runId) => {
+    resumeMissionRun: async (runId, leaseSignal) => {
       // Lazy dynamic import so wake/executor.ts doesn't introduce a circular
       // dependency through the engine barrel. The ESM runtime caches the
       // promise after the first resolve, so there's no per-tick cost.
@@ -69,7 +69,7 @@ export function buildProductionDeps(): WakeDeps {
       // so every caller — wake executor, ingress preempt, approval resume —
       // gets it idempotently.
       const engine = await import("@vex-agent/engine/index.js");
-      await engine.resumeMissionRun(runId);
+      await engine.resumeMissionRun(runId, leaseSignal);
     },
     isProviderReady: isWakeProviderConfigured,
   };

--- a/vex-app/src/main/ipc/__tests__/mission/retry.test.ts
+++ b/vex-app/src/main/ipc/__tests__/mission/retry.test.ts
@@ -26,6 +26,8 @@ const mockClaim = vi.fn();
 const mockCreateLeaseHandle = vi.fn();
 const mockResumeMissionRun = vi.fn();
 const mockRelease = vi.fn();
+const mockListPendingForSession = vi.fn();
+const leaseSignal = new AbortController().signal;
 
 vi.mock("electron", () => {
   const handlers = new Map<
@@ -55,6 +57,9 @@ vi.mock("../../../database/mission-runs-db.js", async (importOriginal) => {
       mockGetLatestRunForSession(...a),
   };
 });
+vi.mock("../../../database/approvals-db.js", () => ({
+  listPendingForSession: (...a: unknown[]) => mockListPendingForSession(...a),
+}));
 vi.mock("../../runtime/_ensure-engine-db-url.js", () => ({
   ensureEngineDbUrl: (...a: unknown[]) => mockEnsureEngineDbUrl(...a),
 }));
@@ -114,6 +119,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockEnsureEngineDbUrl.mockResolvedValue({ ok: true, data: undefined });
   mockEmitControlStateAfterChange.mockResolvedValue(undefined);
+  mockListPendingForSession.mockResolvedValue({
+    ok: true,
+    data: [{ id: "approval-1" }],
+  });
   electronMock.__handlers.clear();
   registerMissionRetryHandler();
 });
@@ -151,7 +160,7 @@ describe("mission.retry", () => {
       previousStatus: "running",
       wakeCancelledCount: 0,
     });
-    mockCreateLeaseHandle.mockReturnValueOnce({});
+    mockCreateLeaseHandle.mockReturnValueOnce({ signal: leaseSignal });
     mockResumeMissionRun.mockResolvedValueOnce({ text: "ok" });
     mockRelease.mockResolvedValue(undefined);
 
@@ -167,7 +176,7 @@ describe("mission.retry", () => {
     // paused_error-only wake cancellation must not fire here.
     expect(mockCancelForSession).not.toHaveBeenCalled();
     await vi.waitFor(() =>
-      expect(mockResumeMissionRun).toHaveBeenCalledWith("run-dead"),
+      expect(mockResumeMissionRun).toHaveBeenCalledWith("run-dead", leaseSignal),
     );
   });
 
@@ -179,8 +188,22 @@ describe("mission.retry", () => {
     const r = await call({ sessionId: SESSION });
     expect(r.data).toEqual({
       outcome: "blocked_approval",
-      pendingApprovalId: "run-1",
+      pendingApprovalId: "approval-1",
     });
+    expect(mockListPendingForSession).toHaveBeenCalledWith(SESSION);
+  });
+
+  it("fails closed when paused_approval has no pending queue row", async () => {
+    mockGetLatestRunForSession.mockResolvedValueOnce({
+      ok: true,
+      data: { missionRunId: "run-1", status: "paused_approval" },
+    });
+    mockListPendingForSession.mockResolvedValueOnce({ ok: true, data: [] });
+
+    const r = await call({ sessionId: SESSION });
+
+    expect(r.ok).toBe(false);
+    expect(r.error?.code).toBe("internal.unexpected");
   });
 
   it("returns blocked_terminal for a terminal run", async () => {
@@ -213,7 +236,7 @@ describe("mission.retry", () => {
       lease: { ownerId: "owner-x" },
       previousStatus: "paused_error",
     });
-    mockCreateLeaseHandle.mockReturnValueOnce({});
+    mockCreateLeaseHandle.mockReturnValueOnce({ signal: leaseSignal });
     mockResumeMissionRun.mockResolvedValueOnce({ text: "ok" });
     mockRelease.mockResolvedValue(undefined);
 
@@ -227,7 +250,7 @@ describe("mission.retry", () => {
     );
     // Fire-and-forget continuation (dynamic-imports the engine) — poll for it.
     await vi.waitFor(() =>
-      expect(mockResumeMissionRun).toHaveBeenCalledWith("run-err"),
+      expect(mockResumeMissionRun).toHaveBeenCalledWith("run-err", leaseSignal),
     );
   });
 

--- a/vex-app/src/main/ipc/__tests__/runtime-resume-dispatch-lease.test.ts
+++ b/vex-app/src/main/ipc/__tests__/runtime-resume-dispatch-lease.test.ts
@@ -21,6 +21,7 @@ const mockClaim = vi.fn();
 const mockCreateLeaseHandle = vi.fn();
 const mockResumeMissionRun = vi.fn();
 const mockRelease = vi.fn();
+const leaseSignal = new AbortController().signal;
 
 vi.mock("../../database/mission-runs-db.js", () => ({
   getActiveRunForSession: (...a: unknown[]) => mockGetActiveRun(...a),
@@ -103,7 +104,7 @@ describe("runResumeDispatch — running status + lease liveness", () => {
       previousStatus: "running",
       wakeCancelledCount: 0,
     });
-    mockCreateLeaseHandle.mockReturnValue({});
+    mockCreateLeaseHandle.mockReturnValue({ signal: leaseSignal });
     mockResumeMissionRun.mockResolvedValue({ text: "ok" });
     mockRelease.mockResolvedValue(undefined);
 
@@ -116,7 +117,7 @@ describe("runResumeDispatch — running status + lease liveness", () => {
       expect.objectContaining({ fromStatuses: ["running"], missionRunId: "run-1" }),
     );
     await vi.waitFor(() =>
-      expect(mockResumeMissionRun).toHaveBeenCalledWith("run-1"),
+      expect(mockResumeMissionRun).toHaveBeenCalledWith("run-1", leaseSignal),
     );
   });
 

--- a/vex-app/src/main/ipc/_shared/pending-approval.ts
+++ b/vex-app/src/main/ipc/_shared/pending-approval.ts
@@ -1,0 +1,24 @@
+import { err, ok, type Result } from "@shared/ipc/result.js";
+import { listPendingForSession } from "../../database/approvals-db.js";
+import { log } from "../../logger/index.js";
+import { controlFailedError } from "../runtime/_errors.js";
+
+/** Resolve the durable approval identity represented by paused_approval. */
+export async function resolvePendingApprovalId(
+  sessionId: string,
+  correlationId: string,
+): Promise<Result<string>> {
+  const pending = await listPendingForSession(sessionId);
+  if (!pending.ok) return pending;
+
+  const approval = pending.data[0];
+  if (approval === undefined) {
+    log.warn(
+      `[runtime-control] paused_approval without pending queue row correlationId=${correlationId}`,
+      { sessionId },
+    );
+    return err(controlFailedError(correlationId));
+  }
+
+  return ok(approval.id);
+}

--- a/vex-app/src/main/ipc/_shared/runtime-resume-dispatch.ts
+++ b/vex-app/src/main/ipc/_shared/runtime-resume-dispatch.ts
@@ -27,6 +27,7 @@ import { controlFailedError } from "../runtime/_errors.js";
 import { ensureEngineDbUrl } from "../runtime/_ensure-engine-db-url.js";
 import { emitControlStateAfterChange } from "../runtime/_emit-control-state.js";
 import { classifyRunLeaseState } from "./lease-state.js";
+import { resolvePendingApprovalId } from "./pending-approval.js";
 
 export interface ResumeFlowInput {
   readonly sessionId: string;
@@ -84,9 +85,14 @@ export async function runResumeDispatch(
       // the lease between this read and the claim.
     }
     if (status === "paused_approval") {
+      const pendingApproval = await resolvePendingApprovalId(
+        input.sessionId,
+        ctx.requestId,
+      );
+      if (!pendingApproval.ok) return pendingApproval;
       return ok({
         outcome: "blocked_approval",
-        pendingApprovalId: runId,
+        pendingApprovalId: pendingApproval.data,
       });
     }
     if (status === "paused_error") {
@@ -173,7 +179,7 @@ export async function runResumeDispatch(
         const { resumeMissionRun } = await import(
           "@vex-agent/engine/index.js"
         );
-        await resumeMissionRun(runId);
+        await resumeMissionRun(runId, handle.signal);
         await markCleared(auditRequest.id, "resumed");
       } catch (cause) {
         log.warn(

--- a/vex-app/src/main/ipc/_shared/runtime-retry-dispatch.ts
+++ b/vex-app/src/main/ipc/_shared/runtime-retry-dispatch.ts
@@ -29,6 +29,7 @@ import { controlFailedError } from "../runtime/_errors.js";
 import { ensureEngineDbUrl } from "../runtime/_ensure-engine-db-url.js";
 import { emitControlStateAfterChange } from "../runtime/_emit-control-state.js";
 import { classifyRunLeaseState } from "./lease-state.js";
+import { resolvePendingApprovalId } from "./pending-approval.js";
 
 export interface RetryFlowInput {
   readonly sessionId: string;
@@ -79,7 +80,15 @@ export async function runRetryDispatch(
       // error_retry wake pending.
     }
     if (status === "paused_approval") {
-      return ok({ outcome: "blocked_approval", pendingApprovalId: runId });
+      const pendingApproval = await resolvePendingApprovalId(
+        input.sessionId,
+        ctx.requestId,
+      );
+      if (!pendingApproval.ok) return pendingApproval;
+      return ok({
+        outcome: "blocked_approval",
+        pendingApprovalId: pendingApproval.data,
+      });
     }
     if (
       status === "completed" ||
@@ -163,7 +172,7 @@ export async function runRetryDispatch(
     void (async () => {
       try {
         const { resumeMissionRun } = await import("@vex-agent/engine/index.js");
-        await resumeMissionRun(runId);
+        await resumeMissionRun(runId, handle.signal);
         await markCleared(auditRequest.id, "resumed");
       } catch (cause) {
         log.warn(


### PR DESCRIPTION
## Summary

- replace the optional lease-loss callback with a required LeaseHandle abort signal and thread it through every production mission resume path
- stop stale runners before later tool dispatches and prevent lease-loss exits from finalizing run state owned by a replacement runner
- re-check deadline and operator Stop after inference, before each sequential tool call, and before synthesized prepared-action follow-ups
- return the durable pending approval ID from resume/retry controls and fail closed when paused_approval has no queue row

## Why grouped

These paths share one runtime-control invariant: only the current owner may dispatch mission work, and UI control results must identify the durable state that blocks execution. Keeping them together gives the ownership/Stop behavior one adversarial regression matrix without mixing in tool-output retrieval changes.

## Validation

- pnpm vitest run --exclude src/__tests__/vex-agent/tools/polymarket-handlers.test.ts (544 files, 7,205 passed, 7 skipped)
- pnpm build
- pnpm --dir vex-app test (358 files, 3,237 passed)
- pnpm --dir vex-app lint

The excluded Polymarket handler file performs a live bridge.assets fetch and failed independently with fetch failed; focused Polymarket behavior is unchanged.