### PR TITLE
feat(app): onboarding ink redesign + prologue flag moves into the persist whitelist

### DIFF
--- a/vex-app/src/renderer/features/setup/SetupGate.tsx
+++ b/vex-app/src/renderer/features/setup/SetupGate.tsx
@@ -35,9 +35,8 @@ import { useUiStore } from "../../stores/uiStore.js";
 import { GATE_SIGIL_PALETTE } from "./gate-sigil-palette.js";
 import {
   GatePrologue,
-  readLastPlayedVersion,
   resolveProloguePlay,
-  writeLastPlayedVersion,
+  sanitizeStoredPrologueVersion,
   type ProloguePlay,
 } from "./gate-prologue/index.js";
 import { useSetupOrchestrator } from "./useSetupOrchestrator.js";
@@ -51,6 +50,7 @@ export function SetupGate(): JSX.Element | null {
   const setCurrentView = useUiStore((s) => s.setCurrentView);
   const openUnlock = useUiStore((s) => s.openUnlock);
   const prologueReplay = useUiStore((s) => s.prologueReplayNonce);
+  const setPrologueVersion = useUiStore((s) => s.setPrologueVersion);
   const reduced = useReducedMotion() === true;
 
   const { status, handoff } = useSetupOrchestrator();
@@ -72,7 +72,11 @@ export function SetupGate(): JSX.Element | null {
     if (isTourReplay) return "full";
     return resolveProloguePlay({
       appVersion: __VEX_APP_VERSION__,
-      lastPlayedVersion: readLastPlayedVersion(),
+      // Rehydrated store state is user-writable localStorage under the
+      // persist whitelist — sanitise before the policy reads it.
+      lastPlayedVersion: sanitizeStoredPrologueVersion(
+        useUiStore.getState().prologueVersion,
+      ),
       reducedMotion: false,
     });
   });
@@ -85,8 +89,8 @@ export function SetupGate(): JSX.Element | null {
     setPrologueDone(true);
     if (persistedRef.current || isTourReplay) return;
     persistedRef.current = true;
-    writeLastPlayedVersion(__VEX_APP_VERSION__);
-  }, [isTourReplay]);
+    setPrologueVersion(__VEX_APP_VERSION__);
+  }, [isTourReplay, setPrologueVersion]);
 
   // Apply the handoff to the view machine beneath the plate, give React
   // one frame to mount the target screen, then start the curtain.

