### PR TITLE
fix(prequote): quote tickets are reusable — one quote authorizes many executes until expiry

### DIFF
--- a/src/__tests__/vex-agent/db/repos/swap-prequotes.test.ts
+++ b/src/__tests__/vex-agent/db/repos/swap-prequotes.test.ts
@@ -5,8 +5,9 @@
  *   - INSERT shape (16 params order matches migration 029 columns)
  *   - safety_detail / route_ref bound via jsonb()::jsonb
  *   - findLatestFreshByMatch predicate: session_id AND match_hash AND kind AND
- *     expires_at > NOW() ORDER BY created_at DESC LIMIT 1 (cross-session +
- *     expired + cross-kind rows miss) — Stage 7 R1 adds the kind predicate
+ *     expires_at > NOW() AND consumed_at IS NULL ORDER BY created_at DESC
+ *     LIMIT 1 (cross-session + expired + consumed + cross-kind rows miss)
+ *   - consumeIfUnconsumed CAS: session-scoped, only unconsumed rows
  *   - existsFreshFailByMatch predicate: session_id AND match_hash AND kind AND
  *     safety_verdict='fail' AND expires_at > NOW() LIMIT 1 (boolean) — Stage 7
  *   - TIMESTAMPTZ Date → ISO normalisation; BIGINT chain_id string → number
@@ -75,6 +76,7 @@ function fullRow(overrides: Partial<Record<string, unknown>> = {}): Record<strin
     route_ref: null,
     created_at: CREATED_AT,
     expires_at: EXPIRES_AT,
+    consumed_at: null,
     ...overrides,
   };
 }
