### PR TITLE
fix(polymarket): "market" buy/sell signs the wrong side of the book — never takes the market

### DIFF
--- a/src/__tests__/vex-agent/tools/polymarket-market-take-price.test.ts
+++ b/src/__tests__/vex-agent/tools/polymarket-market-take-price.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Polymarket omit-price ("market") take-side resolution.
+ *
+ * Live CLOB: getPrice("BUY") = best bid, getPrice("SELL") = best ask — the
+ * resting side, not the taking side. Market buy must take best ask; market
+ * sell must take best bid. These pure helpers + dryRun handlers pin that.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetOrderBook = vi.fn();
+const mockPostOrder = vi.fn();
+const mockGetFeeRate = vi.fn(() => Promise.resolve({ base_fee: 0 }));
+const mockGetPrice = vi.fn();
+const mockResolveMarket = vi.fn();
+
+vi.mock("@tools/polymarket/clob/client.js", () => ({
+  getPolyClobClient: () => ({
+    getOrderBook: (...a: unknown[]) => mockGetOrderBook(...a),
+    getPrice: (...a: unknown[]) => mockGetPrice(...a),
+    postOrder: (...a: unknown[]) => mockPostOrder(...a),
+    getFeeRate: (...a: unknown[]) => mockGetFeeRate(...a),
+  }),
+}));
+vi.mock("@tools/polymarket/gamma/client.js", () => ({
+  getPolyGammaClient: () => ({ resolveMarket: (...a: unknown[]) => mockResolveMarket(...a) }),
+}));
+vi.mock("@tools/polymarket/auth.js", () => ({
+  requirePolyClobCredentials: () => ({
+    apiKey: "test-api-key",
+    apiSecret: "secret",
+    passphrase: "pass",
+  }),
+}));
+vi.mock("@tools/polymarket/clob/signing.js", () => ({
+  buildClobOrder: () => ({ maker: "0xMAKER", side: "BUY" }),
+  signClobOrder: () => Promise.resolve("0xSIGNATURE"),
+}));
+vi.mock("@vex-agent/tools/internal/wallet/resolve.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vex-agent/tools/internal/wallet/resolve.js")>();
+  return {
+    ...actual,
+    resolveSelectedAddress: () => "0x1111111111111111111111111111111111111111",
+    resolveSigningWallet: () => ({
+      family: "eip155" as const,
+      address: "0x1111111111111111111111111111111111111111",
+      privateKey: "0xabc",
+    }),
+  };
+});
+
+const {
+  bestAskFromBook,
+  bestBidFromBook,
+  marketTakePriceFromBook,
+} = await import("../../../vex-agent/tools/protocols/polymarket/handlers-clob/orders.js");
+const { POLYMARKET_HANDLERS } = await import(
+  "../../../vex-agent/tools/protocols/polymarket/handlers.js"
+);
+
+const SIGNING_CTX = {
+  sessionPermission: "full" as const,
+  approved: true,
+  walletResolution: { source: "session" as const, evm: null, solana: null },
+  walletPolicy: { kind: "none" as const },
+};
+
+/** Live-shaped book: worst first, best last (Polymarket REST). */
+const LIVE_SHAPED_BOOK = {
+  bids: [
+    { price: "0.01", size: "10" },
+    { price: "0.40", size: "5" },
+    { price: "0.52", size: "100" }, // best bid
+  ],
+  asks: [
+    { price: "0.99", size: "10" },
+    { price: "0.70", size: "5" },
+    { price: "0.54", size: "100" }, // best ask
+  ],
+};
+
+/** Doc-shaped book: best first (opposite of live). min/max must still win. */
+const DOC_SHAPED_BOOK = {
+  bids: [
+    { price: "0.52", size: "100" },
+    { price: "0.40", size: "5" },
+    { price: "0.01", size: "10" },
+  ],
+  asks: [
+    { price: "0.54", size: "100" },
+    { price: "0.70", size: "5" },
+    { price: "0.99", size: "10" },
+  ],
+};
+
+beforeEach(() => {
+  mockGetOrderBook.mockReset().mockResolvedValue({
+    market: "0x",
+    asset_id: "t",
+    timestamp: "1",
+    hash: "h",
+    ...LIVE_SHAPED_BOOK,
+    min_order_size: "1",
+    tick_size: "0.01",
+    neg_risk: false,
+    last_trade_price: "0.53",
+  });
+  // If getPrice were still used for market path, these inverted values would
+  // produce a resting bid/ask — tests must fail if handlers call them.
+  mockGetPrice.mockReset().mockImplementation((_token: string, side: string) =>
+    Promise.resolve({ price: side === "BUY" || side === "buy" ? 0.52 : 0.54 }),
+  );
+  mockPostOrder.mockReset();
+  mockGetFeeRate.mockReset().mockResolvedValue({ base_fee: 0 });
+  mockResolveMarket.mockReset().mockResolvedValue({
+    clobTokenIds: '["yesTok","noTok"]',
+    negRisk: false,
+    question: "Test market?",
+  });
+});
+
+describe("bestAskFromBook / bestBidFromBook", () => {
+  it("picks min ask and max bid on live-shaped (worst-first) books", () => {
+    expect(bestAskFromBook(LIVE_SHAPED_BOOK.asks)).toBe(0.54);
+    expect(bestBidFromBook(LIVE_SHAPED_BOOK.bids)).toBe(0.52);
+  });
+
+  it("picks min ask and max bid on doc-shaped (best-first) books", () => {
+    expect(bestAskFromBook(DOC_SHAPED_BOOK.asks)).toBe(0.54);
+    expect(bestBidFromBook(DOC_SHAPED_BOOK.bids)).toBe(0.52);
+  });
+
+  it("returns null for empty or unusable levels", () => {
+    expect(bestAskFromBook([])).toBeNull();
+    expect(bestBidFromBook(undefined)).toBeNull();
+    expect(bestAskFromBook([{ price: "0", size: "1" }, { price: "n/a", size: "1" }])).toBeNull();
+  });
+
+  it("ignores garbage levels when a valid best exists", () => {
+    expect(
+      bestAskFromBook([
+        { price: "bad", size: "1" },
+        { price: "0.54", size: "1" },
+        { price: "0", size: "1" },
+      ]),
+    ).toBe(0.54);
+  });
+});
+
+describe("marketTakePriceFromBook", () => {
+  it("BUY takes best ask; SELL takes best bid", () => {
+    expect(marketTakePriceFromBook(LIVE_SHAPED_BOOK, "BUY")).toBe(0.54);
+    expect(marketTakePriceFromBook(LIVE_SHAPED_BOOK, "SELL")).toBe(0.52);
+    expect(marketTakePriceFromBook(DOC_SHAPED_BOOK, "BUY")).toBe(0.54);
+    expect(marketTakePriceFromBook(DOC_SHAPED_BOOK, "SELL")).toBe(0.52);
+  });
+});
+
+describe("polymarket.clob.buy — omit price takes best ask", () => {
+  it("dryRun market buy prices at best ask (0.54), not getPrice BUY bid (0.52)", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.buy"]!(
+      { conditionId: "0xCOND", outcome: "YES", amount: 10, dryRun: true },
+      SIGNING_CTX,
+    );
+    expect(r.success).toBe(true);
+    const out = JSON.parse(r.output);
+    expect(out.price).toBe(0.54);
+    expect(out.shares).toBe((10 / 0.54).toFixed(2));
+    expect(mockGetOrderBook).toHaveBeenCalledWith("yesTok");
+    // Must not consult getPrice for the market take path.
+    expect(mockGetPrice).not.toHaveBeenCalled();
+  });
+
+  it("explicit price is unchanged and skips the book", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.buy"]!(
+      { conditionId: "0xCOND", outcome: "YES", amount: 10, price: 0.65, dryRun: true },
+      SIGNING_CTX,
+    );
+    expect(r.success).toBe(true);
+    const out = JSON.parse(r.output);
+    expect(out.price).toBe(0.65);
+    expect(mockGetOrderBook).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the book has no asks", async () => {
+    mockGetOrderBook.mockResolvedValue({
+      market: "0x",
+      asset_id: "t",
+      timestamp: "1",
+      hash: "h",
+      bids: LIVE_SHAPED_BOOK.bids,
+      asks: [],
+      min_order_size: "1",
+      tick_size: "0.01",
+      neg_risk: false,
+      last_trade_price: "0.53",
+    });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.buy"]!(
+      { conditionId: "0xCOND", outcome: "YES", amount: 10, dryRun: true },
+      SIGNING_CTX,
+    );
+    expect(r.success).toBe(false);
+    expect(r.output).toMatch(/Cannot determine price|illiquid|closed/i);
+  });
+});
+
+describe("polymarket.clob.sell — omit price takes best bid", () => {
+  it("dryRun market sell prices at best bid (0.52), not getPrice SELL ask (0.54)", async () => {
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.sell"]!(
+      { conditionId: "0xCOND", outcome: "YES", amount: 10, dryRun: true },
+      SIGNING_CTX,
+    );
+    expect(r.success).toBe(true);
+    const out = JSON.parse(r.output);
+    expect(out.price).toBe(0.52);
+    expect(out.usdcValue).toBe((10 * 0.52).toFixed(2));
+    expect(mockGetOrderBook).toHaveBeenCalledWith("yesTok");
+    expect(mockGetPrice).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the book has no bids", async () => {
+    mockGetOrderBook.mockResolvedValue({
+      market: "0x",
+      asset_id: "t",
+      timestamp: "1",
+      hash: "h",
+      bids: [],
+      asks: LIVE_SHAPED_BOOK.asks,
+      min_order_size: "1",
+      tick_size: "0.01",
+      neg_risk: false,
+      last_trade_price: "0.53",
+    });
+    const r = await POLYMARKET_HANDLERS["polymarket.clob.sell"]!(
+      { conditionId: "0xCOND", outcome: "YES", amount: 10, dryRun: true },
+      SIGNING_CTX,
+    );
+    expect(r.success).toBe(false);
+  });
+});