--- a/vex-app/src/renderer/features/setup/gate-prologue/__tests__/prologue-policy.test.ts
+++ b/vex-app/src/renderer/features/setup/gate-prologue/__tests__/prologue-policy.test.ts
@@ -1,28 +1,19 @@
 /**
- * Prologue play policy — the decision table and its storage adapter.
+ * Prologue play policy — the decision table and the rehydration sanitiser.
  *
  * These call the REAL exported functions (no re-implementation of the rule
- * in the assertions); the storage cases drive the real localStorage that
- * jsdom provides, plus a throwing stub for the disabled-storage path.
+ * in the assertions). The module is pure: storage itself lives in
+ * `stores/uiStore.ts`'s Zustand persist (the sanctioned renderer
+ * localStorage path), so what these cases pin is the untrusted-payload
+ * boundary and the decision table.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
-  PROLOGUE_VERSION_KEY,
-  readLastPlayedVersion,
   resolveProloguePlay,
-  writeLastPlayedVersion,
+  sanitizeStoredPrologueVersion,
 } from "../prologue-policy.js";
-
-beforeEach(() => {
-  window.localStorage.clear();
-});
-
-afterEach(() => {
-  window.localStorage.clear();
-  vi.restoreAllMocks();
-});
 
 describe("resolveProloguePlay", () => {
   it("plays FULL on a fresh install (nothing recorded yet)", () => {
@@ -74,44 +65,32 @@ describe("resolveProloguePlay", () => {
   });
 });
 
-describe("version persistence", () => {
-  it("round-trips a written version", () => {
-    writeLastPlayedVersion("1.2.3");
-    expect(readLastPlayedVersion()).toBe("1.2.3");
+describe("sanitizeStoredPrologueVersion", () => {
+  // Storage moved into `uiStore`'s Zustand persist (the sanctioned renderer
+  // localStorage path); the payload stays user-writable, so the sanitiser is
+  // the boundary these cases pin.
+  it("passes a plausible stored version through", () => {
+    expect(sanitizeStoredPrologueVersion("1.2.3")).toBe("1.2.3");
   });
 
-  it("reads null when nothing was ever recorded", () => {
-    expect(readLastPlayedVersion()).toBeNull();
+  it("answers null for a non-string (never-recorded, hand-edited, corrupt)", () => {
+    expect(sanitizeStoredPrologueVersion(null)).toBeNull();
+    expect(sanitizeStoredPrologueVersion(undefined)).toBeNull();
+    expect(sanitizeStoredPrologueVersion(42)).toBeNull();
+    expect(sanitizeStoredPrologueVersion({ v: "1.2.3" })).toBeNull();
   });
 
   it("rejects a hand-edited empty or oversized value (storage is user-writable)", () => {
-    window.localStorage.setItem(PROLOGUE_VERSION_KEY, "");
-    expect(readLastPlayedVersion()).toBeNull();
-
-    window.localStorage.setItem(PROLOGUE_VERSION_KEY, "x".repeat(65));
-    expect(readLastPlayedVersion()).toBeNull();
-  });
-
-  it("degrades to FULL (null) when storage throws instead of crashing boot", () => {
-    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
-      throw new Error("storage disabled");
-    });
-    expect(readLastPlayedVersion()).toBeNull();
-  });
-
-  it("swallows a throwing write — a launch that cannot persist just replays", () => {
-    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
-      throw new Error("quota exceeded");
-    });
-    expect(() => writeLastPlayedVersion("1.2.3")).not.toThrow();
+    expect(sanitizeStoredPrologueVersion("")).toBeNull();
+    expect(sanitizeStoredPrologueVersion("x".repeat(65))).toBeNull();
+    expect(sanitizeStoredPrologueVersion("x".repeat(64))).toBe("x".repeat(64));
   });
 
   it("a rejected stored value resolves to a FULL play end-to-end", () => {
-    window.localStorage.setItem(PROLOGUE_VERSION_KEY, "");
     expect(
       resolveProloguePlay({
         appVersion: "0.1.4",
-        lastPlayedVersion: readLastPlayedVersion(),
+        lastPlayedVersion: sanitizeStoredPrologueVersion(""),
         reducedMotion: false,
       }),
     ).toBe("full");

--- a/vex-app/src/renderer/features/setup/gate-prologue/index.ts
+++ b/vex-app/src/renderer/features/setup/gate-prologue/index.ts
@@ -10,10 +10,8 @@
 
 export { GatePrologue, type GatePrologueProps } from "./GatePrologue.js";
 export {
-  PROLOGUE_VERSION_KEY,
-  readLastPlayedVersion,
   resolveProloguePlay,
-  writeLastPlayedVersion,
+  sanitizeStoredPrologueVersion,
   type ProloguePlay,
 } from "./prologue-policy.js";
 export { FULL_TIMELINE, CONDENSED_TIMELINE } from "./prologue-phases.js";

--- a/vex-app/src/renderer/features/setup/gate-prologue/prologue-policy.ts
+++ b/vex-app/src/renderer/features/setup/gate-prologue/prologue-policy.ts
@@ -8,17 +8,16 @@
  * gate's original contract (a static assembled mark, dismissed when the boot
  * pipeline resolves).
  *
- * The decision is a pure function of three inputs so it is testable without a
- * DOM; the localStorage adapter below is the only impure part.
+ * This module is PURE — decision table + input sanitiser, no storage.
  *
- * Storage choice: renderer localStorage, deliberately. This is a COSMETIC
- * flag — it gates an animation, nothing else — so it must not cross IPC into
- * the privileged main process, whose storage is for secrets, wallet state and
- * setup truth. `stores/uiStore.ts` already persists cosmetic renderer state
- * (theme, rail toggles) to localStorage, so this follows an existing pattern
- * rather than inventing one. A missing, unreadable or hand-edited value
- * degrades to "play the full prologue" — the worst case is one extra
- * animation, never a broken boot.
+ * Storage lives in `stores/uiStore.ts` (`prologueVersion`, persisted via the
+ * Zustand persist whitelist — the ONLY sanctioned localStorage path in the
+ * renderer, enforced by `scripts/check-build-artifacts.mjs`). The flag is
+ * COSMETIC — it gates an animation, nothing else — so it must not cross IPC
+ * into the privileged main process, whose storage is for secrets, wallet
+ * state and setup truth. A missing, unreadable or hand-edited value degrades
+ * to "play the full prologue" — the worst case is one extra animation, never
+ * a broken boot.
  */
 
 /** Play variants. `none` is the reduced-motion / failure path. */
