### PR TITLE
fix(portfolio): include wallet token prices in total valuation

### DIFF
--- a/src/__tests__/vex-agent/sync/balance-price-enrichment.test.ts
+++ b/src/__tests__/vex-agent/sync/balance-price-enrichment.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockEvmPrices = vi.fn();
+vi.mock("@tools/evm-chains/token-prices.js", () => ({
+  fetchEvmTokenPricesByAddress: (...args: unknown[]) => mockEvmPrices(...args),
+}));
+
+const mockJupiterPrices = vi.fn();
+vi.mock("@tools/solana-ecosystem/jupiter/jupiter-prices/service.js", () => ({
+  getJupiterPricesByMint: (...args: unknown[]) => mockJupiterPrices(...args),
+}));
+
+vi.mock("@utils/logger.js", () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { enrichKhalaniBalancePrices } = await import(
+  "../../../vex-agent/sync/balance-price-enrichment.js"
+);
+
+const ETH_NATIVE = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const ETH_WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const ETH_USDC = "0xA0b86991c6218b36c1d19d4a2e9eb0cE3606eB48";
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEvmPrices.mockResolvedValue(new Map());
+  mockJupiterPrices.mockResolvedValue({});
+});
+
+describe("enrichKhalaniBalancePrices", () => {
+  it("prices Ethereum native ETH through verified WETH and USDC by address", async () => {
+    mockEvmPrices.mockResolvedValue(
+      new Map([
+        [ETH_WETH.toLowerCase(), 1_909],
+        [ETH_USDC.toLowerCase(), 1],
+      ]),
+    );
+
+    const result = await enrichKhalaniBalancePrices("eip155", [
+      {
+        chainId: 1,
+        address: ETH_NATIVE,
+        symbol: "ETH",
+        name: "Ether",
+        decimals: 18,
+        extensions: { balance: "490600000000000" },
+      },
+      {
+        chainId: 1,
+        address: ETH_USDC,
+        symbol: "USDC",
+        name: "USD Coin",
+        decimals: 6,
+        extensions: { balance: "2070000" },
+      },
+    ]);
+
+    expect(mockEvmPrices).toHaveBeenCalledWith({
+      chainSlug: "ethereum",
+      tokenAddresses: [ETH_WETH, ETH_USDC],
+    });
+    expect(result[0]?.extensions?.price?.usd).toBe("1909");
+    expect(result[1]?.extensions?.price?.usd).toBe("1");
+    expect(result[0]?.extensions?.balance).toBe("490600000000000");
+  });
+
+  it("preserves a valid provider price and does not look it up again", async () => {
+    const result = await enrichKhalaniBalancePrices("eip155", [
+      {
+        chainId: 1,
+        address: ETH_USDC,
+        symbol: "USDC",
+        name: "USD Coin",
+        decimals: 6,
+        extensions: { balance: "2070000", price: { usd: "0.998" } },
+      },
+    ]);
+
+    expect(mockEvmPrices).not.toHaveBeenCalled();
+    expect(result[0]?.extensions?.price?.usd).toBe("0.998");
+  });
+
+  it("uses Jupiter Price V3 for a Solana mint", async () => {
+    mockJupiterPrices.mockResolvedValue({
+      [SOL_MINT]: {
+        createdAt: "2026-08-18T00:00:00Z",
+        liquidity: 1,
+        usdPrice: 185.5,
+        blockId: null,
+        decimals: 9,
+        priceChange24h: null,
+      },
+    });
+
+    const result = await enrichKhalaniBalancePrices("solana", [
+      {
+        chainId: 20_011_000_000,
+        address: SOL_MINT,
+        symbol: "SOL",
+        name: "Wrapped SOL",
+        decimals: 9,
+        extensions: { balance: "1000000000" },
+      },
+    ]);
+
+    expect(mockJupiterPrices).toHaveBeenCalledWith([SOL_MINT]);
+    expect(result[0]?.extensions?.price?.usd).toBe("185.5");
+  });
+
+  it("keeps an unsupported or unpriced holding visible without fabricating a price", async () => {
+    const result = await enrichKhalaniBalancePrices("eip155", [
+      {
+        chainId: 424_242,
+        address: "0x1111111111111111111111111111111111111111",
+        symbol: "UNKNOWN",
+        name: "Unknown",
+        decimals: 18,
+        extensions: { balance: "1000000000000000000" },
+      },
+    ]);
+
+    expect(mockEvmPrices).not.toHaveBeenCalled();
+    expect(result[0]?.extensions?.price).toBeUndefined();
+  });
+});

--- a/src/__tests__/vex-agent/sync/balance-sync.test.ts
+++ b/src/__tests__/vex-agent/sync/balance-sync.test.ts
@@ -32,6 +32,11 @@ vi.mock("../../../vex-agent/sync/local-chain-balance-sync.js", () => ({
   syncLocalChainForWallet: (...args: unknown[]) => mockLocalSync(...args),
 }));
 
