### PR TITLE
feat(vex-app): UIUX rebrand phase 1 - primitives

### DIFF
--- a/vex-app/src/renderer/components/common/AddressDisplay.tsx
+++ b/vex-app/src/renderer/components/common/AddressDisplay.tsx
@@ -3,8 +3,8 @@
  *
  * Truncation: `0x1234…abcd` (6 chars from start, 4 from end). Short
  * enough to scan visually, long enough to disambiguate at a glance.
- * Copy uses `navigator.clipboard.writeText`; visual checkmark feedback
- * for 1.5s. No Toast primitive needed for M8.
+ * Copy + 1.5s checkmark feedback ride the shared `useCopyFeedback` hook
+ * (lib/use-copy-feedback.ts); feedback fires only on a real success.
  *
  * Accessibility:
  *  - Address is rendered in a `<code>` so screen readers announce it
@@ -13,8 +13,9 @@
  *    and "Address copied" so AT users know the action result.
  */
 
-import { useEffect, useRef, useState, type JSX } from "react";
+import { type JSX } from "react";
 import { cn } from "../../lib/utils.js";
+import { useCopyFeedback } from "../../lib/use-copy-feedback.js";
 
 export interface AddressDisplayProps {
   readonly address: string;
@@ -30,7 +31,6 @@ export interface AddressDisplayProps {
   readonly copiedLabel?: string;
 }
 
-const COPY_FEEDBACK_MS = 1500;
 const PREFIX_LEN = 6;
 const SUFFIX_LEN = 4;
 
@@ -65,29 +65,6 @@ function CopyStateGlyph({ copied }: { readonly copied: boolean }): JSX.Element {
   );
 }
 