@@ -41,33 +40,17 @@ export function resolveProloguePlay(input: ProloguePolicyInput): ProloguePlay {
   return input.lastPlayedVersion === input.appVersion ? "condensed" : "full";
 }
 
-/** localStorage key holding the last version whose prologue completed. */
-export const PROLOGUE_VERSION_KEY = "vex-prologue-version";
-
-/** Longest value we will believe — localStorage is user-writable. */
+/** Longest value we will believe — the persisted payload is user-writable. */
 const MAX_VERSION_LENGTH = 64;
 
 /**
- * Read the recorded version. Every failure mode — storage disabled or
- * throwing (private mode, blocked cookies), a non-string, an absurdly long
- * hand-edited value — answers null, which resolves to the full prologue.
+ * Sanitise a rehydrated `prologueVersion` value. localStorage is untrusted
+ * input even through the persist layer (a hand-edited current-version payload
+ * skips `migrate`), so every failure mode — a non-string, an empty or
+ * absurdly long value — answers null, which resolves to the full prologue.
  */
-export function readLastPlayedVersion(): string | null {
-  try {
-    const raw = window.localStorage.getItem(PROLOGUE_VERSION_KEY);
-    if (typeof raw !== "string") return null;
-    if (raw.length === 0 || raw.length > MAX_VERSION_LENGTH) return null;
-    return raw;
-  } catch {
-    return null;
-  }
-}
-
-/** Record the version whose prologue just finished (or was skipped). */
-export function writeLastPlayedVersion(version: string): void {
-  try {
-    window.localStorage.setItem(PROLOGUE_VERSION_KEY, version);
-  } catch {
-    // A launch that cannot persist simply replays the prologue next time.
-  }
+export function sanitizeStoredPrologueVersion(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  if (raw.length === 0 || raw.length > MAX_VERSION_LENGTH) return null;
+  return raw;
 }

--- a/vex-app/src/renderer/stores/__tests__/uiStore.test.ts
+++ b/vex-app/src/renderer/stores/__tests__/uiStore.test.ts
@@ -236,6 +236,7 @@ describe("uiStore", () => {
       sidebarOpen: true,
       bookOpen: true,
       hideDustBalances: true,
+      prologueVersion: null,
     });
     expect(parsed.state.createSessionOpen).toBeUndefined();
     expect(parsed.state.createSessionInitialTurn).toBeUndefined();
@@ -423,6 +424,7 @@ describe("uiStore", () => {
       sidebarOpen: false,
       bookOpen: true,
       hideDustBalances: true,
+      prologueVersion: null,
     });
     expect(parsed.state.logBuffer).toBeUndefined();
     expect(parsed.state.currentView).toBeUndefined();

--- a/vex-app/src/renderer/stores/uiStore.ts
+++ b/vex-app/src/renderer/stores/uiStore.ts
@@ -260,6 +260,15 @@ interface UiState {
    * Persisted (see partialize) — a relaunch keeps the user's choice.
    */
   readonly hideDustBalances: boolean;
+  /**
+   * Build version whose gate prologue last COMPLETED (or was skipped), or
+   * null if never. COSMETIC — `gate-prologue/prologue-policy.ts` condenses
+   * the cinematic on a repeat launch of the same version. Persisted (see
+   * partialize) via this store's Zustand persist — the only sanctioned
+   * renderer localStorage path (`check-build-artifacts.mjs`); coerced on
+   * every rehydrate in `merge` below because the payload is user-writable.
+   */
+  readonly prologueVersion: string | null;
   readonly setSidebarOpen: (value: boolean) => void;
   readonly setBookOpen: (value: boolean) => void;
   readonly toggleBook: () => void;
@@ -269,6 +278,8 @@ interface UiState {
   readonly dismissSetupGate: () => void;
   /** Re-arm the boot gate and replay its full prologue (dev Setup Tour). */
   readonly replayPrologue: () => void;
+  /** Record the version whose prologue just finished (or was skipped). */
+  readonly setPrologueVersion: (version: string) => void;
   /** Arm the unlock-success curtain — called ONLY after the unlock IPC succeeds. */
   readonly beginUnlockCurtain: () => void;
   /** The curtain finished its reveal and unmounts. */
@@ -352,6 +363,7 @@ export const useUiStore = create<UiState>()(
       reasoningEffortBySession: {},
       reviewModal: "none",
       hideDustBalances: true,
+      prologueVersion: null,
       setSidebarOpen: (sidebarOpen) => set({ sidebarOpen }),
       setBookOpen: (bookOpen) => set({ bookOpen }),
       toggleBook: () => set((state) => ({ bookOpen: !state.bookOpen })),
@@ -363,6 +375,7 @@ export const useUiStore = create<UiState>()(
           setupGateActive: true,
           prologueReplayNonce: state.prologueReplayNonce + 1,
         })),
+      setPrologueVersion: (prologueVersion) => set({ prologueVersion }),
       beginUnlockCurtain: () => set({ unlockCurtainActive: true }),
       dismissUnlockCurtain: () => set({ unlockCurtainActive: false }),
       openWizard: (wizardEntryMode) =>
@@ -411,13 +424,14 @@ export const useUiStore = create<UiState>()(
     }),
     {
       name: "vex-ui",
-      version: 6,
+      version: 7,
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         theme: state.theme,
         sidebarOpen: state.sidebarOpen,
         bookOpen: state.bookOpen,
         hideDustBalances: state.hideDustBalances,
+        prologueVersion: state.prologueVersion,
       }),
       // Expand-only migrations, oldest first:
       //   v2: BOOK now opens by default — force it open once on upgrade from v1
