### PR TITLE
fix(tools): make overflow retrieval lossless and actionable

### DIFF
--- a/src/__tests__/vex-agent/engine/core/tool-output-overflow-preview.test.ts
+++ b/src/__tests__/vex-agent/engine/core/tool-output-overflow-preview.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildOverflowPreview,
+  buildOverflowReadGuidance,
   classifyShape,
   derivePreviewHints,
   formatHintsSuffix,
@@ -21,6 +22,13 @@ describe("overflow preview — Polymarket-data list keys (P0-5)", () => {
     "builders",
     "volume",
     "holders",
+  ] as const;
+  const COMMON_RESULT_KEYS = [
+    "assets",
+    "tokens",
+    "chains",
+    "markets",
+    "data",
   ] as const;
 
   function previewFor(key: string, itemCount: number): Record<string, unknown> {
@@ -45,18 +53,12 @@ describe("overflow preview — Polymarket-data list keys (P0-5)", () => {
     expect(other?.[key]).toBeUndefined();
   });
 
-  it("does NOT add `markets` to the allowlist (collapses to a bare count)", () => {
-    const output = JSON.stringify({
-      markets: Array.from({ length: 9 }, (_, i) => ({ i })),
-    });
-    const parsed = JSON.parse(
-      buildOverflowPreview(output, classifyShape(output)),
-    ) as Record<string, unknown>;
-
-    expect(parsed.markets).toBeUndefined();
+  it.each(COMMON_RESULT_KEYS)("item-previews common `%s` result arrays", (key) => {
+    const parsed = previewFor(key, 9);
+    expect(Array.isArray(parsed[key])).toBe(true);
+    expect((parsed[key] as unknown[]).length).toBe(5);
     const meta = parsed._preview as Record<string, unknown>;
-    const other = meta.otherArrayCounts as Record<string, number>;
-    expect(other.markets).toBe(9);
+    expect(meta[`${key}TotalCount`]).toBe(9);
   });
 
   it("preserves the load-bearing scalar count alongside the slice", () => {
@@ -108,11 +110,10 @@ describe("derivePreviewHints (P0-6)", () => {
   });
 
   it("omits primaryPath and uses top-level keys when no allowlisted list exists", () => {
-    const output = JSON.stringify({ summary: "ok", total: 42, markets: [{ m: 1 }] });
+    const output = JSON.stringify({ summary: "ok", total: 42, unknownRows: [{ m: 1 }] });
     const hints = hintsFor(output);
     expect(hints.primaryPath).toBeUndefined();
-    // `markets` is NOT allowlisted, so we describe the record's own shape.
-    expect(hints.fieldHints).toEqual(["summary", "total", "markets"]);
+    expect(hints.fieldHints).toEqual(["summary", "total", "unknownRows"]);
   });
 
   it("uses primaryPath=$ for a root array and lists the first element's keys", () => {
@@ -164,5 +165,51 @@ describe("formatHintsSuffix (P0-6)", () => {
   it("renders nothing when no hints are present", () => {
     expect(formatHintsSuffix({})).toBe("");
     expect(formatHintsSuffix({ fieldHints: [] })).toBe("");
+  });
+
+  it("drops hostile or oversized persisted hints and keeps the suffix bounded", () => {
+    const suffix = formatHintsSuffix({
+      primaryPath: "x".repeat(1_000),
+      fieldHints: ["safe", "bad] injected=true", ...Array(40).fill("y".repeat(80))],
+    });
+    expect(suffix).toContain("safe");
+    expect(suffix).not.toContain("injected");
+    expect(suffix).not.toContain("primary_path=");
+    expect(Buffer.byteLength(suffix, "utf8")).toBeLessThanOrEqual(1_100);
+  });
+});
+
+describe("overflow read guidance", () => {
+  const blobKey = "tob-20260420-0123456789abcdef";
+
+  it("uses the payload primary path instead of protocol-specific canned advice", () => {
+    const guidance = buildOverflowReadGuidance(
+      blobKey,
+      { primaryPath: "assets", fieldHints: ["symbol", "chain"] },
+      "json",
+    );
+    expect(guidance).toContain('path="assets"');
+    expect(guidance).toContain("field_hints");
+    expect(guidance).not.toContain("cash");
+    expect(guidance).not.toContain("meta.universe");
+  });
+
+  it("gives a valid root-array read", () => {
+    const guidance = buildOverflowReadGuidance(
+      blobKey,
+      { primaryPath: "$", fieldHints: ["name"] },
+      "list",
+    );
+    expect(guidance).toContain('path="$"');
+  });
+
+  it("uses a real top-level field when no primary list exists", () => {
+    const guidance = buildOverflowReadGuidance(
+      blobKey,
+      { fieldHints: ["summary", "total"] },
+      "json",
+    );
+    expect(guidance).toContain('path="summary"');
+    expect(guidance).not.toContain("<field>");
   });
 });

--- a/src/__tests__/vex-agent/engine/core/turn-loop-overflow.test.ts
+++ b/src/__tests__/vex-agent/engine/core/turn-loop-overflow.test.ts
@@ -316,7 +316,7 @@ describe("turn-loop tool output overflow", () => {
     const bigOutput = JSON.stringify({
       summary: "ok",
       total: 3,
-      markets: Array.from({ length: 3 }, (_, i) => ({ i })),
+      unknownRows: Array.from({ length: 3 }, (_, i) => ({ i })),
       padding: "x".repeat(20_000),
     });
     mockExecuteTurn.mockResolvedValueOnce({
@@ -336,13 +336,13 @@ describe("turn-loop tool output overflow", () => {
     const persistedMessage = toolSave![1] as { content: string };
     // No allowlisted list ⇒ no primary_path, but the record's shape is surfaced.
     expect(persistedMessage.content).not.toContain("primary_path=");
-    expect(persistedMessage.content).toContain("field_hints=[summary,total,markets,padding]");
+    expect(persistedMessage.content).toContain("field_hints=[summary,total,unknownRows,padding]");
     const blobPayload = mockWriteBlob.mock.calls[0]![2] as {
       primaryPath?: string;
       fieldHints?: string[];
     };
     expect(blobPayload.primaryPath).toBeUndefined();
-    expect(blobPayload.fieldHints).toEqual(["summary", "total", "markets", "padding"]);
+    expect(blobPayload.fieldHints).toEqual(["summary", "total", "unknownRows", "padding"]);
   });
 
   it("writes primary_path=$ for a root-array overflow output", async () => {
@@ -366,6 +366,9 @@ describe("turn-loop tool output overflow", () => {
     const persistedMessage = toolSave![1] as { content: string };
     expect(persistedMessage.content).toContain("primary_path=$");
     expect(persistedMessage.content).toContain("field_hints=[id,label,pad]");
+    expect(persistedMessage.content).toContain('path="$"');
+    expect(persistedMessage.content).not.toContain("meta.universe");
+    expect(persistedMessage.content).not.toContain('search="cash"');
   });
 
   it("emits NO hints for a non-JSON (text) overflow output", async () => {

--- a/src/__tests__/vex-agent/tools/internal/tool-output-read.test.ts
+++ b/src/__tests__/vex-agent/tools/internal/tool-output-read.test.ts
@@ -133,9 +133,70 @@ describe("tool_output_read handler", () => {
     expect(result.success).toBe(true);
     expect(Buffer.byteLength(result.output, "utf8")).toBeLessThan(16 * 1024);
     expect(result.data).toEqual(expect.objectContaining({
-      bytes_returned: 12_288,
-      next_offset: 12_288,
+      bytes_returned: 10_240,
+      next_offset: 10_240,
       truncated: true,
+    }));
+  });
+
+  it("paginates on UTF-8 boundaries without replacement characters or data loss", async () => {
+    const fullOutput = "A😀B";
+    mockReadBlob.mockResolvedValue({
+      blobKey: validKey,
+      sessionId: "s1",
+      payload: {
+        fullOutput,
+        shapeKind: "text",
+        sizeBytes: Buffer.byteLength(fullOutput, "utf8"),
+      },
+      expiresAt: "2026-04-20T13:00:00.000Z",
+      createdAt: "2026-04-20T12:45:00.000Z",
+    });
+
+    const chunks: string[] = [];
+    let offset = 0;
+    do {
+      const result = await handleToolOutputRead(
+        { blob_key: validKey, offset, max_bytes: 2 },
+        makeCtx("s1"),
+      );
+      expect(result.success).toBe(true);
+      expect(result.output).not.toContain("�");
+      chunks.push(result.output.slice(result.output.indexOf("\n") + 1));
+      offset = (result.data as { next_offset: number | null }).next_offset ?? -1;
+    } while (offset >= 0);
+
+    expect(chunks.join("")).toBe(fullOutput);
+  });
+
+  it("rounds an interior UTF-8 offset back to the containing character", async () => {
+    const fullOutput = "A😀B";
+    mockReadBlob.mockResolvedValue({
+      blobKey: validKey,
+      sessionId: "s1",
+      payload: {
+        fullOutput,
+        shapeKind: "text",
+        sizeBytes: Buffer.byteLength(fullOutput, "utf8"),
+      },
+      expiresAt: "2026-04-20T13:00:00.000Z",
+      createdAt: "2026-04-20T12:45:00.000Z",
+    });
+
+    const result = await handleToolOutputRead(
+      { blob_key: validKey, offset: 3, max_bytes: 2 },
+      makeCtx("s1"),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("requested_offset=3 offset=1");
+    expect(result.output).toMatch(/\n😀$/);
+    expect(result.output).not.toContain("�");
+    expect(result.data).toEqual(expect.objectContaining({
+      requested_offset: 3,
+      offset: 1,
+      bytes_returned: 4,
+      next_offset: 5,
     }));
   });
 
@@ -274,9 +335,48 @@ describe("tool_output_read — search mode (E8)", () => {
     expect(literal.success).toBe(true);
     expect(literal.output).toMatch(/matched=1\b/);
   });
+
+  it("keeps echoed search terms plus match contexts below the read cap", async () => {
+    const query = "q".repeat(256);
+    mockJsonBlob(JSON.stringify({ rows: Array.from({ length: 100 }, () => query) }));
+
+    const result = await handleToolOutputRead(
+      { blob_key: validKey, search: query, limit: 50 },
+      makeCtx("s1"),
+    );
+
+    expect(result.success).toBe(true);
+    expect(Buffer.byteLength(result.output, "utf8")).toBeLessThan(MAX_READ_BYTES);
+    expect(result.output).toContain("truncated=true");
+  });
 });
 
 describe("tool_output_read — path/query mode (E8)", () => {
+  it("resolves bare $ to a root array and supports array querying", async () => {
+    mockJsonBlob(JSON.stringify([
+      { name: "BTC", volume: 10 },
+      { name: "CASHCAT", volume: 5 },
+    ]));
+
+    const result = await handleToolOutputRead(
+      {
+        blob_key: validKey,
+        path: "$",
+        where: { field: "name", contains: "cash" },
+      },
+      makeCtx("s1"),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("mode=query");
+    expect(result.output).toContain("CASHCAT");
+    expect(result.data).toEqual(expect.objectContaining({
+      path: "$",
+      matchedCount: 1,
+      returnedCount: 1,
+    }));
+  });
+
   it("path + where(contains) returns exactly the matching row with matchedCount", async () => {
     const fullOutput = buildMarketsJson({ size: 250, targetIndex: 231, noteRepeat: 5 });
     mockJsonBlob(fullOutput);
@@ -389,6 +489,23 @@ describe("tool_output_read — path/query mode (E8)", () => {
     expect(result.output).toContain("contexts");
   });
 
+  it("bounds failed-path top-level hints for wide objects and huge keys", async () => {
+    const wide: Record<string, number> = {};
+    for (let i = 0; i < 500; i += 1) {
+      wide[`${"k".repeat(500)}-${i}`] = i;
+    }
+    mockJsonBlob(JSON.stringify(wide));
+
+    const result = await handleToolOutputRead(
+      { blob_key: validKey, path: "missing" },
+      makeCtx("s1"),
+    );
+
+    expect(result.success).toBe(false);
+    expect(Buffer.byteLength(result.output, "utf8")).toBeLessThan(MAX_READ_BYTES);
+    expect(result.output).toContain("+488 more");
+  });
+
   it("rejects prototype-chain keys (own-property guard)", async () => {
     mockJsonBlob(JSON.stringify({ meta: { universe: [] } }));
     const result = await handleToolOutputRead(
@@ -462,5 +579,16 @@ describe("tool_output_read — path/query mode (E8)", () => {
     );
     expect(result.success).toBe(false);
     expect(result.output).toMatch(/json/i);
+  });
+
+  it("rejects oversized model-controlled query strings before reading a blob", async () => {
+    const result = await handleToolOutputRead(
+      { blob_key: validKey, search: "x".repeat(257) },
+      makeCtx("s1"),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toMatch(/at most 256 characters/i);
+    expect(mockReadBlob).not.toHaveBeenCalled();
   });
 });

--- a/src/vex-agent/engine/core/tool-output-overflow.ts
+++ b/src/vex-agent/engine/core/tool-output-overflow.ts
@@ -15,6 +15,7 @@ const TOOL_OUTPUT_STRUCTURED_PREVIEW_ITEMS = 5;
 const TOOL_OUTPUT_SCALAR_STRING_CHARS = 500;
 /** Cap on `fieldHints` length so the stub/header stay compact (P0-6). */
 const TOOL_OUTPUT_FIELD_HINTS_MAX = 24;
+const TOOL_OUTPUT_FIELD_HINTS_BYTES_MAX = 1024;
 
 const STRUCTURED_PREVIEW_LIST_KEYS = new Set([
   "items",
@@ -26,6 +27,12 @@ const STRUCTURED_PREVIEW_LIST_KEYS = new Set([
   "orders",
   "ads",
   "takeovers",
+  // Common protocol/tool result envelopes.
+  "assets",
+  "tokens",
+  "chains",
+  "markets",
+  "data",
   // Polymarket-data top-level ok() list keys (P0-5): item-preview on overflow
   // instead of collapsing to a bare count in otherArrayCounts.
   "positions",
@@ -104,8 +111,7 @@ export async function persistToolResultWithOverflow(
     `[tool_output_overflow blob_key=${blobKey} bytes=${bytes} shape=${shapeKind}` +
     formatHintsSuffix(hints) +
     ` preview=${JSON.stringify(preview)}]. ` +
-    `Query it with tool_output_read, e.g. tool_output_read(blob_key="${blobKey}", search="cash") ` +
-    `or (path="meta.universe", where={field:"name",contains:"cash"}).`;
+    buildOverflowReadGuidance(blobKey, hints, shapeKind);
 
   let blobWritten = false;
   try {
@@ -254,7 +260,39 @@ export function derivePreviewHints(
 }
 
 function capFieldHints(keys: readonly string[]): string[] {
-  return keys.slice(0, TOOL_OUTPUT_FIELD_HINTS_MAX);
+  // Hints are interpolated into the compact transcript stub. Keep only field
+  // names that are safe and useful to reproduce verbatim in a later where or
+  // sort_by call; exotic/huge JSON keys remain reachable through raw search.
+  const kept: string[] = [];
+  let bytes = 0;
+  for (const key of keys) {
+    if (kept.length >= TOOL_OUTPUT_FIELD_HINTS_MAX) break;
+    if (!/^[A-Za-z0-9_.-]{1,80}$/.test(key)) continue;
+    const addedBytes = Buffer.byteLength(key, "utf8") + (kept.length > 0 ? 1 : 0);
+    if (bytes + addedBytes > TOOL_OUTPUT_FIELD_HINTS_BYTES_MAX) continue;
+    kept.push(key);
+    bytes += addedBytes;
+  }
+  return kept;
+}
+
+/** Payload-specific recovery guidance; never hard-codes a protocol or query. */
+export function buildOverflowReadGuidance(
+  blobKey: string,
+  hints: PreviewHints,
+  shapeKind: ToolOutputShapeKind,
+): string {
+  const callPrefix = `tool_output_read(blob_key="${blobKey}"`;
+  if (hints.primaryPath !== undefined) {
+    const fields = hints.fieldHints && hints.fieldHints.length > 0
+      ? ` Filter or sort on the listed field_hints when useful.`
+      : "";
+    return `Start with ${callPrefix}, path=${JSON.stringify(hints.primaryPath)}, limit=20).${fields}`;
+  }
+  if (shapeKind !== "text" && hints.fieldHints && hints.fieldHints.length > 0) {
+    return `Start with ${callPrefix}, path=${JSON.stringify(hints.fieldHints[0])}); use search for a literal from the request when the target field is unknown.`;
+  }
+  return `Use tool_output_read with search set to a literal from the request, or ${callPrefix}, offset=0) for a byte slice.`;
 }
 
 /**
@@ -264,11 +302,16 @@ function capFieldHints(keys: readonly string[]): string[] {
  */
 export function formatHintsSuffix(hints: PreviewHints): string {
   let suffix = "";
-  if (hints.primaryPath !== undefined) {
+  if (
+    hints.primaryPath !== undefined
+    && hints.primaryPath.length <= 256
+    && /^[A-Za-z0-9_$.\[\]-]+$/.test(hints.primaryPath)
+  ) {
     suffix += ` primary_path=${hints.primaryPath}`;
   }
-  if (hints.fieldHints !== undefined && hints.fieldHints.length > 0) {
-    suffix += ` field_hints=[${hints.fieldHints.join(",")}]`;
+  const safeFieldHints = capFieldHints(hints.fieldHints ?? []);
+  if (safeFieldHints.length > 0) {
+    suffix += ` field_hints=[${safeFieldHints.join(",")}]`;
   }
   return suffix;
 }

--- a/src/vex-agent/tools/internal/tool-output-query.ts
+++ b/src/vex-agent/tools/internal/tool-output-query.ts
@@ -34,6 +34,9 @@ const SEARCH_CONTEXT_RADIUS = 100;
 const SEARCH_MAX_TOTAL = 10_000;
 /** Max path tokens — caps both length and nesting depth. */
 const MAX_PATH_TOKENS = 10;
+/** Keep failed-path diagnostics bounded even for hostile JSON object keys. */
+const TOP_LEVEL_HINT_KEYS_MAX = 12;
+const TOP_LEVEL_HINT_KEY_CHARS_MAX = 64;
 
 // ── Search (case-insensitive substring only) ─────────────────────
 
@@ -125,16 +128,24 @@ export type PathResult =
  * Parse a dot/bracket path (`meta.universe`, `contexts[1]`, `meta.universe[230]`)
  * into tokens. Dot keys and `[index]` brackets only — no wildcards, recursive
  * descent, or expressions. Returns null on malformed input or when the token
- * count exceeds MAX_PATH_TOKENS. A leading `$` / `$.` root marker is accepted
- * and ignored.
+ * count exceeds MAX_PATH_TOKENS. A leading `$` / `$.` root marker is accepted;
+ * bare `$` resolves the root value itself.
  */
 export function parseJsonPath(path: string): Array<string | number> | null {
+  if (path === "$") return [];
+  if (path.length === 0) return null;
+
   const tokens: Array<string | number> = [];
   const n = path.length;
   let i = 0;
-  if (path.startsWith("$")) {
-    i = 1;
-    if (path[i] === ".") i += 1;
+  if (path[0] === "$") {
+    if (path[1] === ".") {
+      i = 2;
+    } else if (path[1] === "[") {
+      i = 1;
+    } else {
+      return null;
+    }
   }
   while (i < n) {
     if (tokens.length >= MAX_PATH_TOKENS) return null;
@@ -197,7 +208,20 @@ export function resolveJsonPath(root: unknown, path: string): PathResult {
 /** Human-readable hint listing the top-level shape for a failed path. */
 export function describeTopLevel(root: unknown): string {
   if (Array.isArray(root)) return `top-level value is an array of length ${root.length}`;
-  if (isRecord(root)) return `top-level keys: [${Object.keys(root).join(", ")}]`;
+  if (isRecord(root)) {
+    const keys = Object.keys(root);
+    const shown = keys
+      .slice(0, TOP_LEVEL_HINT_KEYS_MAX)
+      .map((key) => JSON.stringify(
+        key.length <= TOP_LEVEL_HINT_KEY_CHARS_MAX
+          ? key
+          : `${key.slice(0, TOP_LEVEL_HINT_KEY_CHARS_MAX)}…`,
+      ));
+    const remainder = keys.length > shown.length
+      ? `, … +${keys.length - shown.length} more`
+      : "";
+    return `top-level keys (${keys.length}): [${shown.join(", ")}${remainder}]`;
+  }
   return `top-level value is a ${typeof root}`;
 }
 

--- a/src/vex-agent/tools/internal/tool-output-read.ts
+++ b/src/vex-agent/tools/internal/tool-output-read.ts
@@ -47,19 +47,34 @@ const DEFAULT_READ_BYTES = 8 * 1024;
 export const MAX_READ_BYTES = TOOL_OUTPUT_OVERFLOW_BYTES - 4 * 1024;
 
 /** Header room reserved so header + body always stays under MAX_READ_BYTES. */
-const HEADER_RESERVE_BYTES = 1024;
+const HEADER_RESERVE_BYTES = 2 * 1024;
 const BODY_BUDGET_BYTES = MAX_READ_BYTES - HEADER_RESERVE_BYTES;
 
 const DEFAULT_SEARCH_LIMIT = 10;
 const MAX_SEARCH_LIMIT = 50;
 const DEFAULT_ITEM_LIMIT = 20;
 const MAX_ITEM_LIMIT = 50;
+const MAX_SEARCH_CHARS = 256;
+const MAX_PATH_CHARS = 256;
+const MAX_FIELD_CHARS = 128;
 
 const WhereArgs = z
   .object({
-    field: z.string().min(1, { message: "where.field must be a non-empty string" }),
-    contains: z.string().optional(),
-    equals: z.union([z.string(), z.number(), z.boolean()]).optional(),
+    field: z
+      .string()
+      .min(1, { message: "where.field must be a non-empty string" })
+      .max(MAX_FIELD_CHARS, { message: `where.field must be at most ${MAX_FIELD_CHARS} characters` }),
+    contains: z
+      .string()
+      .max(MAX_SEARCH_CHARS, { message: `where.contains must be at most ${MAX_SEARCH_CHARS} characters` })
+      .optional(),
+    equals: z.union([
+      z.string().max(MAX_SEARCH_CHARS, {
+        message: `where.equals must be at most ${MAX_SEARCH_CHARS} characters`,
+      }),
+      z.number(),
+      z.boolean(),
+    ]).optional(),
   })
   .strict();
 
@@ -81,10 +96,22 @@ const ToolOutputReadArgs = z.object({
     .min(1, { message: "max_bytes must be >= 1" })
     .optional(),
   // ── E8 query params (all optional; byte mode stays the fallback) ──
-  search: z.string().min(1, { message: "search must be a non-empty string" }).optional(),
-  path: z.string().min(1, { message: "path must be a non-empty string" }).optional(),
+  search: z
+    .string()
+    .min(1, { message: "search must be a non-empty string" })
+    .max(MAX_SEARCH_CHARS, { message: `search must be at most ${MAX_SEARCH_CHARS} characters` })
+    .optional(),
+  path: z
+    .string()
+    .min(1, { message: "path must be a non-empty string" })
+    .max(MAX_PATH_CHARS, { message: `path must be at most ${MAX_PATH_CHARS} characters` })
+    .optional(),
   where: WhereArgs.optional(),
-  sort_by: z.string().min(1, { message: "sort_by must be a non-empty field name" }).optional(),
+  sort_by: z
+    .string()
+    .min(1, { message: "sort_by must be a non-empty field name" })
+    .max(MAX_FIELD_CHARS, { message: `sort_by must be at most ${MAX_FIELD_CHARS} characters` })
+    .optional(),
   order: z.enum(["asc", "desc"]).optional(),
   item_offset: z
     .number()
@@ -167,20 +194,30 @@ export async function handleToolOutputRead(
 // ── Byte mode (unchanged fallback) ───────────────────────────────
 
 function runByteSlice(blob: ToolOutputBlob, args: ReadArgs): ToolResult {
-  const offset = args.offset ?? 0;
+  const requestedOffset = args.offset ?? 0;
   const requestedBytes = args.max_bytes ?? DEFAULT_READ_BYTES;
-  const maxBytes = Math.min(requestedBytes, MAX_READ_BYTES);
+  const maxBytes = Math.min(requestedBytes, BODY_BUDGET_BYTES);
 
   const fullBuffer = Buffer.from(blob.payload.fullOutput, "utf8");
   const totalBytes = fullBuffer.byteLength;
-  if (offset > totalBytes) {
+  if (requestedOffset > totalBytes) {
     return fail(
-      `tool_output_read: offset ${offset} is beyond payload size ${totalBytes}.`,
+      `tool_output_read: offset ${requestedOffset} is beyond payload size ${totalBytes}.`,
     );
   }
 
-  const endOffset = Math.min(offset + maxBytes, totalBytes);
-  const content = fullBuffer.subarray(offset, endOffset).toString("utf8");
+  // Byte offsets remain the paging contract, but decoding must never start or
+  // end inside a UTF-8 sequence. Round a caller-supplied interior offset back
+  // to the character start and make the returned end a complete boundary.
+  // Sequential reads using next_offset therefore reconstruct the exact text
+  // without U+FFFD replacement characters or dropped bytes.
+  const offset = alignUtf8Start(fullBuffer, requestedOffset);
+  const endOffset = alignUtf8End(
+    fullBuffer,
+    offset,
+    Math.min(offset + maxBytes, totalBytes),
+  );
+  const content = fullBuffer.toString("utf8", offset, endOffset);
   const bytesReturned = endOffset - offset;
   const nextOffset = endOffset < totalBytes ? endOffset : null;
   const truncated = nextOffset !== null;
@@ -192,7 +229,8 @@ function runByteSlice(blob: ToolOutputBlob, args: ReadArgs): ToolResult {
     ...(blob.payload.fieldHints !== undefined ? { fieldHints: blob.payload.fieldHints } : {}),
   });
   const output =
-    `[tool_output_read blob_key=${blob.blobKey} offset=${offset} ` +
+    `[tool_output_read blob_key=${blob.blobKey} requested_offset=${requestedOffset} ` +
+    `offset=${offset} ` +
     `bytes_returned=${bytesReturned} total_bytes=${totalBytes} ` +
     `shape=${blob.payload.shapeKind} truncated=${truncated} ` +
     `next_offset=${nextOffset ?? "null"}${hintsSuffix}].${continuation}\n` +
@@ -205,6 +243,7 @@ function runByteSlice(blob: ToolOutputBlob, args: ReadArgs): ToolResult {
       blob_key: blob.blobKey,
       shape_kind: blob.payload.shapeKind,
       size_bytes: blob.payload.sizeBytes,
+      requested_offset: requestedOffset,
       offset,
       bytes_returned: bytesReturned,
       next_offset: nextOffset,
@@ -214,6 +253,50 @@ function runByteSlice(blob: ToolOutputBlob, args: ReadArgs): ToolResult {
       expires_at: blob.expiresAt,
     },
   };
+}
+
+function isUtf8ContinuationByte(byte: number | undefined): boolean {
+  return byte !== undefined && (byte & 0xc0) === 0x80;
+}
+
+/** Move an arbitrary byte offset to the start of its containing code point. */
+function alignUtf8Start(buffer: Buffer, offset: number): number {
+  let aligned = offset;
+  while (
+    aligned > 0
+    && aligned < buffer.byteLength
+    && isUtf8ContinuationByte(buffer[aligned])
+  ) {
+    aligned -= 1;
+  }
+  return aligned;
+}
+
+function utf8SequenceBytes(lead: number | undefined): number {
+  if (lead === undefined || (lead & 0x80) === 0) return 1;
+  if ((lead & 0xe0) === 0xc0) return 2;
+  if ((lead & 0xf0) === 0xe0) return 3;
+  if ((lead & 0xf8) === 0xf0) return 4;
+  return 1;
+}
+
+/**
+ * Move a desired end back to a complete boundary. If max_bytes lands inside
+ * the first character, include that one character so pagination progresses.
+ */
+function alignUtf8End(buffer: Buffer, start: number, desiredEnd: number): number {
+  let end = desiredEnd;
+  while (
+    end > start
+    && end < buffer.byteLength
+    && isUtf8ContinuationByte(buffer[end])
+  ) {
+    end -= 1;
+  }
+  if (end === start && start < buffer.byteLength) {
+    return Math.min(buffer.byteLength, start + utf8SequenceBytes(buffer[start]));
+  }
+  return end;
 }
 
 // ── Search mode (raw text, any shape) ────────────────────────────

--- a/src/vex-agent/tools/registry/autonomy.ts
+++ b/src/vex-agent/tools/registry/autonomy.ts
@@ -36,7 +36,7 @@ export const AUTONOMY_TOOLS: readonly ToolDef[] = [
       "When a tool returns more than ~16 KiB, the engine stores the full output off-prompt and leaves a short stub with `blob_key=<key>` in the transcript. " +
       "Prefer targeted modes over blind byte-slicing — a needle deep in the payload (e.g. a coin far down a markets list) is easy to miss with byte offsets alone. Three query modes, plus the byte-slice fallback:\n" +
       "• SEARCH: set `search` to find a literal substring (case-insensitive) anywhere in the RAW payload; each hit returns its byte `offset` and a short context window. Works for any payload shape. Not a regex.\n" +
-      "• PATH: set `path` (dot/[index] only, e.g. `meta.universe`, `contexts[1]`, `meta.universe[230]`) to resolve a sub-value inside a JSON payload.\n" +
+      "• PATH: set `path` (dot/[index] only, e.g. `$` for the root value, `meta.universe`, `contexts[1]`, `meta.universe[230]`) to resolve a value inside a JSON payload.\n" +
       "• ARRAY QUERY: when `path` points at an array, add `where` (filter on a scalar field), `sort_by`+`order` (sort on a scalar field), and `item_offset`+`limit` (paginate). The response reports `returned` and `matched` counts so you can see how much was truncated.\n" +
       "• BYTE SLICE (fallback): omit the above and use `offset`/`max_bytes`. " +
       "Every mode reads the original stored snapshot, is scoped to the current session, and is bounded well under the overflow threshold so results never re-overflow. Read the blob before its TTL expires.",
@@ -56,17 +56,17 @@ export const AUTONOMY_TOOLS: readonly ToolDef[] = [
         max_bytes: {
           type: "integer",
           description:
-            "BYTE-SLICE mode: maximum bytes to return. The runtime caps this below the overflow threshold so reads stay inline.",
+            "BYTE-SLICE mode: target maximum bytes to return. The runtime caps this below the overflow threshold and may include up to one complete UTF-8 character past the target rather than corrupting it.",
         },
         search: {
           type: "string",
           description:
-            "SEARCH mode: find this literal substring in the RAW payload text (case-insensitive). Returns each hit's byte offset and a surrounding context window. Not a regular expression.",
+            "SEARCH mode: find this literal substring in the RAW payload text (case-insensitive, max 256 characters). Returns each hit's byte offset and a surrounding context window. Not a regular expression.",
         },
         path: {
           type: "string",
           description:
-            "PATH mode (JSON payloads): dot/[index] path to a sub-value, e.g. `meta.universe`, `contexts[1]`, `meta.universe[230]`. Max 10 segments; no wildcards.",
+            "PATH mode (JSON payloads): `$` selects the root; otherwise use dot/[index], e.g. `meta.universe`, `contexts[1]`, `meta.universe[230]`. Max 10 segments and 256 characters; no wildcards.",
         },
         where: {
           type: "object",


### PR DESCRIPTION
## Summary

- make bare path $ resolve the stored JSON root, so root-array primary_path guidance is executable
- align byte slices to complete UTF-8 code points and return boundary-safe next_offset values without replacement-character data loss
- derive overflow recovery guidance from the actual payload path/fields instead of hard-coded CASH/meta.universe examples
- preview and hint common result arrays including assets, tokens, chains, markets, and data
- cap model-controlled search/path/filter/sort strings plus top-level failure hints, and reserve output budget for headers so reads cannot recursively overflow

## Why grouped

These issues are one producer/consumer contract: the overflow writer advertises how to navigate a blob, and tool_output_read must execute that advice losslessly within the inline budget. Splitting them would leave intermediate PR states where the advertised path or continuation offsets were still unsafe.

## Validation

- focused overflow/read suites (3 files, 67 passed)
- pnpm vitest run --exclude src/__tests__/vex-agent/tools/polymarket-handlers.test.ts (543 files, 7,212 passed, 7 skipped)
- pnpm build
- pnpm --dir vex-app lint

The excluded Polymarket handler file performs a live bridge.assets fetch; it is outside this retrieval path.