--- a/src/vex-agent/tools/protocols/polymarket/handlers-clob/orders.ts
+++ b/src/vex-agent/tools/protocols/polymarket/handlers-clob/orders.ts
@@ -14,9 +14,11 @@ import type { ChainWallet } from "@tools/wallet/multi-auth.js";
 import { resolveSelectedAddress, resolveSigningWallet, walletScopeErrorToResult } from "@vex-agent/tools/internal/wallet/resolve.js";
 import { parseClobTokenIds } from "@tools/polymarket/helpers.js";
 import { type Hex, getAddress } from "viem";
+import type { OrderBookSummary } from "@tools/polymarket/clob/types.js";
 import type { ProtocolHandler } from "../../types.js";
 import { str, num, ok, fail } from "../../handler-helpers.js";
 import { splitIds } from "./helpers.js";
+
 function usdcToBaseUnits(amount: number): string {
   return Math.round(amount * 10 ** USDC_E_DECIMALS).toString();
 }
@@ -25,6 +27,66 @@ function calcAmounts(side: "BUY" | "SELL", amount: number, price: number): { mak
     return { makerAmount: usdcToBaseUnits(amount * price), takerAmount: usdcToBaseUnits(amount) };
   }
   return { makerAmount: usdcToBaseUnits(amount), takerAmount: usdcToBaseUnits(amount * price) };