@@ -155,7 +157,7 @@ describe("create", () => {
 // ── findLatestFreshByMatch ──────────────────────────────────────────────
 
 describe("findLatestFreshByMatch", () => {
-  it("SELECTs newest fresh row with session_id + match_hash + kind + expires_at predicate", async () => {
+  it("SELECTs newest fresh unconsumed row (session + match + kind + expires + not consumed)", async () => {
     mockQueryOne.mockResolvedValueOnce(null);
     await repo.findLatestFreshByMatch(SESSION_ID, MATCH_HASH, "swap");
     const [sql, params] = mockQueryOne.mock.calls[0]!;
@@ -164,6 +166,7 @@ describe("findLatestFreshByMatch", () => {
     expect(sql).toContain("AND match_hash = $2");
     expect(sql).toContain("AND kind = $3");
     expect(sql).toContain("AND expires_at > NOW()");
+    expect(sql).toContain("AND consumed_at IS NULL");
     expect(sql).toContain("ORDER BY created_at DESC");
     expect(sql).toContain("LIMIT 1");
     expect(params).toEqual([SESSION_ID, MATCH_HASH, "swap"]);
@@ -199,6 +202,7 @@ describe("findLatestFreshByMatch", () => {
       routeRef: null,
       createdAt: CREATED_AT,
       expiresAt: EXPIRES_AT,
+      consumedAt: null,
     });
   });
 
@@ -256,5 +260,36 @@ describe("existsFreshFailByMatch", () => {
     // of expired, cross-session, or cross-kind surfaces as the same null → false.
     mockQueryOne.mockResolvedValueOnce(null);
     expect(await repo.existsFreshFailByMatch(SESSION_ID, MATCH_HASH, "swap")).toBe(false);
+  });
+});
+
+// ── consumeIfUnconsumed (single-use ticket) ─────────────────────────────
+
+describe("consumeIfUnconsumed", () => {
+  it("CAS-updates only the owning session's unconsumed row", async () => {
+    mockExecute.mockResolvedValueOnce(1);
+    const won = await repo.consumeIfUnconsumed(PREQUOTE_ID, SESSION_ID);
+    expect(won).toBe(true);
+    const [sql, params] = mockExecute.mock.calls[0]!;
+    expect(sql).toContain("UPDATE swap_prequotes");
+    expect(sql).toContain("SET consumed_at = NOW()");
+    expect(sql).toContain("WHERE prequote_id = $1");
+    expect(sql).toContain("AND session_id = $2");
+    expect(sql).toContain("AND consumed_at IS NULL");
+    expect(params).toEqual([PREQUOTE_ID, SESSION_ID]);
+  });
+
+  it("returns false when another caller already consumed (or wrong session)", async () => {
+    mockExecute.mockResolvedValueOnce(0);
+    expect(await repo.consumeIfUnconsumed(PREQUOTE_ID, SESSION_ID)).toBe(false);
+  });
+
+  it("maps consumed_at on findLatestFreshByMatch when present", async () => {
+    mockQueryOne.mockResolvedValueOnce(
+      fullRow({ consumed_at: "2026-06-04T10:05:00.000Z" }),
+    );
+    // Note: the SQL predicate excludes consumed rows; this only pins mapRow.
+    const row = await repo.findLatestFreshByMatch(SESSION_ID, MATCH_HASH, "swap");
+    expect(row?.consumedAt).toBe("2026-06-04T10:05:00.000Z");
   });
 });

--- a/src/__tests__/vex-agent/tools/protocols/runtime-prequote-gate.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/runtime-prequote-gate.test.ts
@@ -53,10 +53,12 @@ vi.mock("@vex-agent/db/params.js", () => ({ sanitizeJsonbValue: (v: unknown) => 
 // Gate leaf deps.
 const mockFindLatest = vi.fn<(s: string, h: string, k: string) => Promise<SwapPrequote | null>>();
 const mockExistsFail = vi.fn<(s: string, h: string, k: string) => Promise<boolean>>();
+const mockConsume = vi.fn<(id: string, sessionId: string) => Promise<boolean>>();
 vi.mock("@vex-agent/db/repos/swap-prequotes.js", () => ({
   create: vi.fn(),
   findLatestFreshByMatch: (s: string, h: string, k: string) => mockFindLatest(s, h, k),
   existsFreshFailByMatch: (s: string, h: string, k: string) => mockExistsFail(s, h, k),
+  consumeIfUnconsumed: (id: string, sessionId: string) => mockConsume(id, sessionId),
 }));
 vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
   resolveSelectedAddress: vi.fn(() => "0xWALLET"),
@@ -115,6 +117,7 @@ function prequoteRow(
     walletAddress: "0xWALLET", tokenIn: TOKEN_IN, tokenOut: TOKEN_OUT, amount: "1",
     slippageBps: 50, safetyVerdict: verdict, safetyDetail, routeRef: null,
     createdAt: "2026-06-04T10:00:00.000Z", expiresAt: "2099-01-01T00:00:00.000Z",
+    consumedAt: null,
   };
 }
 
@@ -127,6 +130,7 @@ beforeEach(() => {
   handlerSpy.mockClear();
   mockFindLatest.mockReset().mockResolvedValue(null);
   mockExistsFail.mockReset().mockResolvedValue(false);
+  mockConsume.mockReset().mockResolvedValue(true);
 });
 
 describe("executeProtocolTool — Stage 7 prequote gate", () => {
@@ -212,6 +216,27 @@ describe("executeProtocolTool — Stage 7 prequote gate", () => {
     );
     expect(result.success).toBe(true);
     expect(handlerSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("single-use: successful gated execute consumes the matched prequote", async () => {
+    mockFindLatest.mockResolvedValue(prequoteRow("pass"));
+    const result = await executeProtocolTool(
+      { toolId: "kyberswap.swap.sell", params: swapParams },
+      { ...restrictedCtx, sessionPermission: "full", approved: true },
+    );
+    expect(result.success).toBe(true);
+    expect(mockConsume).toHaveBeenCalledTimes(1);
+    expect(mockConsume).toHaveBeenCalledWith("prequote-1", SESSION_ID);
+  });
+
+  it("single-use: restricted pendingApproval does NOT consume the ticket", async () => {
+    mockFindLatest.mockResolvedValue(prequoteRow("pass"));
+    const result = await executeProtocolTool(
+      { toolId: "kyberswap.swap.sell", params: swapParams },
+      restrictedCtx,
+    );
+    expect(result.pendingApproval).toBe(true);
+    expect(mockConsume).not.toHaveBeenCalled();
   });
 
   it("does NOT gate a non-EXECUTE_GATE_TOOLS mutating tool (no repo reads)", async () => {

--- a/src/vex-agent/db/migrations/044_swap_prequotes_consumed_at.sql
+++ b/src/vex-agent/db/migrations/044_swap_prequotes_consumed_at.sql
@@ -1,0 +1,15 @@
+-- Single-use prequotes: a successful gated execute consumes the matched
+-- ticket so it cannot authorize another broadcast of the same identity
+-- until a new quote is recorded. Unconsumed + unexpired is the gate's
+-- "fresh" definition; multi-fill under one quote is no longer possible.
+--
+-- Forward-only; idempotent IF NOT EXISTS. Existing rows stay usable
+-- (consumed_at NULL) until they expire or are consumed by a future execute.
+
+ALTER TABLE swap_prequotes
+  ADD COLUMN IF NOT EXISTS consumed_at TIMESTAMPTZ;
+
+-- Gate hot path: newest fresh *unconsumed* row for a (session, match_hash, kind).
+CREATE INDEX IF NOT EXISTS idx_swap_prequotes_match_unconsumed
+  ON swap_prequotes (session_id, match_hash, kind, created_at DESC)
+  WHERE consumed_at IS NULL;

--- a/src/vex-agent/db/repos/swap-prequotes.ts
+++ b/src/vex-agent/db/repos/swap-prequotes.ts
@@ -7,12 +7,14 @@
  * trade identity (see `src/vex-agent/tools/protocols/swap-prequote.ts` for the
  * hash + verdict computation and the gate). The Stage-7 gate reads two of the
  * three reads below before a swap EXECUTE: `existsFreshFailByMatch` (any fresh
- * `fail` → block) then `findLatestFreshByMatch` (no fresh row → block; else the
- * verdict authorizes — `pass`/`unknown` allow, a `fail` latest row is a
- * belt-and-suspenders block). All reads are session- AND kind-scoped so a
- * cross-session row or a `bridge` prequote can never authorize/block a `swap`.
+ * `fail` → block) then `findLatestFreshByMatch` (no fresh *unconsumed* row →
+ * block; else the verdict authorizes — `pass`/`unknown` allow, a `fail` latest
+ * row is a belt-and-suspenders block). A successful gated execute CAS-consumes
+ * the matched row (`consumeIfUnconsumed`) so one quote cannot authorize N
+ * broadcasts. All reads are session- AND kind-scoped so a cross-session row or
+ * a `bridge` prequote can never authorize/block a `swap`.
  *
- * Migration: `src/vex-agent/db/migrations/029_swap_prequotes.sql`.
+ * Migrations: `029_swap_prequotes.sql`, `044_swap_prequotes_consumed_at.sql`.
  *
  * **Session ownership invariant** (mirrors wallet-intents): every lookup
  * includes `session_id` in the predicate — a read from a different session
@@ -58,6 +60,8 @@ export interface SwapPrequote {
   routeRef: Record<string, unknown> | null;
   createdAt: string;
   expiresAt: string;
+  /** Set when a gated execute successfully consumed this ticket; null while reusable. */
+  consumedAt: string | null;
 }
 
 export interface CreatePrequoteInput {
@@ -94,7 +98,7 @@ function toIso(value: string | Date): string {
 const SELECT_COLUMNS =
   "prequote_id, session_id, match_hash, kind, family, provider, " +
   "chain_id, wallet_address, token_in, token_out, amount, slippage_bps, " +
-  "safety_verdict, safety_detail, route_ref, created_at, expires_at";
+  "safety_verdict, safety_detail, route_ref, created_at, expires_at, consumed_at";
 
 function mapRow(r: Record<string, unknown>): SwapPrequote {
   return {
@@ -119,6 +123,10 @@ function mapRow(r: Record<string, unknown>): SwapPrequote {
     routeRef: (r.route_ref as Record<string, unknown> | null) ?? null,
     createdAt: toIso(r.created_at as string | Date),
     expiresAt: toIso(r.expires_at as string | Date),
+    consumedAt:
+      r.consumed_at === null || r.consumed_at === undefined
+        ? null
+        : toIso(r.consumed_at as string | Date),
   };
 }
 
@@ -156,11 +164,11 @@ export async function create(input: CreatePrequoteInput): Promise<void> {
 // ── findLatestFreshByMatch (session + kind-scoped) ──────────────────────
 
 /**
- * Newest non-expired prequote row for a (session, match_hash, kind). Returns
- * `null` when no fresh row exists (including cross-session: a row recorded under
- * a different session never matches; and cross-kind: a `bridge` row never
- * authorizes a `swap`). Freshness is `expires_at > NOW()` — an expired row is
- * invisible.
+ * Newest non-expired, **unconsumed** prequote row for a (session, match_hash,
+ * kind). Returns `null` when no usable row exists (including cross-session: a
+ * row recorded under a different session never matches; cross-kind: a `bridge`
+ * row never authorizes a `swap`; and already-consumed: a successful execute
+ * burned the ticket). Freshness is `expires_at > NOW() AND consumed_at IS NULL`.
  *
  * The Stage-7 gate calls this with `kind = "swap"` AFTER `existsFreshFailByMatch`
  * has ruled out any fresh `fail` row, then inspects the returned `safetyVerdict`
@@ -179,11 +187,38 @@ export async function findLatestFreshByMatch(
         AND match_hash = $2
         AND kind = $3
         AND expires_at > NOW()
+        AND consumed_at IS NULL
       ORDER BY created_at DESC
       LIMIT 1`,
     [sessionId, matchHash, kind],
   );
   return row ? mapRow(row) : null;
+}
+
+// ── consumeIfUnconsumed (CAS, session-scoped) ───────────────────────────
+
+/**
+ * Mark a prequote consumed after a successful gated broadcast. Session-scoped
+ * CAS: only the owning session can burn the ticket, and only if it is still
+ * unconsumed. Returns true when this caller won the consume; false when the
+ * row was already consumed, missing, or belongs to another session.
+ *
+ * Call ONLY after `result.success` on a gated execute — never at gate-allow
+ * time (restricted mode would burn the ticket before the human approves).
+ */
+export async function consumeIfUnconsumed(
+  prequoteId: string,
+  sessionId: string,
+): Promise<boolean> {
+  const n = await execute(
+    `UPDATE swap_prequotes
+        SET consumed_at = NOW()
+      WHERE prequote_id = $1
+        AND session_id = $2
+        AND consumed_at IS NULL`,
+    [prequoteId, sessionId],
+  );
+  return n > 0;
 }
 
 // ── existsFreshFailByMatch (session + kind-scoped) ──────────────────────

--- a/src/vex-agent/tools/protocols/runtime.ts
+++ b/src/vex-agent/tools/protocols/runtime.ts
@@ -25,6 +25,7 @@ import type { ActionKind } from "../taxonomy.js";
 import { getProtocolHandler, getProtocolManifest } from "./catalog.js";
 import { isPreviewExecution } from "./capture-validator.js";
 import {
+  EXECUTE_GATE_TOOLS,
   PREQUOTE_QUOTE_TOOLS,
   recordPrequoteFromQuote,
 } from "./swap-prequote.js";
@@ -240,6 +241,7 @@ export async function executeProtocolTool(
   let prequoteVerdict: SafetyVerdict | undefined;
   let prequoteFotTax: number | undefined;
   let prequoteTermLock: { readonly maturityIso: string } | undefined;
+  let matchedPrequoteId: string | undefined;
   const prequoteDecision = await evaluatePrequoteGateDecision(request.toolId, params, scopedContext);
   if (prequoteDecision.kind === "block") {
     return withActionKind({ success: false, output: prequoteDecision.message }, effectiveActionKind);
@@ -247,6 +249,7 @@ export async function executeProtocolTool(
   prequoteVerdict = prequoteDecision.verdict;
   prequoteFotTax = prequoteDecision.fotTax;
   prequoteTermLock = prequoteDecision.termLock;
+  matchedPrequoteId = prequoteDecision.prequoteId;
 
   // Approval gate — mutating tools require approval under restricted permission.
   // Preview (dryRun) is read-only simulation — skip approval. The pending
@@ -331,6 +334,37 @@ export async function executeProtocolTool(
       success: result.success,
       durationMs,
     });
+
+    // Single-use prequote: burn the matched ticket only after a successful
+    // gated broadcast. Never at gate-allow time — restricted mode would
+    // consume before the human approves and strand the next dispatch.
+    if (
+      result.success
+      && matchedPrequoteId !== undefined
+      && scopedContext.sessionId
+      && request.toolId in EXECUTE_GATE_TOOLS
+    ) {
+      try {
+        const { consumeIfUnconsumed } = await import(
+          "@vex-agent/db/repos/swap-prequotes.js"
+        );
+        const burned = await consumeIfUnconsumed(
+          matchedPrequoteId,
+          scopedContext.sessionId,
+        );
+        if (!burned) {
+          logger.warn("protocol.execute.prequote_consume_miss", {
+            toolId: request.toolId,
+            prequoteIdPrefix: matchedPrequoteId.slice(0, 16),
+          });
+        }
+      } catch (err) {
+        logger.warn("protocol.execute.prequote_consume_failed", {
+          toolId: request.toolId,
+          reason: err instanceof Error ? err.constructor.name : typeof err,
+        });
+      }
+    }
 
     // Record a swap prequote on a successful QUOTE (Stage 6c). Quote tools are
     // `mutating:false`, so the `shouldCapture` pipeline below never fires for

--- a/src/vex-agent/tools/protocols/runtime/gates.ts
+++ b/src/vex-agent/tools/protocols/runtime/gates.ts
@@ -74,6 +74,12 @@ export type PrequoteGateDecision =
       readonly fotTax: number | undefined;
       /** Pendle term-lock maturity for the approval preview (typed, unspoofable). */
       readonly termLock: { readonly maturityIso: string } | undefined;
+      /**
+       * Matched prequote id when this allow came from a real gate hit.
+       * Consumed on successful execute so the ticket is single-use.
+       * Undefined when the tool is not gated / is a preview.
+       */
+      readonly prequoteId: string | undefined;
     }
   | { readonly kind: "block"; readonly message: string };
 
@@ -111,9 +117,16 @@ export async function evaluatePrequoteGateDecision(
       // Fee-on-transfer tax + Pendle term-lock ride the same TYPED channel.
       fotTax: decision.fotTax,
       termLock: decision.termLock,
+      prequoteId: decision.prequoteId,
     };
   }
-  return { kind: "allow", verdict: undefined, fotTax: undefined, termLock: undefined };
+  return {
+    kind: "allow",
+    verdict: undefined,
+    fotTax: undefined,
+    termLock: undefined,
+    prequoteId: undefined,
+  };
 }
 
 /**


### PR DESCRIPTION
✅ **Verified in production code paths** — `findLatestFreshByMatch` only checked `expires_at > NOW()`; there was no consume / mark-used / CAS delete after a successful broadcast.

## Summary

Vex’s swap/bridge safety model is **quote-before-broadcast**: execute is only allowed when a fresh prequote matches the exact trade identity (tokens, amount, slippage, recipient, venue, session).

That ticket was **reusable for its entire TTL**. After a successful execute, the same row still matched. The agent could broadcast the **same** trade identity again and again until `expires_at` — **without a new quote** — while the market had already moved.

That is not “best effort caching.” It is a **broken one-shot contract** on a money-moving path. Under **full** permission, those repeats auto-execute. Under **restricted**, each still needs a click, but the second approval is no longer backed by a **new** market price.


## Multi-use vs single-use (the contract)

| | **Multi-use (before)** | **Single-use (after)** |
|--|------------------------|------------------------|
| Quote once | Authorizes **every** matching execute until TTL | Authorizes **one** successful execute |
| After first fill | Ticket still valid | Ticket **consumed** (`consumed_at` set) |
| Second execute, same params | **Allow** (no re-quote) | **Block** — must quote again |
| Third, fourth, … while TTL open | **Allow** | **Block** |
| Market moved against user | Still “quote-backed” | Forced **new quote** (new price) |
| Full permission | Auto **N × size** | Auto **1 × size** per quote |
| Restricted | N approvals possible on one ticket | Still N clicks only if re-quoted |

### Walkthrough (sell 5 ETH)

**Before (multi-use):**

```
quote(5 ETH → USDC) → ticket T
execute → fill #1 (5 ETH)     T still live
execute → fill #2 (5 ETH)     T still live
execute → fill #3 (5 ETH)     T still live until expires_at
total: up to N × 5 ETH on one quote
```

**After (single-use):**

```
quote(5 ETH → USDC) → ticket T
execute → fill #1 (5 ETH)     T consumed
execute → BLOCK (no fresh unconsumed quote)
quote again → ticket T2
execute → fill #2 only after new quote
total: 1 × 5 ETH per quote
```

## Impact

This can still **lose the user money**.

Not “wrong address / keys stolen” — the ticket still binds amount, tokens, recipient, and venue. The damage is **economic**:

| What they thought | What can happen |
|-------------------|-----------------|
| One priced trade of size **S** | Up to **N × S** of the **same** trade while the ticket is still “fresh” |
| Slippage vs a **fresh** price | Later fills vs a **stale** ticket after the market moved against them |
| Autonomy with a quote fence | Autonomy with a **reusable pass** for that size |

**Worst case (full permission):**

1. Operator enables full autonomy for a mission (“rotate into USDC / work this route”).
2. Agent quotes once: e.g. **sell 5 ETH → USDC**, 50 bps.
3. First execute fills. Operator thinks: *one 5 ETH trade, priced once.*
4. Market **gaps down**. The loop keeps firing the **same** params.
5. The prequote gate still **allows** — ticket unconsumed, still inside TTL.
6. Second, third, … execute: another **5 ETH** each time — **no new quote**, no re-price.
7. By the time the ticket expires, the wallet has sold **N × 5 ETH** into a **worse** market than the original quote, while the product still treated each fill as “quote-backed.”

**One line:** one quote can drive **repeated same-size fills under full autonomy as the market moves against the user** — turning a single priced trade into **N fills** and a **much larger realized loss** without a fresh quote.

Restricted mode still needs a click per execute (so not silent drain), but each later approval is **not** backed by a new market price check in the prequote layer.

## Problem

Record time wrote a `swap_prequotes` row with a match hash + expiry.

Gate time did:

```sql
SELECT … FROM swap_prequotes
 WHERE session_id = $1
   AND match_hash = $2
   AND kind = $3
   AND expires_at > NOW()
 ORDER BY created_at DESC
 LIMIT 1
```

There was **no** `consumed_at`, single-use CAS, or delete-on-success.

So “fresh matching quote” meant **“still within the time window”**, not **“not yet used.”**

Identity binding remains strong against *changing* amount/recipient/slippage/venue. Multi-use was the hole against *repeating* that exact identity after the market moved.

## Example

1. Agent quotes: sell **1 ETH → USDC** on Base, **50 bps** slippage. Ticket saved.
2. First execute succeeds.
3. Market moves against the user.
4. Agent executes again with the **same** params. Gate still found the **same** unconsumed ticket.
5. Second (third, …) fill went through **without a new quote**.

| | Intended model | Before this PR |
|--|----------------|----------------|
| One quote | Authorizes **one** broadcast of that identity | Authorized **N** broadcasts until expiry |
| After first fill | Must re-quote | Reused the old ticket |
| Full permission | One auto trade per quote | **Repeated auto size** as price drifts |

## User scenario

1. Operator runs a mission or chat in **full** (or keeps approving under restricted).
2. Agent gets a quote and executes a size considered acceptable *at quote time*.
3. Loop continues. Market moves. Agent fires the **same** size again under the **same** ticket.
4. Operator sees more volume / worse fills than “we quoted once.” There was no new quote step to force re-pricing.

Self-custodial autonomy cannot treat a quote as a **standing multi-fill permit**. That is how size stacks and slippage compounds without a fresh market check — and how **potential money loss** shows up as larger notional + worse prices.

## Fix

1. Migration `044_swap_prequotes_consumed_at.sql` — nullable `consumed_at`.
2. `findLatestFreshByMatch` requires `consumed_at IS NULL`.
3. `consumeIfUnconsumed(prequoteId, sessionId)` — session-scoped CAS after **successful** gated execute only (never at gate-allow — restricted would burn the ticket before human approve).
4. `executeProtocolTool` burns the matched id when `result.success` on an `EXECUTE_GATE_TOOLS` tool.
5. Tests: SQL predicate + CAS + runtime consume on success / no consume on pendingApproval.

## Before / after

| Sequence | Before | After |
|----------|--------|--------|
| Quote → execute | allow | allow |
| Same params → execute again (ticket still in TTL) | **allow** | **block** — must re-quote |
| Re-quote → execute | allow | allow |
| Restricted pendingApproval (no broadcast yet) | n/a | ticket **not** consumed |
| Amount/recipient/slippage changed | block (already) | block (unchanged) |

## Files changed

- `src/vex-agent/db/migrations/044_swap_prequotes_consumed_at.sql`
- `src/vex-agent/db/repos/swap-prequotes.ts`
- `src/vex-agent/tools/protocols/runtime/gates.ts`
- `src/vex-agent/tools/protocols/runtime.ts`
- `src/__tests__/vex-agent/db/repos/swap-prequotes.test.ts`
- `src/__tests__/vex-agent/tools/protocols/runtime-prequote-gate.test.ts`

## Tests run

```bash
pnpm exec vitest run \
  src/__tests__/vex-agent/db/repos/swap-prequotes.test.ts \
  src/__tests__/vex-agent/tools/protocols/runtime-prequote-gate.test.ts \
  src/__tests__/vex-agent/tools/protocols/swap-prequote \
  src/__tests__/vex-agent/tools/protocols/bridge-prequote \
  src/__tests__/vex-agent/tools/protocols/swap-prequote-surface.test.ts
# 13 files, 140+ tests passed (26 focused on repo + runtime gate)

pnpm run build
# root typecheck exit 0
```

## Checklist

- [x] A successful gated execute **consumes** the matching prequote
- [x] A second execute with the same identity **fails closed** until a new quote
- [x] Amount / recipient / slippage / venue binding unchanged
- [x] Restricted pendingApproval does **not** consume the ticket
- [x] Unit tests cover predicate, CAS, success consume, no-consume on pause
- [x] Scope limited to prequote single-use on gated execute paths