@@ -436,6 +450,12 @@ export const useUiStore = create<UiState>()(
       //       the same TRUE default a fresh install gets, so an upgrading
       //       install's dust airdrops hide immediately instead of the field
       //       hydrating `undefined`.
+      //   v7: `prologueVersion` added (gate-prologue play policy, moved here
+      //       from a direct localStorage adapter so the renderer keeps ONE
+      //       sanctioned storage path) — seed null: an upgrading install has
+      //       never recorded a completed prologue under this key, and null
+      //       resolves to the full play, the same first-impression a fresh
+      //       install gets.
       migrate: (persisted, version) => {
         if (persisted === null || typeof persisted !== "object") {
           return persisted;
@@ -445,6 +465,9 @@ export const useUiStore = create<UiState>()(
         if (version < 5) next = { ...next, theme: "chronos" };
         if (version < 6 && !("hideDustBalances" in next)) {
           next = { ...next, hideDustBalances: true };
+        }
+        if (version < 7 && !("prologueVersion" in next)) {
+          next = { ...next, prologueVersion: null };
         }
         return next;
       },
@@ -466,7 +489,16 @@ export const useUiStore = create<UiState>()(
           typeof incoming?.hideDustBalances === "boolean"
             ? incoming.hideDustBalances
             : true;
-        return { ...current, ...incoming, theme, hideDustBalances };
+        // Same posture for the prologue flag: a non-string, empty or
+        // absurdly long hand-edited value degrades to null — which the play
+        // policy resolves to the FULL prologue, never a crash.
+        const prologueVersion: string | null =
+          typeof incoming?.prologueVersion === "string" &&
+          incoming.prologueVersion.length > 0 &&
+          incoming.prologueVersion.length <= 64
+            ? incoming.prologueVersion
+            : null;
+        return { ...current, ...incoming, theme, hideDustBalances, prologueVersion };
       },
     }
   )


### PR DESCRIPTION
The onboarding/setup ink redesign (~45 renderer files) plus one build-blocking fix.

## Fix
`gate-prologue/prologue-policy.ts` called `window.localStorage` directly, which trips the build artifact check (renderer localStorage is allowed only through the Zustand persist whitelist). The flag now lives as `uiStore.prologueVersion`: persisted through the sanctioned path, v6→v7 expand-only migration, coerced on every rehydrate (the payload is user-writable), with the policy module staying pure and exporting the rehydration sanitiser.

## Verification
`pnpm run build` green including **all build artifact checks**; setup + uiStore suites 76/76.