+}
+
+/**
+ * Positive finite level price, or null. Used by best-bid/ask so a single
+ * garbage level cannot poison min/max over the book.
+ */
+function positiveLevelPrice(level: { price: string } | undefined): number | null {
+  if (!level) return null;
+  const n = Number(level.price);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * Best ask = lowest sell offer. Min over levels (sort-order independent).
+ * Polymarket REST books have historically arrived worst-first; never trust
+ * index 0 / last without min/max.
+ */
+export function bestAskFromBook(
+  asks: OrderBookSummary["asks"] | undefined,
+): number | null {
+  if (!asks?.length) return null;
+  let best: number | null = null;
+  for (const level of asks) {
+    const p = positiveLevelPrice(level);
+    if (p === null) continue;
+    if (best === null || p < best) best = p;
+  }
+  return best;
+}
+
+/**
+ * Best bid = highest buy offer. Max over levels (sort-order independent).
+ */
+export function bestBidFromBook(
+  bids: OrderBookSummary["bids"] | undefined,
+): number | null {
+  if (!bids?.length) return null;
+  let best: number | null = null;
+  for (const level of bids) {
+    const p = positiveLevelPrice(level);
+    if (p === null) continue;
+    if (best === null || p > best) best = p;
+  }
+  return best;
+}
+
+/**
+ * Omit-price "market" take price from the order book.
+ *
+ * BUY must take the **best ask**; SELL must take the **best bid**.
+ * Do NOT use `getPrice(side)` for this: on the live CLOB, `getPrice("BUY")`
+ * returns the best **bid** and `getPrice("SELL")` the best **ask** — the
+ * resting side, not the taking side. Using those prices posts a passive
+ * limit that does not cross the spread (market intent → wrong-side rest).
+ */
+export function marketTakePriceFromBook(
+  book: Pick<OrderBookSummary, "bids" | "asks">,
+  side: "BUY" | "SELL",
+): number | null {
+  return side === "BUY" ? bestAskFromBook(book.asks) : bestBidFromBook(book.bids);
 }
 
 // ── Trading (authenticated) ───────────────────────────────────
@@ -45,14 +107,9 @@ export const ORDERS_HANDLERS: Record<string, ProtocolHandler> = {
     const clob = getPolyClobClient();
     let price = num(p, "price") ?? null;
     if (price === null) {
-      const priceResp = await clob.getPrice(tokenId, "BUY");
-      price = priceResp.price;
-      // Fallback: getPrice returns 0 for some markets — use best ask from orderbook
-      if (!price || price <= 0) {
-        const ob = await clob.getOrderBook(tokenId);
-        const bestAsk = ob.asks?.length ? Number(ob.asks[ob.asks.length - 1]?.price) : 0;
-        if (bestAsk > 0) price = bestAsk;
-      }
+      // Market buy = take best ask from the book (not getPrice("BUY") / bid).
+      const ob = await clob.getOrderBook(tokenId);
+      price = marketTakePriceFromBook(ob, "BUY");
     }
     if (!price || price <= 0) return fail(`Cannot determine price for ${outcome} token — price is ${price}. Market may be illiquid or closed.`);
     const shares = amount / price;
@@ -161,14 +218,9 @@ export const ORDERS_HANDLERS: Record<string, ProtocolHandler> = {
     const clob = getPolyClobClient();
     let price = num(p, "price") ?? null;
     if (price === null) {
-      const priceResp = await clob.getPrice(tokenId, "SELL");
-      price = priceResp.price;
-      // Fallback: getPrice returns 0 for some markets — use best bid from orderbook
-      if (!price || price <= 0) {
-        const ob = await clob.getOrderBook(tokenId);
-        const bestBid = ob.bids?.length ? Number(ob.bids[ob.bids.length - 1]?.price) : 0;
-        if (bestBid > 0) price = bestBid;
-      }
+      // Market sell = take best bid from the book (not getPrice("SELL") / ask).
+      const ob = await clob.getOrderBook(tokenId);
+      price = marketTakePriceFromBook(ob, "SELL");
     }
     if (!price || price <= 0) return fail(`Cannot determine price for ${outcome} token — price is ${price}. Market may be illiquid or closed.`);
 


### PR DESCRIPTION
✅ **Verified on live Polymarket** (not docs alone).

Probed production [`/book`](https://clob.polymarket.com/book) and [`/price`](https://clob.polymarket.com/price) on a real token: `side=BUY` → best **bid**, `side=SELL` → best **ask** (e.g. 52¢ / 54¢).

## Summary

Vex can tell an operator they are placing a **market** Polymarket order and then sign and submit a limit that **does not take the market**.

When `price` is omitted, buy is documented as "market at best ask" and sell as "market at best bid." The live path priced from the **opposite** side of the book. A "market buy" became a **passive bid**. A "market sell" became a **passive ask**. Default order type is **GTC**, so the order can sit open while the run treats it as an immediate market-style entry.

That is not a cosmetic mislabel. It is a **signed money-moving order** with the wrong take price, wrong share math, and the wrong urgency. The operator approved a take; the venue received a rest.

## Problem

Manifest contract (what the agent and product promise):

- `polymarket.clob.buy` — omit `price` → *"market order at best ask"*
- `polymarket.clob.sell` — omit `price` → *"market order at best bid"*

Implementation when `price` was omitted:

```ts
// buy
getPrice(tokenId, "BUY")   // live CLOB: BEST BID, not the ask
// sell
getPrice(tokenId, "SELL")  // live CLOB: BEST ASK, not the bid
```

| Stated intent | Required take price | Price used before | Venue outcome (GTC default) |
|---------------|---------------------|-------------------|-----------------------------|
| Market **buy** | best **ask** (54¢) | best **bid** (52¢) | Limit **under** the ask → **does not cross** → rests as a bid |
| Market **sell** | best **bid** (52¢) | best **ask** (54¢) | Limit **over** the bid → **does not hit** → rests as an ask |

A correct orderbook fallback already existed in spirit, but the primary path used `getPrice` on the **resting** side. When the price API works — the normal path — the **wrong side was used every time**.

`shares = amount / price` was computed from that wrong price. The EIP-712 payload, the CLOB submit, and trade capture all inherited it.

Official client docs that say “best is `[0]`” disagree with the **live** book shape we measured; this PR does **not** rely on docs. Take price is **min(asks) / max(bids)** so either sort order still yields the true market side.

## Example (from real Polymarket book: 52¢ / 54¢)

Book observed on production CLOB:

| Level | Price |
|--------|--------|
| Best bid | **52¢** |
| Best ask | **54¢** |

### Buy $10 YES, no `price` — promised market at best ask

| | Promised | Actual before this PR |
|--|----------|----------------------|
| Take price | **54¢** (ask) | **52¢** (bid via live `getPrice(BUY)`) |
| Order | BUY that can **cross** the ask | BUY limit **2¢ below** the ask |
| Default GTC | Take / fill against sellers | **Rests**: "buy only if someone sells down to 52¢" |
| Share size | `≈ 10 / 0.54 ≈ 18.5` | `≈ 10 / 0.52 ≈ 19.2` (wrong price baked into size) |

Operator belief: *I bought YES now with ~$10.*  
Venue reality: *I posted a 52¢ bid that may never fill while YES still costs 54¢ to buy.*

### Sell 10 shares YES, no `price` — promised market at best bid

| | Promised | Actual before this PR |
|--|----------|----------------------|
| Take price | **52¢** (bid) | **54¢** (ask via live `getPrice(SELL)`) |
| Order | SELL that **hits** buyers | SELL limit **2¢ above** the bid |
| Default GTC | Exit into the bid | **Rests**: "sell only if someone pays 54¢" |

### Explicit limits are not the bug

`price: 0.65` still means 0.65. The break is **only** the omit-price path — the one labeled market.

## User scenario

1. A mission/agent decides to enter or exit a Polymarket position and omits `price` (market).
2. Vex resolved price via `getPrice` on the **same side label** as the order — which on the **live** CLOB is the **resting** side, not the **taking** side (confirmed with production `/price` + `/book`).
3. It signed and submitted a GTC limit that **does not cross the spread**.
4. The operator sees "market" language / expected fill path; the book shows a **passive** order on the wrong side.
5. Capital is committed to an order that was never the take they approved. Fills may never arrive; sizing and any downstream capture use the wrong price.

Self-custodial trading cannot afford **stated market intent → passive limit on the wrong side**. That is how positions stay open, exits don't fire, and the ledger lies about what just happened.

## Fix

1. Omit-price **buy** → resolve **best ask** from the order book (`min` over ask levels). Do **not** use `getPrice("BUY")`.
2. Omit-price **sell** → resolve **best bid** from the order book (`max` over bid levels). Do **not** use `getPrice("SELL")`.
3. Min/max over levels so API sort order (worst-first as on production, or best-first) cannot invert "best" again.
4. Fail closed if there is no usable bid/ask — never invent a market price.
5. Unit tests replay **production-observed** 52¢/54¢ books (worst-first) plus best-first books; dryRun handlers assert omit-price buy→ask / sell→bid and that `getPrice` is not called.

## Before / after

| Action | `price` | Before | After |
|--------|---------|--------|--------|
| Buy $10 YES | omitted | Limit at **52¢ bid** — passive, does not take | Limit at **54¢ ask** — takes the market |
| Sell 10 shares | omitted | Limit at **54¢ ask** — passive, does not hit | Limit at **52¢ bid** — takes the market |
| Buy/sell | `0.65` | limit 0.65 | unchanged |
| Buy, no asks | omitted | wrong path | **fail closed** |

## Files changed

- `src/vex-agent/tools/protocols/polymarket/handlers-clob/orders.ts`
- `src/__tests__/vex-agent/tools/polymarket-market-take-price.test.ts`

## Tests run

```bash
pnpm exec vitest run \
  src/__tests__/vex-agent/tools/polymarket-market-take-price.test.ts \
  src/__tests__/vex-agent/tools/polymarket-clob-order-rejection.test.ts
# 2 files, 17 tests passed

pnpm run build
# root typecheck exit 0
```

**Live Polymarket (investigation — top of this PR):**

- `GET clob.polymarket.com/book` — confirmed best bid/ask and array order on a real token
- `GET clob.polymarket.com/price?side=BUY|SELL` — confirmed BUY→bid, SELL→ask on production

**CI (reproducible):**

- market buy without price → best ask (0.54), not bid (0.52)
- market sell without price → best bid (0.52), not ask (0.54)
- min/max works for live-shaped and doc-shaped books
- explicit limit `price` still wins; empty book fails closed
- `getPrice` is not called on the omit-price path

## Checklist

- [x] Bug confirmed against **real Polymarket CLOB** `/book` + `/price` (stated first, above Summary)
- [x] Omit-price buy takes the **best ask**, never prices as a resting bid via `getPrice("BUY")`
- [x] Omit-price sell takes the **best bid**, never prices as a resting ask via `getPrice("SELL")`
- [x] Explicit limit prices unchanged
- [x] Empty / unusable book fails closed
- [x] Share math uses the corrected take price
- [x] Unit tests replay production-observed book shape and pass
- [x] Scope limited to Polymarket CLOB buy/sell when `price` is omitted