+const mockEnrichPrices = vi.fn();
+vi.mock("../../../vex-agent/sync/balance-price-enrichment.js", () => ({
+  enrichKhalaniBalancePrices: (...args: unknown[]) => mockEnrichPrices(...args),
+}));
+
 // Pendle enrichment is its own suite (balance-sync-pendle + merge). Here both the
 // merge and the standalone seed are no-ops so these Khalani-focused tests stay
 // hermetic (the real enrichment reads proj_activity + Pendle RPC/API): the merge
@@ -83,6 +88,9 @@ function emptyScan(scannedChainIds: number[] = []) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockScan.mockResolvedValue(emptyScan());
+  mockEnrichPrices.mockImplementation((_family: string, tokens: unknown[]) =>
+    Promise.resolve([...tokens]),
+  );
   mockLocalSync.mockResolvedValue({ chainId: 4663, tokensUpdated: 0, skipped: true });
   // Khalani registry WITHOUT 4663 (the real-world state today).
   mockGetCachedKhalaniChains.mockResolvedValue([
@@ -129,6 +137,41 @@ describe("syncWalletBalances", () => {
   it("forwards a chainIds filter to the scan", async () => {
     await syncWalletBalances("eip155", EVM_A, [1, 8453]);
     expect(mockScan).toHaveBeenCalledWith({ address: EVM_A, family: "eip155", chainIds: [1, 8453] });
+  });
+
+  it("enriches a live balance-only response before persisting USD values", async () => {
+    const liveShape = {
+      chainId: 1,
+      address: "0xA0b86991c6218b36c1d19d4a2e9eb0cE3606eB48",
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6,
+      extensions: { balance: "2070000" },
+    };
+    mockScan.mockResolvedValue({
+      tokens: [liveShape],
+      scannedChainIds: [1],
+      chainErrors: [],
+    });
+    mockEnrichPrices.mockResolvedValue([
+      {
+        ...liveShape,
+        extensions: {
+          ...liveShape.extensions,
+          price: { usd: "1" },
+        },
+      },
+    ]);
+
+    await syncWalletBalances("eip155", EVM_A, [1]);
+
+    expect(mockEnrichPrices).toHaveBeenCalledWith("eip155", [liveShape]);
+    const rows = mockReplaceBalances.mock.calls[0]?.[2] as Array<{
+      priceUsd: number | null;
+      balanceUsd: number | null;
+    }>;
+    expect(rows[0]?.priceUsd).toBe(1);
+    expect(rows[0]?.balanceUsd).toBeCloseTo(2.07);
   });
 
   // ── Native top-up MUST stay off on the projection path ──────────
@@ -249,6 +292,30 @@ describe("fullBalanceSync — snapshot guard", () => {
     // duration of a pending swap. Only the SNAPSHOT is deferred.
     expect(result.wallets).toHaveLength(3);
     expect(mockScan).toHaveBeenCalled();
+  });
+
+  it("does not record a snapshot baseline while any held asset is unpriced", async () => {
+    mockListWallets.mockImplementation(threeWallets);
+    mockGetBalances.mockResolvedValue([
+      {
+        walletFamily: "eip155",
+        walletAddress: EVM_A,
+        chainId: 1,
+        tokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        tokenSymbol: "ETH",
+        tokenName: "Ether",
+        balanceRaw: "425500000000000",
+        balanceUsd: null,
+        priceUsd: null,
+        decimals: 18,
+      },
+    ]);
+
+    const result = await fullBalanceSync();
+
+    expect(result.wallets.some((wallet) => !wallet.valuationComplete)).toBe(true);
+    expect(mockInsertSnapshot).not.toHaveBeenCalled();
+    expect(result.snapshots).toEqual([]);
   });
 
   it("asks the predicate ONCE, before the wallet loop, for every wallet at once", async () => {

--- a/src/tools/evm-chains/balances.ts
+++ b/src/tools/evm-chains/balances.ts
@@ -21,14 +21,11 @@
 
 import { getAddress, type Chain, type PublicClient, type Transport } from "viem";
 
-import { getDexScreenerClient } from "../dexscreener/client.js";
 import { ERC20_READ_ABI } from "./erc20-reads.js";
 import { getLocalPublicClient } from "./evm-client.js";
 import type { LocalChainConfig } from "./registry.js";
+import { fetchEvmTokenPricesByAddress } from "./token-prices.js";
 import logger from "../../utils/logger.js";
-
-/** DexScreener tokens/v1 caps at 30 addresses per request. */
-const DEXSCREENER_TOKENS_BATCH = 30;
 
 interface TokenMeta {
   decimals: number;
@@ -95,7 +92,10 @@ export async function readLocalChainBalances(
   const meta = await loadTokenMetadata(client, config.id, tokenAddrs);
   const balances = await readErc20Balances(client, walletAddress, tokenAddrs);
   const nativeWei = await client.getBalance({ address: getAddress(walletAddress) });
-  const priceByLower = await fetchPricesByLowerAddress(config, tokenAddrs);
+  const priceByLower = await fetchEvmTokenPricesByAddress({
+    chainSlug: config.dexscreenerSlug,
+    tokenAddresses: tokenAddrs,
+  });
 
   const wrappedNativeLower = config.seedTokens
     .find((token) => token.label.toUpperCase() === `W${config.nativeCurrency.symbol.toUpperCase()}`)
@@ -186,66 +186,6 @@ async function readErc20Balances(
     }
   }
   return result;
-}
-
-// ── Pricing ─────────────────────────────────────────────────────────
-
-/**
- * Best-liquidity DexScreener USD price per token (lowercase address → price).
- * See the module doc for the base-vs-quote-side pricing rule. Fail-soft: any
- * error (incl. a chain slug DexScreener doesn't index) yields an empty map,
- * and priceless tokens simply keep a null USD value downstream.
- */
-async function fetchPricesByLowerAddress(
-  config: LocalChainConfig,
-  tokenAddrs: readonly `0x${string}`[],
-): Promise<Map<string, number>> {
-  const priceByLower = new Map<string, number>();
-  if (tokenAddrs.length === 0) return priceByLower;
-
-  const wanted = new Set(tokenAddrs.map((address) => address.toLowerCase()));
-  // Track the deepest liquidity seen per token so the chosen price is the
-  // best-liquidity venue rather than an arbitrary pair (both sides compete
-  // through the same comparison — the deepest pool wins regardless of side).
-  const bestLiquidity = new Map<string, number>();
-  const consider = (lower: string, price: number, liquidity: number): void => {
-    if (!Number.isFinite(price) || price < 0) return;
-    if (!priceByLower.has(lower) || liquidity > (bestLiquidity.get(lower) ?? -Infinity)) {
-      priceByLower.set(lower, price);
-      bestLiquidity.set(lower, liquidity);
-    }
-  };
-
-  const client = getDexScreenerClient();
-  for (let i = 0; i < tokenAddrs.length; i += DEXSCREENER_TOKENS_BATCH) {
-    const batch = tokenAddrs.slice(i, i + DEXSCREENER_TOKENS_BATCH);
-    try {
-      const pairs = await client.getTokens(config.dexscreenerSlug, batch.join(","));
-      for (const pair of pairs) {
-        if (pair.priceUsd == null) continue;
-        const priceUsd = Number(pair.priceUsd);
-        if (!Number.isFinite(priceUsd) || priceUsd < 0) continue;
-        const liquidity = pair.liquidity?.usd ?? 0;
-
-        const base = pair.baseToken?.address?.toLowerCase();
-        if (base && wanted.has(base)) consider(base, priceUsd, liquidity);
-
-        const quote = pair.quoteToken?.address?.toLowerCase();
-        if (quote && wanted.has(quote)) {
-          const priceNative = Number(pair.priceNative);
-          if (Number.isFinite(priceNative) && priceNative > 0) {
-            consider(quote, priceUsd / priceNative, liquidity);
-          }
-        }
-      }
-    } catch (err) {
-      logger.debug("evm_chains.balances.price_batch_failed", {
-        slug: config.dexscreenerSlug,
-        error: err instanceof Error ? err.name : "unknown",
-      });
-    }
-  }
-  return priceByLower;
 }
 
 /** Test-only: clear the in-process metadata cache. */

--- a/src/tools/evm-chains/token-prices.ts
+++ b/src/tools/evm-chains/token-prices.ts
@@ -1,0 +1,89 @@
+/**
+ * Address-bound EVM token pricing through DexScreener.
+ *
+ * Balance providers are not price providers: Khalani's live balance endpoint
+ * currently returns quantities without USD prices. This module is therefore
+ * shared by both Khalani-backed portfolio sync and direct-RPC local-chain
+ * balance reads.
+ *
+ * A requested token can appear on either side of a pair. DexScreener reports
+ * `priceUsd` for the base token; when the requested token is the quote token,
+ * its USD price is `priceUsd / priceNative`. The deepest-liquidity candidate
+ * wins. Identity is always `(chain slug, contract address)`, never symbol.
+ */
+
+import { getDexScreenerClient } from "../dexscreener/client.js";
+import logger from "../../utils/logger.js";
+
+/** DexScreener's tokens/v1 endpoint accepts at most 30 addresses per call. */
+const DEXSCREENER_TOKENS_BATCH = 30;
+
+export interface EvmTokenPriceRequest {
+  readonly chainSlug: string;
+  readonly tokenAddresses: readonly string[];
+}
+
+/**
+ * Best-liquidity USD price per lowercase token address.
+ *
+ * Pricing is display/projection enrichment, so provider failures are fail-soft:
+ * callers retain the balance with a null valuation and can mark the aggregate
+ * as partial. Raw provider errors are never logged.
+ */
+export async function fetchEvmTokenPricesByAddress(
+  request: EvmTokenPriceRequest,
+): Promise<Map<string, number>> {
+  const priceByLower = new Map<string, number>();
+  if (request.tokenAddresses.length === 0) return priceByLower;
+
+  const uniqueAddresses = [
+    ...new Map(
+      request.tokenAddresses.map((address) => [address.toLowerCase(), address]),
+    ).values(),
+  ];
+  const wanted = new Set(uniqueAddresses.map((address) => address.toLowerCase()));
+  const bestLiquidity = new Map<string, number>();
+
+  const consider = (lower: string, price: number, liquidity: number): void => {
+    if (!Number.isFinite(price) || price <= 0) return;
+    if (
+      !priceByLower.has(lower) ||
+      liquidity > (bestLiquidity.get(lower) ?? -Infinity)
+    ) {
+      priceByLower.set(lower, price);
+      bestLiquidity.set(lower, liquidity);
+    }
+  };
+
+  const client = getDexScreenerClient();
+  for (let i = 0; i < uniqueAddresses.length; i += DEXSCREENER_TOKENS_BATCH) {
+    const batch = uniqueAddresses.slice(i, i + DEXSCREENER_TOKENS_BATCH);
+    try {
+      const pairs = await client.getTokens(request.chainSlug, batch.join(","));
+      for (const pair of pairs) {
+        if (pair.priceUsd == null) continue;
+        const priceUsd = Number(pair.priceUsd);
+        if (!Number.isFinite(priceUsd) || priceUsd <= 0) continue;
+        const liquidity = pair.liquidity?.usd ?? 0;
+
+        const base = pair.baseToken?.address?.toLowerCase();
+        if (base && wanted.has(base)) consider(base, priceUsd, liquidity);
+
+        const quote = pair.quoteToken?.address?.toLowerCase();
+        if (quote && wanted.has(quote)) {
+          const priceNative = Number(pair.priceNative);
+          if (Number.isFinite(priceNative) && priceNative > 0) {
+            consider(quote, priceUsd / priceNative, liquidity);
+          }
+        }
+      }
+    } catch (error) {
+      logger.debug("evm_chains.prices.batch_failed", {
+        slug: request.chainSlug,
+        error: error instanceof Error ? error.name : "unknown",
+      });
+    }
+  }
+
+  return priceByLower;
+}

--- a/src/vex-agent/sync/balance-price-enrichment.ts
+++ b/src/vex-agent/sync/balance-price-enrichment.ts
@@ -1,0 +1,142 @@
+/**
+ * Independent USD-price enrichment for Khalani balance rows.
+ *
+ * Khalani is authoritative for held quantities, not valuation. Its live
+ * balance response may contain only `extensions.balance`, so missing prices
+ * are filled from family-specific, address-bound feeds before projection:
+ * DexScreener for EVM and Jupiter Price V3 for Solana. Existing valid Khalani
+ * prices are preserved.
+ */
+
+import { fetchEvmTokenPricesByAddress } from "@tools/evm-chains/token-prices.js";
+import { chainIdToSlug } from "@tools/kyberswap/chains.js";
+import { getKyberWrappedNativeAddress } from "@tools/kyberswap/wrapped-native.js";
+import { isKhalaniNativeAlias } from "@tools/khalani/native-token-identity.js";
+import type { ChainFamily, KhalaniToken } from "@tools/khalani/types.js";
+import { getJupiterPricesByMint } from "@tools/solana-ecosystem/jupiter/jupiter-prices/service.js";
+import logger from "@utils/logger.js";
+
+const EVM_ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/;
+const SOLANA_ADDRESS_PATTERN = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+const JUPITER_PRICE_BATCH = 50;
+
+function existingUsdPrice(token: KhalaniToken): number | null {
+  const raw = token.extensions?.price?.usd;
+  if (typeof raw !== "string" || raw.trim().length === 0) return null;
+  const price = Number(raw);
+  return Number.isFinite(price) && price > 0 ? price : null;
+}
+
+function withUsdPrice(token: KhalaniToken, priceUsd: number): KhalaniToken {
+  return {
+    ...token,
+    extensions: {
+      ...token.extensions,
+      price: {
+        ...token.extensions?.price,
+        usd: String(priceUsd),
+      },
+    },
+  };
+}
+
+interface EvmLookup {
+  readonly tokenIndex: number;
+  readonly address: string;
+}
+
+async function enrichEvmPrices(
+  tokens: readonly KhalaniToken[],
+): Promise<KhalaniToken[]> {
+  const enriched = [...tokens];
+  const lookupsBySlug = new Map<string, EvmLookup[]>();
+
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex += 1) {
+    const token = tokens[tokenIndex]!;
+    if (existingUsdPrice(token) !== null) continue;
+
+    const slug = chainIdToSlug(token.chainId);
+    if (slug === undefined) continue;
+
+    let lookupAddress: string;
+    if (isKhalaniNativeAlias(token.address)) {
+      try {
+        lookupAddress = getKyberWrappedNativeAddress(slug);
+      } catch {
+        continue;
+      }
+    } else {
+      if (!EVM_ADDRESS_PATTERN.test(token.address)) continue;
+      lookupAddress = token.address;
+    }
+
+    const existing = lookupsBySlug.get(slug) ?? [];
+    existing.push({ tokenIndex, address: lookupAddress });
+    lookupsBySlug.set(slug, existing);
+  }
+
+  for (const [chainSlug, lookups] of lookupsBySlug) {
+    const prices = await fetchEvmTokenPricesByAddress({
+      chainSlug,
+      tokenAddresses: lookups.map((lookup) => lookup.address),
+    });
+    for (const lookup of lookups) {
+      const price = prices.get(lookup.address.toLowerCase());
+      if (price !== undefined) {
+        enriched[lookup.tokenIndex] = withUsdPrice(
+          enriched[lookup.tokenIndex]!,
+          price,
+        );
+      }
+    }
+  }
+
+  return enriched;
+}
+
+async function enrichSolanaPrices(
+  tokens: readonly KhalaniToken[],
+): Promise<KhalaniToken[]> {
+  const enriched = [...tokens];
+  const missing = tokens
+    .map((token, tokenIndex) => ({ token, tokenIndex }))
+    .filter(
+      ({ token }) =>
+        existingUsdPrice(token) === null &&
+        SOLANA_ADDRESS_PATTERN.test(token.address),
+    );
+
+  for (let i = 0; i < missing.length; i += JUPITER_PRICE_BATCH) {
+    const batch = missing.slice(i, i + JUPITER_PRICE_BATCH);
+    try {
+      const prices = await getJupiterPricesByMint(
+        batch.map(({ token }) => token.address),
+      );
+      for (const { token, tokenIndex } of batch) {
+        const price = prices[token.address]?.usdPrice;
+        if (typeof price === "number" && Number.isFinite(price) && price > 0) {
+          enriched[tokenIndex] = withUsdPrice(enriched[tokenIndex]!, price);
+        }
+      }
+    } catch (error) {
+      logger.debug("sync.balance.solana_price_batch_failed", {
+        error: error instanceof Error ? error.name : "unknown",
+      });
+    }
+  }
+
+  return enriched;
+}
+
+/** Fill missing token prices without changing balance quantities or identity. */
+export async function enrichKhalaniBalancePrices(
+  family: ChainFamily,
+  tokens: readonly KhalaniToken[],
+): Promise<KhalaniToken[]> {
+  if (tokens.length === 0 || tokens.every((token) => existingUsdPrice(token) !== null)) {
+    return [...tokens];
+  }
+  return family === "eip155"
+    ? enrichEvmPrices(tokens)
+    : enrichSolanaPrices(tokens);
+}

--- a/src/vex-agent/sync/balance-sync.ts
+++ b/src/vex-agent/sync/balance-sync.ts
@@ -21,6 +21,7 @@ import { PENDLE_SUPPORTED_CHAIN_IDS } from "@tools/pendle/chains.js";
 import { runSingleFlightBalanceSync } from "./balance-sync/single-flight.js";
 import { describeFailureForLog } from "@utils/error-summary.js";
 import logger from "@utils/logger.js";
+import { enrichKhalaniBalancePrices } from "./balance-price-enrichment.js";
 
 /** ChainFamily ("eip155"|"solana") → inventory family ("evm"|"solana"). */
 function toInventoryFamily(family: ChainFamily): InventoryFamily {
@@ -35,6 +36,8 @@ export interface SyncResult {
   tokensUpdated: number;
   chainsUpdated: number;
   totalUsd: number;
+  /** False when at least one non-zero holding has no usable USD price. */
+  valuationComplete: boolean;
 }
 
 export interface WalletSnapshotResult {
@@ -119,6 +122,7 @@ export async function syncWalletBalances(
       tokensUpdated: 0,
       chainsUpdated: 0,
       totalUsd: walletBalances.reduce((sum, b) => sum + (b.balanceUsd ?? 0), 0),
+      valuationComplete: hasCompleteValuation(walletBalances),
     };
   } else {
     base = await syncKhalaniWalletBalances(family, address, khalaniChainIds);
@@ -219,7 +223,7 @@ async function syncKhalaniWalletBalances(
   // Fetch from Khalani. Scanning per chain avoids incomplete multi-chain
   // balance responses and lets cleanup distinguish "empty" from "not scanned".
   const scan = await getTokenBalancesAcrossChains({ address, family, chainIds });
-  const tokens = scan.tokens;
+  const tokens = await enrichKhalaniBalancePrices(family, scan.tokens);
 
   // Group by chainId for transactional replace
   const byChain = new Map<number, BalanceRow[]>();
@@ -267,6 +271,7 @@ async function syncKhalaniWalletBalances(
   // Calculate total USD for this wallet
   const walletBalances = await balancesRepo.getBalances(address);
   const totalUsd = walletBalances.reduce((sum, b) => sum + (b.balanceUsd ?? 0), 0);
+  const valuationComplete = hasCompleteValuation(walletBalances);
 
   logger.info("sync.balance.completed", {
     family,
@@ -283,6 +288,7 @@ async function syncKhalaniWalletBalances(
     tokensUpdated,
     chainsUpdated: byChain.size,
     totalUsd,
+    valuationComplete,
   };
 }
 
@@ -350,40 +356,56 @@ async function runFullBalanceSync(policy: SnapshotPolicy): Promise<FullSyncResul
     walletEntries.map((entry) => entry.address),
   );
 
-  // Project EVERY inventory wallet (≤3 EVM + ≤3 Solana), one snapshot each.
+  // Project EVERY inventory wallet (≤3 EVM + ≤3 Solana) before writing any
+  // snapshot. Snapshot completeness is group-wide: one partially-valued wallet
+  // must suppress the whole cycle rather than minting a misleading baseline.
   for (const { family, address } of walletEntries) {
     const sync = await syncWalletBalances(family, address);
     wallets.push(sync);
     aggregateTotalUsd += sync.totalUsd;
+  }
 
-    if (!snapshotAllowed) continue;
+  const valuationComplete = wallets.every((wallet) => wallet.valuationComplete);
+  const shouldSnapshot = snapshotAllowed && valuationComplete;
 
-    const positions = await buildPositionsBreakdown(family, address);
-    const positionData = positions as { chains?: Array<{ chainId: number }> };
-    const chainSet = new Set<string>();
-    for (const c of positionData.chains ?? []) chainSet.add(String(c.chainId));
-
-    const { snapshotId, pnlVsPrev } = await balancesRepo.insertSnapshot({
-      walletFamily: family,
-      walletAddress: address,
-      snapshotGroupId,
-      totalUsd: sync.totalUsd,
-      positions,
-      activeChains: [...chainSet],
+  if (!valuationComplete) {
+    logger.info("sync.balance.snapshot_deferred", {
+      reason: "incomplete_valuation",
+      hint: "balances still refreshed; the snapshot resumes when every held asset has a USD price",
     });
-    snapshots.push({
-      walletFamily: family,
-      walletAddress: address,
-      snapshotId,
-      totalUsd: sync.totalUsd,
-      pnlVsPrev,
-    });
+  }
+
+  if (shouldSnapshot) {
+    for (let index = 0; index < walletEntries.length; index += 1) {
+      const { family, address } = walletEntries[index]!;
+      const sync = wallets[index]!;
+      const positions = await buildPositionsBreakdown(family, address);
+      const positionData = positions as { chains?: Array<{ chainId: number }> };
+      const chainSet = new Set<string>();
+      for (const c of positionData.chains ?? []) chainSet.add(String(c.chainId));
+
+      const { snapshotId, pnlVsPrev } = await balancesRepo.insertSnapshot({
+        walletFamily: family,
+        walletAddress: address,
+        snapshotGroupId,
+        totalUsd: sync.totalUsd,
+        positions,
+        activeChains: [...chainSet],
+      });
+      snapshots.push({
+        walletFamily: family,
+        walletAddress: address,
+        snapshotId,
+        totalUsd: sync.totalUsd,
+        pnlVsPrev,
+      });
+    }
   }
 
   logger.info("sync.balance.full_completed", {
     wallets: wallets.length,
     snapshots: snapshots.length,
-    snapshotSkipped: !snapshotAllowed,
+    snapshotSkipped: !shouldSnapshot,
     totalUsd: aggregateTotalUsd.toFixed(2),
     snapshotGroupId,
   });
@@ -449,7 +471,11 @@ export async function selectiveBalanceSync(chainHint: string): Promise<Selective
 function mapTokenToBalance(family: ChainFamily, walletAddress: string, token: KhalaniToken): BalanceRow {
   const balanceRaw = token.extensions?.balance ?? "0";
   const priceUsdStr = token.extensions?.price?.usd;
-  const priceUsd = priceUsdStr ? parseFloat(priceUsdStr) : null;
+  const parsedPriceUsd = priceUsdStr ? Number(priceUsdStr) : Number.NaN;
+  const priceUsd =
+    Number.isFinite(parsedPriceUsd) && parsedPriceUsd > 0
+      ? parsedPriceUsd
+      : null;
 
   // Calculate USD value: balance in human units * price
   let balanceUsd: number | null = null;
@@ -474,6 +500,22 @@ function mapTokenToBalance(family: ChainFamily, walletAddress: string, token: Kh
     priceUsd,
     decimals: token.decimals,
   };
+}
+
+/**
+ * A total is complete only when every non-zero row has a finite USD value.
+ * Malformed raw balances are treated conservatively as held/unknown.
+ */
+function hasCompleteValuation(rows: readonly BalanceRow[]): boolean {
+  return rows.every((row) => {
+    let isZero = false;
+    try {
+      isZero = BigInt(row.balanceRaw) === 0n;
+    } catch {
+      return false;
+    }
+    return isZero || (row.balanceUsd !== null && Number.isFinite(row.balanceUsd));
+  });
 }
 
 /** Build the per-chain token breakdown for ONE wallet's snapshot row. */

--- a/vex-app/src/renderer/features/appShell/__tests__/PositionBlock.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/PositionBlock.test.tsx
@@ -221,6 +221,10 @@ describe("PositionBlock zero-balance display", () => {
     expect(screen.getByText("ETH")).not.toBeNull();
     expect(screen.getByText("0.005 ETH")).not.toBeNull();
     expect(screen.getByText("—")).not.toBeNull();
+    expect(screen.getByLabelText("Partial valuation")).not.toBeNull();
+    expect(
+      screen.getByText("partial · unpriced assets excluded"),
+    ).not.toBeNull();
     expect(screen.queryByText("$0.00")).toBeNull();
     expect(screen.queryByText("No priced balances.")).toBeNull();
     expect(container.querySelectorAll("li")).toHaveLength(1);

--- a/vex-app/src/renderer/features/appShell/__tests__/WelcomePortfolioPanel.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/WelcomePortfolioPanel.test.tsx
@@ -241,6 +241,33 @@ describe("WelcomePortfolioPanel — overview scope chips", () => {
     expect(overviewRegion().getByText("vs last snapshot")).not.toBeNull();
   });
 
+  it("marks an aggregate as partial and suppresses snapshot comparison while a held asset is unpriced", () => {
+    mockUsePortfolio.mockReturnValue(
+      loaded(
+        portfolio({
+          liveTotalUsd: 1.17,
+          tokens: [
+            {
+              chainId: 1,
+              symbol: "USDC",
+              balanceUsd: null,
+              amount: 2.07,
+            },
+          ],
+        }),
+      ),
+    );
+
+    render(<WelcomePortfolioPanel bookOpen onToggle={() => {}} />);
+
+    expect(overviewRegion().getByText("$1.17")).not.toBeNull();
+    expect(overviewRegion().getByLabelText("Partial valuation")).not.toBeNull();
+    expect(
+      overviewRegion().getByText("partial · unpriced assets excluded"),
+    ).not.toBeNull();
+    expect(overviewRegion().queryByText("vs last snapshot")).toBeNull();
+  });
+
   it("puts the Primary badge on family-primary chips only (index 0 per family)", () => {
     render(<WelcomePortfolioPanel bookOpen onToggle={() => {}} />);
     const chips = scopeChips();

--- a/vex-app/src/renderer/features/appShell/book/PositionBlock.tsx
+++ b/vex-app/src/renderer/features/appShell/book/PositionBlock.tsx
@@ -41,6 +41,7 @@ import { CardStateNote, PortfolioCard } from "./portfolio/PortfolioCard.js";
 import { GlobalWalletSwitcher } from "./GlobalWalletSwitcher.js";
 import { PositionChains } from "./PositionChains.js";
 import { PortfolioRefreshButton } from "./PortfolioRefreshButton.js";
+import { hasUnpricedHoldings } from "./portfolio/valuation.js";
 
 export function PositionBlock({
   activeSessionId,
@@ -161,6 +162,7 @@ function TotalFigure({
   readonly portfolio: PortfolioDto;
 }): JSX.Element {
   const { liveTotalUsd, snapshotTotalUsd, pnlVsPrev } = portfolio;
+  const partial = hasUnpricedHoldings(portfolio.tokens);
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-start justify-between gap-2">
@@ -169,9 +171,21 @@ function TotalFigure({
       </div>
       {/* Serif is rationed to this ONE display figure (typography law, C2). */}
       <span className="font-serif text-[34px] leading-none tracking-[-0.01em] tabular-nums text-foreground">
-        {formatUsd(liveTotalUsd)}
+        <span>{formatUsd(liveTotalUsd)}</span>
+        {partial ? (
+          <span
+            className="ml-0.5 font-mono text-[13px] text-[var(--vex-text-3)]"
+            aria-label="Partial valuation"
+          >
+            +
+          </span>
+        ) : null}
       </span>
-      {snapshotTotalUsd !== null ? (
+      {partial ? (
+        <span className="font-mono text-[10px] text-[var(--vex-text-3)]">
+          partial · unpriced assets excluded
+        </span>
+      ) : snapshotTotalUsd !== null ? (
         <span className="flex items-baseline gap-1.5 text-[11px] tabular-nums text-[var(--vex-text-3)]">
           <span>snapshot {formatUsd(snapshotTotalUsd)}</span>
           {pnlVsPrev !== null ? (

--- a/vex-app/src/renderer/features/appShell/book/portfolio/PortfolioOverviewCard.tsx
+++ b/vex-app/src/renderer/features/appShell/book/portfolio/PortfolioOverviewCard.tsx
@@ -32,6 +32,7 @@ import {
   flattenPortfolioWallets,
   type PortfolioWallet,
 } from "./wallet-scope.js";
+import { hasUnpricedHoldings } from "./valuation.js";
 
 export function PortfolioOverviewCard(): JSX.Element {
   const globalQuery = usePortfolio(null);
@@ -104,6 +105,8 @@ function TotalFigure({
 }: {
   readonly portfolio: PortfolioDto | null;
 }): JSX.Element {
+  const partial =
+    portfolio !== null && hasUnpricedHoldings(portfolio.tokens);
   return (
     <div className="flex flex-col gap-1">
       <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--vex-text-3)]">
@@ -111,9 +114,21 @@ function TotalFigure({
       </span>
       {/* Serif is rationed to this ONE display figure (typography law). */}
       <span className="font-serif text-[34px] leading-none tracking-[-0.01em] text-foreground">
-        {formatUsd(portfolio?.liveTotalUsd ?? null)}
+        <span>{formatUsd(portfolio?.liveTotalUsd ?? null)}</span>
+        {partial ? (
+          <span
+            className="ml-0.5 font-mono text-[13px] text-[var(--vex-text-3)]"
+            aria-label="Partial valuation"
+          >
+            +
+          </span>
+        ) : null}
       </span>
-      {portfolio !== null &&
+      {partial ? (
+        <span className="font-mono text-[10px] text-[var(--vex-text-3)]">
+          partial · unpriced assets excluded
+        </span>
+      ) : portfolio !== null &&
       portfolio.snapshotTotalUsd !== null &&
       portfolio.pnlVsPrev !== null ? (
         <span className="flex items-baseline gap-1.5 font-mono text-[11px] tabular-nums">

--- a/vex-app/src/renderer/features/appShell/book/portfolio/valuation.ts
+++ b/vex-app/src/renderer/features/appShell/book/portfolio/valuation.ts
@@ -1,0 +1,8 @@
+import type { PositionTokenDto } from "@shared/schemas/portfolio.js";
+
+/** True when the portfolio contains a held token excluded from its USD sum. */
+export function hasUnpricedHoldings(
+  tokens: readonly PositionTokenDto[],
+): boolean {
+  return tokens.some((token) => token.balanceUsd === null);
+}


### PR DESCRIPTION
## Summary

Fix portfolio totals that excluded wallet assets when balance responses did not include USD pricing.

## Root cause

Khalani’s balance endpoint returns token quantities in `extensions.balance`, but does not always return `extensions.price`.

These assets were persisted with `balance_usd = null`, so the portfolio aggregate silently excluded them. This made a partial valuation appear to be the complete portfolio total.

## Changes

- Enrich missing EVM token prices through DexScreener using contract addresses.
- Price native EVM assets through their verified wrapped-native contracts.
- Enrich missing Solana token prices through Jupiter Price V3 using mint addresses.
- Preserve valid prices already supplied by the balance provider.
- Share EVM pricing logic between Khalani-backed and direct-RPC balance syncs.
- Mark portfolio totals as partial when any holding remains unpriced.
- Suppress snapshot comparisons and prevent incomplete valuations from creating misleading snapshot baselines.
- Add regression coverage for backend valuation and portfolio UI behavior.

## Expected behavior

Portfolio totals now include every wallet token for which a reliable USD price is available across supported EVM chains and Solana.

For the reported portfolio, this includes:

- Robinhood ETH
- Ethereum USDC
- Ethereum ETH

Based on the balances in the screenshot, the total should display approximately `$4.18`. The exact amount varies with live market prices.

If a held token cannot be priced, it remains visible and the portfolio total is clearly marked as partial instead of appearing complete.

## Safety

This change only affects balance projection, price enrichment, snapshots, and portfolio display.

It does not modify:

- Private-key or vault handling
- Transaction signing
- Transfers, swaps, bridges, or other fund-moving operations
- Approval gates
- Wallet ownership or address selection

## Verification

- 39 backend pricing and balance-sync tests passed.
- 27 portfolio renderer tests passed.
- Root TypeScript check passed.
- Root production build passed.
- Renderer production build passed.
- Live read-only pricing verification returned valid WETH and USDC prices.
- `git diff --check` passed.

## Local workspace note

The full lint ratchet currently reports unrelated type errors in:

- `src/main/database/migrate-runner.ts`
- `src/renderer/lib/api/market.ts`
- `src/renderer/lib/api/updates.ts`

These are associated with pre-existing uncommitted dependency-lockfile upgrades and are not part of this portfolio fix.
