### PR TITLE
fix(hyperliquid): show positions immediately after trades

### DIFF
--- a/src/__tests__/vex-agent/sync/executor.test.ts
+++ b/src/__tests__/vex-agent/sync/executor.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startSyncExecutor } from "../../../vex-agent/sync/executor.js";
+import { requestSyncTick } from "../../../vex-agent/sync/executor-wake.js";
 
 describe("sync executor", () => {
   beforeEach(() => {
@@ -41,6 +42,21 @@ describe("sync executor", () => {
     await vi.advanceTimersByTimeAsync(5000);
 
     expect(deps.syncTick).not.toHaveBeenCalled();
+  });
+
+  it("drains newly enqueued work immediately instead of waiting for the interval", async () => {
+    const deps = {
+      initSync: vi.fn().mockResolvedValue(undefined),
+      syncTick: vi.fn().mockResolvedValue(undefined),
+    };
+    const handle = startSyncExecutor({ intervalMs: 60_000, deps });
+    await vi.advanceTimersByTimeAsync(0);
+
+    requestSyncTick();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(deps.syncTick).toHaveBeenCalledTimes(1);
+    await handle.stop();
   });
 
   it("owns and tears down the Hyperliquid watcher with the sync executor", async () => {

--- a/src/__tests__/vex-agent/tools/protocols/hyperliquid-open-safety.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/hyperliquid-open-safety.test.ts
@@ -100,6 +100,58 @@ describe("Hyperliquid synchronous open safety", () => {
     });
   });
 
+  it("projects a venue-confirmed position into a renderer-complete capture immediately", async () => {
+    const liveState = {
+      marginSummary: { accountValue: "250" },
+      withdrawable: "200",
+      assetPositions: [{ position: {
+        coin: "BTC",
+        szi: "1",
+        entryPx: "100",
+        liquidationPx: "50",
+        positionValue: "101",
+        unrealizedPnl: "1.25",
+        cumFunding: { sinceOpen: "-0.25" },
+        leverage: { type: "isolated", value: 3 },
+      } }],
+    };
+    const capture = await capturePerpSafely(
+      {
+        clearinghouseState: vi.fn().mockResolvedValue(liveState),
+        frontendOpenOrders: vi.fn().mockResolvedValue([full]),
+      } as never,
+      "0xabc",
+      "BTC",
+      {} as never,
+      false,
+    );
+
+    expect(capture).toMatchObject({
+      status: "open",
+      inputValueUsd: "100",
+      currentValueUsd: "101",
+      unrealizedPnlUsd: "1",
+      meta: {
+        coin: "BTC",
+        contracts: "1",
+        signedSize: "1",
+        side: "long",
+        entryPx: "100",
+        markPx: "101",
+        leverage: "3",
+        marginMode: "isolated",
+        liquidationPx: "50",
+        slPrice: "90",
+        protectionState: "PROTECTED",
+        cumFundingSinceOpen: "-0.25",
+        accountEquityUsd: "250",
+        accountWithdrawableUsd: "200",
+        accountTotalUnrealizedPnlUsd: "1.25",
+        confirmedAt: expect.any(String),
+      },
+    });
+  });
+
   it("applies leverage/margin mode before entry and exposes rejection to the caller", async () => {
     const updateLeverage = vi.fn(async () => accepted);
     await expect(applyOpenLeverage({ updateLeverage }, 7, 3, "isolated")).resolves.toEqual(accepted);

--- a/src/vex-agent/sync/executor-wake.ts
+++ b/src/vex-agent/sync/executor-wake.ts
@@ -1,0 +1,20 @@
+/**
+ * In-process wake signal for newly enqueued sync work.
+ *
+ * Persistence remains the source of truth: a missed signal is harmless because
+ * the periodic executor still drains the queue. The signal only removes the
+ * normal one-minute wait after a mutation.
+ */
+
+type SyncWakeListener = () => void;
+
+const listeners = new Set<SyncWakeListener>();
+
+export function requestSyncTick(): void {
+  for (const listener of listeners) listener();
+}
+
+export function subscribeSyncTickWake(listener: SyncWakeListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/src/vex-agent/sync/executor.ts
+++ b/src/vex-agent/sync/executor.ts
@@ -12,6 +12,7 @@
 
 import { initSync, syncTick } from "./index.js";
 import { startHyperliquidMarketWatcher, type HyperliquidMarketWatcherHandle } from "./hyperliquid-market-watcher.js";
+import { subscribeSyncTickWake } from "./executor-wake.js";
 import logger from "@utils/logger.js";
 
 export interface SyncExecutorHandle {
@@ -48,6 +49,7 @@ export function startSyncExecutor(options: SyncStartOptions = {}): SyncExecutorH
   let inFlight: Promise<void> | null = null;
   let timer: NodeJS.Timeout | null = null;
   let marketWatcher: HyperliquidMarketWatcherHandle | null = null;
+  let wakePending = false;
 
   const runOne = async (): Promise<void> => {
     try {
@@ -69,12 +71,28 @@ export function startSyncExecutor(options: SyncStartOptions = {}): SyncExecutorH
   const schedule = (delayMs: number): void => {
     if (stopped) return;
     timer = setTimeout(() => {
+      timer = null;
       inFlight = runOne().finally(() => {
         inFlight = null;
-        schedule(intervalMs);
+        const nextDelay = wakePending && initialized ? 0 : intervalMs;
+        wakePending = false;
+        schedule(nextDelay);
       });
     }, delayMs);
   };
+
+  const unsubscribeWake = subscribeSyncTickWake(() => {
+    if (stopped) return;
+    if (inFlight !== null || !initialized) {
+      wakePending = true;
+      return;
+    }
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    schedule(0);
+  });
 
   schedule(0);
   logger.info("sync.executor.started", { intervalMs });
@@ -82,6 +100,7 @@ export function startSyncExecutor(options: SyncStartOptions = {}): SyncExecutorH
   return {
     async stop(): Promise<void> {
       stopped = true;
+      unsubscribeWake();
       if (timer) clearTimeout(timer);
       if (inFlight) {
         try {

--- a/src/vex-agent/tools/protocols/hyperliquid/handler-shared.ts
+++ b/src/vex-agent/tools/protocols/hyperliquid/handler-shared.ts
@@ -17,6 +17,11 @@ import { normalizeProviderDecimal, parseDecimalString } from "@tools/hyperliquid
 import type { ProtocolExecutionContext } from "../types.js";
 import type { ToolResult } from "../../types.js";
 import { buildPositionProtectionSnapshot } from "./protection-snapshot.js";
+import {
+  accountSnapshot,
+  parseHyperliquidClearinghouseState,
+  projectOpenCapture,
+} from "@vex-agent/sync/hyperliquid-reconciler/projections.js";
 import { redact } from "../../../../lib/diagnostics/text-redaction.js";
 import logger from "@utils/logger.js";
 
@@ -221,10 +226,42 @@ export async function capturePerp(
   const active = !new Decimal(snapshot.positionSize).isZero();
   const value = positive(string(position, "positionValue"));
   const entry = positive(string(position, "entryPx"));
+  const policyMeta = context.hyperliquidPolicy?.kind === "available" ? {
+    policyVersion: context.hyperliquidPolicy.snapshot.version,
+    policyProvenance: context.hyperliquidPolicy.snapshot.provenance,
+  } : {};
+
+  // A clearinghouse-confirmed position must be renderable immediately. Route
+  // the post-submit state through the same canonical builder as the periodic
+  // reconciler so side, mark, PnL, funding, leverage, and confirmation time do
+  // not drift between the execution and reconciliation paths.
+  if (active) {
+    const projected = projectImmediateOpenCapture(state, address, coin, snapshot, position);
+    if (projected !== null) {
+      const projectedMeta = record(projected["meta"]) ?? {};
+      return {
+        ...projected,
+        meta: {
+          ...projectedMeta,
+          ...(forceUnprotected ? { protectionState: "unprotected_by_user_choice" } : {}),
+          ...policyMeta,
+          ...extraMeta,
+        },
+      };
+    }
+    logger.warn("hyperliquid.post_submit_capture_incomplete", {
+      coin,
+      hint: "Live position could not be normalized; reconciliation will retry.",
+    });
+  }
+
   return {
     type: "perps",
     chain: "hyperliquid",
-    status: active ? "open" : closedWhenFlat ? "closed" : "pending",
+    // The active path reaches this fallback only when the live payload could
+    // not satisfy the canonical renderer projection. Keep it pending so an
+    // incomplete row cannot masquerade as authoritative open-position state.
+    status: !active && closedWhenFlat ? "closed" : "pending",
     walletAddress: address,
     positionKey: `hyperliquid:perp:${coin}:${address}`,
     instrumentKey: `hyperliquid:perp:${coin}`,
@@ -238,13 +275,73 @@ export async function capturePerp(
       entryPx: snapshot.entryPx,
       liquidationPx: snapshot.liquidationPx,
       protectionState: forceUnprotected ? "unprotected_by_user_choice" : snapshot.state,
-      ...(context.hyperliquidPolicy?.kind === "available" ? {
-        policyVersion: context.hyperliquidPolicy.snapshot.version,
-        policyProvenance: context.hyperliquidPolicy.snapshot.provenance,
-      } : {}),
+      ...(active ? { captureState: "normalization_pending" } : {}),
+      ...policyMeta,
       ...extraMeta,
     },
   };
+}
+
+function projectImmediateOpenCapture(
+  stateResponse: unknown,
+  walletAddress: string,
+  coin: string,
+  snapshot: ReturnType<typeof buildPositionProtectionSnapshot>,
+  rawPosition: Record<string, unknown> | undefined,
+): Record<string, unknown> | null {
+  if (rawPosition === undefined) return null;
+  try {
+    const state = parseHyperliquidClearinghouseState(stateResponse);
+    const position = state.assetPositions
+      .map((entry) => entry.position)
+      .find((candidate) => candidate.coin === coin);
+    if (position === undefined) return null;
+    const markPx = immediateMarkPrice(rawPosition, snapshot.positionSize);
+    if (markPx === undefined) return null;
+    const confirmedAt = new Date().toISOString();
+    return projectOpenCapture({
+      walletAddress,
+      coin,
+      position,
+      markPx,
+      account: accountSnapshot(state),
+      marketWatchlist: [],
+      snapshot,
+      fills: [],
+      localPosition: null,
+      confirmedAt,
+      reconcileBucket: Math.floor(Date.parse(confirmedAt) / 60_000),
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** clearinghouseState exposes current notional, so mark = value / |size|. */
+function immediateMarkPrice(
+  position: Record<string, unknown>,
+  positionSize: string,
+): string | undefined {
+  const direct = string(position, "markPx");
+  if (direct !== undefined) {
+    try {
+      return normalizeProviderDecimal(direct, "Hyperliquid position mark price");
+    } catch {
+      // Fall through to the venue's current position value.
+    }
+  }
+  const value = string(position, "positionValue");
+  if (value === undefined) return undefined;
+  try {
+    const size = new Decimal(positionSize).abs();
+    if (size.isZero()) return undefined;
+    return normalizeProviderDecimal(
+      new Decimal(value).div(size).toFixed(),
+      "Hyperliquid position mark price",
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 export async function capturePerpSafely(

--- a/src/vex-agent/tools/protocols/runtime/capture.ts
+++ b/src/vex-agent/tools/protocols/runtime/capture.ts
@@ -49,12 +49,13 @@ export async function captureExecution(
   }
 
   // Enqueue sync runs for this namespace (only on success — failed mutations don't need projection refresh)
+  let syncEnqueued = false;
   if (result.success && executionId > 0) {
     try {
       const { getJobsForNamespace, enqueueRun } = await import("@vex-agent/db/repos/sync.js");
       const jobs = await getJobsForNamespace(namespace);
       for (const job of jobs) {
-        await enqueueRun(job.id, executionId);
+        if (await enqueueRun(job.id, executionId) > 0) syncEnqueued = true;
       }
     } catch (err) {
       logger.warn("protocol.execute.sync_enqueue_failed", {
@@ -79,6 +80,7 @@ export async function captureExecution(
         toolId, namespace, executionId,
         hint: "Capture blocked by validator — not sent to projection pipeline",
       });
+      await wakeSyncExecutor(syncEnqueued);
       return;
     }
     try {
@@ -89,6 +91,23 @@ export async function captureExecution(
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  }
+
+  // Wake only after the inline projection attempt. Hyperliquid reconciliation
+  // can now observe the activity/position row rather than racing the capture
+  // pipeline, while the persisted queue remains the crash-safe backstop.
+  await wakeSyncExecutor(syncEnqueued);
+}
+
+async function wakeSyncExecutor(syncEnqueued: boolean): Promise<void> {
+  if (!syncEnqueued) return;
+  try {
+    const { requestSyncTick } = await import("@vex-agent/sync/executor-wake.js");
+    requestSyncTick();
+  } catch (err) {
+    logger.warn("protocol.execute.sync_wake_failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 

--- a/vex-app/src/main/database/__tests__/hyperliquid-positions.test.ts
+++ b/vex-app/src/main/database/__tests__/hyperliquid-positions.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SESSION = "00000000-0000-4000-8000-000000000001";
+const WALLET = "0x1111111111111111111111111111111111111111";
+const POSITION_KEY = `hyperliquid:perp:BTC:${WALLET}`;
+const NOW = "2026-07-21T12:02:00.000Z";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  connect: vi.fn(),
+  end: vi.fn(),
+  buildPoolConfig: vi.fn(),
+  getSessionWalletScope: vi.fn(),
+  log: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("pg", () => {
+  function MockClient() {
+    return { query: mocks.query, connect: mocks.connect, end: mocks.end };
+  }
+  return { Client: MockClient };
+});
+vi.mock("../db-config.js", () => ({ buildPoolConfig: mocks.buildPoolConfig }));
+vi.mock("../sessions-db.js", () => ({ getSessionWalletScope: mocks.getSessionWalletScope }));
+vi.mock("../../logger/index.js", () => ({ log: mocks.log }));
+
+const { getHyperliquidPositions } = await import("../hyperliquid-db.js");
+
+function positionRow(data: Record<string, unknown>) {
+  return {
+    position_key: POSITION_KEY,
+    contracts: "1",
+    entry_price_usd: "100",
+    unrealized_pnl_usd: "1",
+    data,
+    last_refresh_at: NOW,
+    synced_at: NOW,
+    opened_at: NOW,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(NOW));
+  vi.clearAllMocks();
+  mocks.buildPoolConfig.mockResolvedValue({
+    host: "127.0.0.1",
+    port: 5432,
+    database: "vex",
+    user: "vex",
+    password: "secret",
+  });
+  mocks.connect.mockResolvedValue(undefined);
+  mocks.end.mockResolvedValue(undefined);
+  mocks.getSessionWalletScope.mockResolvedValue({
+    ok: true,
+    data: { evm: { id: "wallet", address: WALLET }, solana: null },
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("getHyperliquidPositions", () => {
+  it("returns an immediate canonical capture as a visible position", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [positionRow({
+      coin: "BTC",
+      contracts: "1",
+      signedSize: "1",
+      side: "long",
+      entryPx: "100",
+      markPx: "101",
+      liquidationPx: "50",
+      slPrice: "90",
+      leverage: "3",
+      marginMode: "isolated",
+      protectionState: "PROTECTED",
+      cumFundingSinceOpen: "-0.25",
+      confirmedAt: NOW,
+    })] });
+
+    const result = await getHyperliquidPositions(SESSION);
+
+    expect(result).toEqual({
+      ok: true,
+      data: expect.objectContaining({
+        syncStatus: "settled",
+        positions: [expect.objectContaining({
+          coin: "BTC",
+          side: "long",
+          markPx: "101",
+          fundingAccrued: "-0.25",
+          protectionState: "PROTECTED",
+        })],
+      }),
+    });
+    expect(mocks.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a recent active capture as syncing when its projection is not renderable", async () => {
+    mocks.query
+      .mockResolvedValueOnce({ rows: [positionRow({
+        coin: "BTC",
+        contracts: "1",
+        entryPx: "100",
+        protectionState: "PROTECTED",
+      })] })
+      .mockResolvedValueOnce({
+        rows: [{ capture_status: "open", created_at: "2026-07-21T12:01:30.000Z" }],
+      });
+
+    const result = await getHyperliquidPositions(SESSION);
+
+    expect(result).toEqual({
+      ok: true,
+      data: expect.objectContaining({ positions: [], syncStatus: "syncing" }),
+    });
+  });
+
+  it("surfaces a delayed state instead of claiming an old pending capture is empty", async () => {
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ capture_status: "pending", created_at: "2026-07-21T11:59:00.000Z" }],
+      });
+
+    const result = await getHyperliquidPositions(SESSION);
+
+    expect(result).toEqual({
+      ok: true,
+      data: expect.objectContaining({ positions: [], syncStatus: "delayed" }),
+    });
+  });
+});

--- a/vex-app/src/main/database/hyperliquid-db.ts
+++ b/vex-app/src/main/database/hyperliquid-db.ts
@@ -23,6 +23,7 @@ import {
   hyperliquidRiskProposalDtoSchema,
   type HyperliquidAccountDto,
   type HyperliquidPositionDto,
+  type HyperliquidPositionSyncStatus,
   type HyperliquidPositionsDto,
   type HyperliquidRiskProposalDto,
   type HyperliquidRiskAdjustment,
@@ -40,6 +41,7 @@ const QUERY_TIMEOUT_MS = 5_000;
 const HYPERLIQUID_DB_CORRELATION_ID = "hyperliquid-db";
 
 interface HyperliquidPositionRow {
+  readonly position_key: string | null;
   readonly contracts: string | number | null;
   readonly entry_price_usd: string | number | null;
   readonly unrealized_pnl_usd: string | number | null;
@@ -47,6 +49,11 @@ interface HyperliquidPositionRow {
   readonly last_refresh_at: string | Date | null;
   readonly synced_at: string | Date | null;
   readonly opened_at: string | Date | null;
+}
+
+interface HyperliquidActiveCaptureRow {
+  readonly capture_status: string;
+  readonly created_at: string | Date;
 }
 
 interface HyperliquidPolicyRow {
@@ -287,11 +294,11 @@ function watchlistFromRows(rows: readonly HyperliquidPositionRow[]): readonly Hy
   return [];
 }
 
-// W6 diagnostic (incident 2026-07-13): a session whose selected wallet has an
-// OPEN perp capture in proj_activity but zero rows in proj_open_positions is the
-// signature of the W7 projection-write defect. Warn once per (session,wallet)
-// per 10 min, via a bounded expiring map — the main process is long-lived and
-// must not grow this unbounded. The warn is redacted (6-char fingerprint only).
+// A recent active capture with no renderable projection means the empty list is
+// not authoritative yet. This covers both a resting/pending venue order and a
+// projection row that is still incomplete. Beyond the normal 60s reconcile +
+// 5s push window, surface `delayed` and emit one bounded diagnostic.
+const EMPTY_POSITION_DELAY_MS = 90_000;
 const MISSING_PROJECTION_WARN_TTL_MS = 10 * 60_000;
 const MISSING_PROJECTION_WARN_MAX = 500;
 const missingProjectionWarnedAt = new Map<string, number>();
@@ -307,40 +314,54 @@ function pruneMissingProjectionWarnMap(now: number): void {
   }
 }
 
-async function warnOnMissingHyperliquidProjection(
+async function emptyPositionSyncStatus(
   client: Client,
   sessionId: string,
   walletAddress: string,
   correlationId: string,
-): Promise<void> {
-  const key = `${sessionId} ${walletAddress}`;
-  const now = Date.now();
-  const existing = missingProjectionWarnedAt.get(key);
-  if (existing !== undefined && existing > now) return;
+): Promise<HyperliquidPositionSyncStatus> {
+  let activeCapture: HyperliquidActiveCaptureRow | undefined;
   try {
-    const probe = await client.query<{ exists: boolean }>(
-      `SELECT EXISTS (
-         SELECT 1 FROM (
-           SELECT DISTINCT ON (position_key) capture_status
-           FROM proj_activity
-           WHERE namespace = 'hyperliquid' AND product_type = 'perps'
-             AND wallet_address = $1 AND position_key IS NOT NULL
-           ORDER BY position_key, created_at DESC, id DESC
-         ) latest
-         WHERE capture_status = 'open'
-       ) AS exists`,
+    const probe = await client.query<HyperliquidActiveCaptureRow>(
+      `SELECT capture_status, created_at
+       FROM (
+         SELECT DISTINCT ON (position_key) capture_status, created_at, id
+         FROM proj_activity
+         WHERE namespace = 'hyperliquid' AND product_type = 'perps'
+           AND wallet_address = $1 AND position_key IS NOT NULL
+         ORDER BY position_key, created_at DESC, id DESC
+       ) latest
+       WHERE capture_status IN ('pending', 'open', 'executed')
+       ORDER BY created_at DESC, id DESC
+       LIMIT 1`,
       [walletAddress],
     );
-    if (probe.rows[0]?.exists !== true) return;
+    activeCapture = probe.rows[0];
   } catch (cause) {
-    log.warn("[hyperliquid-db] missing-projection probe failed", cause);
-    return;
+    log.warn("[hyperliquid-db] empty-position status probe failed", cause);
+    return "delayed";
   }
-  pruneMissingProjectionWarnMap(now);
-  missingProjectionWarnedAt.set(key, now + MISSING_PROJECTION_WARN_TTL_MS);
-  log.warn(
-    `[hyperliquid-db] open perp capture present but projection empty wallet=${walletAddress.slice(0, 6)} correlationId=${correlationId}`,
-  );
+  if (activeCapture === undefined) return "settled";
+
+  const now = Date.now();
+  const createdAt = new Date(activeCapture.created_at).getTime();
+  const syncStatus = Number.isFinite(createdAt) && now - createdAt <= EMPTY_POSITION_DELAY_MS
+    ? "syncing"
+    : "delayed";
+
+  // Keep the original W6 projection diagnostic, but include pending captures
+  // and delayed consistency without exposing the full wallet address.
+  const key = `${sessionId}\u0000${walletAddress}`;
+  const existing = missingProjectionWarnedAt.get(key);
+  const shouldWarn = syncStatus === "delayed" || activeCapture.capture_status !== "pending";
+  if (shouldWarn && (existing === undefined || existing <= now)) {
+    pruneMissingProjectionWarnMap(now);
+    missingProjectionWarnedAt.set(key, now + MISSING_PROJECTION_WARN_TTL_MS);
+    log.warn(
+      `[hyperliquid-db] active perp capture has no renderable position status=${activeCapture.capture_status} sync=${syncStatus} wallet=${walletAddress.slice(0, 6)} correlationId=${correlationId}`,
+    );
+  }
+  return syncStatus;
 }
 
 /** Session-scoped positions. An absent EVM selection returns an empty DTO before SQL. */
@@ -355,6 +376,7 @@ export async function getHyperliquidPositions(
   if (walletAddress === undefined) return ok({
     sessionId,
     positions: [],
+    syncStatus: "settled",
     account: emptyAccount(),
     watchlist: [],
     updatedAt: now,
@@ -363,7 +385,7 @@ export async function getHyperliquidPositions(
   return withClient(async (client) => {
     try {
       const result = await client.query<HyperliquidPositionRow>(
-        `SELECT contracts, entry_price_usd, unrealized_pnl_usd, data,
+        `SELECT position_key, contracts, entry_price_usd, unrealized_pnl_usd, data,
                 last_refresh_at, synced_at, opened_at
          FROM proj_open_positions
          WHERE namespace = 'hyperliquid'
@@ -377,12 +399,13 @@ export async function getHyperliquidPositions(
       const positions = result.rows
         .map(positionFromRow)
         .filter((value): value is HyperliquidPositionDto => value !== null);
-      if (positions.length === 0) {
-        await warnOnMissingHyperliquidProjection(client, sessionId, walletAddress, correlationId);
-      }
+      const syncStatus = positions.length === 0
+        ? await emptyPositionSyncStatus(client, sessionId, walletAddress, correlationId)
+        : "settled";
       return ok(hyperliquidPositionsDtoSchema.parse({
         sessionId,
         positions,
+        syncStatus,
         account: accountFromRows(result.rows),
         watchlist: watchlistFromRows(result.rows),
         updatedAt: now,

--- a/vex-app/src/main/market/__tests__/hyperliquid-positions-service.test.ts
+++ b/vex-app/src/main/market/__tests__/hyperliquid-positions-service.test.ts
@@ -158,6 +158,36 @@ describe("setupHyperliquidPositionsService", () => {
     await stop();
   });
 
+  it("publishes when an empty position state becomes delayed", async () => {
+    const publish = vi.fn();
+    let syncStatus: "syncing" | "delayed" = "syncing";
+    const info = {
+      allMids: vi.fn().mockResolvedValue({ BTC: "100100" }),
+      clearinghouseState: vi.fn().mockResolvedValue(state()),
+    };
+    const stop = setupHyperliquidPositionsService({
+      hasExposure: async () => true,
+      listSessionIds: async () => [SESSION],
+      listHypervexingSessionIds: () => [SESSION],
+      getPositions: async (): Promise<Result<HyperliquidPositionsDto>> => ({
+        ok: true,
+        data: { ...snapshot(), positions: [], syncStatus },
+      }),
+      getSessionWalletScope: async () => scope(),
+      createInfoClient: () => info,
+      publish,
+      now: () => new Date(ISO),
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    syncStatus = "delayed";
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(publish).toHaveBeenCalledTimes(2);
+    expect(publish).toHaveBeenLastCalledWith(expect.objectContaining({ syncStatus: "delayed" }));
+    await stop();
+  });
+
   it("switches the next self-scheduled tick from 15 seconds to 5 seconds when Hypervexing begins", async () => {
     let hypervexing = false;
     const info = {

--- a/vex-app/src/main/market/hyperliquid-positions-service.ts
+++ b/vex-app/src/main/market/hyperliquid-positions-service.ts
@@ -128,6 +128,7 @@ function stableSerialize(value: unknown): string {
 function snapshotFingerprint(snapshot: HyperliquidPositionsDto): string {
   return stableSerialize({
     positions: snapshot.positions.map(({ updatedAt: _updatedAt, ...position }) => position),
+    syncStatus: snapshot.syncStatus,
     account: snapshot.account,
     watchlist: snapshot.watchlist,
   });

--- a/vex-app/src/renderer/features/appShell/book/HyperliquidPositionsBlock.tsx
+++ b/vex-app/src/renderer/features/appShell/book/HyperliquidPositionsBlock.tsx
@@ -142,7 +142,34 @@ export function HyperliquidPositionsBlock({
   }
   const positions = result?.ok ? result.data.positions : [];
   if (positions.length === 0) {
-    return <BookBlock title="Hyperliquid"><p className="text-[11px] text-[var(--vex-text-3)]">No open Hyperliquid perpetual positions.</p></BookBlock>;
+    const syncStatus = result?.ok ? result.data.syncStatus ?? "settled" : "settled";
+    if (syncStatus === "syncing") {
+      return (
+        <BookBlock title="Hyperliquid" trailing="syncing">
+          <p
+            role="status"
+            aria-live="polite"
+            className="text-[11px] text-[var(--vex-text-3)]"
+          >
+            Trade accepted — waiting for Hyperliquid to confirm the position…
+          </p>
+        </BookBlock>
+      );
+    }
+    if (syncStatus === "delayed") {
+      return (
+        <BookBlock title="Hyperliquid" trailing="check venue">
+          <p role="alert" className="text-[11px] text-[var(--vex-warn-text)]">
+            Position status is delayed. Verify your live exposure on Hyperliquid before trading again.
+          </p>
+        </BookBlock>
+      );
+    }
+    return (
+      <BookBlock title="Hyperliquid">
+        <p className="text-[11px] text-[var(--vex-text-3)]">No open Hyperliquid perpetual positions.</p>
+      </BookBlock>
+    );
   }
   return (
     <BookBlock title="Hyperliquid" trailing={`${positions.length} open`}>

--- a/vex-app/src/renderer/features/appShell/book/__tests__/HyperliquidPositionsBlock.test.tsx
+++ b/vex-app/src/renderer/features/appShell/book/__tests__/HyperliquidPositionsBlock.test.tsx
@@ -115,6 +115,34 @@ describe("HyperliquidPositionsBlock — workspace-mode gate", () => {
     expect(screen.getByText("1 open")).not.toBeNull();
     expect(screen.getByText("0.01 BTC")).not.toBeNull();
   });
+
+  it("shows a live syncing state instead of claiming a recent trade is absent", () => {
+    mockMode("hypervexing");
+    mockUseHyperliquidPositions.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { ok: true, data: { positions: [], syncStatus: "syncing" } },
+    });
+
+    render(<HyperliquidPositionsBlock sessionId={SESSION} />);
+
+    expect(screen.getByRole("status").textContent).toContain("waiting for Hyperliquid");
+    expect(screen.queryByText("No open Hyperliquid perpetual positions.")).toBeNull();
+  });
+
+  it("warns before another trade when venue confirmation is delayed", () => {
+    mockMode("hypervexing");
+    mockUseHyperliquidPositions.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { ok: true, data: { positions: [], syncStatus: "delayed" } },
+    });
+
+    render(<HyperliquidPositionsBlock sessionId={SESSION} />);
+
+    expect(screen.getByRole("alert").textContent).toContain("Verify your live exposure");
+    expect(screen.queryByText("No open Hyperliquid perpetual positions.")).toBeNull();
+  });
 });
 
 const NOW = Date.parse("2026-07-11T12:03:00.000Z");

--- a/vex-app/src/shared/schemas/__tests__/hyperliquid.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/hyperliquid.test.ts
@@ -48,6 +48,7 @@ describe("Hyperliquid shared schemas", () => {
     expect(hyperliquidPositionsDtoSchema.safeParse({
       sessionId: "00000000-0000-4000-8000-000000000001",
       positions: [],
+      syncStatus: "syncing",
       account: { equityUsd: "1000", withdrawableUsd: null, totalUnrealizedPnlUsd: "-2.5" },
       watchlist: [{ coin: "BTC", midPx: "100000", change24hPct: "1.25", openInterestUsd: "1000000000" }],
       updatedAt: ISO,

--- a/vex-app/src/shared/schemas/hyperliquid.ts
+++ b/vex-app/src/shared/schemas/hyperliquid.ts
@@ -101,10 +101,24 @@ export const hyperliquidWatchlistItemDtoSchema = z.object({
 }).strict();
 export type HyperliquidWatchlistItemDto = z.infer<typeof hyperliquidWatchlistItemDtoSchema>;
 
+/**
+ * Whether an empty position list is authoritative. `syncing` means a recent
+ * accepted/pending capture has not produced a renderable position yet;
+ * `delayed` is the same condition beyond the normal reconciliation window.
+ */
+export const hyperliquidPositionSyncStatusSchema = z.enum([
+  "settled",
+  "syncing",
+  "delayed",
+]);
+export type HyperliquidPositionSyncStatus = z.infer<typeof hyperliquidPositionSyncStatusSchema>;
+
 export const hyperliquidPositionsDtoSchema = z
   .object({
     sessionId: z.string().uuid(),
     positions: z.array(hyperliquidPositionDtoSchema).max(100),
+    /** Optional only so an older main process remains compatible during upgrade handoff. */
+    syncStatus: hyperliquidPositionSyncStatusSchema.optional(),
     /** Present on main reads/pushes; optional only for backward-compatible preload upgrades. */
     account: hyperliquidAccountDtoSchema.optional(),
     /** Present on main reads/pushes; empty only before the reconciler has a market slice. */


### PR DESCRIPTION
## Summary

- project the immediate post-submit clearinghouse snapshot through the same canonical Hyperliquid position builder as periodic reconciliation
- wake the persisted sync queue immediately after the inline projection attempt instead of waiting for the one-minute scheduler interval
- distinguish settled, syncing, and delayed empty states so the UI does not claim there is no exposure while a trade is still being projected
- add capture, database mapping, push-service, schema, scheduler, and renderer regressions

## Root cause

The execution capture only persisted size, entry, liquidation, and protection metadata. The renderer mapper requires side, mark price, unrealized PnL, funding, and a confirmation timestamp, so it silently discarded the new row until periodic reconciliation enriched it. When capture normalization failed, the UI still rendered the same definitive empty state.

## User impact

A venue-confirmed position now becomes renderable from the first post-submit snapshot. Incomplete or pending snapshots remain explicitly non-authoritative, trigger an immediate reconciliation pass, and render as syncing or delayed with a warning to verify venue exposure before trading again.

## Validation

- `pnpm exec vitest run src/__tests__/vex-agent/sync/executor.test.ts src/__tests__/vex-agent/tools/protocols/hyperliquid-open-safety.test.ts`
- `pnpm --dir vex-app test` — 3,242 passed
- `pnpm run build`
- `pnpm --dir vex-app run lint`
- Full engine suite: 7,251 passed and 7 skipped; the sole failure is the unrelated live-network `polymarket.bridge.assets` test (`fetch failed`), reproduced in isolation. This diff does not touch Polymarket.