-/**
- * Permissionless copy: an off-screen readonly textarea + the selection copy
- * command. Deprecated API, but the reliable path in a renderer whose
- * permissions API is deny-all — no privileged IPC surface needed for a
- * public address string.
- */
-function copyViaSelection(text: string): boolean {
-  try {
-    const ta = document.createElement("textarea");
-    ta.value = text;
-    ta.setAttribute("readonly", "");
-    ta.style.position = "fixed";
-    ta.style.opacity = "0";
-    document.body.appendChild(ta);
-    ta.select();
-    const ok = document.execCommand("copy");
-    ta.remove();
-    return ok;
-  } catch {
-    return false;
-  }
-}
-
 export function AddressDisplay({
   address,
   className,
@@ -96,32 +73,7 @@ export function AddressDisplay({
   copyLabel = "Copy address",
   copiedLabel = "Address copied",
 }: AddressDisplayProps): JSX.Element {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, []);
-
-  const handleCopy = async (): Promise<void> => {
-    // The shell's permission handlers are deny-all (main/permissions.ts), so
-    // `navigator.clipboard.writeText` is rejected in the renderer. Try it
-    // first (future-proof), then fall back to the selection-based copy path,
-    // which needs no permissions API. Feedback fires ONLY on a real success.
-    let ok = false;
-    try {
-      await navigator.clipboard.writeText(address);
-      ok = true;
-    } catch {
-      ok = copyViaSelection(address);
-    }
-    if (!ok) return;
-    setCopied(true);
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
-  };
+  const { copied, onCopy } = useCopyFeedback(address);
 
   const displayed = truncate ? truncateAddress(address) : address;
 
@@ -139,9 +91,7 @@ export function AddressDisplay({
         </code>
         <button
           type="button"
-          onClick={() => {
-            void handleCopy();
-          }}
+          onClick={onCopy}
           aria-label={copied ? copiedLabel : copyLabel}
           className={cn(
             "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[4px]",
@@ -183,9 +133,7 @@ export function AddressDisplay({
       </code>
       <button
         type="button"
-        onClick={() => {
-          void handleCopy();
-        }}
+        onClick={onCopy}
         aria-label={copied ? copiedLabel : copyLabel}
         className="rounded-sm px-1 text-[10px] font-mono uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >

--- a/vex-app/src/renderer/components/ui/__tests__/disclosure-row.test.tsx
+++ b/vex-app/src/renderer/components/ui/__tests__/disclosure-row.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * DisclosureRow tests: leading crossfade structure (idle icon + hover
+ * chevron in one 16px box), open-state chevron, toggle paths (leading
+ * button, whole-row click, keyboard), and collapsed-content policy.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { DisclosureRow } from "../disclosure-row.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderRow(overrides: Partial<Parameters<typeof DisclosureRow>[0]> = {}) {
+  const onToggle = vi.fn();
+  const { container } = render(
+    <DisclosureRow
+      icon={<svg data-testid="tool-icon" />}
+      title="Read file"
+      open={false}
+      expandable
+      onToggle={onToggle}
+      {...overrides}
+    >
+      <div data-testid="body">expanded body</div>
+    </DisclosureRow>,
+  );
+  return { onToggle, container };
+}
+
+describe("DisclosureRow", () => {
+  it("collapsed: stacks the idle icon and the hover chevron in the leading box", () => {
+    const { container } = renderRow();
+    expect(container.querySelector(".vex-disclosure-icon-idle")).not.toBeNull();
+    expect(
+      container.querySelector(".vex-disclosure-chevron-hover"),
+    ).not.toBeNull();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  it("open: shows the chevron alone and renders children", () => {
+    const { container } = renderRow({ open: true });
+    expect(container.querySelector(".vex-disclosure-icon-idle")).toBeNull();
+    expect(container.querySelector(".vex-disclosure-chevron-hover")).toBeNull();
+    expect(screen.getByTestId("body")).not.toBeNull();
+  });
+
+  it("toggles from the leading button with aria-expanded", () => {
+    const { onToggle, container } = renderRow();
+    const leading = container.querySelector("button.vex-disclosure-leading")!;
+    expect(leading.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(leading);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("expandOnRowClick: whole row is the target, keyboard included", () => {
+    const { onToggle } = renderRow({ expandOnRowClick: true });
+    const row = screen.getByRole("button");
+    fireEvent.click(row);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(row, { key: "Enter" });
+    fireEvent.keyDown(row, { key: " " });
+    expect(onToggle).toHaveBeenCalledTimes(3);
+    fireEvent.keyDown(row, { key: "a" });
+    expect(onToggle).toHaveBeenCalledTimes(3);
+  });
+
+  it("non-expandable rows render a passive leading span", () => {
+    const { container } = renderRow({ expandable: false });
+    expect(container.querySelector("button.vex-disclosure-leading")).toBeNull();
+    expect(container.querySelector("span.vex-disclosure-leading")).not.toBeNull();
+  });
+
+  it("keeps collapsedContent while open only when asked", () => {
+    const collapsed = <span data-testid="summary">summary</span>;
+    const { container } = renderRow({
+      open: true,
+      collapsedContent: collapsed,
+    });
+    expect(screen.queryByTestId("summary")).toBeNull();
+    cleanup();
+    renderRow({ open: true, collapsedContent: collapsed, keepContentWhenOpen: true });
+    expect(screen.getByTestId("summary")).not.toBeNull();
+    void container;
+  });
+});

--- a/vex-app/src/renderer/components/ui/__tests__/menu.test.tsx
+++ b/vex-app/src/renderer/components/ui/__tests__/menu.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Menu tests: entry rendering (item/separator/label), selection, the
+ * check-not-fill selected marker, danger rows, outside-pointer + Escape
+ * dismissal, and portal mode rendering into document.body.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Menu, type MenuEntry } from "../menu.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const ITEMS: readonly MenuEntry[] = [
+  { id: "rename", label: "Rename" },
+  { type: "separator", id: "sep" },
+  { type: "label", id: "head", text: "Danger zone" },
+  { id: "delete", label: "Delete", danger: true },
+];
+
+function renderMenu(overrides: Partial<Parameters<typeof Menu>[0]> = {}) {
+  const onSelect = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <Menu
+      open
+      anchor={<button type="button">trigger</button>}
+      items={ITEMS}
+      onSelect={onSelect}
+      onClose={onClose}
+      {...overrides}
+    />,
+  );
+  return { onSelect, onClose };
+}
+
+describe("Menu", () => {
+  it("renders items, separator, and heading; selects on click", () => {
+    const { onSelect, onClose } = renderMenu();
+    expect(screen.getByRole("separator")).not.toBeNull();
+    expect(screen.getByText("Danger zone")).not.toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+    expect(onSelect).toHaveBeenCalledWith("rename");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("marks the selected row with a trailing check, not a fill", () => {
+    renderMenu({ selectedId: "rename" });
+    const item = screen.getByRole("menuitem", { name: "Rename" });
+    expect(item.querySelector(".vex-menu-check")).not.toBeNull();
+    const other = screen.getByRole("menuitem", { name: "Delete" });
+    expect(other.querySelector(".vex-menu-check")).toBeNull();
+  });
+
+  it("styles danger rows", () => {
+    renderMenu();
+    expect(
+      screen.getByRole("menuitem", { name: "Delete" }).className,
+    ).toContain("vex-menu-danger");
+  });
+
+  it("closes on outside pointerdown but not on inside presses", () => {
+    const { onClose } = renderMenu();
+    fireEvent.pointerDown(screen.getByRole("menuitem", { name: "Rename" }));
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.pointerDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape", () => {
+    const { onClose } = renderMenu();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing while closed and detaches the dismiss listener", () => {
+    const onClose = vi.fn();
+    render(
+      <Menu
+        open={false}
+        anchor={<button type="button">trigger</button>}
+        items={ITEMS}
+        onSelect={() => {}}
+        onClose={onClose}
+      />,
+    );
+    expect(screen.queryByRole("menu")).toBeNull();
+    fireEvent.pointerDown(document.body);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("portal mode renders the list as a direct child of document.body", () => {
+    renderMenu({ portal: true });
+    const menu = screen.getByRole("menu");
+    expect(menu.className).toContain("vex-menu-portal");
+    expect(menu.parentElement).toBe(document.body);
+  });
+
+  it("skips the scroll cap when a submenu is present", () => {
+    renderMenu({
+      items: [
+        { id: "parent", label: "More", submenu: [{ id: "child", label: "Child" }] },
+      ],
+    });
+    expect(screen.getByRole("menu").className).not.toContain(
+      "vex-menu-scrollable",
+    );
+  });
+
+  it("opens a submenu on hover and selects from it", () => {
+    const { onSelect } = renderMenu({
+      items: [
+        { id: "parent", label: "More", submenu: [{ id: "child", label: "Child" }] },
+      ],
+    });
+    fireEvent.mouseEnter(
+      screen.getByRole("menuitem", { name: "More" }).parentElement!,
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Child" }));
+    expect(onSelect).toHaveBeenCalledWith("child");
+  });
+});

--- a/vex-app/src/renderer/components/ui/__tests__/pill-and-banner.test.tsx
+++ b/vex-app/src/renderer/components/ui/__tests__/pill-and-banner.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Pill + ConnectionBanner smoke behaviors: interactive-vs-static rendering
+ * and the banner's quiet-when-connected contract.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Pill } from "../pill.js";
+import { ConnectionBanner } from "../connection-banner.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Pill", () => {
+  it("renders a static span without onClick and a button with it", () => {
+    const { rerender } = render(<Pill>chip</Pill>);
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText("chip").tagName).toBe("SPAN");
+
+    const onClick = vi.fn();
+    rerender(<Pill onClick={onClick}>chip</Pill>);
+    fireEvent.click(screen.getByRole("button", { name: "chip" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("stamps variant classes from aliases", () => {
+    render(<Pill variant="danger">bad</Pill>);
+    expect(screen.getByText("bad").className).toContain("bg-danger-wash");
+  });
+});
+
+describe("ConnectionBanner", () => {
+  it("stays quiet while connected and shows the strip during backoff", () => {
+    const { rerender } = render(
+      <ConnectionBanner reconnecting={false} label="Reconnecting" />,
+    );
+    expect(screen.queryByRole("status")).toBeNull();
+    rerender(<ConnectionBanner reconnecting label="Reconnecting" />);
+    expect(screen.getByRole("status").textContent).toBe("Reconnecting");
+  });
+});

--- a/vex-app/src/renderer/components/ui/__tests__/state-dot.test.tsx
+++ b/vex-app/src/renderer/components/ui/__tests__/state-dot.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * StateDot tests: data-state stamping for the solid states, size, and the
+ * ongoing pixel chase (8 outer cells, negative phase delays so the chase is
+ * mid-flight at first paint).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { StateDot } from "../state-dot.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("StateDot", () => {
+  it.each(["done", "warning", "error"] as const)(
+    "solid state %s renders a sized dot with data-state",
+    (state) => {
+      const { container } = render(<StateDot state={state} size={12} />);
+      const dot = container.querySelector(".vex-state-dot")!;
+      expect(dot.getAttribute("data-state")).toBe(state);
+      expect((dot as HTMLElement).style.width).toBe("12px");
+      expect(dot.getAttribute("aria-hidden")).toBe("true");
+    },
+  );
+
+  it("ongoing renders the 3x3 outer-cell chase with phased negative delays", () => {
+    const { container } = render(<StateDot state="ongoing" />);
+    const matrix = container.querySelector(".vex-state-matrix")!;
+    expect(matrix.getAttribute("data-state")).toBe("ongoing");
+    const cells = matrix.querySelectorAll("rect.vex-state-cell");
+    expect(cells.length).toBe(8);
+    cells.forEach((cell, index) => {
+      expect((cell as SVGElement).style.animationDelay).toBe(
+        `${(index - 8) * 125}ms`,
+      );
+    });
+  });
+});

--- a/vex-app/src/renderer/components/ui/__tests__/toast.test.tsx
+++ b/vex-app/src/renderer/components/ui/__tests__/toast.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Toast + ToastHost tests: timed lifecycle, the CSS/TSX timing invariant
+ * (HOLD_MS/FADE_MS must equal the stylesheet's fade delay/duration), tones,
+ * and the store's replace/clear semantics.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { FADE_MS, HOLD_MS, Toast } from "../toast.js";
+import { ToastHost } from "../toast-host.js";
+import { clearToast, getToastSnapshot, showToast } from "../../../lib/toast.js";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  // Drain any live toast so store state never leaks between tests.
+  const current = getToastSnapshot();
+  if (current !== null) clearToast(current.id);
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("Toast", () => {
+  it("renders an alert and reports done after HOLD_MS + FADE_MS", () => {
+    const onDone = vi.fn();
+    render(<Toast text="Saved" onDone={onDone} />);
+    expect(screen.getByRole("alert").textContent).toBe("Saved");
+    act(() => vi.advanceTimersByTime(HOLD_MS + FADE_MS - 1));
+    expect(onDone).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the tone and shows the leading glyph only for non-neutral tones", () => {
+    const { rerender } = render(
+      <Toast text="x" tone="warning" onDone={() => {}} />,
+    );
+    const warning = screen.getByRole("alert");
+    expect(warning.getAttribute("data-tone")).toBe("warning");
+    expect(warning.querySelector(".vex-toast-icon")).not.toBeNull();
+    rerender(<Toast text="x" onDone={() => {}} />);
+    const neutral = screen.getByRole("alert");
+    expect(neutral.getAttribute("data-tone")).toBe("neutral");
+    expect(neutral.querySelector(".vex-toast-icon")).toBeNull();
+  });
+
+  it("pins the timing constants the stylesheet fade must mirror", () => {
+    // The CSS side (ui-primitives.css: `vex-toast-fade 1000ms ease 3000ms
+    // forwards`) cannot be read here - the renderer test pipeline empties
+    // .css imports, including ?raw - so this pin plus the INVARIANT
+    // comments on both sides is the guard: changing either constant fails
+    // here and points at the stylesheet.
+    expect(HOLD_MS).toBe(3000);
+    expect(FADE_MS).toBe(1000);
+  });
+});
+
+describe("ToastHost + store", () => {
+  it("shows, replaces, and clears toasts from the store", () => {
+    render(<ToastHost />);
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    act(() => showToast("first"));
+    expect(screen.getByRole("alert").textContent).toBe("first");
+
+    act(() => showToast("second", { tone: "error" }));
+    const replaced = screen.getByRole("alert");
+    expect(replaced.textContent).toBe("second");
+    expect(replaced.getAttribute("data-tone")).toBe("error");
+
+    act(() => vi.advanceTimersByTime(HOLD_MS + FADE_MS));
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(getToastSnapshot()).toBeNull();
+  });
+
+  it("ignores a stale clear for an already-replaced toast", () => {
+    render(<ToastHost />);
+    act(() => showToast("first"));
+    const first = getToastSnapshot()!;
+    act(() => showToast("second"));
+    act(() => clearToast(first.id));
+    expect(screen.getByRole("alert").textContent).toBe("second");
+  });
+});

--- a/vex-app/src/renderer/components/ui/__tests__/tooltip.test.tsx
+++ b/vex-app/src/renderer/components/ui/__tests__/tooltip.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Tooltip tests: sided rendering, hover/focus trigger independence, hover
+ * delay, and the disabled prop dropping a visible bubble.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Tooltip } from "../tooltip.js";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // jsdom rects are all zero, which the viewport-fit pass reads as "no room
+  // above" and flips top -> bottom; give every element a real mid-viewport
+  // rect so the requested side survives the fit.
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+    top: 100,
+    bottom: 120,
+    left: 100,
+    right: 140,
+    width: 40,
+    height: 20,
+    x: 100,
+    y: 100,
+    toJSON: () => ({}),
+  } as DOMRect);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function anchorButton(): HTMLElement {
+  return screen.getByRole("button", { name: "anchor" });
+}
+
+describe("Tooltip", () => {
+  it.each(["top", "bottom", "left", "right"] as const)(
+    "renders the bubble on side %s with the side stamped",
+    (side) => {
+      render(
+        <Tooltip label="hint" side={side}>
+          <button type="button">anchor</button>
+        </Tooltip>,
+      );
+      fireEvent.mouseEnter(anchorButton());
+      const bubble = screen.getByRole("tooltip");
+      expect(bubble.textContent).toBe("hint");
+      expect(bubble.getAttribute("data-side")).toBe(side);
+      fireEvent.mouseLeave(anchorButton());
+      expect(screen.queryByRole("tooltip")).toBeNull();
+    },
+  );
+
+  it("delays hover show but keeps keyboard focus immediate", () => {
+    render(
+      <Tooltip label="hint" delayMs={300}>
+        <button type="button">anchor</button>
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(anchorButton());
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    act(() => vi.advanceTimersByTime(300));
+    expect(screen.getByRole("tooltip")).not.toBeNull();
+    fireEvent.mouseLeave(anchorButton());
+    fireEvent.focus(anchorButton());
+    expect(screen.getByRole("tooltip")).not.toBeNull();
+  });
+
+  it("hides only after both hover and focus clear", () => {
+    render(
+      <Tooltip label="hint">
+        <button type="button">anchor</button>
+      </Tooltip>,
+    );
+    fireEvent.focus(anchorButton());
+    fireEvent.mouseEnter(anchorButton());
+    fireEvent.mouseLeave(anchorButton());
+    // mouseLeave drops the bubble outright; a still-focused anchor re-shows
+    // on the next focus event, but hide-on-blur must respect focus state.
+    fireEvent.focus(anchorButton());
+    expect(screen.getByRole("tooltip")).not.toBeNull();
+    fireEvent.blur(anchorButton());
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("drops a visible bubble when disabled flips true", () => {
+    const { rerender } = render(
+      <Tooltip label="hint">
+        <button type="button">anchor</button>
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(anchorButton());
+    expect(screen.getByRole("tooltip")).not.toBeNull();
+    rerender(
+      <Tooltip label="hint" disabled>
+        <button type="button">anchor</button>
+      </Tooltip>,
+    );
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+});

--- a/vex-app/src/renderer/components/ui/button.tsx
+++ b/vex-app/src/renderer/components/ui/button.tsx
@@ -1,42 +1,47 @@
 /**
- * shadcn-pattern Button primitive — owned source per skill §2.
- * Pure CSS variants via CVA, no Radix, no asChild slot in M1
- * (defer Radix Slot until something actually composes it).
+ * Button primitive: capsule silhouette (radius = height / 2) on tokens v2.
+ * `primary` is INK/PAPER; `accent` marks the main action only. Hover is an
+ * immediate color change - no transition, no shadow depth.
  */
 
 import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib/utils.js";
 
-/* Brand button language (landing .btn/.wl-btn): pill silhouette + mono
- * uppercase micro-type. `default` is the landing's solid cobalt CTA;
- * `outline` is the hairline ghost. Active press is a 2% settle, hover is a
- * color change only — depth never comes from shadows. */
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full font-mono text-[11px] font-medium uppercase tracking-[0.16em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-1 whitespace-nowrap rounded-capsule text-[14px] leading-[22px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground hover:bg-primary/85",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        primary:
+          "bg-button-primary text-ink-on-primary enabled:hover:bg-button-primary-hover",
+        accent:
+          "bg-accent-primary text-ink-on-accent enabled:hover:bg-accent-hover",
+        ghost:
+          "bg-transparent enabled:hover:bg-interactive-hover enabled:active:bg-interactive-active",
         outline:
-          "border border-border bg-transparent hover:bg-accent hover:text-accent-foreground",
+          "border border-line-2 bg-transparent enabled:hover:bg-interactive-hover",
+        toolbar: "bg-surface-overlay/50 text-ink-on-chrome",
+        // Legacy names kept until phases 3-4 migrate call sites: `default`
+        // was the solid CTA (now the accent action), `secondary` the quiet
+        // pair (now outline), `destructive` the danger action.
+        default:
+          "bg-accent-primary text-ink-on-accent enabled:hover:bg-accent-hover",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline normal-case tracking-normal font-sans text-sm",
+          "border border-line-2 bg-transparent enabled:hover:bg-interactive-hover",
+        destructive:
+          "bg-danger text-ink-on-accent enabled:hover:bg-danger/90",
+        link: "text-accent-primary underline-offset-4 enabled:hover:underline",
       },
       size: {
-        default: "h-9 px-5",
-        sm: "h-8 px-4",
-        lg: "h-11 px-7",
-        icon: "h-9 w-9",
+        default: "h-9 px-3.5",
+        sm: "h-7 px-2.5 text-[12px] leading-[18px]",
+        lg: "h-11 px-5",
+        icon: "h-9 w-9 px-0",
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: "primary",
       size: "default",
     },
   }

--- a/vex-app/src/renderer/components/ui/connection-banner.tsx
+++ b/vex-app/src/renderer/components/ui/connection-banner.tsx
@@ -1,0 +1,22 @@
+/**
+ * ConnectionBanner: top strip surfacing connection loss. Purely
+ * presentational - the owner subscribes to connection state and passes
+ * `reconnecting` and localized copy down; only an actual outage shows the
+ * strip.
+ */
+
+import type { JSX } from "react";
+
+export function ConnectionBanner({ reconnecting, label }: {
+  /** True while the connection is in backoff/retry. */
+  readonly reconnecting: boolean;
+  /** Banner copy, resolved by the owner. */
+  readonly label: string;
+}): JSX.Element | null {
+  if (!reconnecting) return null;
+  return (
+    <div className="vex-connection-banner" role="status">
+      {label}
+    </div>
+  );
+}

--- a/vex-app/src/renderer/components/ui/dialog.tsx
+++ b/vex-app/src/renderer/components/ui/dialog.tsx
@@ -16,9 +16,9 @@
  *     before opening (the trigger).
  *
  * CSP: NO inline `style` attributes anywhere. Every effect is Tailwind
- * + classes from `globals.css`. Backdrop styling rides on the native
- * `::backdrop` pseudo-element via a Tailwind arbitrary variant
- * `backdrop:bg-...` so we don't need a separate sibling div.
+ * + classes from `globals.css`. Backdrop styling (mask + blur) rides on the
+ * native `::backdrop` pseudo-element via the `.vex-dialog` rules in
+ * `global-css/ui-primitives.css`, so we don't need a separate sibling div.
  *
  * Sub-components mirror shadcn naming so application code reads the
  * same as the rest of the project (`<DialogContent>`, `<DialogHeader>`,
@@ -216,29 +216,17 @@ export const DialogContent = forwardRef<HTMLDialogElement, DialogContentProps>(
           // Center the dialog box itself — keeps backdrop-target clicks
           // on the dialog element, not the inner content (so the
           // currentTarget check above is reliable).
-          "fixed inset-0 m-auto max-h-[85vh] w-full max-w-md overflow-hidden",
-          // Brand chrome (Chronos glass, owner correction round 2026-07-20):
-          // floating glass surface — translucent ink + backdrop-blur carries
-          // legibility, a static grain overlay decorates (never a filter on
-          // content — the previous DistortedGlass displacement filter warped
-          // dialog text and is retired), and the white/10 hairline +
-          // rounded-2xl mark it as a floating surface. The rgba fallbacks
-          // keep dialogs identical OUTSIDE the shell scope (wizard/unlock),
-          // where the --vex-* tokens are undefined.
-          "rounded-2xl border border-[var(--vex-line-strong,rgba(255,255,255,0.1))] bg-[var(--vex-glass-strong,rgba(11,15,29,0.82))] p-0 text-card-foreground shadow-none backdrop-blur-xl",
-          "backdrop:bg-black/70 backdrop:backdrop-blur-none",
+          "fixed inset-0 m-auto max-h-[85vh] w-full max-w-[380px] overflow-hidden",
+          // Tokens-v2 chrome: solid layer-2 card, the system's boldest
+          // radius (24), lv3 elevation (its 1px layer draws the edge on
+          // dark). The backdrop mask + blur ride the .vex-dialog class in
+          // ui-primitives.css (native ::backdrop pseudo-element).
+          "vex-dialog rounded-[24px] border border-line-1 bg-surface-2 p-0 text-ink-primary shadow-lv3",
           "open:flex open:flex-col",
           className,
         )}
         {...rest}
       >
-        {/* Decorative static grain over the panel — an empty overlay (no
-         * filter, no defs), so it works identically in wizard/unlock dialogs
-         * mounted outside the shell. -z-10 keeps it under the content. */}
-        <div
-          aria-hidden
-          className="vex-noise vex-noise--panel pointer-events-none absolute inset-0 -z-10 rounded-[inherit]"
-        />
         {children}
       </dialog>
     );
@@ -253,7 +241,9 @@ export const DialogHeader = forwardRef<
   <div
     ref={ref}
     className={cn(
-      "flex shrink-0 flex-col gap-1.5 border-b border-border px-6 py-4",
+      // Asymmetric header: 22 top / 14 right (close-control seat) / 12
+      // bottom / 24 left; no divider - whitespace separates.
+      "flex shrink-0 flex-col gap-1.5 pt-[22px] pr-3.5 pb-3 pl-6",
       className,
     )}
     {...props}
@@ -270,13 +260,9 @@ export const DialogTitle = forwardRef<
     <h2
       ref={ref}
       id={id ?? ctx.titleId}
-      // Brand modal title — the Chronos editorial serif (Instrument Serif),
-      // consistent across every dialog (2026-07-20 redesign; the mono stamp
-      // register is retired for dialog titles).
-      className={cn(
-        "font-serif text-[24px] font-normal leading-tight",
-        className,
-      )}
+      // Chrome register, weight capped at 500 (the serif voice is gate-only
+      // since the tokens-v2 rebrand).
+      className={cn("text-[16px] font-medium leading-6", className)}
       {...props}
     />
   );
@@ -292,7 +278,7 @@ export const DialogDescription = forwardRef<
     <p
       ref={ref}
       id={id ?? ctx.descriptionId}
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn("text-sm text-ink-secondary", className)}
       {...props}
     />
   );
@@ -306,6 +292,7 @@ export const DialogBody = forwardRef<
   <div
     ref={ref}
     className={cn(
+      // 24px side padding keeps the 332px content column at max-w 380.
       "flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5",
       className,
     )}
@@ -321,7 +308,7 @@ export const DialogFooter = forwardRef<
   <div
     ref={ref}
     className={cn(
-      "flex shrink-0 flex-row justify-end gap-2 border-t border-border px-6 py-3",
+      "flex shrink-0 flex-row justify-end gap-2 px-6 pt-3 pb-6",
       className,
     )}
     {...props}

--- a/vex-app/src/renderer/components/ui/disclosure-row.tsx
+++ b/vex-app/src/renderer/components/ui/disclosure-row.tsx
@@ -1,0 +1,99 @@
+/**
+ * DisclosureRow: shared 24px disclosure chrome for compact flow rows. The
+ * 16px leading box crossfades icon <-> chevron on hover (house pattern:
+ * "this row expands" without a permanent chevron); expanded content is
+ * controlled by the owner.
+ */
+
+import type { JSX, KeyboardEvent, MouseEvent, ReactNode } from "react";
+import { IconChevronDown } from "../icons/index.js";
+import { cn } from "../../lib/utils.js";
+
+export interface DisclosureRowProps {
+  readonly icon: ReactNode;
+  readonly title: string;
+  readonly open: boolean;
+  readonly expandable: boolean;
+  readonly onToggle: () => void;
+  /** Makes the complete title row the disclosure target. */
+  readonly expandOnRowClick?: boolean;
+  /** Crossfade the collapsed icon to a chevron while the row is hovered. */
+  readonly previewChevron?: boolean;
+  /** Keeps `collapsedContent` inline while open. */
+  readonly keepContentWhenOpen?: boolean;
+  readonly collapsedContent?: ReactNode;
+  readonly children?: ReactNode;
+  readonly className?: string;
+  readonly titleClassName?: string;
+}
+
+export function DisclosureRow({
+  icon,
+  title,
+  open,
+  expandable,
+  onToggle,
+  expandOnRowClick = false,
+  previewChevron = expandable,
+  keepContentWhenOpen = false,
+  collapsedContent,
+  children,
+  className,
+  titleClassName,
+}: DisclosureRowProps): JSX.Element {
+  const rowExpands = expandable && expandOnRowClick;
+  const toggleFromLeading = (event: MouseEvent<HTMLButtonElement>): void => {
+    event.stopPropagation();
+    onToggle();
+  };
+  const toggleFromKeyboard = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (!rowExpands || (event.key !== "Enter" && event.key !== " ")) return;
+    event.preventDefault();
+    onToggle();
+  };
+  const collapsedLeading = previewChevron ? (
+    <>
+      <span className="vex-disclosure-icon-idle">{icon}</span>
+      <IconChevronDown size={14} className="vex-disclosure-chevron-hover" />
+    </>
+  ) : (
+    icon
+  );
+  const leading = open ? <IconChevronDown size={14} /> : collapsedLeading;
+
+  return (
+    <div
+      className={cn("vex-disclosure-root", className)}
+      data-open={open || undefined}
+    >
+      <div
+        className="vex-disclosure-row"
+        data-disclosure-row
+        data-expandable={rowExpands || undefined}
+        role={rowExpands ? "button" : undefined}
+        tabIndex={rowExpands ? 0 : undefined}
+        aria-expanded={rowExpands ? open : undefined}
+        onClick={rowExpands ? onToggle : undefined}
+        onKeyDown={rowExpands ? toggleFromKeyboard : undefined}
+      >
+        {expandable && !rowExpands ? (
+          <button
+            type="button"
+            className="vex-disclosure-leading"
+            aria-expanded={open}
+            onClick={toggleFromLeading}
+          >
+            {leading}
+          </button>
+        ) : (
+          <span className="vex-disclosure-leading">{leading}</span>
+        )}
+        <span className={cn("vex-disclosure-title", titleClassName)}>
+          {title}
+        </span>
+        {(keepContentWhenOpen || !open) && collapsedContent}
+      </div>
+      {open && children}
+    </div>
+  );
+}

--- a/vex-app/src/renderer/components/ui/drop-overlay.tsx
+++ b/vex-app/src/renderer/components/ui/drop-overlay.tsx
@@ -1,0 +1,68 @@
+/**
+ * DropOverlay: full-viewport invitation shown while a file drag is over the
+ * page. Decoration only: pointer-events none keeps drag targeting on the
+ * page below, so the owner's document-level listeners keep an accurate
+ * enter/leave count and own accept/reject. Body-portaled so a transformed
+ * ancestor cannot trap the fixed layer. Copy arrives via props.
+ */
+
+import type { JSX, ReactPortal } from "react";
+import { createPortal } from "react-dom";
+
+export interface DropOverlayLabels {
+  /** Headline inviting the drop, or naming why it is unavailable. */
+  readonly title: string;
+  /** Limits line under the title; shown only while drops are accepted. */
+  readonly desc?: string;
+}
+
+export function DropOverlay({ disabled, labels }: {
+  /** Drops are currently refused; drops the desc line and greys the cards. */
+  readonly disabled: boolean;
+  readonly labels: DropOverlayLabels;
+}): ReactPortal {
+  return createPortal(
+    <div className="vex-drop-overlay" role="status">
+      <div className="vex-drop-overlay-wrap">
+        <div className="vex-drop-overlay-illustration" aria-hidden="true">
+          <DropIllustration disabled={disabled} />
+        </div>
+        <div className="vex-drop-overlay-title">{labels.title}</div>
+        {!disabled && labels.desc !== undefined && (
+          <div className="vex-drop-overlay-desc">{labels.desc}</div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+/** Tilted photo-and-note cards in the accent family; greyed when disabled. */
+function DropIllustration({ disabled }: { readonly disabled: boolean }): JSX.Element {
+  const cardA = disabled
+    ? "var(--vex-alias-label-dimmed)"
+    : "var(--vex-alias-accent-wash)";
+  const cardB = disabled
+    ? "var(--vex-alias-label-dimmed)"
+    : "var(--vex-alias-accent-hover)";
+  const cardC = disabled
+    ? "var(--vex-alias-label-tertiary)"
+    : "var(--vex-alias-accent-primary)";
+  const stroke = "var(--vex-alias-bg-base)";
+  return (
+    <svg width="115" height="84" viewBox="0 0 115 84" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect y="17" width="44" height="44" rx="12" transform="rotate(-22.7 0 17)" fill={cardA} />
+      <rect x="73.4" y="8.5" width="44" height="50" rx="8" transform="rotate(17.4 73.4 8.5)" fill={cardB} />
+      <path d="M77.5 26.3 101 33.8M72.3 42.8l14.1 4.5M74.9 34.5l23.5 7.5" stroke={stroke} strokeWidth="3" />
+      <rect x="31.6" y="38.7" width="45" height="44.4" rx="12" fill={cardC} />
+      <path d="M39 73c0.7-1.3 2.8-6.9 4.6-11.8 0.6-1.8 3.2-1.8 3.9 0 1.5 3.7 3.3 7.5 4.5 8 2.3 1 6-9.8 16 1" stroke={stroke} strokeWidth="3" />
+      <circle cx="60.6" cy="52.2" r="4.4" fill={stroke} />
+      {disabled && (
+        <g>
+          <circle cx="54" cy="57" r="14" stroke={stroke} strokeWidth="3.5" fill="none" />
+          <path d="M44 47l20 20" stroke={stroke} strokeWidth="3.5" strokeLinecap="round" />
+        </g>
+      )}
+    </svg>
+  );
+}

--- a/vex-app/src/renderer/components/ui/hover-card.tsx
+++ b/vex-app/src/renderer/components/ui/hover-card.tsx
@@ -1,0 +1,144 @@
+/**
+ * HoverCard: delayed hover-preview card portaled to document.body, fixed at
+ * the anchor's right edge and repositioned on scroll/resize while open. The
+ * card is hit-testable on purpose: leaving the anchor only arms a
+ * grace-delayed close, so the pointer can cross the 8px gap and settle on
+ * the card. The portaled card is a React child of the wrapper, so one pair
+ * of wrapper handlers covers anchor and card alike.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type JSX,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { usePointerGrace } from "../../lib/pointer-grace.js";
+
+/** Gap between the anchor's right edge and the card. */
+const OFFSET = 8;
+/** Clamp margin to the viewport bottom edge. */
+const EDGE = 8;
+
+export function HoverCard({
+  anchor,
+  content,
+  openDelayMs = 500,
+  disabled = false,
+}: {
+  /** The hover target (rendered in place inside a wrapper span). */
+  readonly anchor: ReactNode;
+  /** Card content; readable and selectable, no dismissal affordance. */
+  readonly content: ReactNode;
+  /** Hover dwell before the card shows. */
+  readonly openDelayMs?: number;
+  /** Suppress opening; turning true closes an open card. */
+  readonly disabled?: boolean;
+}): JSX.Element {
+  const rootRef = useRef<HTMLSpanElement>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+
+  const close = useCallback(() => {
+    setOpen(false);
+  }, []);
+  const { arm: armClose, cancel: cancelClose } = usePointerGrace(close);
+
+  const clearTimer = (): void => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  // Owner disabling mid-hover (menu opened, drag started) closes immediately.
+  useEffect(() => {
+    if (!disabled) return;
+    clearTimer();
+    cancelClose();
+    close();
+  }, [disabled, cancelClose, close]);
+
+  useEffect(() => clearTimer, []);
+
+  // Fixed-position from the anchor rect before paint; track the anchor while
+  // open (capture-phase scroll catches nested panes).
+  useLayoutEffect(() => {
+    if (!open) {
+      setPos(null);
+      return;
+    }
+    const place = (): void => {
+      const wrapper = rootRef.current;
+      if (wrapper === null) return;
+      const r = wrapper.getBoundingClientRect();
+      const h = cardRef.current?.offsetHeight ?? 0;
+      const top =
+        r.top + h > window.innerHeight - EDGE
+          ? window.innerHeight - h - EDGE
+          : r.top;
+      setPos({ left: r.right + OFFSET, top });
+    };
+    place();
+    window.addEventListener("scroll", place, true);
+    window.addEventListener("resize", place);
+    return () => {
+      window.removeEventListener("scroll", place, true);
+      window.removeEventListener("resize", place);
+    };
+  }, [open]);
+
+  // The first placement ran before the card mounted (height read 0): once
+  // the real height is measurable, correct the bottom-edge clamp. The
+  // correction converges - a clamped top satisfies the guard, so it runs once.
+  useLayoutEffect(() => {
+    if (!open || pos === null) return;
+    const h = cardRef.current?.offsetHeight ?? 0;
+    if (pos.top + h > window.innerHeight - EDGE) {
+      setPos({ left: pos.left, top: window.innerHeight - h - EDGE });
+    }
+  }, [open, pos]);
+
+  const card = open && pos !== null && (
+    <div ref={cardRef} className="vex-hover-card" style={pos}>
+      {content}
+    </div>
+  );
+
+  return (
+    <span
+      ref={rootRef}
+      className="vex-hover-card-root"
+      onPointerEnter={() => {
+        if (disabled) return;
+        // Coming back inside during the grace (the gap, or the card itself)
+        // keeps the current card rather than restarting the dwell.
+        cancelClose();
+        if (open) return;
+        clearTimer();
+        timerRef.current = setTimeout(() => setOpen(true), openDelayMs);
+      }}
+      onPointerLeave={() => {
+        clearTimer();
+        if (open) armClose();
+      }}
+      // A press inside the anchor dismisses the card immediately; a press on
+      // the card itself starts a selection, so the card stays mounted.
+      onPointerDownCapture={(e) => {
+        if (cardRef.current?.contains(e.target as Node)) return;
+        clearTimer();
+        cancelClose();
+        close();
+      }}
+    >
+      {anchor}
+      {card !== false && createPortal(card, document.body)}
+    </span>
+  );
+}

--- a/vex-app/src/renderer/components/ui/image-lightbox.tsx
+++ b/vex-app/src/renderer/components/ui/image-lightbox.tsx
@@ -1,0 +1,66 @@
+/**
+ * ImageLightbox: document-level original-image preview opened by clicking a
+ * thumbnail. Closes on Escape, backdrop press, or the close control, and
+ * restores focus to the opener on unmount. Body-portaled: an opener inside
+ * a transformed/filtered ancestor would otherwise trap the fixed backdrop.
+ * Copy (dialog/close labels) arrives via props.
+ */
+
+import { useEffect, useRef, type ReactPortal } from "react";
+import { createPortal } from "react-dom";
+import { IconClose } from "../icons/index.js";
+
+export interface ImageLightboxLabels {
+  /** Accessible name of the preview dialog. */
+  readonly dialog: string;
+  /** Accessible label of the close control. */
+  readonly close: string;
+}
+
+export function ImageLightbox({ src, alt, labels, onClose }: {
+  readonly src: string;
+  readonly alt: string;
+  readonly labels: ImageLightboxLabels;
+  readonly onClose: () => void;
+}): ReactPortal {
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+  const restoreRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    restoreRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    closeRef.current?.focus();
+    const onKeyDown = (event: globalThis.KeyboardEvent): void => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      restoreRef.current?.focus();
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      className="vex-lightbox"
+      role="dialog"
+      aria-modal="true"
+      aria-label={labels.dialog}
+    >
+      <div className="vex-lightbox-mask" aria-hidden="true" onMouseDown={onClose} />
+      <img className="vex-lightbox-image" src={src} alt={alt} />
+      <button
+        ref={closeRef}
+        type="button"
+        className="vex-lightbox-close"
+        aria-label={labels.close}
+        onClick={onClose}
+      >
+        <IconClose size={16} />
+      </button>
+    </div>,
+    document.body,
+  );
+}

--- a/vex-app/src/renderer/components/ui/input.tsx
+++ b/vex-app/src/renderer/components/ui/input.tsx
@@ -1,8 +1,7 @@
 /**
- * shadcn-pattern Input primitive — owned source per skill §2.
- * Pure CSS, no Radix. Uses semantic Tailwind tokens (border-input,
- * bg-background, ring-ring) so the Vex paletka tokens defined in
- * `globals.css` flow through automatically.
+ * Input primitive on tokens v2: r-md, input-tier stroke (one step thinner
+ * in dark), accent caret. Deliberately NO focus ring - the caret and the
+ * stroke are the whole focus treatment.
  *
  * Forwarded ref is the plumbing the wizard's password fields need
  * (uncontrolled `<input type="password">` with React Hook Form's
@@ -20,13 +19,11 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       ref={ref}
       type={type}
       className={cn(
-        // Landing .wl-form input grammar: transparent field, hairline border,
-        // focus lights the border with the accent (no shadow depth).
-        "flex h-9 w-full rounded-lg border border-input bg-transparent px-3 py-1 text-sm transition-colors",
+        "flex h-9 w-full rounded-md border border-line-input bg-transparent px-3 py-1 text-sm text-ink-primary caret-accent-primary",
         "file:border-0 file:bg-transparent file:text-sm file:font-medium",
-        "placeholder:text-muted-foreground",
-        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:border-[var(--color-ring)]",
-        "disabled:cursor-not-allowed disabled:opacity-50",
+        "placeholder:text-ink-tertiary",
+        "focus-visible:outline-none",
+        "disabled:cursor-not-allowed disabled:opacity-40",
         className
       )}
       {...props}

--- a/vex-app/src/renderer/components/ui/label.tsx
+++ b/vex-app/src/renderer/components/ui/label.tsx
@@ -15,7 +15,7 @@ export const Label = forwardRef<HTMLLabelElement, LabelProps>(
     <label
       ref={ref}
       className={cn(
-        "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        "text-sm font-medium leading-none text-ink-secondary peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
         className
       )}
       {...props}

--- a/vex-app/src/renderer/components/ui/menu.tsx
+++ b/vex-app/src/renderer/components/ui/menu.tsx
@@ -1,0 +1,339 @@
+/**
+ * Menu: controlled dropdown primitive. Default is pure CSS positioning
+ * relative to the anchor wrapper; opt-in `portal` renders the list into
+ * document.body, fixed-positioned from the anchor rect, for anchors inside
+ * overflow-clipping containers. Entries cover items, separators, and
+ * non-interactive labels; submenus open on hover/focus inside the same
+ * root. No entry animation by design. Copy arrives via entry labels.
+ */
+
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type JSX,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { IconCheck } from "../icons/index.js";
+import { usePointerGrace } from "../../lib/pointer-grace.js";
+import { cn } from "../../lib/utils.js";
+
+/** Selectable row (optionally with a nested submenu). */
+export interface MenuItem {
+  readonly id: string;
+  readonly label: ReactNode;
+  readonly disabled?: boolean;
+  /** Leading 16px icon (14 in compact). */
+  readonly icon?: ReactNode;
+  /** Destructive row: error-colored text/icon and danger hover fill. */
+  readonly danger?: boolean;
+  /** Nested card opened to the right on hover/focus. */
+  readonly submenu?: readonly MenuItem[];
+}
+
+/** Hairline between item groups (not selectable). */
+export interface MenuSeparator {
+  readonly type: "separator";
+  readonly id: string;
+}
+
+/** Non-interactive heading row above a group of items. */
+export interface MenuLabel {
+  readonly type: "label";
+  readonly id: string;
+  readonly text: string;
+}
+
+export type MenuEntry = MenuItem | MenuSeparator | MenuLabel;
+
+function isSeparator(entry: MenuEntry): entry is MenuSeparator {
+  return "type" in entry && entry.type === "separator";
+}
+
+function isLabel(entry: MenuEntry): entry is MenuLabel {
+  return "type" in entry && entry.type === "label";
+}
+
+/** Unplaced portal list: hidden but laid out so offsetWidth/Height are real. */
+const MEASURE_STYLE: CSSProperties = { visibility: "hidden", left: 0, top: 0 };
+
+/** Clamp margin between a portaled list and the viewport edges. */
+const MARGIN = 12;
+
+export interface MenuProps {
+  /** Whether the list is showing (owner-controlled). */
+  readonly open: boolean;
+  /** The trigger element (rendered in place). */
+  readonly anchor: ReactNode;
+  readonly items: readonly MenuEntry[];
+  /** Rows pinned below the scrolling items area, behind a hairline. */
+  readonly footer?: readonly MenuEntry[];
+  readonly selectedId?: string;
+  /** Independent option groups: rows shown as selected. */
+  readonly selectedIds?: readonly string[];
+  readonly onSelect: (id: string) => void;
+  /** Invoked on outside pointerdown or Escape. */
+  readonly onClose: () => void;
+  readonly align?: "start" | "end";
+  readonly side?: "bottom" | "top" | "right";
+  /** Render into document.body, fixed-positioned from the anchor rect. */
+  readonly portal?: boolean;
+  /** Close once the pointer has left trigger + list for the pointer grace. */
+  readonly closeOnPointerLeave?: boolean;
+  /** Reduced row spacing, standard typography. */
+  readonly dense?: boolean;
+  /** Reduced typography and spacing. */
+  readonly compact?: boolean;
+  /**
+   * Portal mode only: supply the anchor rect directly instead of measuring
+   * the wrapper span (render-prop anchors, effect-positioned proxies).
+   * Return null to skip placement for that frame.
+   */
+  readonly getAnchorRect?: () => DOMRect | null;
+  readonly className?: string;
+}
+
+export function Menu({
+  open,
+  anchor,
+  items,
+  footer,
+  selectedId,
+  selectedIds,
+  onSelect,
+  onClose,
+  align = "start",
+  side = "bottom",
+  portal = false,
+  closeOnPointerLeave = false,
+  dense = false,
+  compact = false,
+  getAnchorRect,
+  className,
+}: MenuProps): JSX.Element {
+  const rootRef = useRef<HTMLSpanElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const [openSubmenuId, setOpenSubmenuId] = useState<string | null>(null);
+  const [fixedPos, setFixedPos] = useState<CSSProperties | null>(null);
+  const { arm: armClose, cancel: cancelClose } = usePointerGrace(onClose);
+
+  // Portal mode: fixed-position the list from the anchor rect before paint;
+  // track the anchor while open (capture-phase scroll catches nested panes).
+  // getAnchorRect trumps measuring the wrapper span: a child layout effect
+  // runs before the parent's, so a wrapper the host positions in its own
+  // effect measures stale here.
+  useLayoutEffect(() => {
+    if (!open || !portal) {
+      setFixedPos(null);
+      return;
+    }
+    const place = (): void => {
+      const r =
+        getAnchorRect !== undefined
+          ? getAnchorRect()
+          : rootRef.current?.getBoundingClientRect() ?? null;
+      if (r === null) return;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const listEl = listRef.current;
+      const lw = listEl?.offsetWidth ?? 0;
+      const lh = listEl?.offsetHeight ?? 0;
+
+      let x: number;
+      let y: number;
+      if (side === "right") {
+        x = r.right + 4;
+        y = r.top;
+      } else if (align === "start") {
+        x = r.left;
+        y = side === "bottom" ? r.bottom + 4 : r.top - lh - 4;
+      } else {
+        x = r.right - lw;
+        y = side === "bottom" ? r.bottom + 4 : r.top - lh - 4;
+      }
+
+      if (lw > 0) x = Math.min(Math.max(x, MARGIN), vw - lw - MARGIN);
+      if (lh > 0) y = Math.min(Math.max(y, MARGIN), vh - lh - MARGIN);
+
+      setFixedPos({ left: x, top: y });
+    };
+    // First run measures the hidden pre-render (same commit as `open`), so
+    // alignment and clamping use real dimensions before anything paints.
+    place();
+    window.addEventListener("scroll", place, true);
+    window.addEventListener("resize", place);
+    return () => {
+      window.removeEventListener("scroll", place, true);
+      window.removeEventListener("resize", place);
+    };
+  }, [open, portal, align, side, getAnchorRect]);
+
+  useEffect(() => {
+    if (!open) {
+      setOpenSubmenuId(null);
+      return;
+    }
+    const onPointerDown = (e: PointerEvent): void => {
+      if (!(e.target instanceof Node)) return;
+      // The portaled list is outside the anchor subtree; check both.
+      if (rootRef.current?.contains(e.target) === true) return;
+      if (listRef.current?.contains(e.target) === true) return;
+      onClose();
+    };
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, onClose]);
+
+  // A close from selection/Escape/outside click outruns a pending grace
+  // close; left armed it would shut a list reopened inside the grace window.
+  // Its own effect: the listener effect above re-runs on every `onClose`
+  // identity change and would cancel the grace mid-transit.
+  useEffect(() => {
+    if (!open) cancelClose();
+  }, [open, cancelClose]);
+
+  // The submenu card is absolutely positioned outside the list box; the
+  // scroll clip would crop it, so only submenu-free menus get the height cap.
+  const scrollable = !items.some(
+    (entry) =>
+      !isSeparator(entry) &&
+      !isLabel(entry) &&
+      entry.submenu !== undefined &&
+      entry.submenu.length > 0,
+  );
+
+  const renderEntry = (entry: MenuEntry): JSX.Element => {
+    if (isSeparator(entry)) {
+      return <div key={entry.id} className="vex-menu-separator" role="separator" />;
+    }
+    if (isLabel(entry)) {
+      return (
+        <div key={entry.id} className="vex-menu-heading" role="presentation">
+          {entry.text}
+        </div>
+      );
+    }
+    const hasSub = entry.submenu !== undefined && entry.submenu.length > 0;
+    const subOpen = hasSub && openSubmenuId === entry.id;
+    const selected =
+      entry.id === selectedId || selectedIds?.includes(entry.id) === true;
+    return (
+      <div
+        key={entry.id}
+        className="vex-menu-item-wrap"
+        onMouseEnter={() => setOpenSubmenuId(hasSub ? entry.id : null)}
+        onMouseLeave={() => setOpenSubmenuId(null)}
+      >
+        <button
+          type="button"
+          role="menuitem"
+          className={cn("vex-menu-item", entry.danger === true && "vex-menu-danger")}
+          disabled={entry.disabled}
+          aria-haspopup={hasSub ? "menu" : undefined}
+          aria-expanded={hasSub ? subOpen : undefined}
+          onFocus={() => setOpenSubmenuId(hasSub ? entry.id : null)}
+          onClick={() => {
+            if (hasSub) {
+              setOpenSubmenuId(entry.id);
+              return;
+            }
+            onSelect(entry.id);
+          }}
+        >
+          {entry.icon !== undefined && (
+            <span className="vex-menu-item-icon">{entry.icon}</span>
+          )}
+          <span className="vex-menu-item-label">{entry.label}</span>
+          {/* Selection marker is a trailing check, never a fill. */}
+          {selected && <IconCheck size={16} className="vex-menu-check" />}
+        </button>
+        {subOpen && entry.submenu !== undefined && (
+          <div
+            className={cn("vex-menu-submenu", compact && "vex-menu-compact")}
+            role="menu"
+          >
+            {entry.submenu.map((sub) => (
+              <button
+                key={sub.id}
+                type="button"
+                role="menuitem"
+                className="vex-menu-item"
+                disabled={sub.disabled}
+                onClick={() => onSelect(sub.id)}
+              >
+                {sub.icon !== undefined && (
+                  <span className="vex-menu-item-icon">{sub.icon}</span>
+                )}
+                <span className="vex-menu-item-label">{sub.label}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // Portal lists render hidden until placed: the placement effect measures
+  // this pre-render in the same commit, so the first painted frame is
+  // already at the final position.
+  const list = open && (
+    <div
+      ref={listRef}
+      className={cn(
+        "vex-menu",
+        dense && "vex-menu-dense",
+        compact && "vex-menu-compact",
+        scrollable && "vex-menu-scrollable",
+        portal && "vex-menu-portal",
+        side === "top" && !portal && "vex-menu-side-top",
+        align === "end" && !portal && "vex-menu-align-end",
+      )}
+      style={portal ? fixedPos ?? MEASURE_STYLE : undefined}
+      role="menu"
+      // React portals bubble synthetic events through the REACT tree:
+      // without this stop, an item click re-fires the anchor row's own
+      // onClick (open/toggle) after onSelect.
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="vex-menu-viewport" role="presentation">
+        {items.map(renderEntry)}
+      </div>
+      {footer !== undefined && footer.length > 0 && (
+        <div className="vex-menu-footer" role="presentation">
+          {footer.map(renderEntry)}
+        </div>
+      )}
+    </div>
+  );
+
+  // Pointer-leave dismissal watches the WRAPPER, not the list: React's
+  // enter/leave traversal runs over the React tree, so trigger and portaled
+  // list are one region here - crossing the 4px gap never counts as leaving.
+  return (
+    <span
+      ref={rootRef}
+      className={cn("vex-menu-root", className)}
+      onPointerEnter={closeOnPointerLeave ? cancelClose : undefined}
+      onPointerLeave={
+        closeOnPointerLeave
+          ? () => {
+              if (open) armClose();
+            }
+          : undefined
+      }
+    >
+      {anchor}
+      {portal ? list !== false && createPortal(list, document.body) : list}
+    </span>
+  );
+}

--- a/vex-app/src/renderer/components/ui/pill.tsx
+++ b/vex-app/src/renderer/components/ui/pill.tsx
@@ -1,0 +1,67 @@
+/**
+ * Pill: small capsule label chip (view switchers, filters, badges).
+ * Interactive when onClick is supplied (renders a button); otherwise a
+ * static span. Capsule radius = height / 2.
+ */
+
+import type { ButtonHTMLAttributes, JSX, ReactNode } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../../lib/utils.js";
+
+const pillVariants = cva(
+  "inline-flex items-center gap-1 whitespace-nowrap rounded-capsule border-0",
+  {
+    variants: {
+      variant: {
+        neutral: "bg-surface-2 text-ink-secondary",
+        accent: "bg-accent-wash text-accent-primary",
+        danger: "bg-danger-wash text-danger",
+      },
+      size: {
+        md: "h-6 px-2 text-[12px] leading-[18px]",
+        sm: "h-5 px-1.5 text-[11px] leading-[14px]",
+      },
+    },
+    defaultVariants: {
+      variant: "neutral",
+      size: "md",
+    },
+  },
+);
+
+export interface PillProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof pillVariants> {
+  readonly children?: ReactNode;
+}
+
+export function Pill({
+  variant,
+  size,
+  className,
+  children,
+  onClick,
+  ...rest
+}: PillProps): JSX.Element {
+  if (onClick === undefined) {
+    return (
+      <span className={cn(pillVariants({ variant, size }), className)}>
+        {children}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className={cn(
+        pillVariants({ variant, size }),
+        "cursor-pointer enabled:hover:bg-interactive-hover",
+        className,
+      )}
+      onClick={onClick}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/vex-app/src/renderer/components/ui/select-menu.tsx
+++ b/vex-app/src/renderer/components/ui/select-menu.tsx
@@ -197,9 +197,9 @@ export function SelectMenu({
         onClick={() => (open ? setOpen(false) : openMenu())}
         onKeyDown={handleKeyDown}
         className={cn(
-          "flex h-9 w-full items-center justify-between gap-2 rounded-lg border border-white/[0.08] bg-white/[0.035] px-2 text-left text-sm text-foreground",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent,var(--color-accent-primary))]",
-          "disabled:cursor-not-allowed disabled:opacity-60",
+          "flex h-9 w-full items-center justify-between gap-2 rounded-lg border border-line-input bg-transparent px-2 text-left text-sm text-ink-primary",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary",
+          "disabled:cursor-not-allowed disabled:opacity-40",
           className,
         )}
       >
@@ -207,7 +207,7 @@ export function SelectMenu({
           className={cn(
             "min-w-0 truncate",
             shimmerLabels && "vex-preview-shimmer",
-            selectedIndex < 0 && "text-[var(--color-text-muted)]",
+            selectedIndex < 0 && "text-ink-tertiary",
           )}
           data-shimmer-text={shimmerLabels ? selectedLabel : undefined}
         >
@@ -218,7 +218,7 @@ export function SelectMenu({
           size={15}
           aria-hidden
           className={cn(
-            "shrink-0 text-[var(--color-text-muted)] transition-transform",
+            "shrink-0 text-ink-tertiary transition-transform",
             open && "rotate-180",
           )}
         />
@@ -230,14 +230,13 @@ export function SelectMenu({
           role="listbox"
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy}
-          // Solid semantic popover surface (A6) — depth from luminance + a
-          // hairline, never backdrop blur or a resting glow. `placement`
-          // flips the anchor edge (down vs up); everything else is shared.
-          // The listbox FLOATS (absolute + z-30 + its own max-h scroll): it
-          // overlays whatever follows the trigger and never pushes layout —
-          // the Personalize dialog's chip rows sit under it while open.
+          // Solid layer-2 popover: hairline + lv3 elevation, never blur or
+          // glow; its scrollbar rebinds to the elevated (l2) pair.
+          // `placement` flips the anchor edge (down vs up). The listbox
+          // FLOATS (absolute + z-30 + its own max-h scroll): it overlays
+          // whatever follows the trigger and never pushes layout.
           className={cn(
-            "absolute left-0 right-0 z-30 max-h-56 overflow-y-auto rounded-lg border border-border bg-popover p-1 text-popover-foreground",
+            "vex-scroll-elevated absolute left-0 right-0 z-30 max-h-56 overflow-y-auto rounded-xl border border-line-1 bg-surface-2 p-1 text-ink-primary shadow-lv3",
             placement === "top" ? "bottom-full mb-1" : "top-full mt-1",
           )}
         >
@@ -255,9 +254,9 @@ export function SelectMenu({
                 className={cn(
                   "flex cursor-pointer items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-sm",
                   active
-                    ? "bg-[var(--vex-accent-fill-12,color-mix(in_oklab,var(--color-accent-primary)_12%,transparent))] text-foreground"
-                    : "text-[var(--color-text-secondary)]",
-                  selected && !active && "text-foreground",
+                    ? "bg-interactive-hover text-ink-primary"
+                    : "text-ink-secondary",
+                  selected && !active && "text-ink-primary",
                 )}
               >
                 <span
@@ -269,7 +268,7 @@ export function SelectMenu({
                 {selected ? (
                   <span
                     aria-hidden
-                    className="ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--vex-accent,var(--color-accent-primary))]"
+                    className="ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-accent-primary"
                   />
                 ) : null}
               </li>

--- a/vex-app/src/renderer/components/ui/state-dot.tsx
+++ b/vex-app/src/renderer/components/ui/state-dot.tsx
@@ -1,0 +1,58 @@
+/**
+ * StateDot: state indicator. done/warning/error: a solid core inside a
+ * same-color 10%-opacity halo. ongoing: a pixel-art chase - the 8 outer
+ * cells of a 3x3 matrix light up clockwise with a stepped, flat-hold trail.
+ * Colors resolve through state aliases only.
+ */
+
+import type { JSX } from "react";
+import { cn } from "../../lib/utils.js";
+
+export type StateDotState = "done" | "warning" | "ongoing" | "error";
+
+/** Outer 3x3 matrix cells (2px pixels on a 10px grid), clockwise from top-left. */
+const MATRIX_CELLS: readonly (readonly [number, number])[] = [
+  [0, 0], [4, 0], [8, 0], [8, 4], [8, 8], [4, 8], [0, 8], [0, 4],
+];
+
+export function StateDot({ state, size = 10, className }: {
+  readonly state: StateDotState;
+  /** Outer diameter in px. */
+  readonly size?: number;
+  readonly className?: string;
+}): JSX.Element {
+  if (state === "ongoing") {
+    return (
+      <svg
+        className={cn("vex-state-matrix", className)}
+        data-state="ongoing"
+        width={size}
+        height={size}
+        viewBox="0 0 10 10"
+        shapeRendering="crispEdges"
+        aria-hidden="true"
+      >
+        {MATRIX_CELLS.map(([x, y], index) => (
+          <rect
+            key={`${x}-${y}`}
+            className="vex-state-cell"
+            x={x}
+            y={y}
+            width="2"
+            height="2"
+            /* Negative delay phases the chase so every cell animates from mount. */
+            style={{ animationDelay: `${(index - MATRIX_CELLS.length) * 125}ms` }}
+          />
+        ))}
+      </svg>
+    );
+  }
+  return (
+    <span
+      className={cn("vex-state-dot", className)}
+      data-state={state}
+      style={{ width: size, height: size }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/vex-app/src/renderer/components/ui/tabs.tsx
+++ b/vex-app/src/renderer/components/ui/tabs.tsx
@@ -75,10 +75,9 @@ export const TabsList = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement
     <div
       ref={ref}
       role="tablist"
-      // Landing hairline grammar — transparent rail bounded by a hairline,
-      // never a filled muted slab.
+      // Transparent rail bounded by a hairline, never a filled muted slab.
       className={cn(
-        "inline-flex h-9 items-center justify-center gap-1 rounded-lg border border-white/[0.16] bg-transparent p-1 text-[var(--color-text-muted)]",
+        "inline-flex h-9 items-center justify-center gap-1 rounded-lg border border-line-3 bg-transparent p-1 text-ink-tertiary",
         className
       )}
       {...props}
@@ -151,13 +150,13 @@ export const TabsTrigger = forwardRef<HTMLButtonElement, TabsTriggerProps>(
         data-tab-value={value}
         onClick={() => ctx.setValue(value)}
         onKeyDown={handleKeyDown}
-        // Mono micro-label triggers (landing chrome register); the active
-        // tab is an accent-fill step, not a shadowed slab.
+        // Chrome-register triggers (13/20 max w500); the active tab is a
+        // quiet interactive wash, not a shadowed slab.
         className={cn(
-          "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 font-mono text-[11px] font-medium uppercase tracking-[0.14em] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-[13px] leading-5 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           isActive
-            ? "bg-[color-mix(in_oklab,var(--color-accent-primary)_12%,transparent)] text-[var(--color-text-primary)]"
-            : "text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]",
+            ? "bg-interactive-active text-ink-primary"
+            : "text-ink-tertiary hover:text-ink-primary",
           className
         )}
         {...props}

--- a/vex-app/src/renderer/components/ui/toast-host.tsx
+++ b/vex-app/src/renderer/components/ui/toast-host.tsx
@@ -1,0 +1,22 @@
+/**
+ * ToastHost: mounts once near the app root and renders the store's current
+ * toast. Keyed by the per-show id so re-showing restarts the CSS cycle.
+ */
+
+import { useCallback, useSyncExternalStore, type JSX } from "react";
+import { Toast } from "./toast.js";
+import {
+  clearToast,
+  getToastSnapshot,
+  subscribeToast,
+} from "../../lib/toast.js";
+
+export function ToastHost(): JSX.Element | null {
+  const toast = useSyncExternalStore(subscribeToast, getToastSnapshot);
+  const id = toast?.id;
+  const onDone = useCallback(() => {
+    if (id !== undefined) clearToast(id);
+  }, [id]);
+  if (toast === null) return null;
+  return <Toast key={toast.id} text={toast.text} tone={toast.tone} onDone={onDone} />;
+}

--- a/vex-app/src/renderer/components/ui/toast.tsx
+++ b/vex-app/src/renderer/components/ui/toast.tsx
@@ -1,0 +1,43 @@
+/**
+ * Toast: transient top-center banner on a dark plate in both themes.
+ * Slides in, holds, fades out via CSS only, then reports done so the host
+ * unmounts it. Rendered through a body portal so a transformed/filtered
+ * ancestor cannot trap the fixed banner.
+ */
+
+import { useEffect, type ReactPortal } from "react";
+import { createPortal } from "react-dom";
+import { IconWarning } from "../icons/index.js";
+import type { ToastTone } from "../../lib/toast.js";
+
+/**
+ * INVARIANT: HOLD_MS + FADE_MS drive the unmount timer and MUST equal the
+ * vex-toast-fade delay (3000ms) and duration (1000ms) in
+ * styles/global-css/ui-primitives.css - a mismatched sheet either cuts the
+ * fade or leaves an invisible banner.
+ */
+export const HOLD_MS = 3000;
+export const FADE_MS = 1000;
+
+export function Toast({ text, tone = "neutral", onDone }: {
+  readonly text: string;
+  readonly tone?: ToastTone;
+  /** Called once the fade completes; unmount the toast here. */
+  readonly onDone: () => void;
+}): ReactPortal {
+  useEffect(() => {
+    const timer = setTimeout(onDone, HOLD_MS + FADE_MS);
+    return () => clearTimeout(timer);
+  }, [onDone]);
+  return createPortal(
+    <div className="vex-toast" data-tone={tone} role="alert">
+      {tone !== "neutral" && (
+        <span className="vex-toast-icon" aria-hidden>
+          <IconWarning size={16} />
+        </span>
+      )}
+      <span className="vex-toast-text">{text}</span>
+    </div>,
+    document.body,
+  );
+}

--- a/vex-app/src/renderer/components/ui/tooltip.tsx
+++ b/vex-app/src/renderer/components/ui/tooltip.tsx
@@ -1,0 +1,228 @@
+/**
+ * Tooltip: hover/focus label bubble (dark plate, white text in both themes).
+ * The anchor is the child element itself (cloneElement, no wrapper node), so
+ * attaching a tooltip never changes the anchor's layout context. The bubble
+ * is position:fixed with coordinates from the anchor's rect at show time, so
+ * it escapes ancestor overflow clipping without a portal. Copy arrives via
+ * the `label` prop.
+ */
+
+import {
+  cloneElement,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type FocusEventHandler,
+  type JSX,
+  type MouseEventHandler,
+  type MutableRefObject,
+  type ReactElement,
+  type Ref,
+} from "react";
+
+export type TooltipSide = "top" | "bottom" | "left" | "right";
+
+interface AnchorProps {
+  ref?: Ref<HTMLElement> | undefined;
+  onMouseEnter?: MouseEventHandler | undefined;
+  onMouseLeave?: MouseEventHandler | undefined;
+  onFocus?: FocusEventHandler | undefined;
+  onBlur?: FocusEventHandler | undefined;
+}
+
+type TooltipLabel = string | (() => string);
+
+const EDGE_MARGIN = 12;
+/** Gap between the anchor edge and the bubble, every side. */
+const OFFSET = 8;
+
+export function Tooltip({
+  label,
+  side = "right",
+  delayMs = 0,
+  disabled = false,
+  maxWidth,
+  children,
+}: {
+  /** Bubble text, or a resolver evaluated only while visible. */
+  readonly label: TooltipLabel;
+  readonly side?: TooltipSide;
+  /** Hover delay; keyboard focus remains immediate. */
+  readonly delayMs?: number;
+  /** Suppress the bubble; the anchor renders identically (no remount). */
+  readonly disabled?: boolean;
+  /** Width cap for labels the 50vw default would render as a slab. */
+  readonly maxWidth?: number;
+  readonly children: ReactElement<AnchorProps>;
+}): JSX.Element {
+  const anchor = useRef<HTMLElement | null>(null);
+  // Forward the child's own ref so wrapping never severs the owner's ref.
+  const childRef = (children as ReactElement<AnchorProps> & {
+    ref?: Ref<HTMLElement>;
+  }).ref;
+  const mergedRef = useCallback(
+    (el: HTMLElement | null) => {
+      anchor.current = el;
+      if (typeof childRef === "function") childRef(el);
+      else if (childRef != null) {
+        (childRef as MutableRefObject<HTMLElement | null>).current = el;
+      }
+    },
+    [childRef],
+  );
+  // Anchor edges rather than final coordinates: a vertical flip re-derives
+  // the bubble's top from the opposite edge.
+  const [pos, setPos] = useState<{
+    x: number;
+    top: number;
+    bottom: number;
+  } | null>(null);
+  // Where the bubble actually sits: the requested side until the viewport
+  // refuses it.
+  const [placement, setPlacement] = useState<TooltipSide>(side);
+  const bubble = useRef<HTMLSpanElement | null>(null);
+  const resolvedLabel =
+    pos === null ? null : typeof label === "function" ? label() : label;
+  const y =
+    pos === null
+      ? 0
+      : placement === "right" || placement === "left"
+        ? pos.top + (pos.bottom - pos.top) / 2
+        : placement === "top"
+          ? pos.top - OFFSET
+          : pos.bottom + OFFSET;
+
+  // Viewport fit: horizontally the bubble slides back inside; vertically it
+  // flips to the opposite side (the only move that does not cover the anchor
+  // being read), and only into a side that genuinely fits. Each measurement
+  // resets the base position first, so a shorter label or a larger viewport
+  // releases a previous adjustment without another render.
+  useLayoutEffect(() => {
+    if (pos === null) return;
+    const fit = (): void => {
+      const el = bubble.current;
+      if (el === null) return;
+      el.style.left = `${pos.x}px`;
+      const r = el.getBoundingClientRect();
+      let dx = 0;
+      if (r.right > window.innerWidth - EDGE_MARGIN) {
+        dx = window.innerWidth - EDGE_MARGIN - r.right;
+      }
+      if (r.left + dx < EDGE_MARGIN) dx = EDGE_MARGIN - r.left;
+      el.style.left = `${pos.x + dx}px`;
+      if (side === "right" || side === "left") return;
+      const fitsBelow =
+        pos.bottom + OFFSET + r.height <= window.innerHeight - EDGE_MARGIN;
+      const fitsAbove = pos.top - OFFSET - r.height >= EDGE_MARGIN;
+      if (placement === "bottom" && !fitsBelow && fitsAbove) {
+        setPlacement("top");
+      }
+      if (placement === "top" && !fitsAbove && fitsBelow) {
+        setPlacement("bottom");
+      }
+    };
+    fit();
+    window.addEventListener("resize", fit);
+    return () => window.removeEventListener("resize", fit);
+  }, [placement, pos, resolvedLabel, side]);
+
+  const showTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Hover and focus are independent triggers: the bubble hides only after
+  // BOTH clear (hovering away from a focused anchor must not drop it).
+  const triggers = useRef({ hover: false, focus: false });
+
+  const cancelShow = useCallback(() => {
+    if (showTimer.current === null) return;
+    clearTimeout(showTimer.current);
+    showTimer.current = null;
+  }, []);
+  // Disabling mid-hover must drop an already-visible bubble: no mouseleave
+  // fires for it.
+  useEffect(() => {
+    if (disabled) {
+      cancelShow();
+      triggers.current = { hover: false, focus: false };
+      setPos(null);
+    }
+    return cancelShow;
+  }, [cancelShow, disabled]);
+
+  const show = (): void => {
+    if (disabled) return;
+    const el = anchor.current;
+    if (el === null) return;
+    const r = el.getBoundingClientRect();
+    // Every show starts from the requested side; the fit pass flips it only
+    // where this anchor's position demands it.
+    setPlacement(side);
+    const x =
+      side === "right"
+        ? r.right + OFFSET
+        : side === "left"
+          ? r.left - OFFSET
+          : r.left + r.width / 2;
+    setPos({ x, top: r.top, bottom: r.bottom });
+  };
+  const showAfterHoverDelay = (): void => {
+    cancelShow();
+    if (delayMs <= 0) {
+      show();
+      return;
+    }
+    showTimer.current = setTimeout(() => {
+      showTimer.current = null;
+      show();
+    }, delayMs);
+  };
+  const hide = (): void => {
+    cancelShow();
+    if (!triggers.current.hover && !triggers.current.focus) setPos(null);
+  };
+
+  return (
+    <>
+      {cloneElement(children, {
+        ref: mergedRef,
+        onMouseEnter: (e) => {
+          children.props.onMouseEnter?.(e);
+          triggers.current.hover = true;
+          showAfterHoverDelay();
+        },
+        onMouseLeave: (e) => {
+          children.props.onMouseLeave?.(e);
+          triggers.current.hover = false;
+          cancelShow();
+          setPos(null);
+        },
+        onFocus: (e) => {
+          children.props.onFocus?.(e);
+          triggers.current.focus = true;
+          cancelShow();
+          show();
+        },
+        onBlur: (e) => {
+          children.props.onBlur?.(e);
+          triggers.current.focus = false;
+          hide();
+        },
+      })}
+      {pos !== null && (
+        <span
+          ref={bubble}
+          className="vex-tooltip"
+          data-side={placement}
+          style={{
+            left: pos.x,
+            top: y,
+            ...(maxWidth === undefined ? {} : { maxWidth }),
+          }}
+          role="tooltip"
+        >
+          {resolvedLabel}
+        </span>
+      )}
+    </>
+  );
+}

--- a/vex-app/src/renderer/features/appShell/__tests__/shell-design-guard.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/shell-design-guard.test.ts
@@ -166,19 +166,10 @@ const WHITELIST: readonly WhitelistEntry[] = [
       "backdrop-blur + a static grain overlay, matching the approved " +
       "profile-menu mock.",
   },
-  {
-    // Owner decree 2026-07-20, Chronos glass law: the shared Dialog base
-    // (a shell primitive also scanned here) wears the same floating glass
-    // chrome — every modal is a Chronos glass surface per the approved
-    // Personalize mock.
-    file: "components/ui/dialog.tsx",
-    pattern: "backdrop-blur (glass)",
-    reason:
-      "Owner-decreed Chronos glass surface (2026-07-20 law): the Dialog " +
-      "base is a floating glass panel (translucent ink + backdrop-blur + " +
-      "grain, white/10 hairline, rounded-2xl). The ::backdrop dim itself " +
-      "stays blur-free (backdrop:backdrop-blur-none).",
-  },
+  // REMOVED (rebrand phase 1, 2026-08-20): the Dialog base is a solid
+  // layer-2 card on tokens v2 - its backdrop-blur exemption became inert
+  // when the glass chrome retired, so the entry is deleted rather than
+  // kept as a stale sanction.
   {
     // Welcome Portfolio tab (approved harness plan v6, 2026-07-20): the
     // welcome stage's floating card stack (Overview / Wallets / Balances)

--- a/vex-app/src/renderer/lib/__tests__/head-tail-cap.test.ts
+++ b/vex-app/src/renderer/lib/__tests__/head-tail-cap.test.ts
@@ -1,0 +1,41 @@
+/**
+ * headTailCap boundary tests: the exact cap edge, over-cap splits (odd and
+ * even maxLines), and the expanded uncap.
+ */
+
+import { describe, expect, it } from "vitest";
+import { headTailCap } from "../head-tail-cap.js";
+
+describe("headTailCap", () => {
+  it("a list at or under the cap hides nothing", () => {
+    expect(headTailCap(10, 10, false)).toEqual({
+      hidden: 0,
+      capped: false,
+      headLines: 5,
+      tailLines: 5,
+    });
+    expect(headTailCap(3, 10, false).capped).toBe(false);
+    expect(headTailCap(3, 10, false).hidden).toBe(-7);
+  });
+
+  it("one row over the cap starts capping", () => {
+    const cap = headTailCap(11, 10, false);
+    expect(cap.capped).toBe(true);
+    expect(cap.hidden).toBe(1);
+  });
+
+  it("odd maxLines gives the head the extra row", () => {
+    const cap = headTailCap(100, 7, false);
+    expect(cap.headLines).toBe(4);
+    expect(cap.tailLines).toBe(3);
+    expect(cap.headLines + cap.tailLines).toBe(7);
+  });
+
+  it("expanded uncaps but keeps the metrics", () => {
+    const cap = headTailCap(100, 10, true);
+    expect(cap.capped).toBe(false);
+    expect(cap.hidden).toBe(90);
+    expect(cap.headLines).toBe(5);
+    expect(cap.tailLines).toBe(5);
+  });
+});

--- a/vex-app/src/renderer/lib/__tests__/use-copy-feedback.test.ts
+++ b/vex-app/src/renderer/lib/__tests__/use-copy-feedback.test.ts
@@ -1,0 +1,73 @@
+/**
+ * useCopyFeedback tests: success flips `copied` for the feedback window; a
+ * refused write leaves the flag untouched (the control never claims a copy
+ * the host declined).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { COPY_FEEDBACK_MS, useCopyFeedback } from "../use-copy-feedback.js";
+
+function stubClipboard(writeText: () => Promise<void>): void {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("useCopyFeedback", () => {
+  it("flips copied on success and clears after the feedback window", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    stubClipboard(writeText);
+    const { result } = renderHook(() => useCopyFeedback("0xabc"));
+    expect(result.current.copied).toBe(false);
+    await act(async () => {
+      result.current.onCopy();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(writeText).toHaveBeenCalledWith("0xabc");
+    expect(result.current.copied).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(COPY_FEEDBACK_MS);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("stays false when the host refuses the write", async () => {
+    stubClipboard(vi.fn().mockRejectedValue(new Error("denied")));
+    // jsdom has no execCommand; define the selection fallback as refusing.
+    Object.defineProperty(document, "execCommand", {
+      value: vi.fn().mockReturnValue(false),
+      configurable: true,
+    });
+    const { result } = renderHook(() => useCopyFeedback("0xabc"));
+    await act(async () => {
+      result.current.onCopy();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("honors a custom feedback duration", async () => {
+    stubClipboard(vi.fn().mockResolvedValue(undefined));
+    const { result } = renderHook(() => useCopyFeedback("x", 100));
+    await act(async () => {
+      result.current.onCopy();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.copied).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+});

--- a/vex-app/src/renderer/lib/clipboard.ts
+++ b/vex-app/src/renderer/lib/clipboard.ts
@@ -1,0 +1,36 @@
+/**
+ * Renderer clipboard write shared by copy controls. Reports whether the host
+ * accepted the write; success feedback stays with each control.
+ */
+
+/**
+ * Write text to the clipboard. The shell's permission handlers are deny-all
+ * (main/permissions.ts), so `navigator.clipboard.writeText` may reject; the
+ * fallback is an off-screen readonly textarea + the selection copy command,
+ * which needs no permissions API. Returns true only on a real success.
+ */
+export async function writeClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return copyViaSelection(text);
+  }
+}
+
+function copyViaSelection(text: string): boolean {
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand("copy");
+    ta.remove();
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/vex-app/src/renderer/lib/head-tail-cap.ts
+++ b/vex-app/src/renderer/lib/head-tail-cap.ts
@@ -1,0 +1,40 @@
+/**
+ * Head/tail height-cap arithmetic for long DISPLAY lists: `ceil(maxLines/2)`
+ * head rows and the remainder as tail rows; a list within the cap shows
+ * every row.
+ *
+ * CONSTRAINT: display-only. This cap must NEVER be applied to content that
+ * reaches the agent's context - the agent always receives the whole payload
+ * (truncation decree); only the on-screen rendering is capped.
+ */
+
+export interface HeadTailCap {
+  /** Rows beyond the cap (total - maxLines); <= 0 means nothing is hidden. */
+  readonly hidden: number;
+  /** Whether the list is over the cap and not expanded. */
+  readonly capped: boolean;
+  /** Head-slice row count: `ceil(maxLines / 2)`. */
+  readonly headLines: number;
+  /** Tail-slice row count: the remainder after the head. */
+  readonly tailLines: number;
+}
+
+/**
+ * Compute the head/tail split for `total` rows against `maxLines`. Pure
+ * arithmetic; the caller slices its own rows so it can layer its own
+ * concerns (e.g. restoring a tail header) on top.
+ */
+export function headTailCap(
+  total: number,
+  maxLines: number,
+  expanded: boolean,
+): HeadTailCap {
+  const hidden = total - maxLines;
+  const headLines = Math.ceil(maxLines / 2);
+  return {
+    hidden,
+    capped: hidden > 0 && !expanded,
+    headLines,
+    tailLines: maxLines - headLines,
+  };
+}

--- a/vex-app/src/renderer/lib/pointer-grace.ts
+++ b/vex-app/src/renderer/lib/pointer-grace.ts
@@ -1,0 +1,47 @@
+/**
+ * Cancelable delayed close for pointer-dismissed popups (HoverCard,
+ * hover-closing Menu). Both float free of their anchor, so the pointer must
+ * cross ground belonging to neither on the way in; closing on the first
+ * pointerleave would make the popup unreachable.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+
+/** Grace covering the anchor->popup gap at a hand's travel speed. */
+export const POINTER_GRACE_MS = 200;
+
+export interface PointerGrace {
+  /** Schedule the close POINTER_GRACE_MS from now, replacing any pending one. */
+  readonly arm: () => void;
+  /** Abort a pending close (the pointer came back). */
+  readonly cancel: () => void;
+}
+
+/**
+ * Delay a pointer-dismissed popup's close so the pointer can cross the gap.
+ * `close` is read at fire time, so callers may pass a fresh closure each
+ * render. A pending close is dropped on unmount.
+ */
+export function usePointerGrace(close: () => void): PointerGrace {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeRef = useRef(close);
+  closeRef.current = close;
+
+  const cancel = useCallback(() => {
+    if (timerRef.current === null) return;
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  const arm = useCallback(() => {
+    cancel();
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      closeRef.current();
+    }, POINTER_GRACE_MS);
+  }, [cancel]);
+
+  useEffect(() => cancel, [cancel]);
+
+  return { arm, cancel };
+}

--- a/vex-app/src/renderer/lib/toast.ts
+++ b/vex-app/src/renderer/lib/toast.ts
@@ -1,0 +1,55 @@
+/**
+ * Toast store: a tiny module-level slot the ToastHost subscribes to.
+ * `showToast(text, {tone})` replaces the current toast (a fresh id restarts
+ * the CSS cycle via a React key); the host clears the slot when the toast's
+ * timed lifecycle completes.
+ */
+
+export type ToastTone = "neutral" | "warning" | "error";
+
+export interface ToastEntry {
+  /** Per-show sequence; keying the rendered toast by it restarts the cycle. */
+  readonly id: number;
+  readonly text: string;
+  readonly tone: ToastTone;
+}
+
+type Listener = (toast: ToastEntry | null) => void;
+
+let current: ToastEntry | null = null;
+let sequence = 0;
+const listeners = new Set<Listener>();
+
+function emit(): void {
+  for (const listener of listeners) listener(current);
+}
+
+/** Show a toast, replacing any visible one. Copy arrives resolved from the caller. */
+export function showToast(
+  text: string,
+  options?: { readonly tone?: ToastTone },
+): void {
+  sequence += 1;
+  current = { id: sequence, text, tone: options?.tone ?? "neutral" };
+  emit();
+}
+
+/** Clear the current toast (the host calls this when the fade completes). */
+export function clearToast(id: number): void {
+  if (current === null || current.id !== id) return;
+  current = null;
+  emit();
+}
+
+/** Subscribe to toast changes; returns the unsubscribe. */
+export function subscribeToast(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Current toast snapshot (for useSyncExternalStore). */
+export function getToastSnapshot(): ToastEntry | null {
+  return current;
+}

--- a/vex-app/src/renderer/lib/use-anchored-max-height.ts
+++ b/vex-app/src/renderer/lib/use-anchored-max-height.ts
@@ -1,0 +1,45 @@
+/**
+ * Viewport-fit hook for bottom-anchored overlays: the element's bottom edge
+ * is laid out independent of its height, so it grows upward and only the top
+ * edge can collide with the viewport - clamp the design cap to the space
+ * between that edge and the viewport top.
+ */
+
+import { useLayoutEffect, useState } from "react";
+import type { RefObject } from "react";
+
+/** Safe distance kept to the viewport top edge (mirrors the Menu portal margin). */
+const MARGIN = 12;
+
+/**
+ * Clamp a bottom-anchored overlay's max-height to the viewport.
+ * @param ref - the overlay element; a null current (closed) skips measuring.
+ * @param cap - design max-height in px (the clamp never exceeds it).
+ * @param signal - re-measure trigger: pass the overlay's render state so
+ *   anchor moves re-fit; resize/scroll re-fit while mounted.
+ * @returns the max-height to apply inline, in px.
+ */
+export function useAnchoredMaxHeight(
+  ref: RefObject<HTMLElement | null>,
+  cap: number,
+  signal: unknown,
+): number {
+  const [maxHeight, setMaxHeight] = useState(cap);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (el === null) return;
+    const fit = (): void => {
+      setMaxHeight(
+        Math.min(cap, Math.max(0, el.getBoundingClientRect().bottom - MARGIN)),
+      );
+    };
+    fit();
+    window.addEventListener("resize", fit);
+    window.addEventListener("scroll", fit, true);
+    return () => {
+      window.removeEventListener("resize", fit);
+      window.removeEventListener("scroll", fit, true);
+    };
+  }, [ref, cap, signal]);
+  return maxHeight;
+}

--- a/vex-app/src/renderer/lib/use-copy-feedback.ts
+++ b/vex-app/src/renderer/lib/use-copy-feedback.ts
@@ -1,0 +1,44 @@
+/**
+ * Copy-to-clipboard hook with transient success feedback: write the text,
+ * and on success flip a `copied` flag the caller renders as its success
+ * state. A refused write leaves the flag untouched, so the control never
+ * claims a copy the host declined.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { writeClipboard } from "./clipboard.js";
+
+/** Default duration the `copied` flag stays true after a successful write. */
+export const COPY_FEEDBACK_MS = 1500;
+
+export interface CopyFeedback {
+  /** True for the feedback window after a successful write. */
+  readonly copied: boolean;
+  /** Copy the hook's text; silent on a refused write. */
+  readonly onCopy: () => void;
+}
+
+export function useCopyFeedback(
+  text: string,
+  feedbackMs: number = COPY_FEEDBACK_MS,
+): CopyFeedback {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const onCopy = useCallback(() => {
+    void writeClipboard(text).then((ok) => {
+      if (!ok) return;
+      setCopied(true);
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), feedbackMs);
+    });
+  }, [text, feedbackMs]);
+
+  return { copied, onCopy };
+}

--- a/vex-app/src/renderer/lib/use-dismiss-outside.ts
+++ b/vex-app/src/renderer/lib/use-dismiss-outside.ts
@@ -1,0 +1,30 @@
+/**
+ * Outside-pointer dismissal for trigger-owned popovers: while the surface is
+ * open, a pointerdown outside the root closes it.
+ */
+
+import { useEffect } from "react";
+import type { RefObject } from "react";
+
+/**
+ * Close an open popover when a pointerdown lands outside its root element.
+ * @param root - element containing both the trigger and the open surface.
+ * @param open - whether the surface is showing; false detaches the listener.
+ * @param setOpen - invoked with false on an outside pointerdown.
+ */
+export function useDismissOutside(
+  root: RefObject<HTMLElement | null>,
+  open: boolean,
+  setOpen: (open: boolean) => void,
+): void {
+  useEffect(() => {
+    if (!open) return;
+    const closeOutside = (event: PointerEvent): void => {
+      if (event.target instanceof Node && !root.current?.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", closeOutside);
+    return () => document.removeEventListener("pointerdown", closeOutside);
+  }, [root, open, setOpen]);
+}

--- a/vex-app/src/renderer/styles/global-css/tokens.css
+++ b/vex-app/src/renderer/styles/global-css/tokens.css
@@ -175,9 +175,22 @@
   --vex-alias-state-error: var(--color-red-400);
   --vex-alias-state-error-wash: var(--color-red-900);
 
+  /* Input stroke: one step weaker than l2 in dark only - a full l2 stroke
+   * reads loud on the luminance ladder; celeris re-points this at l2. */
+  --vex-alias-border-input: rgba(255, 255, 255, 0.06);
+
+  /* Overlay masks: dialog/lightbox dim (mask-1) and the frosted drop sheet. */
+  --vex-alias-bg-mask-1: rgba(0, 0, 0, 0.5);
+  --vex-alias-bg-mask-drop: rgba(14, 17, 29, 0.7);
+  /* Backdrop blur behind modal surfaces; paired with mask-1. */
+  --vex-mask-blur: blur(2px);
+
   /* Chrome plates: tooltips and toasts are DARK in both themes. */
   --vex-alias-tooltip-bg: var(--color-gray-800);
   --vex-alias-toast-bg: var(--color-gray-850);
+  /* Text painted on the theme-invariant dark chrome plates above; stays
+   * white in celeris too, so it lives only on :root. */
+  --vex-alias-label-on-chrome: #ffffff;
 
   /* Scrollbar tint pairs (consumed through the runtime indirection in
    * scrollbars.css, not directly). l1 = page-level, l2 = elevated cards. */
@@ -206,6 +219,10 @@
   --vex-alias-border-l2: rgba(10, 13, 24, 0.1);
   --vex-alias-border-l3: rgba(10, 13, 24, 0.12);
   --vex-alias-border-l4: rgba(10, 13, 24, 0.16);
+  --vex-alias-border-input: rgba(10, 13, 24, 0.1);
+
+  --vex-alias-bg-mask-1: rgba(10, 13, 24, 0.24);
+  --vex-alias-bg-mask-drop: rgba(255, 255, 255, 0.7);
 
   /* Celeris caption (#a7aec1) sits ~2:1 on white - below the readability
    * floor, so it serves disabled/decoration only; running metadata uses
@@ -272,6 +289,10 @@
   --color-line-2: var(--vex-alias-border-l2);
   --color-line-3: var(--vex-alias-border-l3);
   --color-line-4: var(--vex-alias-border-l4);
+  --color-line-input: var(--vex-alias-border-input);
+  --color-mask-1: var(--vex-alias-bg-mask-1);
+  --color-mask-drop: var(--vex-alias-bg-mask-drop);
+  --color-ink-on-chrome: var(--vex-alias-label-on-chrome);
 
   --color-accent-primary: var(--vex-alias-accent-primary);
   --color-accent-hover: var(--vex-alias-accent-hover);

--- a/vex-app/src/renderer/styles/global-css/ui-primitives.css
+++ b/vex-app/src/renderer/styles/global-css/ui-primitives.css
@@ -1,0 +1,10 @@
+/* Chrome for the shared UI primitives (components/ui): toast, tooltip,
+ * hover card, menu, disclosure row, state dot, connection banner, drop
+ * overlay, image lightbox, and the dialog backdrop. Split by responsibility
+ * into the same-named sibling folder; this manifest only imports (CSS
+ * @import must precede all rules). Aliases only; every animated surface
+ * carries its prefers-reduced-motion block. */
+
+@import "./ui-primitives/overlays.css";
+@import "./ui-primitives/menu.css";
+@import "./ui-primitives/indicators.css";

--- a/vex-app/src/renderer/styles/global-css/ui-primitives/indicators.css
+++ b/vex-app/src/renderer/styles/global-css/ui-primitives/indicators.css
@@ -1,0 +1,149 @@
+/* Inline indicator chrome: disclosure row crossfade and the state dot. */
+
+/* ── Disclosure row ────────────────────────────────────────────────────────
+ * 24px header, 16px leading box; hover crossfades icon <-> chevron in the
+ * one box - "this row expands" without a permanent chevron. */
+.vex-disclosure-root {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+}
+
+.vex-disclosure-row {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  height: 24px;
+  min-width: 0;
+}
+
+.vex-disclosure-row[data-expandable] {
+  cursor: pointer;
+}
+
+.vex-disclosure-leading {
+  position: relative;
+  flex: none;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 6px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--vex-alias-label-tertiary);
+}
+
+button.vex-disclosure-leading {
+  cursor: pointer;
+}
+
+.vex-disclosure-icon-idle {
+  display: inline-flex;
+  opacity: 1;
+  transition: opacity 100ms ease;
+}
+
+.vex-disclosure-chevron-hover {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  opacity: 0;
+  transition: opacity 100ms ease;
+}
+
+.vex-disclosure-row:hover .vex-disclosure-icon-idle {
+  opacity: 0;
+}
+
+.vex-disclosure-row:hover .vex-disclosure-chevron-hover {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vex-disclosure-icon-idle,
+  .vex-disclosure-chevron-hover {
+    transition: none;
+  }
+}
+
+.vex-disclosure-title {
+  flex: none;
+  font-size: 14px;
+  line-height: 24px;
+  color: var(--vex-alias-label-secondary);
+}
+
+/* ── State dot ─────────────────────────────────────────────────────────────
+ * Solid states: same-color halo (::before, 0.10 opacity) around a 6/10
+ * core; color rides currentColor set per state. Ongoing: pixel chase with
+ * flat keyframe holds (duplicate-stop trick, no tweening); phase offsets
+ * come from per-rect animation-delay (index * -125ms) set inline. */
+.vex-state-dot,
+.vex-state-matrix {
+  --vex-state-ongoing: var(--vex-alias-accent-primary);
+}
+
+.vex-state-dot {
+  position: relative;
+  display: inline-block;
+  flex: none;
+}
+
+.vex-state-dot::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.1;
+}
+
+.vex-state-dot::after {
+  content: "";
+  position: absolute;
+  inset: 20%;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.vex-state-dot[data-state="done"] {
+  color: var(--vex-alias-state-success);
+}
+
+.vex-state-dot[data-state="warning"] {
+  color: var(--vex-alias-state-warn);
+}
+
+.vex-state-dot[data-state="error"] {
+  color: var(--vex-alias-state-error);
+}
+
+.vex-state-matrix {
+  flex: none;
+  color: var(--vex-state-ongoing);
+}
+
+.vex-state-cell {
+  fill: currentColor;
+  opacity: 0.15;
+  animation: vex-state-dot-chase 1s infinite;
+}
+
+@keyframes vex-state-dot-chase {
+  0%, 12.4% { opacity: 1; }
+  12.5%, 24.9% { opacity: 0.6; }
+  25%, 37.4% { opacity: 0.35; }
+  37.5%, 100% { opacity: 0.15; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vex-state-cell {
+    animation: none;
+    opacity: 0.5;
+  }
+}

--- a/vex-app/src/renderer/styles/global-css/ui-primitives/menu.css
+++ b/vex-app/src/renderer/styles/global-css/ui-primitives/menu.css
@@ -1,0 +1,220 @@
+/* Menu primitive chrome: dropdown card, items, submenu bridge. */
+
+/* ── Menu ──────────────────────────────────────────────────────────────────
+ * Dropdown card: 4px inset pad, r12, lv3, NO entry animation. */
+.vex-menu-root {
+  position: relative;
+  display: inline-flex;
+}
+
+.vex-menu,
+.vex-menu-submenu {
+  box-sizing: border-box;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--vex-alias-border-l1);
+  border-radius: 12px;
+  background: var(--vex-alias-bg-layer-2);
+  box-shadow: var(--shadow-lv3);
+  /* Elevated surface: the scrollbar pair takes the l2 tier; the custom
+   * properties inherit to whichever descendant actually scrolls. */
+  --vex-scrollbar-thumb: var(--vex-alias-scrollbar-l2);
+  --vex-scrollbar-thumb-hover: var(--vex-alias-scrollbar-l2-hover);
+}
+
+.vex-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 100;
+  min-width: 218px;
+  max-width: 360px;
+}
+
+/* Portal mode: fixed, coordinates from the anchor rect; must layer above
+ * dialog overlays - an anchor inside a dialog expects its menu on top. */
+.vex-menu-portal {
+  position: fixed;
+  top: auto;
+  left: auto;
+  z-index: 1100;
+}
+
+.vex-menu-side-top {
+  top: auto;
+  bottom: calc(100% + 4px);
+}
+
+.vex-menu-align-end {
+  left: auto;
+  right: 0;
+}
+
+/* Card stops 12px short of the viewport edges (24 = 2x the portal margin);
+ * taller content scrolls inside the viewport so a pinned footer stays
+ * visible. Submenu-bearing menus skip this - the clip would crop the side
+ * card. */
+.vex-menu-scrollable {
+  max-height: calc(100vh - 24px);
+}
+
+.vex-menu-viewport {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.vex-menu-scrollable .vex-menu-viewport {
+  overflow-y: auto;
+}
+
+.vex-menu-footer {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid var(--vex-alias-border-l2);
+}
+
+.vex-menu-item-wrap {
+  position: relative;
+}
+
+.vex-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 40px;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 22px;
+  color: var(--vex-alias-label-primary);
+  text-align: left;
+}
+
+.vex-menu-item:hover:not(:disabled) {
+  background: var(--vex-alias-interactive-hover);
+}
+
+.vex-menu-item:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.vex-menu-dense .vex-menu-item {
+  min-height: 34px;
+  padding-block: 5px;
+}
+
+.vex-menu-dense .vex-menu-heading {
+  padding-block: 4px;
+}
+
+.vex-menu.vex-menu-compact,
+.vex-menu-submenu.vex-menu-compact {
+  min-width: 164px;
+  padding: 2px;
+  border-radius: 7px;
+}
+
+.vex-menu-compact .vex-menu-item {
+  min-height: 26px;
+  gap: 6px;
+  padding: 3px 7px;
+  border-radius: 5px;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.vex-menu-compact .vex-menu-item-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.vex-menu-compact .vex-menu-separator {
+  margin: 2px;
+}
+
+.vex-menu-compact .vex-menu-heading {
+  padding: 4px 7px;
+  font-size: 11px;
+  line-height: 16px;
+}
+
+.vex-menu-item-icon {
+  display: inline-flex;
+  flex: none;
+  width: 16px;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  color: var(--vex-alias-label-tertiary);
+}
+
+.vex-menu-item-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Selection marker is the trailing check, never a fill. */
+.vex-menu-check {
+  flex: none;
+  color: var(--vex-alias-label-primary);
+}
+
+.vex-menu-danger {
+  color: var(--vex-alias-state-error);
+}
+
+.vex-menu-danger .vex-menu-item-icon {
+  color: var(--vex-alias-state-error);
+}
+
+.vex-menu-danger:hover:not(:disabled) {
+  background: var(--vex-alias-interactive-danger);
+}
+
+.vex-menu-heading {
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--vex-alias-label-tertiary);
+}
+
+.vex-menu-separator {
+  height: 1px;
+  margin: 4px 2px;
+  background: var(--vex-alias-border-l1);
+}
+
+/* Nested card to the right, bottom-aligned with the parent card: item-wrap
+ * sits in the list's 4px pad, so -4px matches the outer bottom edge and
+ * 100% + 10px yields a 6px visual gap between card edges. ::before bridges
+ * the gap so the pointer crosses without a mouseleave. */
+.vex-menu-submenu {
+  position: absolute;
+  top: auto;
+  bottom: -4px;
+  left: calc(100% + 10px);
+  z-index: 101;
+  min-width: 163px;
+}
+
+.vex-menu-submenu::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -10px;
+  width: 10px;
+}

--- a/vex-app/src/renderer/styles/global-css/ui-primitives/overlays.css
+++ b/vex-app/src/renderer/styles/global-css/ui-primitives/overlays.css
@@ -1,0 +1,281 @@
+/* Floating chrome for the shared primitives: toast, tooltip, hover card,
+ * connection banner, drop overlay, image lightbox. */
+
+/* ── Elevated-surface scrollbar rebind ─────────────────────────────────────
+ * Contract from scrollbars.css: an elevated surface rebinds the indirection
+ * PAIR on its own container; every rendering path reads the pair. */
+.vex-scroll-elevated {
+  --vex-scrollbar-thumb: var(--vex-alias-scrollbar-l2);
+  --vex-scrollbar-thumb-hover: var(--vex-alias-scrollbar-l2-hover);
+}
+
+/* ── Dialog backdrop ───────────────────────────────────────────────────────
+ * Native <dialog> top-layer mask: dim + soft blur. Lives here (not a
+ * Tailwind class string) so the TSX stays free of backdrop-filter chrome. */
+dialog.vex-dialog::backdrop {
+  background: var(--vex-alias-bg-mask-1);
+  backdrop-filter: var(--vex-mask-blur);
+}
+
+/* ── Toast ─────────────────────────────────────────────────────────────────
+ * Transient top-center banner on a dark plate in BOTH themes. CSS-only exit:
+ * the fade delay (3000ms) and duration (1000ms) MUST equal HOLD_MS/FADE_MS
+ * in components/ui/toast.tsx - the component unmounts at their sum. */
+.vex-toast {
+  position: fixed;
+  top: 120px;
+  left: 50%;
+  /* Above the lightbox backdrop (1000): failures reported over a preview
+   * must stay readable. */
+  z-index: 1100;
+  /* Announcement only - never hit-testable, even between fade end and the
+   * throttled background-tab unmount timer. */
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: min(560px, calc(100vw - 48px));
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: var(--vex-alias-toast-bg);
+  color: var(--vex-alias-label-on-chrome);
+  font-size: 14px;
+  line-height: 22px;
+  box-shadow: var(--shadow-lv3);
+  transform: translateX(-50%);
+  animation:
+    vex-toast-in 160ms ease-out,
+    vex-toast-fade 1000ms ease 3000ms forwards;
+}
+
+.vex-toast-icon {
+  display: grid;
+  place-items: center;
+  flex: none;
+}
+
+.vex-toast[data-tone="warning"] .vex-toast-icon {
+  color: var(--vex-alias-state-warn);
+}
+
+.vex-toast[data-tone="error"] .vex-toast-icon {
+  color: var(--vex-alias-state-error);
+}
+
+.vex-toast-text {
+  min-width: 0;
+}
+
+@keyframes vex-toast-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+@keyframes vex-toast-fade {
+  to {
+    opacity: 0;
+  }
+}
+
+/* Reduced motion drops the slide-in; the delayed fade (opacity, not
+ * movement) still ends the banner before the timed unmount. */
+@media (prefers-reduced-motion: reduce) {
+  .vex-toast {
+    animation: vex-toast-fade 1000ms ease 3000ms forwards;
+  }
+}
+
+/* ── Tooltip ───────────────────────────────────────────────────────────────
+ * Dark plate + white text in both themes; fade only, no arrow. */
+.vex-tooltip {
+  position: fixed;
+  z-index: 1200;
+  /* Fixed-position shrink-to-fit measures only left->viewport-edge space, so
+   * right-edge anchors would wrap early; max-content sizes by the label. */
+  width: max-content;
+  max-width: 50vw;
+  padding: 3px 7px;
+  border-radius: 8px;
+  background: var(--vex-alias-tooltip-bg);
+  color: var(--vex-alias-label-on-chrome);
+  font-size: 13px;
+  line-height: 20px;
+  white-space: pre-line;
+  overflow-wrap: break-word;
+  pointer-events: none;
+  animation: vex-tooltip-in 150ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.vex-tooltip[data-side="right"],
+.vex-tooltip[data-side="left"] {
+  transform: translateY(-50%);
+}
+
+.vex-tooltip[data-side="left"] {
+  translate: -100% 0;
+}
+
+.vex-tooltip[data-side="bottom"] {
+  transform: translateX(-50%);
+}
+
+.vex-tooltip[data-side="top"] {
+  transform: translate(-50%, -100%);
+}
+
+@keyframes vex-tooltip-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vex-tooltip {
+    animation: none;
+  }
+}
+
+/* ── Hover card ────────────────────────────────────────────────────────────
+ * 244px preview card on the dark chrome plate in both themes. Hit-testable
+ * on purpose: resting the pointer on it holds it open (grace close). */
+.vex-hover-card-root {
+  position: relative;
+  display: block;
+}
+
+.vex-hover-card {
+  position: fixed;
+  z-index: 1200;
+  box-sizing: border-box;
+  width: 244px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: var(--vex-alias-tooltip-bg);
+  color: var(--vex-alias-label-on-chrome);
+  box-shadow: var(--shadow-lv3);
+}
+
+/* ── Connection banner ─────────────────────────────────────────────────── */
+.vex-connection-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1200;
+  padding: 4px 12px;
+  text-align: center;
+  font-size: 12px;
+  line-height: 18px;
+  background: var(--vex-alias-state-error);
+  color: var(--vex-alias-label-on-chrome);
+}
+
+/* ── Drop overlay ──────────────────────────────────────────────────────────
+ * Full-viewport drop invitation. pointer-events: none - decoration only;
+ * drag events must keep hitting the page so the owner's enter/leave count
+ * stays balanced. */
+.vex-drop-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  background-color: var(--vex-alias-bg-mask-drop);
+  backdrop-filter: blur(10px);
+  animation: vex-drop-overlay-in 160ms ease-out;
+}
+
+@keyframes vex-drop-overlay-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vex-drop-overlay {
+    animation: none;
+  }
+}
+
+.vex-drop-overlay-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: -3%;
+  padding: 0 40px;
+  color: var(--vex-alias-label-primary);
+  text-align: center;
+}
+
+.vex-drop-overlay-illustration {
+  width: 115px;
+  height: 84px;
+}
+
+.vex-drop-overlay-title {
+  margin-top: 16px;
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: 500;
+}
+
+.vex-drop-overlay-desc {
+  margin-top: 16px;
+  font-size: 14px;
+  line-height: 22px;
+  color: var(--vex-alias-label-tertiary);
+  white-space: pre-wrap;
+}
+
+/* ── Image lightbox ─────────────────────────────────────────────────────── */
+.vex-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 40px;
+}
+
+/* Separate mask layer, not a background on the backdrop: backdrop-filter
+ * there would blur the previewed image and close control with the page. */
+.vex-lightbox-mask {
+  position: absolute;
+  inset: 0;
+  background: var(--vex-alias-bg-mask-1);
+  backdrop-filter: var(--vex-mask-blur);
+}
+
+.vex-lightbox-image {
+  position: relative;
+  max-width: min(100%, 1600px);
+  max-height: calc(100vh - 80px);
+  object-fit: contain;
+  border-radius: 12px;
+  background: var(--vex-alias-composer);
+  box-shadow: var(--shadow-lv3);
+}
+
+.vex-lightbox-close {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--vex-alias-border-input);
+  border-radius: 999px;
+  background: var(--vex-alias-composer);
+  color: var(--vex-alias-label-primary);
+  cursor: pointer;
+}

--- a/vex-app/src/renderer/styles/globals.css
+++ b/vex-app/src/renderer/styles/globals.css
@@ -14,6 +14,7 @@
 @import "./global-css/motion-primitives.css";
 @import "./global-css/chronos-motion.css";
 @import "./global-css/scrollbars.css";
+@import "./global-css/ui-primitives.css";
 @import "./global-css/console.css";
 @import "./global-css/pending-ring.css";
 @import "./global-css/setup-gate.css";


### PR DESCRIPTION
Phase 1 of the UIUX rebrand, stacked on the phase-0 foundation (#93). Parallel to phase 2 (#94) with disjoint file ownership.

New primitive set on tokens v2, geometry taken verbatim from the reference catalog:
- Toast host (dark plate in both themes, CSS-only exit with the HOLD/FADE invariant pinned on both sides), sided Tooltip, HoverCard with pointer grace, portal Menu (MenuEntry union, anchored max-height, dismiss-on-outside, dense/compact, submenu pointer bridge), Pill, generic DisclosureRow (leading-slot crossfade), StateDot (flat-hold pixel chase, per-cell phase delays), ConnectionBanner, DropOverlay, ImageLightbox
- Shared lib: showToast store, clipboard + copy-feedback hook, pointer-grace, anchored-max-height, dismiss-outside, display-only head-tail cap (agent-context use is banned by a stated constraint)

Core primitives restyled behind unchanged APIs: capsule Button (primary = ink, accent = the main action, legacy variants mapped), Input (no focus ring, accent caret), Dialog as a solid layer-2 card (glass + serif retired), SelectMenu/Tabs on aliases. The now-inert dialog glass whitelist entry in the design guard is removed.

Reduced-motion block on every animated surface (including the state-dot chase, a gap in the reference).

Verification: lint, 5381 tests (12 new behavior-test files), build + artifact checks - all green. Named gap: the toast CSS/TSX timing invariant is comment-pinned, not CSS-parse-tested (renderer vitest returns empty for css?raw - measured).