### PR TITLE
test(ci): deflake staged-execute-safety and feed-list-params

### DIFF
--- a/src/__tests__/dexscreener/feed-list-params.test.ts
+++ b/src/__tests__/dexscreener/feed-list-params.test.ts
@@ -79,6 +79,7 @@ describe("DexScreener feed + narrative param validation", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   // ── limit: the value that meant two opposite things ─────────────
@@ -144,6 +145,18 @@ describe("DexScreener feed + narrative param validation", () => {
   // array natural. Both spellings are now accepted and must agree exactly —
   // see `./list-string-array-params.test.ts` for the equivalence pins.
   it("chainIds sent as an array is accepted and means the same as the comma string", async () => {
+    // The clock is FROZEN for the two calls, and only the clock — `toFake: ["Date"]`
+    // leaves timers alone so the awaited handlers still settle normally. Both
+    // payloads carry `eventAgeSeconds`, floor((now − updatedAt)/1000) per row
+    // (`feed-list/feed-row.ts:304-311`), computed from `Date.now()` at response
+    // time (`handlers/feeds.ts:111`). The 30 fixture rows carry 30 different
+    // millisecond fractions, so ANY delay between the two calls flips roughly
+    // delayMs/1000 × 30 rows to a different whole second. That is the flake: it
+    // is not a rare second boundary, it is one boundary per row per second, and
+    // a loaded CI runner supplies the delay. Freezing pins the equivalence being
+    // asserted — the two spellings — instead of the clock.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date());
     const fromArray = await run("dexscreener.profiles", { chainIds: ["base", "solana"] });
     const fromString = await run("dexscreener.profiles", { chainIds: "base,solana" });
     expect(fromArray.ok).toBe(true);

--- a/src/__tests__/vex-agent/tools/khalani-handlers/staged-execute-safety.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-handlers/staged-execute-safety.test.ts
@@ -165,6 +165,20 @@ vi.mock("@vex-agent/tools/registry/relay-reveal.js", () => ({
   resolveRelayRevealRoute: (...a: unknown[]) => mockResolveRelayRevealRoute(...(a as [])),
 }));
 
+/**
+ * The fee-on-transfer oracle is a LIVE NETWORK CALL on the EVM pre-quote path
+ * (`bridge-execute.ts:272` → `bridge-fee/fee-eligibility.ts:57`). Unstubbed it
+ * cost ~550 ms per EVM case and, on a loaded runner, outlived vitest's 10 s
+ * timeout — the still-running handler then consumed the NEXT test's
+ * `mockResolvedValueOnce` values and called the CAS mocks after
+ * `clearAllMocks`. Stubbed exactly as in the sibling `bridge-fee-execute.test.ts`;
+ * the eligibility logic itself still runs for real.
+ */
+const mockHoneypotFot = vi.fn(async () => ({ isHoneypot: false, isFOT: false, tax: 0 }));
+vi.mock("@tools/kyberswap/token-api/client.js", () => ({
+  getKyberTokenApiClient: () => ({ getHoneypotFotInfo: (...a: unknown[]) => mockHoneypotFot(...(a as [])) }),
+}));
+
 const mockLoggerWarn = vi.fn();
 vi.mock("@utils/logger.js", () => {
   const stub = { warn: (...a: unknown[]) => mockLoggerWarn(...a), info: vi.fn(), debug: vi.fn(), error: vi.fn() };


### PR DESCRIPTION
Fixes the intermittent CI failures on `main` and PR branches (khalani `staged-execute-safety.test.ts` timeouts + cross-test mock bleed; dexscreener `feed-list-params.test.ts` deep-equal divergence).

## Root causes (proven, not guessed)
1. **staged-execute-safety** left the fee-on-transfer oracle unstubbed — every EVM-source case made a **real HTTP call** to the KyberSwap token API (`bridge-execute.ts:272` → `fee-eligibility.ts:57`), ~550 ms each, 12.87 s of the file's 13.99 s runtime. Under CI load one call crosses vitest's 10 s timeout; vitest abandons the test but the handler promise keeps running, consumes the **next** test's `mockResolvedValueOnce` queue and hits the CAS mocks after `clearAllMocks` — exactly the observed `'0xambig' vs '0xdeposithash'` and *called 2 times* failures. Fix: stub the network boundary (same pattern as sibling `bridge-fee-execute.test.ts`); file runtime **12.87 s → 34 ms**. The eligibility logic itself still executes.
2. **feed-list-params** compares two handler payloads whose per-row `eventAgeSeconds` derives from `Date.now()` at response time — any inter-call delay flips ~delayMs/1000 × 30 rows across their own second boundaries. Fix: freeze `Date` (only `Date`; timers untouched) for that test.

No assertion weakened, no retries added, no product change — the money path was audited for fire-and-forget work and every async step is awaited.

## Stability proof
- 20/20 consecutive isolated runs of both files.
- 3/3 runs under recreated contention (two concurrent vitest processes over engine+tools).
- Full root suite: **8,581/8,581**; `tsc --noEmit` clean.

Note for a follow-up: other suites on the EVM bridge/swap paths may carry the same latent unstubbed oracle call (symptom: uniform ~550 ms per-test times).

🤖 Generated with [Claude Code](https://claude.com/claude-code)