### PR TITLE
fix(security, high): stop blind wallet_send_confirm approvals that can move full intent funds

### DIFF
--- a/src/__tests__/vex-agent/engine/core/approval-runtime/expire-approval.test.ts
+++ b/src/__tests__/vex-agent/engine/core/approval-runtime/expire-approval.test.ts
@@ -137,6 +137,12 @@ vi.mock("@utils/logger.js", () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+const mockCancelIfPending = vi.fn().mockResolvedValue(null);
+vi.mock("@vex-agent/db/repos/wallet-intents.js", () => ({
+  cancelIfPending: (...a: unknown[]) => mockCancelIfPending(...a),
+  getById: vi.fn(),
+}));
+
 // approval-intents repo: keep markExecutionStatus mockable so we can pin
 // the non-tx audit calls. getExpired is mocked per-test for sweep cases.
 const mockMarkExecutionStatus = vi.fn().mockResolvedValue(undefined);
@@ -293,6 +299,8 @@ beforeEach(() => {
   mockCreateLeaseHandle.mockReset();
   mockResumeMissionRun.mockReset();
   mockReleaseLeaseAndEmit.mockReset();
+  mockCancelIfPending.mockReset();
+  mockCancelIfPending.mockResolvedValue(null);
 
   // Default lease claim path — happy: claim succeeds, handle returned.
   mockClaimRunLeaseAndFlipToRunning.mockResolvedValue({
@@ -339,5 +347,21 @@ describe("expireApproval", () => {
 
     const outcome = await expireApproval(APPROVAL_ID);
     expect(outcome.kind).toBe("already_approved");
+  });
+
+  it("wallet_send_confirm expire cancels the linked pending wallet intent", async () => {
+    const intentId = "intent-00000000-0000-4000-8000-000000000077";
+    programSnapshotOnly(
+      buildSnapshotRow({
+        queue_tool_call: {
+          command: "wallet_send_confirm",
+          args: { network: "eip155", intentId },
+        },
+      }),
+    );
+
+    const outcome = await expireApproval(APPROVAL_ID);
+    expect(outcome.kind).toBe("rejected");
+    expect(mockCancelIfPending).toHaveBeenCalledWith(intentId, SESSION_ID);
   });
 });

--- a/src/__tests__/vex-agent/engine/core/approval-runtime/prepare-reject.test.ts
+++ b/src/__tests__/vex-agent/engine/core/approval-runtime/prepare-reject.test.ts
@@ -137,6 +137,14 @@ vi.mock("@utils/logger.js", () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+// wallet_send_confirm reject must CAS-cancel the linked wallet intent so a
+// later thin re-confirm cannot revive a user-rejected transfer.
+const mockCancelIfPending = vi.fn().mockResolvedValue(null);
+vi.mock("@vex-agent/db/repos/wallet-intents.js", () => ({
+  cancelIfPending: (...a: unknown[]) => mockCancelIfPending(...a),
+  getById: vi.fn(),
+}));
+
 // approval-intents repo: keep markExecutionStatus mockable so we can pin
 // the non-tx audit calls. getExpired is mocked per-test for sweep cases.
 const mockMarkExecutionStatus = vi.fn().mockResolvedValue(undefined);
@@ -293,6 +301,8 @@ beforeEach(() => {
   mockCreateLeaseHandle.mockReset();
   mockResumeMissionRun.mockReset();
   mockReleaseLeaseAndEmit.mockReset();
+  mockCancelIfPending.mockReset();
+  mockCancelIfPending.mockResolvedValue(null);
 
   // Default lease claim path — happy: claim succeeds, handle returned.
   mockClaimRunLeaseAndFlipToRunning.mockResolvedValue({
@@ -337,6 +347,37 @@ describe("prepareReject", () => {
     );
 
     expect(mockClaimRunLeaseAndFlipToRunning).toHaveBeenCalled();
+  });
+
+  it("wallet_send_confirm reject cancels the linked pending wallet intent", async () => {
+    const intentId = "intent-00000000-0000-4000-8000-000000000099";
+    programSnapshotOnly(
+      buildSnapshotRow({
+        queue_tool_call: {
+          command: "wallet_send_confirm",
+          args: { network: "eip155", intentId },
+        },
+      }),
+    );
+
+    await prepareReject(APPROVAL_ID, "No");
+
+    expect(mockCancelIfPending).toHaveBeenCalledWith(intentId, SESSION_ID);
+  });
+
+  it("non-wallet reject does not touch wallet_intents", async () => {
+    programSnapshotOnly(
+      buildSnapshotRow({
+        queue_tool_call: {
+          command: "kyberswap.swap.sell",
+          args: { amountIn: "1" },
+        },
+      }),
+    );
+
+    await prepareReject(APPROVAL_ID, "No");
+
+    expect(mockCancelIfPending).not.toHaveBeenCalled();
   });
 
   it("default reason 'No reason provided' when not supplied", async () => {

--- a/src/__tests__/vex-agent/engine/core/prepared-action-approval-intent.test.ts
+++ b/src/__tests__/vex-agent/engine/core/prepared-action-approval-intent.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const enqueueWith = vi.fn();
 const createWith = vi.fn();
 const updateStatus = vi.fn();
+const mockGetById = vi.fn();
 
 vi.mock("@vex-agent/db/repos/approvals.js", () => ({ enqueueWith }));
 vi.mock("@vex-agent/db/repos/approval-intents.js", () => ({ createWith }));
@@ -10,12 +11,16 @@ vi.mock("@vex-agent/db/repos/mission-runs.js", () => ({ updateStatus }));
 vi.mock("@vex-agent/db/client.js", () => ({
   withTransaction: async (fn: (client: object) => Promise<unknown>) => fn({}),
 }));
+vi.mock("@vex-agent/db/repos/wallet-intents.js", () => ({
+  getById: (...a: unknown[]) => mockGetById(...a),
+}));
 
 const { enqueueApprovalIntent } = await import(
   "../../../../vex-agent/engine/core/turn-loop-tool-batch/approval-stop.js"
 );
 
 const PREPARED_EXPIRY = "2026-07-12T10:10:00.000Z";
+const INTENT_ID = "intent-00000000-0000-4000-8000-000000000001";
 const TRUSTED_PREVIEW = {
   toolName: "wallet_send_confirm",
   criticalArgs: {
@@ -27,10 +32,34 @@ const TRUSTED_PREVIEW = {
   },
 };
 
+function pendingWalletIntent(overrides: Record<string, unknown> = {}) {
+  return {
+    intentId: INTENT_ID,
+    sessionId: "session-1",
+    walletAddress: "SoLanaAddr1111111111111111111111111111111",
+    network: "solana" as const,
+    chainAlias: null,
+    toAddress: "3SnLmaqoEczS2ft7RLQ1BRhtsLuAauWnx9K7pDjSRQrp",
+    amount: "32.813008",
+    token: "ANSEM",
+    previewJson: { label: "x", criticalArgs: {} },
+    status: "pending" as const,
+    expiresAt: PREPARED_EXPIRY,
+    consumedAt: null,
+    cancelledAt: null,
+    txHash: null,
+    failureReason: null,
+    idempotencyKey: INTENT_ID,
+    createdAt: "2026-07-12T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-07-12T10:00:00.000Z"));
   vi.clearAllMocks();
+  mockGetById.mockResolvedValue(pendingWalletIntent());
 });
 
 afterEach(() => vi.useRealTimers());
@@ -49,7 +78,7 @@ function baseArgs(overrides: Record<string, unknown> = {}) {
       name: "wallet_send_confirm",
       arguments: {
         network: "solana",
-        intentId: "intent-00000000-0000-4000-8000-000000000001",
+        intentId: INTENT_ID,
         to: "model-spoofed-recipient",
         amount: "999999",
       },
@@ -74,7 +103,7 @@ function baseArgs(overrides: Record<string, unknown> = {}) {
 }
 
 describe("prepared-action approval intent", () => {
-  it("uses the trusted wallet preview and never outlives the prepared intent", async () => {
+  it("binds wallet_send_confirm preview from the wallet_intents row (ignores model spoof + trustedPreview args)", async () => {
     await enqueueApprovalIntent(
       baseArgs({
         trustedPreview: TRUSTED_PREVIEW,
@@ -82,10 +111,20 @@ describe("prepared-action approval intent", () => {
       }),
     );
 
+    expect(mockGetById).toHaveBeenCalledWith(INTENT_ID, "session-1");
     expect(createWith).toHaveBeenCalledWith(
       {},
       expect.objectContaining({
-        previewJson: TRUSTED_PREVIEW,
+        previewJson: {
+          toolName: "wallet_send_confirm",
+          criticalArgs: {
+            network: "solana",
+            chain: null,
+            to: "3SnLmaqoEczS2ft7RLQ1BRhtsLuAauWnx9K7pDjSRQrp",
+            amount: "32.813008",
+            token: "ANSEM",
+          },
+        },
         expiresAt: PREPARED_EXPIRY,
       }),
     );
@@ -96,8 +135,8 @@ describe("prepared-action approval intent", () => {
     expect(JSON.stringify(stored.previewJson)).not.toContain("999999");
   });
 
-  it("floors the approval TTL at the trusted expiry when it is earlier than the default 1h window", async () => {
-    // System time 10:00:00; trusted expiry 10:10:00 — well inside the 1h
+  it("floors the approval TTL at the wallet intent expiry when it is earlier than the default 1h window", async () => {
+    // System time 10:00:00; intent expiry 10:10:00 — well inside the 1h
     // default (11:00:00), so the approval must expire with the intent, not
     // outlive it.
     await enqueueApprovalIntent(
@@ -110,7 +149,10 @@ describe("prepared-action approval intent", () => {
     expect(stored.expiresAt).toBe(PREPARED_EXPIRY);
   });
 
-  it("falls back to the default 1h TTL when the trusted expiry is LATER than the default window", async () => {
+  it("floors at the default 1h TTL when the wallet intent lives longer than the default window", async () => {
+    mockGetById.mockResolvedValueOnce(
+      pendingWalletIntent({ expiresAt: "2026-07-12T23:00:00.000Z" }),
+    );
     await enqueueApprovalIntent(
       baseArgs({
         trustedPreview: TRUSTED_PREVIEW,
@@ -123,40 +165,78 @@ describe("prepared-action approval intent", () => {
     );
   });
 
-  it("floors the approval TTL at an ALREADY-PAST trusted expiry (fail closed via the existing expiry sweep, never re-extended to the default window)", async () => {
-    // System time 10:00:00; trusted expiry is in the past. The prepared
-    // wallet intent is already expired, so the synthesized approval must be
-    // too — it must never silently gain a fresh 1h window.
+  it("floors the approval TTL at an ALREADY-PAST wallet intent expiry only via fail-closed bind (never enqueues)", async () => {
+    // System time 10:00:00; intent already expired — bind refuses so we never
+    // silently mint a fresh 1h approval window over a dead intent.
     const pastExpiry = "2026-07-12T09:00:00.000Z";
-    await enqueueApprovalIntent(
-      baseArgs({
-        trustedPreview: TRUSTED_PREVIEW,
-        trustedExpiresAt: pastExpiry,
-      }),
+    mockGetById.mockResolvedValueOnce(
+      pendingWalletIntent({ expiresAt: pastExpiry }),
     );
-    const stored = createWith.mock.calls[0]![1];
-    expect(stored.expiresAt).toBe(pastExpiry);
+    await expect(
+      enqueueApprovalIntent(
+        baseArgs({
+          trustedPreview: TRUSTED_PREVIEW,
+          trustedExpiresAt: pastExpiry,
+        }),
+      ),
+    ).rejects.toThrow(/intent expired/);
+    expect(createWith).not.toHaveBeenCalled();
   });
 
-  it("falls back to the default 1h TTL when the trusted expiry is malformed", async () => {
-    await enqueueApprovalIntent(
-      baseArgs({
-        trustedPreview: TRUSTED_PREVIEW,
-        trustedExpiresAt: "not-a-date",
-      }),
-    );
-    const stored = createWith.mock.calls[0]![1];
-    expect(stored.expiresAt).toBe(
-      new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-    );
-  });
-
-  it("builds the args-derived preview (untrusted-tool default path) when no trusted preview is supplied", async () => {
+  it("direct model wallet_send_confirm path still binds full to/amount from the DB row (no thin card)", async () => {
+    // No trustedPreview — the historical bug path that painted network+intentId only.
     await enqueueApprovalIntent(baseArgs());
     const stored = createWith.mock.calls[0]![1];
-    // The default (non-handoff) path derives the preview from the tool's own
-    // args via the allow-listed builder — model-visible fields only, still
-    // never the raw untouched args object.
     expect(stored.previewJson.toolName).toBe("wallet_send_confirm");
+    expect(stored.previewJson.criticalArgs).toEqual({
+      network: "solana",
+      chain: null,
+      to: "3SnLmaqoEczS2ft7RLQ1BRhtsLuAauWnx9K7pDjSRQrp",
+      amount: "32.813008",
+      token: "ANSEM",
+    });
+    expect(stored.previewJson.criticalArgs).not.toHaveProperty("intentId");
+    expect(stored.expiresAt).toBe(PREPARED_EXPIRY);
+  });
+
+  it("fails closed and does not enqueue when the wallet intent is missing", async () => {
+    mockGetById.mockResolvedValueOnce(null);
+    await expect(enqueueApprovalIntent(baseArgs())).rejects.toThrow(
+      /intent not found/,
+    );
+    expect(createWith).not.toHaveBeenCalled();
+    expect(enqueueWith).not.toHaveBeenCalled();
+  });
+
+  it("non-wallet tools still use args-derived / trusted preview path", async () => {
+    await enqueueApprovalIntent(
+      baseArgs({
+        toolCall: {
+          id: "swap-call",
+          name: "kyberswap.swap.sell",
+          arguments: {
+            chain: "ethereum",
+            tokenIn: "USDC",
+            tokenOut: "ETH",
+            amountIn: "100",
+          },
+        },
+        result: {
+          success: false,
+          output: "approval required",
+          pendingApproval: true,
+          actionKind: "user_wallet_broadcast",
+        },
+        intentActionKind: "user_wallet_broadcast",
+      }),
+    );
+    expect(mockGetById).not.toHaveBeenCalled();
+    const stored = createWith.mock.calls[0]![1];
+    expect(stored.previewJson.toolName).toBe("kyberswap.swap.sell");
+    expect(stored.previewJson.criticalArgs).toMatchObject({
+      chain: "ethereum",
+      tokenIn: "USDC",
+      amountIn: "100",
+    });
   });
 });

--- a/src/__tests__/vex-agent/engine/core/wallet-send-approval.test.ts
+++ b/src/__tests__/vex-agent/engine/core/wallet-send-approval.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Wallet-send approval binding — preview from durable intent row + cancel on reject.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetById = vi.fn();
+const mockCancelIfPending = vi.fn();
+
+vi.mock("@vex-agent/db/repos/wallet-intents.js", () => ({
+  getById: (...a: unknown[]) => mockGetById(...a),
+  cancelIfPending: (...a: unknown[]) => mockCancelIfPending(...a),
+}));
+
+vi.mock("@utils/logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const {
+  bindWalletSendConfirmApproval,
+  cancelWalletIntentAfterApprovalRejection,
+} = await import("@vex-agent/engine/core/wallet-send-approval.js");
+
+const SESSION = "session-1";
+const INTENT_ID = "intent-00000000-0000-4000-8000-000000000001";
+
+function pendingIntent(overrides: Record<string, unknown> = {}) {
+  return {
+    intentId: INTENT_ID,
+    sessionId: SESSION,
+    walletAddress: "0xwallet",
+    network: "eip155" as const,
+    chainAlias: "base",
+    toAddress: "0xrealrecipient00000000000000000000000001",
+    amount: "1.5",
+    token: "USDC",
+    previewJson: { label: "x", criticalArgs: {} },
+    status: "pending" as const,
+    expiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
+    consumedAt: null,
+    cancelledAt: null,
+    txHash: null,
+    failureReason: null,
+    idempotencyKey: INTENT_ID,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-12T10:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("bindWalletSendConfirmApproval", () => {
+  it("builds criticalArgs from the wallet_intents row, never from model args", async () => {
+    mockGetById.mockResolvedValueOnce(pendingIntent());
+    const bound = await bindWalletSendConfirmApproval(SESSION, {
+      network: "eip155",
+      intentId: INTENT_ID,
+      to: "0xmodel-spoofed",
+      amount: "999999",
+    });
+    expect(mockGetById).toHaveBeenCalledWith(INTENT_ID, SESSION);
+    expect(bound.preview).toEqual({
+      toolName: "wallet_send_confirm",
+      criticalArgs: {
+        network: "eip155",
+        chain: "base",
+        to: "0xrealrecipient00000000000000000000000001",
+        amount: "1.5",
+        token: "USDC",
+      },
+    });
+    expect(JSON.stringify(bound.preview)).not.toContain("0xmodel-spoofed");
+    expect(JSON.stringify(bound.preview)).not.toContain("999999");
+    expect(bound.expiresAt).toBe(pendingIntent().expiresAt);
+  });
+
+  it("fails closed when intent is missing", async () => {
+    mockGetById.mockResolvedValueOnce(null);
+    await expect(
+      bindWalletSendConfirmApproval(SESSION, {
+        network: "eip155",
+        intentId: INTENT_ID,
+      }),
+    ).rejects.toThrow(/intent not found/);
+  });
+
+  it("fails closed when intent is not pending", async () => {
+    mockGetById.mockResolvedValueOnce(pendingIntent({ status: "cancelled" }));
+    await expect(
+      bindWalletSendConfirmApproval(SESSION, {
+        network: "eip155",
+        intentId: INTENT_ID,
+      }),
+    ).rejects.toThrow(/intent is cancelled/);
+  });
+
+  it("fails closed when intent is expired", async () => {
+    mockGetById.mockResolvedValueOnce(
+      pendingIntent({ expiresAt: "2026-07-12T09:00:00.000Z" }),
+    );
+    await expect(
+      bindWalletSendConfirmApproval(SESSION, {
+        network: "eip155",
+        intentId: INTENT_ID,
+      }),
+    ).rejects.toThrow(/intent expired/);
+  });
+
+  it("fails closed on network mismatch", async () => {
+    mockGetById.mockResolvedValueOnce(pendingIntent({ network: "solana" }));
+    await expect(
+      bindWalletSendConfirmApproval(SESSION, {
+        network: "eip155",
+        intentId: INTENT_ID,
+      }),
+    ).rejects.toThrow(/network mismatch/);
+  });
+
+  it("fails closed when network/intentId missing from args", async () => {
+    await expect(
+      bindWalletSendConfirmApproval(SESSION, { network: "eip155" }),
+    ).rejects.toThrow(/missing network or intentId/);
+    expect(mockGetById).not.toHaveBeenCalled();
+  });
+});
+
+describe("cancelWalletIntentAfterApprovalRejection", () => {
+  it("cancels pending wallet intent for wallet_send_confirm queue rows", async () => {
+    mockCancelIfPending.mockResolvedValueOnce(pendingIntent({ status: "cancelled" }));
+    await cancelWalletIntentAfterApprovalRejection(SESSION, {
+      command: "wallet_send_confirm",
+      args: { network: "eip155", intentId: INTENT_ID },
+    });
+    expect(mockCancelIfPending).toHaveBeenCalledWith(INTENT_ID, SESSION);
+  });
+
+  it("supports legacy {name, arguments} queue shape", async () => {
+    mockCancelIfPending.mockResolvedValueOnce(null);
+    await cancelWalletIntentAfterApprovalRejection(SESSION, {
+      name: "wallet_send_confirm",
+      arguments: { network: "solana", intentId: INTENT_ID },
+    });
+    expect(mockCancelIfPending).toHaveBeenCalledWith(INTENT_ID, SESSION);
+  });
+
+  it("no-ops for non-wallet tools", async () => {
+    await cancelWalletIntentAfterApprovalRejection(SESSION, {
+      command: "kyberswap.swap.sell",
+      args: { amountIn: "1" },
+    });
+    expect(mockCancelIfPending).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when intentId is missing", async () => {
+    await cancelWalletIntentAfterApprovalRejection(SESSION, {
+      command: "wallet_send_confirm",
+      args: { network: "eip155" },
+    });
+    expect(mockCancelIfPending).not.toHaveBeenCalled();
+  });
+
+  it("swallows cancel DB errors (approval reject must still complete)", async () => {
+    mockCancelIfPending.mockRejectedValueOnce(new Error("db down"));
+    await expect(
+      cancelWalletIntentAfterApprovalRejection(SESSION, {
+        command: "wallet_send_confirm",
+        args: { intentId: INTENT_ID },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/wallet-send-confirm-attack-path.test.ts
+++ b/src/__tests__/vex-agent/engine/core/wallet-send-confirm-attack-path.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Regression: restricted wallet_send_confirm blind/spoof approval attack.
+ *
+ * Attack (pre-fix):
+ *   1. prepare creates a full wallet_intents row + rich follow-up card
+ *   2. user rejects (approval flips; intent stayed pending)
+ *   3. agent re-calls wallet_send_confirm with only {network, intentId}
+ *   4. enqueue painted a thin card (no to/amount) OR a spoofed to/amount
+ *   5. user approves thin card → confirm loads full intent → real transfer
+ *
+ * Post-fix guarantees pinned here:
+ *   A. Direct confirm enqueue ALWAYS binds to/amount/token/chain from the row
+ *   B. Model-spoofed to/amount never appear in previewJson
+ *   C. Reject cancels the wallet intent
+ *   D. After cancel, re-bind / re-enqueue fail closed (no second card)
+ *   E. Confirm handler refuses a cancelled intent (no pendingApproval)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const enqueueWith = vi.fn();
+const createWith = vi.fn();
+const updateStatus = vi.fn();
+const mockGetById = vi.fn();
+const mockCancelIfPending = vi.fn();
+const mockConsumeIfPending = vi.fn();
+
+vi.mock("@vex-agent/db/repos/approvals.js", () => ({ enqueueWith }));
+vi.mock("@vex-agent/db/repos/approval-intents.js", () => ({ createWith }));
+vi.mock("@vex-agent/db/repos/mission-runs.js", () => ({ updateStatus }));
+vi.mock("@vex-agent/db/client.js", () => ({
+  withTransaction: async (fn: (client: object) => Promise<unknown>) => fn({}),
+}));
+vi.mock("@vex-agent/db/repos/wallet-intents.js", () => ({
+  getById: (...a: unknown[]) => mockGetById(...a),
+  cancelIfPending: (...a: unknown[]) => mockCancelIfPending(...a),
+  consumeIfPending: (...a: unknown[]) => mockConsumeIfPending(...a),
+  create: vi.fn(),
+  markExecuted: vi.fn(),
+  markFailed: vi.fn(),
+  markAuditFailed: vi.fn(),
+}));
+
+vi.mock("@utils/logger.js", () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Confirm handler also resolves a signing wallet — not reached on cancelled path.
+vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
+  resolveSelectedAddress: vi.fn(),
+  resolveSigningWallet: vi.fn(),
+  walletScopeErrorToResult: (err: unknown) => {
+    throw err;
+  },
+}));
+
+const { enqueueApprovalIntent } = await import(
+  "../../../../vex-agent/engine/core/turn-loop-tool-batch/approval-stop.js"
+);
+const {
+  bindWalletSendConfirmApproval,
+  cancelWalletIntentAfterApprovalRejection,
+} = await import("../../../../vex-agent/engine/core/wallet-send-approval.js");
+const { handleWalletSendConfirm } = await import(
+  "../../../../vex-agent/tools/internal/wallet/send.js"
+);
+
+const SESSION = "session-attack-1";
+const INTENT_ID = "intent-00000000-0000-4000-8000-0000000000aa";
+const REAL_TO = "0xRealRecipient00000000000000000000000001";
+const REAL_AMOUNT = "42.5";
+const SPOOF_TO = "0xLooksHarmless000000000000000000000002";
+const SPOOF_AMOUNT = "0.01";
+const EXPIRES = "2026-07-12T10:10:00.000Z";
+
+function pendingIntent(overrides: Record<string, unknown> = {}) {
+  return {
+    intentId: INTENT_ID,
+    sessionId: SESSION,
+    walletAddress: "0xabcdef1234567890abcdef1234567890abcdef12",
+    network: "eip155" as const,
+    chainAlias: "base",
+    toAddress: REAL_TO,
+    amount: REAL_AMOUNT,
+    token: "USDC",
+    previewJson: { label: "x", criticalArgs: {} },
+    status: "pending" as const,
+    expiresAt: EXPIRES,
+    consumedAt: null,
+    cancelledAt: null,
+    txHash: null,
+    failureReason: null,
+    idempotencyKey: INTENT_ID,
+    createdAt: "2026-07-12T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function thinConfirmArgs(extra: Record<string, unknown> = {}) {
+  return {
+    network: "eip155",
+    intentId: INTENT_ID,
+    ...extra,
+  };
+}
+
+function enqueueDirectConfirm(args: Record<string, unknown> = thinConfirmArgs()) {
+  return enqueueApprovalIntent({
+    context: {
+      sessionId: SESSION,
+      sessionPermission: "restricted",
+      missionRunId: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    toolCall: {
+      id: "attack-confirm-1",
+      name: "wallet_send_confirm",
+      arguments: args,
+    },
+    result: {
+      success: false,
+      output: "Transfer requires approval under restricted permission.",
+      pendingApproval: true,
+      actionKind: "user_wallet_broadcast",
+    },
+    toolContext: {
+      sessionPermission: "restricted",
+      sessionKind: "agent",
+      missionRunId: null,
+      missionId: null,
+      contextUsageBand: "normal",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    intentActionKind: "user_wallet_broadcast",
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-12T10:00:00.000Z"));
+  vi.clearAllMocks();
+  mockGetById.mockResolvedValue(pendingIntent());
+  mockCancelIfPending.mockImplementation(async (intentId: string, sessionId: string) => {
+    if (intentId !== INTENT_ID || sessionId !== SESSION) return null;
+    return pendingIntent({ status: "cancelled", cancelledAt: new Date().toISOString() });
+  });
+});
+
+afterEach(() => vi.useRealTimers());
+
+describe("wallet_send_confirm attack-path regression", () => {
+  it("A+B: thin/spoofed direct confirm still enqueues a FULL card from the DB row", async () => {
+    await enqueueDirectConfirm(
+      thinConfirmArgs({ to: SPOOF_TO, amount: SPOOF_AMOUNT }),
+    );
+
+    expect(createWith).toHaveBeenCalledTimes(1);
+    const stored = createWith.mock.calls[0]![1] as {
+      previewJson: {
+        toolName: string;
+        criticalArgs: Record<string, unknown>;
+      };
+    };
+
+    // Full money context present
+    expect(stored.previewJson.toolName).toBe("wallet_send_confirm");
+    expect(stored.previewJson.criticalArgs).toEqual({
+      network: "eip155",
+      chain: "base",
+      to: REAL_TO,
+      amount: REAL_AMOUNT,
+      token: "USDC",
+    });
+
+    // Not a thin card
+    expect(stored.previewJson.criticalArgs).not.toHaveProperty("intentId");
+    expect(Object.keys(stored.previewJson.criticalArgs).sort()).toEqual(
+      ["amount", "chain", "network", "to", "token"].sort(),
+    );
+
+    // Spoof never lands in the approval the user sees
+    const serialized = JSON.stringify(stored.previewJson);
+    expect(serialized).not.toContain(SPOOF_TO);
+    expect(serialized).not.toContain(SPOOF_AMOUNT);
+    expect(serialized).toContain(REAL_TO);
+    expect(serialized).toContain(REAL_AMOUNT);
+  });
+
+  it("C+D: reject cancels intent; re-enqueue / re-bind fail closed (no second card)", async () => {
+    // Step 1 — first direct confirm would have shown a full card
+    await enqueueDirectConfirm();
+    expect(createWith).toHaveBeenCalledTimes(1);
+
+    // Step 2 — user rejects the approval → wallet intent cancelled
+    await cancelWalletIntentAfterApprovalRejection(SESSION, {
+      command: "wallet_send_confirm",
+      args: { network: "eip155", intentId: INTENT_ID },
+    });
+    expect(mockCancelIfPending).toHaveBeenCalledWith(INTENT_ID, SESSION);
+
+    // Step 3 — intent is now cancelled in DB
+    mockGetById.mockResolvedValue(
+      pendingIntent({ status: "cancelled", cancelledAt: EXPIRES }),
+    );
+
+    // Step 4 — agent tries the attack: re-call confirm with only intentId
+    await expect(enqueueDirectConfirm()).rejects.toThrow(/intent is cancelled/);
+    // No second approval row
+    expect(createWith).toHaveBeenCalledTimes(1);
+    expect(enqueueWith).toHaveBeenCalledTimes(1);
+
+    await expect(
+      bindWalletSendConfirmApproval(SESSION, thinConfirmArgs()),
+    ).rejects.toThrow(/intent is cancelled/);
+  });
+
+  it("E: confirm handler refuses cancelled intent (no pendingApproval retry surface)", async () => {
+    mockGetById.mockResolvedValue(
+      pendingIntent({ status: "cancelled", cancelledAt: EXPIRES }),
+    );
+
+    const result = await handleWalletSendConfirm(
+      thinConfirmArgs(),
+      {
+        sessionId: SESSION,
+        sessionPermission: "restricted",
+        approved: false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    );
+
+    expect(result.pendingApproval).toBeUndefined();
+    expect(result.success).toBe(false);
+    expect(result.output).toMatch(/cancelled/i);
+    expect(mockConsumeIfPending).not.toHaveBeenCalled();
+  });
+
+  it("missing intent fails closed before any approval is written", async () => {
+    mockGetById.mockResolvedValue(null);
+    await expect(enqueueDirectConfirm()).rejects.toThrow(/intent not found/);
+    expect(createWith).not.toHaveBeenCalled();
+    expect(enqueueWith).not.toHaveBeenCalled();
+  });
+
+  it("expired intent fails closed before any approval is written", async () => {
+    mockGetById.mockResolvedValue(
+      pendingIntent({ expiresAt: "2026-07-12T09:59:00.000Z" }),
+    );
+    await expect(enqueueDirectConfirm()).rejects.toThrow(/intent expired/);
+    expect(createWith).not.toHaveBeenCalled();
+  });
+
+  it("happy restricted path still surfaces real to/amount for a live pending intent", async () => {
+    const bound = await bindWalletSendConfirmApproval(SESSION, thinConfirmArgs());
+    expect(bound.preview.criticalArgs.to).toBe(REAL_TO);
+    expect(bound.preview.criticalArgs.amount).toBe(REAL_AMOUNT);
+    expect(bound.expiresAt).toBe(EXPIRES);
+
+    const approvalId = await enqueueDirectConfirm();
+    expect(typeof approvalId).toBe("string");
+    expect(approvalId.startsWith("approval-")).toBe(true);
+    expect(createWith.mock.calls[0]![1].previewJson.criticalArgs.to).toBe(REAL_TO);
+  });
+});

--- a/src/vex-agent/engine/core/approval-runtime/post-tx/reject.ts
+++ b/src/vex-agent/engine/core/approval-runtime/post-tx/reject.ts
@@ -27,6 +27,7 @@ import {
   type PreparedContinuation,
   type RejectPrepareOutcome,
 } from "../types.js";
+import { cancelWalletIntentAfterApprovalRejection } from "../../wallet-send-approval.js";
 
 import { flipRunToPausedError, RESUME_CLAIM_ERROR_KIND } from "./recovery.js";
 
@@ -59,6 +60,11 @@ async function runRejectionSideEffects(
   const toolCallId = row.queue_tool_call_id ?? row.tool_call_id ?? approvalId;
 
   try {
+    // Reject/expire/policy-drift of wallet_send_confirm must kill the
+    // underlying wallet intent. Otherwise a later direct confirm call can
+    // re-enqueue a thin approval card for the still-pending transfer.
+    await cancelWalletIntentAfterApprovalRejection(sessionId, row.queue_tool_call);
+
     await refreshBlobTtlForRecentMessages(sessionId);
 
     await appendMessage(

--- a/src/vex-agent/engine/core/turn-loop-tool-batch/approval-stop.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch/approval-stop.ts
@@ -24,6 +24,7 @@ import {
   buildPolicySnapshot,
   type IntentPreview,
 } from "../approval-intent-preview.js";
+import { bindWalletSendConfirmApproval } from "../wallet-send-approval.js";
 
 /**
  * Puzzle 5 phase 3 — TTL stamped at enqueue (not at approve). The approve
@@ -93,25 +94,45 @@ export async function enqueueApprovalIntent(args: {
 
   const approvalId = `approval-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const intentRiskLevel = riskLevelFromActionKind(intentActionKind);
-  // Stage 7 R5: carry the gate-matched swap safety verdict (typed, off the
-  // ToolResult — NOT raw args) into the preview so restricted-mode approval
-  // surfaces `pass` / `unknown` ("UNVERIFIED") before the human approves.
-  const intentPreview =
-    trustedPreview ??
-    buildIntentPreview(
-      toolCall.name,
+
+  // wallet_send_confirm: ALWAYS bind preview + expiry to the durable
+  // wallet_intents row (session-scoped). Tool args are only {network,intentId};
+  // building from args alone yields a blind card, and model-supplied to/amount
+  // keys must never paint a lying preview. Fail closed if the intent is not a
+  // live pending row — never enqueue without enough context to decide.
+  // trustedPreview from prepare→follow-up is ignored here on purpose: the row
+  // is the source of truth (and matches the prepare-time preview when healthy).
+  let intentPreview: IntentPreview;
+  let boundWalletExpiresAt: string | undefined;
+  if (toolCall.name === "wallet_send_confirm") {
+    const bound = await bindWalletSendConfirmApproval(
+      context.sessionId,
       toolCall.arguments,
-      result.prequote
-        ? {
-            prequoteVerdict: result.prequote.verdict,
-            fotTax: result.prequote.fotTax,
-            // Wave 5 (Pendle): the term-lock maturity rides the same typed channel;
-            // buildIntentPreview renders the fixed lock warning (never from args).
-            termLock: result.prequote.termLock,
-            ...(result.hyperliquid ? { hyperliquid: result.hyperliquid } : {}),
-          }
-        : result.hyperliquid ? { hyperliquid: result.hyperliquid } : undefined,
     );
+    intentPreview = bound.preview;
+    boundWalletExpiresAt = bound.expiresAt;
+  } else {
+    // Stage 7 R5: carry the gate-matched swap safety verdict (typed, off the
+    // ToolResult — NOT raw args) into the preview so restricted-mode approval
+    // surfaces `pass` / `unknown` ("UNVERIFIED") before the human approves.
+    intentPreview =
+      trustedPreview ??
+      buildIntentPreview(
+        toolCall.name,
+        toolCall.arguments,
+        result.prequote
+          ? {
+              prequoteVerdict: result.prequote.verdict,
+              fotTax: result.prequote.fotTax,
+              // Wave 5 (Pendle): the term-lock maturity rides the same typed channel;
+              // buildIntentPreview renders the fixed lock warning (never from args).
+              termLock: result.prequote.termLock,
+              ...(result.hyperliquid ? { hyperliquid: result.hyperliquid } : {}),
+            }
+          : result.hyperliquid ? { hyperliquid: result.hyperliquid } : undefined,
+      );
+  }
+
   const intentPolicy = buildPolicySnapshot(toolContext);
   // Phase 3: stamp `expires_at` at enqueue so the approve gate +
   // scheduled sweep have a DB-visible TTL boundary (see APPROVAL_TTL_MS
@@ -119,14 +140,20 @@ export async function enqueueApprovalIntent(args: {
   // phase 3 to accept the structured builder shapes directly — no
   // `as unknown as Record<string, unknown>` cast needed. A trusted prepared
   // action's own expiry floors this so the approval can never outlive the
-  // underlying wallet intent.
+  // underlying wallet intent. wallet_send_confirm always floors at the
+  // live intent row expiry as well.
   const defaultExpiresAtMs = Date.now() + APPROVAL_TTL_MS;
   const trustedExpiresAtMs =
     trustedExpiresAt === undefined ? Number.POSITIVE_INFINITY : Date.parse(trustedExpiresAt);
+  const boundWalletExpiresAtMs =
+    boundWalletExpiresAt === undefined
+      ? Number.POSITIVE_INFINITY
+      : Date.parse(boundWalletExpiresAt);
   const intentExpiresAt = new Date(
     Math.min(
       defaultExpiresAtMs,
       Number.isFinite(trustedExpiresAtMs) ? trustedExpiresAtMs : defaultExpiresAtMs,
+      Number.isFinite(boundWalletExpiresAtMs) ? boundWalletExpiresAtMs : defaultExpiresAtMs,
     ),
   ).toISOString();
 

--- a/src/vex-agent/engine/core/wallet-send-approval.ts
+++ b/src/vex-agent/engine/core/wallet-send-approval.ts
@@ -1,0 +1,127 @@
+/**
+ * Wallet-send approval binding — bind restricted-mode approval previews to the
+ * durable `wallet_intents` row, and cancel that row when the approval dies.
+ *
+ * Security boundary (restricted fund moves):
+ *   - `wallet_send_confirm` tool args are only `{ network, intentId }`. Building
+ *     the approval preview from those args alone produces a blind card (no to /
+ *     amount). A poisoned agent can re-call confirm after the user rejects a
+ *     rich prepare→follow-up card while the intent is still `pending`.
+ *   - Preview MUST be built from the session-scoped wallet intent row, never
+ *     from model-controlled args (including spoofed `to`/`amount` keys).
+ *   - Reject / expire / policy-drift of a confirm approval MUST cancel the
+ *     underlying intent so "Reject" is a real abort, not only a queue flip.
+ */
+
+import * as walletIntentsRepo from "@vex-agent/db/repos/wallet-intents.js";
+import logger from "@utils/logger.js";
+
+import type { IntentPreview } from "./approval-intent-preview.js";
+
+export interface BoundWalletSendConfirmApproval {
+  readonly preview: IntentPreview;
+  /** ISO expiry of the wallet intent — approval must not outlive it. */
+  readonly expiresAt: string;
+}
+
+/**
+ * Load the session-scoped pending wallet intent and build a renderer-safe
+ * preview from authoritative row columns. Fails closed when the intent is
+ * missing, expired, non-pending, or network-mismatched — never enqueue a
+ * blind or spoofable card.
+ */
+export async function bindWalletSendConfirmApproval(
+  sessionId: string,
+  args: Record<string, unknown>,
+): Promise<BoundWalletSendConfirmApproval> {
+  const intentId = typeof args.intentId === "string" ? args.intentId : "";
+  const network = typeof args.network === "string" ? args.network : "";
+  if (intentId.length === 0 || network.length === 0) {
+    throw new Error(
+      "wallet_send_confirm approval refused: missing network or intentId",
+    );
+  }
+  if (network !== "eip155" && network !== "solana") {
+    throw new Error(
+      `wallet_send_confirm approval refused: invalid network "${network}"`,
+    );
+  }
+
+  const intent = await walletIntentsRepo.getById(intentId, sessionId);
+  if (intent === null) {
+    throw new Error(
+      "wallet_send_confirm approval refused: intent not found for this session",
+    );
+  }
+  if (intent.network !== network) {
+    throw new Error(
+      `wallet_send_confirm approval refused: network mismatch (intent=${intent.network}, args=${network})`,
+    );
+  }
+  if (intent.status !== "pending") {
+    throw new Error(
+      `wallet_send_confirm approval refused: intent is ${intent.status}`,
+    );
+  }
+  if (new Date(intent.expiresAt) <= new Date()) {
+    throw new Error(
+      `wallet_send_confirm approval refused: intent expired at ${intent.expiresAt}`,
+    );
+  }
+
+  // Authoritative columns only — never model args, never preview_json alone
+  // (preview_json is denormalised convenience; to/amount live on the row).
+  return {
+    preview: {
+      toolName: "wallet_send_confirm",
+      criticalArgs: {
+        network: intent.network,
+        chain: intent.chainAlias,
+        to: intent.toAddress,
+        amount: intent.amount,
+        token: intent.token,
+      },
+    },
+    expiresAt: intent.expiresAt,
+  };
+}
+
+/**
+ * After an approval for `wallet_send_confirm` is rejected / expired /
+ * policy-drifted, CAS-cancel the linked wallet intent so it cannot be
+ * re-confirmed via a later thin approval card.
+ *
+ * Best-effort: a cancel miss (already terminal / wrong session) is fine; a
+ * thrown DB error is logged and swallowed so the approval reject path still
+ * completes (intent TTL remains a backstop).
+ */
+export async function cancelWalletIntentAfterApprovalRejection(
+  sessionId: string,
+  queueToolCall: Record<string, unknown>,
+): Promise<void> {
+  const name = queueToolCall.command ?? queueToolCall.name;
+  if (name !== "wallet_send_confirm") return;
+
+  const rawArgs = queueToolCall.args ?? queueToolCall.arguments;
+  if (typeof rawArgs !== "object" || rawArgs === null || Array.isArray(rawArgs)) {
+    return;
+  }
+  const intentId = (rawArgs as Record<string, unknown>).intentId;
+  if (typeof intentId !== "string" || intentId.length === 0) return;
+
+  try {
+    const cancelled = await walletIntentsRepo.cancelIfPending(intentId, sessionId);
+    if (cancelled !== null) {
+      logger.info("engine.approval_runtime.wallet_intent_cancelled_on_reject", {
+        intentId,
+        sessionId,
+      });
+    }
+  } catch (cause) {
+    logger.warn("engine.approval_runtime.wallet_intent_cancel_failed", {
+      intentId,
+      sessionId,
+      errorKind: cause instanceof Error ? cause.constructor.name : typeof cause,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Restricted-mode transfer approvals could be shown without a real recipient or amount. Approving that card still executed the full transfer from the stored intent. Rejecting the first (rich) card also did not cancel the underlying wallet intent, so a later confirm call could put up a second, incomplete card for the same transfer.

This PR closes that gap.

## Severity and fund impact

**Severity: High** (restricted-mode wallet safety / informed-consent failure)

**Impact on user funds:** Direct. This is not display-only noise.

- The approval UI is the last human gate before `wallet_send_confirm` broadcasts from the user’s selected wallet.
- A thin or spoofed card can hide the real `to` / `amount` / `token` while approve still loads the full `wallet_intents` row and sends those funds on-chain.
- Worst case for a restricted session: user believes they rejected (or never clearly saw) a transfer, later approves an incomplete card, and loses the prepared amount to the prepared recipient.
- Scope is one prepared intent at a time (session-scoped, ~10 minute intent TTL), not arbitrary unbounded drain — but for that intent the loss is the **full transfer amount**, irreversible once broadcast.
- Attack model is poisoned / prompt-injected / careless agent behavior in restricted mode (default), not a remote unauthenticated attacker.

**Why High (not Critical):** requires a live pending intent, a restricted session, and a user click on Approve. Still fund-moving and product-promise breaking.

**User-facing risk if unfixed:** “I approved something that didn’t show where the money was going” and “I already said no, why did it ask again with less detail?”

## What was broken

`wallet_send_confirm` only takes `{ network, intentId }`. The money fields live on the `wallet_intents` row created by prepare.

The happy path was fine: prepare → engine follow-up enqueued a card with a trusted preview (`to`, `amount`, `token`, `chain`).

The broken path was direct confirm (including a second confirm after reject):

1. Approval enqueue built the preview from tool args only.
2. With only `network` + `intentId` present, the UI showed a thin card.
3. If the model also passed fake `to` / `amount` keys, those could show up in the card even though execution ignored them and used the DB row.
4. Reject / expire flipped the approval queue, but left the wallet intent `pending` until TTL.
5. Approving the thin card ran confirm, loaded the full intent, and broadcast.

That breaks the restricted-mode promise: fund moves should only proceed after an informed approval.

## Fix

1. **Bind preview to the intent row**  
   For every `wallet_send_confirm` enqueue, load `wallet_intents` by `intentId` + session and build `criticalArgs` only from row columns (`network`, `chain`, `to`, `amount`, `token`). Model args are not used for the card. Approval TTL is floored to the intent expiry.

2. **Fail closed**  
   If the intent is missing, not pending, expired, or network-mismatched, do not enqueue an approval.

3. **Cancel on reject / expire / policy-drift**  
   When a `wallet_send_confirm` approval dies, CAS-cancel the linked wallet intent (`cancelIfPending`). Reject is a real abort of the transfer, not only of the queue row.

Main code:
- `src/vex-agent/engine/core/wallet-send-approval.ts` (new)
- `src/vex-agent/engine/core/turn-loop-tool-batch/approval-stop.ts`
- `src/vex-agent/engine/core/approval-runtime/post-tx/reject.ts`

## Test plan

- [x] Unit tests for bind + cancel helpers
- [x] Enqueue tests: full preview from DB; spoofed args ignored; missing / expired / cancelled intent does not enqueue
- [x] Reject + expire cancel the linked wallet intent
- [x] Attack-path regression: thin/spoofed re-confirm after reject cannot open a second blind card; confirm refuses cancelled intents
- [x] Existing wallet prepare/confirm, prepared-follow-up, and approval-runtime suites still pass (111 related tests)
- [x] `tsc --noEmit` clean

## Out of scope

- Hiding `wallet_send_confirm` from the model catalog (engine-only follow-up). Not required for this fix: re-calls now always get a full card for a live intent, and fail closed after reject/cancel.

## Residual notes

Cancel on reject is best-effort if the DB write throws (logged; approval reject still completes). Even in that case, preview binding still prevents a blind card; intent TTL remains a backstop.