### PR TITLE
fix(wallet): stop Solana send from turning a positive amount into a zero-size transfer

### DIFF
--- a/src/__tests__/solana/solana-amount-parse.test.ts
+++ b/src/__tests__/solana/solana-amount-parse.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Solana amount string → atomic base units (no float intermediate).
+ *
+ * Pins the send-path contract: a positive-looking amount must not convert
+ * to zero base units, and conversion must not use Number/Math.round.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ErrorCodes } from "../../errors.js";
+import {
+  parseDecimalToAtomic,
+  parsePositiveDecimalToAtomic,
+  parseSolAmount,
+  parseSplAmount,
+  SOL_DECIMALS,
+  uiToTokenAmount,
+} from "@tools/solana-ecosystem/shared/solana-validation.js";
+import { validatePrepareParams } from "../../vex-agent/tools/internal/wallet/send/validation.js";
+
+function codeOf(err: unknown): string | undefined {
+  return err && typeof err === "object" && "code" in err
+    ? String((err as { code: unknown }).code)
+    : undefined;
+}
+
+describe("parseDecimalToAtomic / parsePositiveDecimalToAtomic", () => {
+  it("converts normal SOL amounts to exact lamports", () => {
+    expect(parsePositiveDecimalToAtomic("0.001", SOL_DECIMALS)).toBe(1_000_000n);
+    expect(parsePositiveDecimalToAtomic("0.1", SOL_DECIMALS)).toBe(100_000_000n);
+    expect(parsePositiveDecimalToAtomic("1", SOL_DECIMALS)).toBe(1_000_000_000n);
+    expect(parsePositiveDecimalToAtomic("1.5", SOL_DECIMALS)).toBe(1_500_000_000n);
+    expect(parsePositiveDecimalToAtomic("0.000000001", SOL_DECIMALS)).toBe(1n);
+  });
+
+  it("converts normal SPL amounts at 6 decimals", () => {
+    expect(parsePositiveDecimalToAtomic("1", 6)).toBe(1_000_000n);
+    expect(parsePositiveDecimalToAtomic("1.25", 6)).toBe(1_250_000n);
+    expect(parsePositiveDecimalToAtomic("0.000001", 6)).toBe(1n);
+  });
+
+  it("rejects amounts that cannot represent one base unit (SOL, 9 decimals)", () => {
+    for (const amount of ["0.0000000004", "0.0000000001", "1e-12", "1e-10", "0"]) {
+      expect(() => parsePositiveDecimalToAtomic(amount, SOL_DECIMALS)).toThrow();
+      try {
+        parsePositiveDecimalToAtomic(amount, SOL_DECIMALS);
+      } catch (err) {
+        expect(codeOf(err)).toBe(ErrorCodes.INVALID_AMOUNT);
+      }
+    }
+  });
+
+  it("rejects amounts that cannot represent one base unit (SPL, 6 decimals)", () => {
+    for (const amount of ["0.0000004", "0.0000001", "1e-7", "0"]) {
+      expect(() => parsePositiveDecimalToAtomic(amount, 6)).toThrow();
+      try {
+        parsePositiveDecimalToAtomic(amount, 6);
+      } catch (err) {
+        expect(codeOf(err)).toBe(ErrorCodes.INVALID_AMOUNT);
+      }
+    }
+  });
+
+  it("expands scientific notation without float (1e-9 SOL = 1 lamport)", () => {
+    expect(parsePositiveDecimalToAtomic("1e-9", SOL_DECIMALS)).toBe(1n);
+    expect(parsePositiveDecimalToAtomic("1E-9", SOL_DECIMALS)).toBe(1n);
+  });
+
+  it("allows zero via parseDecimalToAtomic but not parsePositiveDecimalToAtomic", () => {
+    expect(parseDecimalToAtomic("0", SOL_DECIMALS)).toBe(0n);
+    expect(parseDecimalToAtomic("0.0", SOL_DECIMALS)).toBe(0n);
+    expect(() => parsePositiveDecimalToAtomic("0", SOL_DECIMALS)).toThrow();
+  });
+
+  it("rejects negative and malformed amounts", () => {
+    expect(() => parseDecimalToAtomic("-1", SOL_DECIMALS)).toThrow();
+    expect(() => parseDecimalToAtomic("not-a-number", SOL_DECIMALS)).toThrow();
+    expect(() => parseDecimalToAtomic("", SOL_DECIMALS)).toThrow();
+  });
+});
+
+describe("parseSolAmount / parseSplAmount", () => {
+  it("returns exact lamports for SOL strings", () => {
+    expect(parseSolAmount("0.001").lamports).toBe(1_000_000n);
+    expect(parseSolAmount("1").lamports).toBe(1_000_000_000n);
+  });
+
+  it("returns exact atoms for SPL strings", () => {
+    expect(parseSplAmount("1.25", 6).atomic).toBe(1_250_000n);
+  });
+});
+
+describe("uiToTokenAmount", () => {
+  it("rejects values that collapse to zero base units", () => {
+    expect(() => uiToTokenAmount(4e-10, SOL_DECIMALS)).toThrow();
+    expect(codeOf(
+      (() => {
+        try {
+          uiToTokenAmount(4e-10, SOL_DECIMALS);
+        } catch (err) {
+          return err;
+        }
+      })(),
+    )).toBe(ErrorCodes.INVALID_AMOUNT);
+  });
+
+  it("accepts one full base unit", () => {
+    expect(uiToTokenAmount(1e-9, SOL_DECIMALS)).toBe(1n);
+    expect(uiToTokenAmount(1, 6)).toBe(1_000_000n);
+  });
+});
+
+describe("validatePrepareParams — Solana native zero-atomic guard", () => {
+  const base = {
+    network: "solana",
+    to: "11111111111111111111111111111111",
+    token: null as string | null,
+  };
+
+  it("rejects SOL amounts that cannot become one lamport before intent creation", () => {
+    for (const amount of ["0.0000000004", "1e-12", "0.0000000001"]) {
+      const result = validatePrepareParams({ ...base, amount });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.result.success).toBe(false);
+      }
+    }
+  });
+
+  it("accepts a normal SOL amount", () => {
+    const result = validatePrepareParams({ ...base, amount: "0.001" });
+    expect(result.ok).toBe(true);
+  });
+
+  it("still accepts SPL prepare without decimals (execute enforces atoms)", () => {
+    // Without mint decimals at prepare we cannot convert — presence check only.
+    // Sub-atomic SPL is rejected at execute via parsePositiveDecimalToAtomic.
+    const result = validatePrepareParams({
+      network: "solana",
+      to: "11111111111111111111111111111111",
+      amount: "0.0000004",
+      token: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/tools/solana-ecosystem/shared/solana-validation.ts
+++ b/src/tools/solana-ecosystem/shared/solana-validation.ts
@@ -6,6 +6,9 @@ import { PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { loadConfig } from "../../../config/store.js";
 import { VexError, ErrorCodes } from "../../../errors.js";
 
+/** SOL mint decimals / lamports-per-SOL exponent. */
+export const SOL_DECIMALS = 9;
+
 export function validateSolanaAddress(addr: string): string {
   try {
     const pubkey = new PublicKey(addr);
@@ -23,6 +26,115 @@ export function tokenAmountToUi(rawAmount: string | bigint, decimals: number): n
   return Number(BigInt(rawAmount)) / 10 ** decimals;
 }
 
+/**
+ * Expand `mantissa * 10^exp` into a plain decimal string without IEEE-754.
+ * `intPart` / `fracPart` are the digits on either side of the mantissa decimal.
+ */
+function expandScientific(intPart: string, fracPart: string, exp: number): string {
+  const digits = `${intPart}${fracPart}`;
+  if (digits.length === 0 || /^0+$/.test(digits)) return "0";
+  const point = intPart.length + exp;
+  if (point <= 0) {
+    return `0.${"0".repeat(-point)}${digits}`;
+  }
+  if (point >= digits.length) {
+    return `${digits}${"0".repeat(point - digits.length)}`;
+  }
+  return `${digits.slice(0, point)}.${digits.slice(point)}`;
+}
+
+/**
+ * Convert a non-negative decimal amount string into atomic base units.
+ *
+ * No float intermediate: the amount is treated as a decimal string (optionally
+ * scientific notation) and scaled by `10 ** decimals` with integer arithmetic.
+ * Fractional digits beyond `decimals` are rejected when any excess digit is
+ * non-zero — the amount is not silently truncated.
+ */
+export function parseDecimalToAtomic(value: string, decimals: number): bigint {
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 255) {
+    throw new VexError(
+      ErrorCodes.INVALID_AMOUNT,
+      `Invalid token decimals: ${decimals}`,
+      "Decimals must be an integer between 0 and 255.",
+    );
+  }
+
+  let s = value.trim();
+  if (s.length === 0) {
+    throw new VexError(
+      ErrorCodes.INVALID_AMOUNT,
+      "Amount cannot be empty.",
+      "Provide a positive decimal amount.",
+    );
+  }
+  if (s.startsWith("+")) s = s.slice(1);
+  if (s.startsWith("-")) {
+    throw new VexError(
+      ErrorCodes.INVALID_AMOUNT,
+      `Amount must be non-negative: ${value}`,
+      "Provide a positive decimal amount.",
+    );
+  }
+
+  const sci = /^(\d+)(?:\.(\d+))?[eE]([+-]?\d+)$/.exec(s);
+  if (sci) {
+    const exp = Number(sci[3]);
+    if (!Number.isSafeInteger(exp) || exp < -256 || exp > 256) {
+      throw new VexError(
+        ErrorCodes.INVALID_AMOUNT,
+        `Invalid amount: ${value}`,
+        "Scientific exponent is out of range.",
+      );
+    }
+    s = expandScientific(sci[1]!, sci[2] ?? "", exp);
+  }
+
+  if (!/^\d+(\.\d+)?$/.test(s)) {
+    throw new VexError(
+      ErrorCodes.INVALID_AMOUNT,
+      `Invalid amount: ${value}`,
+      "Amount must be a decimal number (e.g. 1.5) or scientific notation.",
+    );
+  }
+
+  const [wholePart, fracPart = ""] = s.split(".");
+  if (fracPart.length > decimals) {
+    const excess = fracPart.slice(decimals);
+    if (/[1-9]/.test(excess)) {
+      throw new VexError(
+        ErrorCodes.INVALID_AMOUNT,
+        `Amount has more than ${decimals} decimal places: ${value}`,
+        "Use fewer fractional digits, or an amount of at least one base unit.",
+      );
+    }
+  }
+
+  const frac = fracPart.slice(0, decimals).padEnd(decimals, "0");
+  const digits = `${wholePart}${frac}`.replace(/^0+/, "") || "0";
+  return BigInt(digits);
+}
+
+/**
+ * Like `parseDecimalToAtomic`, but rejects amounts that convert to **zero**
+ * base units. Use on fund-moving paths so a positive-looking string cannot
+ * become a zero-size transfer.
+ */
+export function parsePositiveDecimalToAtomic(
+  value: string,
+  decimals: number,
+): bigint {
+  const atomic = parseDecimalToAtomic(value, decimals);
+  if (atomic === 0n) {
+    throw new VexError(
+      ErrorCodes.INVALID_AMOUNT,
+      `Amount is too small to transfer: ${value}`,
+      "Amount must be at least one base unit on-chain.",
+    );
+  }
+  return atomic;
+}
+
 export function uiToTokenAmount(uiAmount: number, decimals: number): bigint {
   if (!Number.isFinite(uiAmount) || uiAmount <= 0) {
     throw new VexError(
@@ -32,7 +144,11 @@ export function uiToTokenAmount(uiAmount: number, decimals: number): bigint {
     );
   }
 
-  return BigInt(Math.round(uiAmount * 10 ** decimals));
+  // Number callers (e.g. Jupiter quote sizing) still enter as float — route
+  // through the string parser so conversion and zero-atomic rejection share
+  // one implementation. `toFixed` is only used to re-materialise a decimal
+  // string from an already-validated positive finite number.
+  return parsePositiveDecimalToAtomic(uiAmount.toFixed(decimals), decimals);
 }
 
 export function looksLikeSolanaAddress(value: string): boolean {
@@ -40,34 +156,21 @@ export function looksLikeSolanaAddress(value: string): boolean {
 }
 
 export function parseSolAmount(value: string): { lamports: bigint; ui: number } {
-  const ui = Number(value);
-  if (Number.isNaN(ui) || ui < 0) {
-    throw new VexError(
-      ErrorCodes.SOLANA_INSUFFICIENT_BALANCE,
-      `Invalid SOL amount: ${value}`,
-      "Amount must be a non-negative number.",
-    );
-  }
-  if (ui > 1_000_000_000) {
+  const lamports = parseDecimalToAtomic(value, SOL_DECIMALS);
+  // Soft upper bound retained from the prior Number path (1e9 SOL).
+  if (lamports > BigInt(1_000_000_000) * BigInt(LAMPORTS_PER_SOL)) {
     throw new VexError(
       ErrorCodes.SOLANA_INSUFFICIENT_BALANCE,
       `SOL amount too large: ${value}`,
     );
   }
-  const lamports = BigInt(Math.round(ui * LAMPORTS_PER_SOL));
+  const ui = Number(lamports) / LAMPORTS_PER_SOL;
   return { lamports, ui };
 }
 
 export function parseSplAmount(value: string, decimals: number): { atomic: bigint; ui: number } {
-  const ui = Number(value);
-  if (Number.isNaN(ui) || ui < 0) {
-    throw new VexError(
-      ErrorCodes.SOLANA_INSUFFICIENT_BALANCE,
-      `Invalid token amount: ${value}`,
-      "Amount must be a non-negative number.",
-    );
-  }
-  const atomic = BigInt(Math.round(ui * 10 ** decimals));
+  const atomic = parseDecimalToAtomic(value, decimals);
+  const ui = tokenAmountToUi(atomic, decimals);
   return { atomic, ui };
 }
 

--- a/src/vex-agent/tools/internal/wallet/send-execute-solana.ts
+++ b/src/vex-agent/tools/internal/wallet/send-execute-solana.ts
@@ -30,7 +30,11 @@ import {
   getSolanaConnection,
   signAndSubmitLegacyTxStaged,
 } from "@tools/solana-ecosystem/shared/solana-transaction.js";
-import { solanaExplorerUrl } from "@tools/solana-ecosystem/shared/solana-validation.js";
+import {
+  parsePositiveDecimalToAtomic,
+  solanaExplorerUrl,
+  SOL_DECIMALS,
+} from "@tools/solana-ecosystem/shared/solana-validation.js";
 import { resolveJupiterToken } from "@tools/solana-ecosystem/jupiter/jupiter-tokens/service.js";
 
 import type { WalletIntent } from "@vex-agent/db/repos/wallet-intents.js";
@@ -72,7 +76,9 @@ export async function executeSolanaTransfer(
       || intent.token === "native"
       || intent.token.toUpperCase() === "SOL"
     ) {
-      const lamports = BigInt(Math.round(Number(intent.amount) * 1e9));
+      // String → lamports (no float). Zero atomic is rejected so a
+      // positive-looking amount cannot become a zero-size transfer.
+      const lamports = parsePositiveDecimalToAtomic(intent.amount, SOL_DECIMALS);
       const balance = await connection.getBalance(keypair.publicKey);
       if (BigInt(balance) < lamports) {
         return preBroadcastFailed(
@@ -122,16 +128,15 @@ export async function executeSolanaTransfer(
         keypair.publicKey,
       );
       const sourceAccount = await getAccount(connection, sourceAtaAddress);
-      const atomicAmount = BigInt(
-        Math.round(Number(intent.amount) * 10 ** tokenMeta.decimals),
-      );
+      const mintInfo = await getMint(connection, mintPubkey);
+      const decimals = tokenMeta.decimals || mintInfo.decimals;
+      // String → atoms (no float); reject zero atomic before balance check.
+      const atomicAmount = parsePositiveDecimalToAtomic(intent.amount, decimals);
       if (sourceAccount.amount < atomicAmount) {
         return preBroadcastFailed(
           new Error(`Insufficient token balance for ${intent.token}`),
         );
       }
-      const mintInfo = await getMint(connection, mintPubkey);
-      const decimals = tokenMeta.decimals || mintInfo.decimals;
 
       transaction = new Transaction();
       if (!destinationAtaExists) {

--- a/src/vex-agent/tools/internal/wallet/send/validation.ts
+++ b/src/vex-agent/tools/internal/wallet/send/validation.ts
@@ -8,6 +8,11 @@
  * in the executors.
  */
 
+import {
+  parsePositiveDecimalToAtomic,
+  SOL_DECIMALS,
+} from "@tools/solana-ecosystem/shared/solana-validation.js";
+
 import type { ToolResult } from "../../../types.js";
 import { str } from "../../types.js";
 
@@ -52,6 +57,26 @@ export function validatePrepareParams(
   const numAmount = Number(amount);
   if (!Number.isFinite(numAmount) || numAmount <= 0) {
     return { ok: false, result: fail(`Invalid amount: ${amount}`) };
+  }
+
+  // Solana native/SOL: decimals are known at prepare. Reject amounts that
+  // cannot become at least one lamport so we never create an intent that
+  // later executes as a zero-size transfer. SPL mints need token metadata
+  // for decimals — those are checked at execute with the same converter.
+  if (network === "solana") {
+    const isNative =
+      token === null
+      || token === "native"
+      || token.toUpperCase() === "SOL";
+    if (isNative) {
+      try {
+        parsePositiveDecimalToAtomic(amount, SOL_DECIMALS);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : `Invalid amount: ${amount}`;
+        return { ok: false, result: fail(message) };
+      }
+    }
   }
 
   return { ok: true, values: { network, to, amount, token, chain } };


### PR DESCRIPTION
## Summary

Solana `wallet_send` can accept a **positive** transfer amount, take the operator through prepare/confirm, and then convert that amount into **zero base units** before broadcast.

That is a broken amount boundary on a fund-moving path: the product treats the amount as valid, the operator can approve it, and the executor still builds a transfer with **no economic size**. EVM already rejects this class of failure with string→bigint conversion (`parseUnits`). Solana did not.

## Problem

Solana execute converted the amount like this:

```ts
BigInt(Math.round(Number(intent.amount) * 1e9))           // SOL
BigInt(Math.round(Number(intent.amount) * 10 ** decimals)) // SPL
```

Prepare only required:

```ts
Number.isFinite(amount) && amount > 0
```

Those two checks are not the same contract.

A value can be **positive in UI / agent input** and still become **0 lamports or 0 token atoms** after float conversion. There was no post-convert guard that the atomic amount is still positive. Confirm can already have **CAS-consumed** the wallet intent by the time execute discovers the amount is gone.

So the failure is not "bad RPC" or "insufficient balance." It is **amount validation that lies**: prepare says yes, execute materializes zero.

This sits on the same surface as real transfers. An agent can emit these amounts; an operator can approve them; the app still progresses an intent that cannot represent a positive on-chain send.

## User scenario

1. A run prepares a Solana transfer with a positive amount string (for example `1e-12` SOL, `0.0000000004` SOL, or a sub-atomic SPL size such as `0.0000004` on a 6-decimal mint).
2. Prepare accepts it — the amount is finite and greater than zero.
3. The operator reviews and confirms. The intent is consumed.
4. Execute converts with `Number` + `Math.round` and gets **0** base units.
5. The product has already treated this as a real send. The user is left with a late failure (or a zero-size construction) on a path that should have rejected the amount at the boundary.

That is the wrong failure mode for self-custodial money movement: **approval first, amount truth second**.

## Fix

1. **Decimal-string → bigint conversion** for SOL and SPL (`parseDecimalToAtomic` / `parsePositiveDecimalToAtomic`) — no float intermediate; scientific notation expanded with integer string math.
2. **Fail closed on `0n`** — never build a zero-size transfer from an accepted positive string.
3. **Reject at prepare** for Solana native/SOL when the amount cannot become at least one lamport (decimals known). SPL still enforced at execute once mint decimals are resolved.
4. **Tests** pin the failing amount forms and normal happy-path sizes.

## Before / after

| Amount | Before | After |
|--------|--------|--------|
| `0.001` SOL | correct lamports | unchanged |
| `1` on a 6-decimal mint | correct atoms | unchanged |
| `0.0000000004` SOL | prepare accepts → **0** lamports at execute | **rejected** |
| `1e-12` SOL | prepare accepts → **0** | **rejected** |
| `0.0000004` on 6-decimal SPL | prepare accepts → **0** at execute | **rejected** at execute |

## Files changed

- `src/tools/solana-ecosystem/shared/solana-validation.ts`
- `src/vex-agent/tools/internal/wallet/send-execute-solana.ts`
- `src/vex-agent/tools/internal/wallet/send/validation.ts`
- `src/__tests__/solana/solana-amount-parse.test.ts`

## Tests run

```bash
pnpm exec vitest run src/__tests__/solana
# 6 files, 38 tests passed (14 new amount-parse cases)

pnpm run build
# root typecheck exit 0
```

Covered:

- positive amounts that collapse to zero base units are rejected
- normal SOL / SPL amounts still convert to exact base units
- Solana native prepare rejects zero-lamport amounts before intent creation
- scientific notation expanded without float (`1e-9` → 1 lamport)

## Checklist

- [x] A positive amount can no longer become a zero-size Solana transfer after confirm
- [x] Amount truth is enforced on the send path (string→bigint + non-zero atomic)
- [x] Failure is early and explicit for native SOL at prepare; execute always rejects zero atomic
- [x] Unit tests added and passing
- [x] Scope limited to Solana amount → base units on send