### PR TITLE
feat(vex-app): UIUX rebrand phase 3d - book panel and welcome hero

### DIFF
--- a/vex-app/src/renderer/components/icons/glyphs/objects.tsx
+++ b/vex-app/src/renderer/components/icons/glyphs/objects.tsx
@@ -140,3 +140,14 @@ export const IconLink = ({ size = 16, className }: GlyphProps): JSX.Element => (
     </g>
   </svg>
 );
+
+export const IconLock = ({ size = 16, className }: GlyphProps): JSX.Element => (
+  <svg width={size} height={size} className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M12 2.8C9.18335 2.8 6.9 5.08335 6.9 7.9V9.7H5.5C4.83726 9.7 4.3 10.2373 4.3 10.9V19.9C4.3 20.5627 4.83726 21.1 5.5 21.1H18.5C19.1627 21.1 19.7 20.5627 19.7 19.9V10.9C19.7 10.2373 19.1627 9.7 18.5 9.7H17.1V7.9C17.1 5.08335 14.8167 2.8 12 2.8ZM15.5 9.7H8.5V7.9C8.5 5.96701 10.067 4.4 12 4.4C13.933 4.4 15.5 5.96701 15.5 7.9V9.7ZM11.2 13.3H12.8V17.5H11.2V13.3Z"
+      fill="currentColor"
+      fillRule="evenodd"
+      clipRule="evenodd"
+    />
+  </svg>
+);

--- a/vex-app/src/renderer/features/appShell/BookPanel.tsx
+++ b/vex-app/src/renderer/features/appShell/BookPanel.tsx
@@ -10,7 +10,10 @@
  *  - SESSION stage: the rail below, now carrying the SAME `PortfolioCard`
  *    stack rather than the retired hairline/mono-ledger `BookBlock` grammar
  *    (owner decree: one card system app-wide). Card order — Position,
- *    Wallets, Balances, Activity, Runtime & Cost, Session.
+ *    Wallets, Balances, Activity, Runtime & Cost, Session. An ADDITIVE
+ *    inspect mode (A32/E13, `book/inspect/`) overlays a tool-call view while
+ *    the inspect store holds a payload; the stack hides via CSS, never
+ *    unmounts.
  *
  * The rail floats over the Eclipse backdrop as soft translucent ink
  * (`--vex-rail` + backdrop-blur, guard-whitelisted for exactly this file and
@@ -30,7 +33,14 @@
  * still owns the stage/viewport collapse edges — unchanged by this redesign.
  */
 
-import { useMemo, useRef, useState, type JSX, type ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+  type ReactNode,
+} from "react";
 import { motion } from "motion/react";
 import {
   PanelRightCloseIcon,
@@ -60,6 +70,8 @@ import {
   resolveBookSectionOrder,
   type BookSectionId,
 } from "./book/section-order.js";
+import { BookInspectPanel } from "./book/inspect/BookInspectPanel.js";
+import { useToolInspectStore } from "./book/inspect/inspect-store.js";
 import { useUiStore } from "../../stores/uiStore.js";
 import { useScrollbarVisibility } from "../../lib/useScrollbarVisibility.js";
 import type { SessionPermission } from "@shared/schemas/sessions.js";
@@ -76,7 +88,7 @@ function renderBookSection(
     case "wallets":
       return <SessionWalletsCard sessionId={sessionId} />;
     case "balances":
-      return <BalancesCard sessionId={sessionId} />;
+      return <BalancesCard scope={{ kind: "session", sessionId }} />;
     case "activity":
       return <SessionActivityCard sessionId={sessionId} />;
     case "runtime":
@@ -132,6 +144,19 @@ export function BookPanel({
     ? (sessionQuery.data.data?.permission ?? null)
     : null;
 
+  // INSPECT mode (A32/E13) — an ADDITIVE view: while a tool-call payload for
+  // THIS session is open, the inspect panel shows and the card stack hides
+  // via CSS (it stays mounted, so no card state or query is lost and the
+  // stack's enter stagger never replays on close). A session switch closes
+  // the view — a stale call from another session must never render.
+  const inspect = useToolInspectStore((s) => s.inspect);
+  const closeToolInspect = useToolInspectStore((s) => s.closeToolInspect);
+  useEffect(() => {
+    closeToolInspect();
+  }, [activeSessionId, closeToolInspect]);
+  const inspecting =
+    inspect !== null && inspect.sessionId === activeSessionId;
+
   // WELCOME stage: the floating Portfolio tab replaces the rail entirely.
   if (activeSessionId === null) {
     return <WelcomePortfolioPanel bookOpen={bookOpen} onToggle={onToggle} />;
@@ -160,7 +185,7 @@ export function BookPanel({
         )}
       >
         {bookOpen ? (
-          <span className="vex-micro text-[var(--vex-text-3)]">
+          <span className="font-doto text-[10px] uppercase tracking-[0.14em] text-ink-tertiary">
             v{__VEX_APP_VERSION__}
           </span>
         ) : null}
@@ -176,6 +201,9 @@ export function BookPanel({
         </SidebarIconButton>
       </div>
 
+      {bookOpen && inspecting && inspect !== null ? (
+        <BookInspectPanel inspect={inspect} />
+      ) : null}
       {bookOpen ? (
         <motion.ul
           variants={stackVariants}
@@ -183,7 +211,10 @@ export function BookPanel({
           animate="show"
           role="list"
           ref={stackRef}
-          className="vex-scroll vex-scroll-overlay flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto"
+          className={cn(
+            "vex-scroll vex-scroll-overlay flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto",
+            inspecting && "hidden",
+          )}
         >
           {order.map((id, index) => (
             <ReorderableSection

--- a/vex-app/src/renderer/features/appShell/SessionPanel.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionPanel.tsx
@@ -61,6 +61,8 @@ import { useEngineErrorLiveSync } from "../../lib/api/engine-errors.js";
 import { SessionErrorBanner } from "./SessionErrorBanner.js";
 import { SessionSleepBanner } from "./SessionSleepBanner.js";
 import { useUsageLiveSync } from "../../lib/api/usage.js";
+import { useWindowTitleSync } from "../../lib/window-title.js";
+import { useTurnCompleteNotification } from "../../lib/turn-notification.js";
 import { useSession } from "../../lib/api/sessions.js";
 import { cn } from "../../lib/utils.js";
 import { useStreamPreview } from "../../stores/streamStore.js";
@@ -123,6 +125,15 @@ export function SessionPanel({
     if (!detailQuery.data?.ok) return null;
     return detailQuery.data.data;
   }, [activeSessionId, detailQuery.data]);
+
+  // E15 + A34: the native window title mirrors the active session, with the
+  // unseen-turn badge while an answer landed unfocused (existing transcript
+  // spine only — no new IPC).
+  const unseenTurn = useTurnCompleteNotification(activeSessionId);
+  useWindowTitleSync(
+    activeSession?.title ?? activeSession?.initialGoal ?? null,
+    unseenTurn,
+  );
 
   const detailError =
     detailQuery.data && detailQuery.data.ok === false

--- a/vex-app/src/renderer/features/appShell/SessionWelcomeHero.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionWelcomeHero.tsx
@@ -1,102 +1,108 @@
 /**
- * Welcome stage — the Grok-style LOGO ROW crown (owner decree 2026-07-21).
- *
- * The H1 "What should I execute?" display statement is DELETED. What remains
- * above the composer is ONE centered logo row borrowing Grok's home
- * [icon + wordmark] grammar:
- *
- *   - the VexSigil particle-constellation mark (falls back to the clean
- *     monogram <img> in jsdom / on canvas failure), sized to the Grok icon
- *     slot rather than the old full-crown height;
- *   - beside it, the PREVIEW · v{version} badge redesigned as a wordmark-
- *     position hallmark: White House face (Instrument Sans), letterspaced
- *     caps, SOLID text wearing the `.vex-preview-shimmer` overlay
- *     (globals.css — an ::after duplicate via data-shimmer-text sweeps a
- *     translucent white band over the glyphs on a slow ~3.2s loop; the base
- *     text is never background-clipped; stilled under reduced motion). The
- *     honest build-stage tooltip carries over from the retired pill via a
- *     plain `title` attribute.
- *
- * The parent (`SessionPanel`) seats this crown directly above the composer
- * and centers [logo row + input + chips] vertically as one column — the
- * Grok home composition. This component no longer bottom-anchors itself
- * (the old `mt-auto` is gone); it is plain flow content plus one absolute
- * band:
- *
- *   BOTTOM BAND (absolute at the stage's bottom edge — the parent's
- *   trailing spacer keeps this band clear): ONLY the centered BACKED BY
- *   hallmark (unchanged by the 2026-07-21 logo-row round). The only other
- *   copy on the stage.
- *
- * Load-in: the one-shot .vex-rise choreography — the logo row takes the
- * base slot as one unit; the parent stages the instrument at d2 and the
- * chips row at d3 on SIBLING elements outside this component; the bottom
- * band closes at d4. Mount-once: no class re-toggles on re-render.
- * Pure presentation: no session state, no composer coupling.
+ * Welcome stage crown — the rebrand hero (accepted mockup, 2026-08-20): the
+ * vx script mark over a Doto date eyebrow, the display headline, and the
+ * Agent | Studio runtime-mode toggle (Studio reserved: disabled with a lock
+ * until vex-studio ships — seam #2). The parent (`SessionPanel`) seats this
+ * directly above the composer and centers the column; the "BACKED BY"
+ * footer band is retired. Load-in rides the one-shot `.vex-rise`
+ * choreography; the composer and chips stagger on sibling elements.
  */
 
 import type { JSX } from "react";
-import { VexSigil } from "./VexSigil.js";
+import { IconLock } from "../../components/icons/index.js";
+import { cn } from "../../lib/utils.js";
+import { useUiStore } from "../../stores/uiStore.js";
 
-/** Sigil sizing — the crown mark ABOVE the PREVIEW wordmark (owner decree
- * 2026-07-21 round 2: "logo VEX musi być nad preview i ma być w chuj
- * większe" — the side-by-side Grok row shrank it to badge scale). */
-const SIGIL_CLASS = "h-36 md:h-44";
-
-/** The wordmark-slot text — also the badge's accessible name. */
-const PREVIEW_LABEL = `PREVIEW · v${__VEX_APP_VERSION__}`;
-
-/** Honest build-stage disclosure, carried over from the retired pill. */
+/** Honest build-stage disclosure (carried from the retired PREVIEW badge). */
 const PREVIEW_TITLE =
   `Preview build (v${__VEX_APP_VERSION__}). Vex is pre-1.0 and evolving. ` +
   "Self-custodial — you control your keys and every action. " +
   "Verify before moving funds. Not financial advice.";
 
-export function SessionWelcomeHero(): JSX.Element {
-  return (
-    <>
-      {/* LOGO CROWN — the BIG sigil stacked OVER the PREVIEW wordmark
-       * (owner decree 2026-07-21 round 2: the side-by-side row shrank the
-       * mark to badge scale — now the mark dominates and the wordmark sits
-       * beneath it), one centered unit riding the base .vex-rise slot.
-       * pb-2 + the composer's own mt-6 keep the breath before the input. */}
-      <div className="relative z-10 flex w-full flex-col items-center px-8 pb-2 text-center">
-        <div className="vex-rise flex flex-col items-center justify-center gap-4">
-          <VexSigil className={SIGIL_CLASS} />
-          {/* PREVIEW BADGE — the wordmark slot. Instrument Sans (the WH
-           * face; the serif is rationed to the Portfolio Total Value),
-           * letterspaced caps in the secondary tone so the sweeping white
-           * shimmer band reads against it. Static SPAN, not a control. */}
-          <span
-            className="vex-preview-shimmer font-sans text-[13px] font-medium uppercase tracking-[0.42em] text-[var(--vex-text-2)] md:text-sm"
-            data-shimmer-text={PREVIEW_LABEL}
-            title={PREVIEW_TITLE}
-            aria-label={PREVIEW_LABEL}
-          >
-            {PREVIEW_LABEL}
-          </span>
-        </div>
-      </div>
+/** "WEDNESDAY · AUG 20" — computed once per mount; a date, not a clock. */
+function eyebrowDate(): string {
+  const now = new Date();
+  const weekday = now.toLocaleDateString("en-US", { weekday: "long" });
+  const day = now.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return `${weekday} · ${day}`.toUpperCase();
+}
 
-      {/* BOTTOM BAND — the landing .hero-bottom at the stage's bottom edge:
-       * ONLY the centered BACKED BY hallmark (owner decree 2026-07-21: the
-       * "Executes through" integrations rail + chain-coverage line are
-       * retired; the flanking barcode/LOCAL-FIRST/YOU-SIGN copy went in the
-       * 2026-07-20 round). Click-transparent (pointer-events-none). */}
-      <div className="vex-rise vex-rise-d4 pointer-events-none absolute inset-x-0 bottom-0 z-10 flex flex-col gap-3.5 px-8 pb-5 sm:px-12">
-        {/* BACKED BY — the partner hallmark: a monochrome mark at
-         * opacity-70, comfortable spacing. A hallmark, not a billboard. */}
-        <div className="flex items-center justify-center gap-4">
-          <span className="font-sans text-[10px] uppercase tracking-[0.3em] text-[var(--vex-text-3)]">
-            Backed by
-          </span>
-          <img
-            src="/logo/virtuals.svg"
-            alt="Virtuals"
-            className="h-7 w-7 opacity-70"
-          />
-        </div>
+export function SessionWelcomeHero(): JSX.Element {
+  // READ-ONLY seam: the slot exists so the toggle can light up the moment
+  // Studio ships; nothing here may switch it.
+  const runtimeMode = useUiStore((s) => s.runtimeMode);
+
+  return (
+    <div className="relative z-10 flex w-full flex-col items-center px-8 pb-2 text-center">
+      <div className="vex-rise flex flex-col items-center justify-center gap-3">
+        {/* vx script mark — white over the chronos night photo, brand blue on
+          * the celeris day scene (arbitrary parent variant on the theme
+          * attribute; no JS theme read). */}
+        <img
+          src="/brand/vex-mark-white.svg"
+          alt=""
+          aria-hidden
+          className="h-16 w-auto [[data-vex-theme=celeris]_&]:hidden"
+        />
+        <img
+          src="/brand/vex-mark-color.svg"
+          alt=""
+          aria-hidden
+          className="hidden h-16 w-auto [[data-vex-theme=celeris]_&]:block"
+        />
+        <span
+          className="font-doto text-[11px] font-medium uppercase tracking-[0.32em] text-ink-tertiary"
+          title={PREVIEW_TITLE}
+        >
+          {eyebrowDate()}
+        </span>
+        <h1 className="font-display text-[30px] font-medium leading-[38px] tracking-[-0.01em] text-ink-primary">
+          What should I execute?
+        </h1>
+        <RuntimeModeToggle runtimeMode={runtimeMode} />
       </div>
-    </>
+    </div>
+  );
+}
+
+/**
+ * Agent | Studio segmented capsule. Studio is a reserved seat: disabled,
+ * wearing the lock, explained by its title — the interaction space ships now
+ * so the studio mode plugs in without a layout change. Neither segment
+ * writes the store.
+ */
+function RuntimeModeToggle({
+  runtimeMode,
+}: {
+  readonly runtimeMode: "agent" | "studio";
+}): JSX.Element {
+  return (
+    <div
+      role="group"
+      aria-label="Runtime mode"
+      className="flex h-9 items-center gap-0.5 rounded-capsule border border-line-2 bg-surface-1 p-0.5 shadow-lv1"
+    >
+      <span
+        aria-current={runtimeMode === "agent" ? "true" : undefined}
+        className={cn(
+          "inline-flex h-full items-center rounded-capsule px-3.5 text-[12.5px]",
+          runtimeMode === "agent"
+            ? "bg-interactive-active font-medium text-ink-primary"
+            : "text-ink-tertiary",
+        )}
+      >
+        Agent
+      </span>
+      <button
+        type="button"
+        disabled
+        title="Vex Studio - coming soon"
+        aria-label="Studio mode (coming soon)"
+        className="inline-flex h-full cursor-not-allowed items-center gap-1.5 rounded-capsule px-3.5 text-[12.5px] text-ink-caption"
+      >
+        Studio
+        <IconLock size={12} className="shrink-0" />
+      </button>
+    </div>
   );
 }

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/shell-sidebar.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/shell-sidebar.test.tsx
@@ -331,20 +331,19 @@ describe("AppShell", () => {
   it("renders the Vex shell hero and the profile footer with the night-shift hallmark", async () => {
     renderShell();
 
-    // The H1 display statement is DELETED (owner decree 2026-07-21): the
-    // welcome crown is the [sigil + PREVIEW wordmark] logo row, pinned
-    // close-range in SessionWelcomeHero.test.tsx and via the badge below.
+    // The rebrand hero headline is back (accepted mockup, 2026-08-20),
+    // pinned close-range in SessionWelcomeHero.test.tsx.
     expect(
-      screen.queryByRole("heading", { name: /What should I execute\?/i }),
-    ).toBeNull();
+      screen.getByRole("heading", { name: /What should I execute\?/i }),
+    ).not.toBeNull();
     expect(screen.getAllByRole("button", { name: /New session/i }).length).toBeGreaterThan(0);
     // Healthy runtime → the profile subtitle speaks the Chronos hallmark.
     await screen.findByText("The night shift is active.");
     // The bare version stamp lives in the SESSION rail's collapse header;
     // on the welcome stage the right edge is the floating Portfolio tab
-    // (no version chrome) and the hero's PREVIEW badge carries the version.
+    // (no version chrome) and the hero carries only the eyebrow tooltip.
     expect(screen.queryByText("v0.0.0-test")).toBeNull();
-    expect(screen.getByText("PREVIEW · v0.0.0-test")).not.toBeNull();
+    expect(screen.queryByText(/^PREVIEW · v/)).toBeNull();
   });
 
   it("profile menu carries exactly six entries (no Missions — Sessions covers it)", async () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/welcome-create.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/welcome-create.test.tsx
@@ -368,17 +368,15 @@ beforeEach(() => {
 });
 
 describe("AppShell", () => {
-  it("shows the PREVIEW build badge on the no-session welcome stage", async () => {
+  it("shows the rebrand hero headline on the no-session welcome stage", async () => {
     sessionsListMock.mockResolvedValueOnce({ ok: true, data: [] });
     useUiStore.setState({ activeSessionId: null });
     renderShell();
 
-    // The PREVIEW wordmark badge is the welcome sentinel now — the H1
-    // display statement is deleted (owner decree 2026-07-21).
-    await screen.findByText("PREVIEW · v0.0.0-test");
-    expect(
-      screen.queryByRole("heading", { name: /What should I execute/i }),
-    ).toBeNull();
+    // The headline is the welcome sentinel again (accepted mockup,
+    // 2026-08-20); the PREVIEW wordmark retired with the Grok logo row.
+    await screen.findByRole("heading", { name: /What should I execute/i });
+    expect(screen.queryByText(/^PREVIEW · v/)).toBeNull();
   });
 
   it("welcome composer Send opens the creator with the draft carried + name pre-filled (welcome→create)", async () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/BalancesCard.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/BalancesCard.test.tsx
@@ -85,7 +85,13 @@ function mountWith(
     isError: false,
     data: { ok: true, data: portfolio(tokens) },
   });
-  return render(<BalancesCard sessionId={sessionId} />);
+  return render(
+    <BalancesCard
+      scope={
+        sessionId === null ? { kind: "global" } : { kind: "session", sessionId }
+      }
+    />,
+  );
 }
 
 beforeEach(() => {

--- a/vex-app/src/renderer/features/appShell/__tests__/BookPanel.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/BookPanel.test.tsx
@@ -33,8 +33,17 @@ vi.mock("../book/SessionWalletsCard.js", () => ({
   SessionWalletsCard: () => <div data-testid="card-wallets" />,
 }));
 vi.mock("../book/portfolio/BalancesCard.js", () => ({
-  BalancesCard: ({ sessionId }: { readonly sessionId?: string | null }) => (
-    <div data-testid="card-balances" data-session-id={sessionId ?? ""} />
+  BalancesCard: ({
+    scope,
+  }: {
+    readonly scope:
+      | { readonly kind: "global" }
+      | { readonly kind: "session"; readonly sessionId: string };
+  }) => (
+    <div
+      data-testid="card-balances"
+      data-session-id={scope.kind === "session" ? scope.sessionId : ""}
+    />
   ),
 }));
 vi.mock("../book/SessionActivityCard.js", () => ({

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionWelcomeHero.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionWelcomeHero.test.tsx
@@ -1,35 +1,15 @@
 /**
- * SessionWelcomeHero — Grok-style logo-row contract (owner decree
- * 2026-07-21).
- *
- * Pins the pieces other suites and the design system depend on:
- *   1. the H1 "What should I execute?" is DELETED — no heading of any level
- *      renders on the stage (shell-sidebar / welcome-create assert the same
- *      absence through the full AppShell; this is the close-range pin), and
- *      the retired barcode flicker class is gone with it;
- *   2. the crown is ONE centered logo row — the VexSigil mark beside the
- *      PREVIEW · v{version} wordmark badge (Grok's [icon + wordmark]
- *      grammar) — riding the base .vex-rise slot as one unit;
- *   3. the badge contract: White House face (Instrument Sans via
- *      font-sans), SOLID base text wearing the `.vex-preview-shimmer`
- *      overlay through `data-shimmer-text` (the delta-shimmer idiom — the
- *      base text is never background-clipped), the honest build-stage
- *      tooltip via a plain `title`, a static non-interactive SPAN;
- *   4. the hero's ONLY imagery is the sigil (jsdom: the canvas falls back
- *      to the plain monogram <img> INSIDE [data-vex-sigil]) plus the bottom
- *      band's partner mark;
- *   5. the bottom band is unchanged: ONLY the centered BACKED BY hallmark,
- *      closing the rise choreography at d4;
- *   6. retired compositions stay dead: the H1, the rotating tagline quips,
- *      the eyebrow status line, the old hairline PREVIEW pill's border
- *      chrome, the integrations rail, and the theme switch.
+ * SessionWelcomeHero — the rebrand hero contract (accepted mockup,
+ * 2026-08-20): vx mark pair themed by CSS, Doto date eyebrow carrying the
+ * honest build-stage disclosure, the display headline, the reserved
+ * Agent | Studio toggle (Studio disabled + lock, runtimeMode read-only),
+ * and the retirement of the BACKED BY footer (studio seam #2).
  */
 
-import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useUiStore } from "../../../stores/uiStore.js";
 import { SessionWelcomeHero } from "../SessionWelcomeHero.js";
-
-const PREVIEW_LABEL = "PREVIEW · v0.0.0-test";
 
 /** The five retired rotator quips — must never render again. */
 const RETIRED_QUIPS = [
@@ -40,101 +20,80 @@ const RETIRED_QUIPS = [
   "VEX is listening.",
 ] as const;
 
+beforeEach(() => {
+  useUiStore.setState({ runtimeMode: "agent" });
+});
+
 describe("SessionWelcomeHero", () => {
-  it("deletes the H1 — no heading renders on the stage at all", () => {
-    render(<SessionWelcomeHero />);
-    expect(screen.queryByRole("heading")).toBeNull();
-    expect(screen.queryByText(/What should I execute/i)).toBeNull();
-  });
-
-  it("renders the logo row: sigil + PREVIEW wordmark side by side as one rising unit", () => {
+  it("renders the vx mark pair: white for chronos, brand color revealed only under the celeris theme attribute", () => {
     const { container } = render(<SessionWelcomeHero />);
-    const sigil = container.querySelector("[data-vex-sigil]");
-    expect(sigil).not.toBeNull();
-    const badge = screen.getByText(PREVIEW_LABEL);
-    // One row: the mark and the wordmark share the same flex parent.
-    const row = sigil?.parentElement ?? null;
-    expect(row).not.toBeNull();
-    expect(badge.parentElement).toBe(row);
-    expect(row?.classList.contains("items-center")).toBe(true);
-    // The row takes the base .vex-rise slot as ONE unit (no delay modifier);
-    // its children carry no rise classes of their own.
-    expect(row?.classList.contains("vex-rise")).toBe(true);
-    expect(row?.classList.contains("vex-rise-d1")).toBe(false);
-    expect(badge.classList.contains("vex-rise")).toBe(false);
-    expect(sigil?.classList.contains("vex-rise")).toBe(false);
+    const marks = Array.from(container.querySelectorAll("img"));
+    expect(marks.map((img) => img.getAttribute("src"))).toEqual([
+      "/brand/vex-mark-white.svg",
+      "/brand/vex-mark-color.svg",
+    ]);
+    // Theme selection is pure CSS on the html attribute — the white mark
+    // hides under celeris, the color mark shows only there. No JS theme read.
+    expect(marks[0]?.className).toContain("[[data-vex-theme=celeris]_&]:hidden");
+    expect(marks[1]?.className).toContain("hidden");
+    expect(marks[1]?.className).toContain("[[data-vex-theme=celeris]_&]:block");
+    for (const mark of marks) {
+      expect(mark.getAttribute("aria-hidden")).toBe("true");
+    }
   });
 
-  it("badge: Instrument Sans wordmark with the shimmer overlay, solid base text, honest tooltip", () => {
+  it("speaks the date in the Doto eyebrow and keeps the honest preview disclosure as its tooltip", () => {
+    const { container } = render(<SessionWelcomeHero />);
+    const eyebrow = container.querySelector(".font-doto");
+    expect(eyebrow).not.toBeNull();
+    // A date, uppercase, e.g. "WEDNESDAY · AUG 20" — pinned by grammar, not
+    // by today's value.
+    expect(eyebrow?.textContent).toMatch(/^[A-Z]+ · [A-Z]{3} \d{1,2}$/);
+    expect(eyebrow?.getAttribute("title")).toContain("Preview build (v0.0.0-test)");
+    expect(eyebrow?.getAttribute("title")).toContain("Self-custodial");
+  });
+
+  it("renders the headline as the stage's one heading", () => {
     render(<SessionWelcomeHero />);
-    const badge = screen.getByText(PREVIEW_LABEL);
-    expect(badge.textContent).toBe(PREVIEW_LABEL);
-    // Shimmer contract (the .vex-delta-shimmer idiom): the overlay
-    // duplicates the SOLID text via data-shimmer-text — the class must
-    // pair with the attribute or the ::after band has nothing to clip to.
-    expect(badge.classList.contains("vex-preview-shimmer")).toBe(true);
-    expect(badge.getAttribute("data-shimmer-text")).toBe(PREVIEW_LABEL);
-    // White House face: Instrument Sans, not the serif and not the mono.
-    expect(badge.classList.contains("font-sans")).toBe(true);
-    expect(badge.classList.contains("font-serif")).toBe(false);
-    expect(badge.classList.contains("font-mono")).toBe(false);
-    // Honest build-stage disclosure carried over from the retired pill.
-    expect(badge.getAttribute("title")).toBe(
-      "Preview build (v0.0.0-test). Vex is pre-1.0 and evolving. " +
-        "Self-custodial — you control your keys and every action. " +
-        "Verify before moving funds. Not financial advice.",
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading.textContent).toBe("What should I execute?");
+  });
+
+  it("reserves the Studio seat: disabled, wearing the lock, and never writing runtimeMode", () => {
+    render(<SessionWelcomeHero />);
+    const studio = screen.getByRole("button", {
+      name: "Studio mode (coming soon)",
+    });
+    expect(studio).toHaveProperty("disabled", true);
+    expect(studio.querySelector("svg")).not.toBeNull();
+    fireEvent.click(studio);
+    expect(useUiStore.getState().runtimeMode).toBe("agent");
+  });
+
+  it("marks the Agent segment as the current runtime mode without offering a switch", () => {
+    render(<SessionWelcomeHero />);
+    const group = screen.getByRole("group", { name: "Runtime mode" });
+    const agent = Array.from(group.querySelectorAll("span")).find(
+      (el) => el.textContent === "Agent",
     );
-    expect(badge.getAttribute("aria-label")).toBe(PREVIEW_LABEL);
-    // Non-interactive: a static disclosure wordmark, not a button/link, and
-    // the old hairline pill chrome is gone (no border classes).
-    expect(badge.tagName).toBe("SPAN");
-    expect(badge.className).not.toContain("border");
+    expect(agent?.getAttribute("aria-current")).toBe("true");
+    // Agent is a state readout, not a control — no button, no store write.
+    expect(agent?.tagName).toBe("SPAN");
   });
 
-  it("carries the sigil crown (decorative, with the jsdom monogram fallback) plus the partner mark", () => {
-    const { container } = render(<SessionWelcomeHero />);
-    const sigil = container.querySelector("[data-vex-sigil]");
-    expect(sigil).not.toBeNull();
-    // Decorative contract on the mark.
-    expect(sigil?.getAttribute("aria-hidden")).toBe("true");
-    expect(sigil?.className).toContain("pointer-events-none");
-    // jsdom: the sigil's canvas 2D is unavailable → its <img> fallback lives
-    // INSIDE the sigil box (the VEX monogram).
-    const sigilImg = sigil?.querySelector("[data-vex-sigil-fallback]");
-    expect(sigilImg?.getAttribute("src")).toBe("/logo_clean.png");
-    // The only other imagery on the stage is the bottom band's partner mark.
-    const backing = Array.from(container.querySelectorAll("img")).filter(
-      (img) =>
-        sigil?.contains(img) === false && (img.getAttribute("alt") ?? "") !== "",
-    );
-    expect(backing.map((img) => img.getAttribute("alt"))).toEqual(["Virtuals"]);
-  });
-
-  it("keeps the BACKED BY bottom band unchanged, closing the rise at d4", () => {
+  it("retires the BACKED BY footer band entirely (studio seam #2)", () => {
     render(<SessionWelcomeHero />);
-    expect(screen.getByText("Backed by")).not.toBeNull();
-    expect(screen.getByAltText("Virtuals")).not.toBeNull();
-    // The band rises LAST (d4) as one unit.
-    const bottomRow = screen.getByText("Backed by").closest(".vex-rise");
-    expect(bottomRow).not.toBeNull();
-    expect(bottomRow?.classList.contains("vex-rise-d4")).toBe(true);
-    // The retired Robinhood mark and mode switch stay dead.
-    expect(screen.queryByAltText("Robinhood")).toBeNull();
-    expect(screen.queryByRole("switch")).toBeNull();
+    expect(screen.queryByText(/Backed by/i)).toBeNull();
+    expect(screen.queryByAltText("Virtuals")).toBeNull();
   });
 
-  it("retired compositions stay dead: quips, eyebrow, barcode, integrations rail", () => {
+  it("retired compositions stay dead: quips, PREVIEW wordmark, sigil, integrations rail", () => {
     const { container } = render(<SessionWelcomeHero />);
-    // The rotating tagline quips (retired 2026-07-21) never render.
     for (const quip of RETIRED_QUIPS) {
       expect(screen.queryByText(quip)).toBeNull();
     }
-    // No eyebrow status line, no barcode flicker (deleted with the H1).
-    expect(container.querySelector(".vex-eyebrow")).toBeNull();
-    expect(container.querySelector(".vex-title-barcode")).toBeNull();
-    // The "Executes through" integrations rail stays retired.
+    expect(screen.queryByText(/^PREVIEW · v/)).toBeNull();
+    expect(container.querySelector("[data-vex-sigil]")).toBeNull();
     expect(screen.queryByText(/Executes through/i)).toBeNull();
-    // The phase-5 img-in-text quips (the inline monogram mechanism).
-    expect(screen.queryByAltText("Vex")).toBeNull();
   });
 });

--- a/vex-app/src/renderer/features/appShell/__tests__/shell-design-guard.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/shell-design-guard.test.ts
@@ -170,21 +170,12 @@ const WHITELIST: readonly WhitelistEntry[] = [
   // layer-2 card on tokens v2 - its backdrop-blur exemption became inert
   // when the glass chrome retired, so the entry is deleted rather than
   // kept as a stale sanction.
-  {
-    // Welcome Portfolio tab (approved harness plan v6, 2026-07-20): the
-    // welcome stage's floating card stack (Overview / Wallets / Balances)
-    // joins the Chronos glass family. Deliberately scoped to the SINGLE
-    // PortfolioCard chrome every card composes (the HvZone precedent) — no
-    // other portfolio file may carry backdrop-blur; the round handle button
-    // is intentionally blur-free ink.
-    file: "features/appShell/book/portfolio/PortfolioCard.tsx",
-    pattern: "backdrop-blur (glass)",
-    reason:
-      "Approved welcome Portfolio tab (plan v6, 2026-07-20): the floating " +
-      "portfolio cards wear translucent ink (--vex-rail) with " +
-      "backdrop-blur + static grain over the current shell backdrop, via this " +
-      "one card chrome that every card composes.",
-  },
+  // REMOVED (rebrand phase 3, 2026-08-20): PortfolioCard is a solid
+  // layer-1 card on tokens v2 (border + lv1 shadow) — its backdrop-blur
+  // exemption became inert when the glass chrome retired, so the entry is
+  // deleted rather than kept as a stale sanction. Glass remains sanctioned
+  // ONLY on the two side rails, the ShellScreen overlays, and the profile
+  // menu.
 ];
 
 interface Violation {

--- a/vex-app/src/renderer/features/appShell/book/GlobalWalletAddresses.tsx
+++ b/vex-app/src/renderer/features/appShell/book/GlobalWalletAddresses.tsx
@@ -84,8 +84,8 @@ export function GlobalWalletAddresses(): JSX.Element | null {
         />
       ) : null}
       {remaining.length > 0 ? (
-        <div className="mt-0.5 flex flex-col gap-1 border-t border-[var(--vex-line)] pt-1.5">
-          <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[var(--vex-text-3)]">
+        <div className="mt-0.5 flex flex-col gap-1 border-t border-line-2 pt-1.5">
+          <span className="font-doto text-[9px] uppercase tracking-[0.18em] text-ink-tertiary">
             {remaining.length} more {remaining.length === 1 ? "wallet" : "wallets"}
           </span>
           {remaining.map((wallet) => (
@@ -121,12 +121,12 @@ function AddressRow({
     <div className="flex items-center gap-2">
       <span className="flex w-11 shrink-0 items-center gap-1.5">
         <ChainIcon chainId={chainId} size={13} />
-        <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[var(--vex-text-3)]">
+        <span className="font-doto text-[9px] uppercase tracking-[0.18em] text-ink-tertiary">
           {caption}
         </span>
       </span>
       {wallet.label.length > 0 ? (
-        <span className="shrink-0 truncate text-[11px] text-[var(--vex-text-2)]">
+        <span className="shrink-0 truncate text-[11px] text-ink-secondary">
           {wallet.label}
         </span>
       ) : null}

--- a/vex-app/src/renderer/features/appShell/book/GlobalWalletSwitcher.tsx
+++ b/vex-app/src/renderer/features/appShell/book/GlobalWalletSwitcher.tsx
@@ -153,14 +153,14 @@ function WalletChip({
       aria-pressed={pressed}
       onClick={onClick}
       className={cn(
-        "inline-flex h-6 max-w-[120px] items-center gap-1 rounded-full border px-2 font-mono text-[9px] uppercase tracking-[0.14em] transition-colors",
+        "inline-flex h-6 max-w-[120px] items-center gap-1 rounded-full border px-2 text-[10.5px] transition-colors",
         pressed
-          ? "border-[var(--vex-accent-border-strong)] text-[var(--vex-text)]"
-          : "border-[var(--vex-line)] text-[var(--vex-text-3)] hover:border-[var(--vex-line-strong)] hover:text-[var(--vex-text-2)]",
+          ? "border-accent-primary text-ink-primary"
+          : "border-line-2 text-ink-tertiary hover:border-line-3 hover:text-ink-secondary",
       )}
     >
       {chainId !== undefined ? <ChainIcon chainId={chainId} size={11} /> : null}
-      <span className="truncate normal-case tracking-normal">{label}</span>
+      <span className="truncate">{label}</span>
     </button>
   );
 }
@@ -193,16 +193,16 @@ function DefaultHoldings({
       ) : tokens.length > 0 ? (
         // Wallet HAS tokens but every row rounds to $0.00 — say so instead
         // of leaving an unexplained gap under the total.
-        <p className="font-mono text-[11px] text-[var(--vex-text-3)]">
+        <p className="text-[11px] text-ink-tertiary">
           No priced balances.
         </p>
       ) : (
-        <p className="text-[11px] text-[var(--vex-text-3)]">
+        <p className="text-[11px] text-ink-tertiary">
           No token balances.
         </p>
       )}
       {remainder > 0 ? (
-        <p className="font-mono text-[10px] tracking-[0.14em] text-[var(--vex-text-3)]">
+        <p className="font-doto text-[10px] tracking-[0.14em] text-ink-tertiary">
           +{remainder} more
         </p>
       ) : null}
@@ -226,19 +226,19 @@ function TokenRow({ token }: { readonly token: PositionTokenDto }): JSX.Element 
   // never a fabricated $0.00).
   const quantity = formatTokenQuantity(token.amount, symbol);
   return (
-    <li className="flex items-baseline justify-between gap-3 border-b border-[var(--vex-line)] py-1.5 last:border-b-0">
-      <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-[var(--vex-text-2)]">
+    <li className="flex items-baseline justify-between gap-3 border-b border-line-1 py-1.5 last:border-b-0">
+      <span className="min-w-0 flex-1 truncate text-[11px] text-ink-secondary">
         {symbol ?? "—"}
       </span>
-      <span className="flex shrink-0 items-baseline gap-2 font-mono text-[11px] tabular-nums">
+      <span className="flex shrink-0 items-baseline gap-2 text-[11px] font-semibold tabular-nums">
         {quantity !== null ? (
-          <span className="text-[var(--vex-text-3)]">{quantity}</span>
+          <span className="text-ink-tertiary">{quantity}</span>
         ) : null}
         <span
           className={
             token.balanceUsd === null
-              ? "text-[var(--vex-text-3)]"
-              : "text-[var(--vex-text)]"
+              ? "text-ink-tertiary"
+              : "text-ink-primary"
           }
         >
           {formatUsd(token.balanceUsd)}
@@ -267,21 +267,21 @@ function WalletScopedHoldings({
 
   if (query.isLoading) {
     return (
-      <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--vex-text-3)]">
+      <p className="font-doto text-[10px] uppercase tracking-[0.14em] text-ink-tertiary">
         Loading…
       </p>
     );
   }
   if ((result !== undefined && !result.ok) || query.isError) {
     return (
-      <p className="text-[11px] text-[var(--vex-warn-text)]">
+      <p className="text-[11px] text-warning-label">
         Couldn&apos;t load this wallet&apos;s holdings.
       </p>
     );
   }
   if (portfolio === null) {
     return (
-      <p className="text-[11px] text-[var(--vex-text-3)]">
+      <p className="text-[11px] text-ink-tertiary">
         No holdings for this wallet.
       </p>
     );
@@ -290,10 +290,10 @@ function WalletScopedHoldings({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-baseline justify-between gap-2">
-        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--vex-text-3)]">
+        <span className="font-doto text-[10px] uppercase tracking-[0.14em] text-ink-tertiary">
           Wallet total
         </span>
-        <span className="font-mono text-[13px] tabular-nums text-[var(--vex-text)]">
+        <span className="text-[13px] font-semibold tabular-nums text-ink-primary">
           {formatUsd(portfolio.liveTotalUsd)}
         </span>
       </div>

--- a/vex-app/src/renderer/features/appShell/book/ImageLockerCard.tsx
+++ b/vex-app/src/renderer/features/appShell/book/ImageLockerCard.tsx
@@ -31,7 +31,7 @@
 import { useState, type JSX } from "react";
 import type { VexError } from "@shared/ipc/result.js";
 import type { ImageOnchainVariant } from "@shared/schemas/images.js";
-import { PlusIcon, VexIcon } from "../../../components/icons/index.js";
+import { IconPlus } from "../../../components/icons/index.js";
 import {
   useDeleteLockerImage,
   useLockerImages,
@@ -145,7 +145,7 @@ export function ImageLockerCard({
       )}
 
       {notice !== null ? (
-        <p className="mt-2 text-[11px] leading-relaxed text-[var(--vex-warn-text)]">
+        <p className="mt-2 text-[11px] leading-relaxed text-warning-label">
           {notice}
         </p>
       ) : null}
@@ -154,16 +154,16 @@ export function ImageLockerCard({
         type="button"
         onClick={runUpload}
         disabled={busy}
-        className="mt-2.5 flex w-full items-center justify-center gap-1.5 rounded-full border border-[var(--vex-line)] py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-[var(--vex-text-2)] transition-colors hover:text-[var(--vex-text)] disabled:opacity-50"
+        className="mt-2.5 flex w-full items-center justify-center gap-1.5 rounded-full border border-line-2 py-1.5 font-doto text-[10px] uppercase tracking-[0.16em] text-ink-secondary transition-colors hover:text-ink-primary disabled:opacity-50"
       >
-        <VexIcon icon={PlusIcon} size={12} aria-hidden />
+        <IconPlus size={12} />
         {busy ? "Adding…" : "Add image"}
       </button>
 
       {/* The ONLY way a user reaches the launch dialog, now inside the card
           that holds the image every launch needs. The chips sit beside it so
           the launchpad is chosen where the picture is. */}
-      <div className="mt-2.5 flex flex-col gap-2 border-t border-[var(--vex-line)] pt-2.5">
+      <div className="mt-2.5 flex flex-col gap-2 border-t border-line-2 pt-2.5">
         <LaunchPlatformChips value={platform} onChange={setPlatform} />
         <TokenLaunchButton
           sessionId={sessionId}

--- a/vex-app/src/renderer/features/appShell/book/PortfolioRefreshButton.tsx
+++ b/vex-app/src/renderer/features/appShell/book/PortfolioRefreshButton.tsx
@@ -61,17 +61,17 @@ export function PortfolioRefreshButton(): JSX.Element {
         disabled={inFlight}
         aria-label="Refresh portfolio"
         title="Refresh portfolio"
-        className="rounded p-1 text-[var(--vex-text-3)] transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        className="rounded p-1 text-ink-tertiary transition-colors hover:text-ink-primary disabled:cursor-not-allowed disabled:opacity-50"
       >
-        <RefreshCwIcon spinning={inFlight} />
+        <RefreshGlyph spinning={inFlight} />
       </button>
       {feedback.kind === "throttled" ? (
-        <span className="text-[10px] tabular-nums text-[var(--vex-text-3)]">
+        <span className="text-[10px] tabular-nums text-ink-tertiary">
           just refreshed — retry in {feedback.retryAfterSeconds}s
         </span>
       ) : null}
       {feedback.kind === "unavailable" ? (
-        <span className="text-[10px] text-[var(--vex-warn-text)]">
+        <span className="text-[10px] text-warning-label">
           could not refresh — showing last known
         </span>
       ) : null}
@@ -79,7 +79,7 @@ export function PortfolioRefreshButton(): JSX.Element {
   );
 }
 
-function RefreshCwIcon({ spinning }: { readonly spinning: boolean }): JSX.Element {
+function RefreshGlyph({ spinning }: { readonly spinning: boolean }): JSX.Element {
   return (
     <svg
       width="13"

--- a/vex-app/src/renderer/features/appShell/book/PositionBlock.tsx
+++ b/vex-app/src/renderer/features/appShell/book/PositionBlock.tsx
@@ -1,7 +1,7 @@
 /**
  * POSITION — the wallet portfolio card. Card-system grammar (`PortfolioCard`,
- * C3) since the book became one card stack: the serif display total from
- * `PortfolioOverviewCard`'s hero convention, the snapshot/PnL line, and the
+ * C3) since the book became one card stack: the display total from
+ * `PortfolioOverviewCard`'s hero convention (Inter Tight 600 tabular), the snapshot/PnL line, and the
  * resolved wallet COUNT in the card's trailing slot.
  *
  * Dual-scope, driven purely by `activeSessionId`:
@@ -24,7 +24,7 @@
  * cross-wallet aggregate — selecting one wallet in the switcher never changes
  * it; the wallet-scoped body shows that wallet's own total separately.
  *
- * Signal Tape language: serif display figure, semantic up/down on the PnL,
+ * Signal Tape language: one display figure, semantic up/down on the PnL,
  * `tabular-nums` on every figure.
  */
 
@@ -164,15 +164,16 @@ function TotalFigure({
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-start justify-between gap-2">
-        <span className="text-[10.5px] text-[var(--vex-text-3)]">Total value</span>
+        <span className="text-[10.5px] text-ink-tertiary">Total value</span>
         <PortfolioRefreshButton />
       </div>
-      {/* Serif is rationed to this ONE display figure (typography law, C2). */}
-      <span className="font-serif text-[34px] leading-none tracking-[-0.01em] tabular-nums text-foreground">
+      {/* Display figure: Inter Tight 600 tabular — the serif retired to the
+        * gate voice (tokens v2 typography law). */}
+      <span className="font-display text-[30px] font-semibold leading-none tracking-[-0.01em] tabular-nums text-ink-primary">
         {formatUsd(liveTotalUsd)}
       </span>
       {snapshotTotalUsd !== null ? (
-        <span className="flex items-baseline gap-1.5 text-[11px] tabular-nums text-[var(--vex-text-3)]">
+        <span className="flex items-baseline gap-1.5 text-[11px] tabular-nums text-ink-tertiary">
           <span>snapshot {formatUsd(snapshotTotalUsd)}</span>
           {pnlVsPrev !== null ? (
             <span
@@ -190,7 +191,7 @@ function TotalFigure({
 
 /** Up = success, down = warn, flat/zero = muted. No glow, token colours only. */
 function pnlToneClass(pnl: number): string {
-  if (pnl > 0) return "text-[var(--color-success)]";
-  if (pnl < 0) return "text-[var(--vex-warn-text)]";
-  return "text-[var(--vex-text-3)]";
+  if (pnl > 0) return "text-success";
+  if (pnl < 0) return "text-warning-label";
+  return "text-ink-tertiary";
 }

--- a/vex-app/src/renderer/features/appShell/book/PositionChains.tsx
+++ b/vex-app/src/renderer/features/appShell/book/PositionChains.tsx
@@ -92,7 +92,7 @@ export function PositionChains({
       <div className="flex items-center justify-between gap-2">
         <span className="flex min-w-0 items-center gap-1.5">
           <ChainIcon chainId={selectedChainId} size={14} />
-          <span className="truncate text-[11px] text-[var(--vex-text-2)]">
+          <span className="truncate text-[11px] text-ink-secondary">
             {chainName(selectedChainId)}
           </span>
         </span>
@@ -114,10 +114,10 @@ export function PositionChains({
               // A faint plinth behind every mark keeps dark-inked brand icons
               // visible on the ink canvas (owner report: "Base was
               // invisible"); the native title names the network on hover.
-              "inline-flex h-6 w-6 items-center justify-center rounded-full border bg-white/[0.05] transition-colors",
+              "inline-flex h-6 w-6 items-center justify-center rounded-full border bg-interactive-hover transition-colors",
               id === selectedChainId
-                ? "border-[var(--vex-accent-border-strong)]"
-                : "border-transparent hover:border-[var(--vex-line-strong)]",
+                ? "border-accent-primary"
+                : "border-transparent hover:border-line-3",
             )}
           >
             <ChainIcon chainId={id} size={13} />
@@ -129,7 +129,7 @@ export function PositionChains({
           type="button"
           aria-haspopup="dialog"
           onClick={() => setMoreOpen(true)}
-          className="inline-flex h-6 items-center rounded-full border border-transparent px-1.5 text-[10.5px] text-[var(--vex-text-3)] transition-colors hover:border-[var(--vex-line-strong)] hover:text-[var(--vex-text-2)]"
+          className="inline-flex h-6 items-center rounded-full border border-transparent px-1.5 text-[10.5px] text-ink-tertiary transition-colors hover:border-line-3 hover:text-ink-secondary"
         >
           more
         </button>
@@ -143,7 +143,7 @@ export function PositionChains({
       {moreOpen ? (
         <Dialog open={moreOpen} onOpenChange={setMoreOpen}>
           <DialogContent className="max-w-sm">
-            <DialogHeader className="gap-1.5 border-[var(--vex-line)] py-4">
+            <DialogHeader className="gap-1.5 border-line-2 py-4">
               <DialogTitle>Networks</DialogTitle>
               <DialogDescription>
                 Every network holding a balance in this position.
@@ -162,11 +162,11 @@ export function PositionChains({
                           setSelectedChainId(c.chainId);
                           setMoreOpen(false);
                         }}
-                        className="flex w-full items-center justify-between gap-3 border-b border-[var(--vex-line)] py-2 text-left transition-colors last:border-b-0 hover:text-[var(--vex-text)]"
+                        className="flex w-full items-center justify-between gap-3 border-b border-line-1 py-2 text-left transition-colors last:border-b-0 hover:text-ink-primary"
                       >
                         <span className="flex min-w-0 items-center gap-2">
                           <ChainIcon chainId={c.chainId} size={14} />
-                          <span className="truncate text-[12px] text-[var(--vex-text-2)]">
+                          <span className="truncate text-[12px] text-ink-secondary">
                             {chainName(c.chainId)}
                           </span>
                         </span>
@@ -176,7 +176,7 @@ export function PositionChains({
                   ))}
                 </ul>
               ) : (
-                <p className="text-[11px] text-[var(--vex-text-3)]">
+                <p className="text-[11px] text-ink-tertiary">
                   No funded networks yet.
                 </p>
               )}
@@ -202,8 +202,8 @@ function ChainTotalFigure({
   return (
     <span
       className={cn(
-        "shrink-0 text-[11px] tabular-nums",
-        unpriced ? "text-[var(--vex-text-3)]" : "text-[var(--vex-text)]",
+        "shrink-0 text-[11px] font-semibold tabular-nums",
+        unpriced ? "text-ink-tertiary" : "text-ink-primary",
       )}
     >
       {unpriced ? "—" : formatUsd(totalUsd)}
@@ -247,7 +247,7 @@ function ChainTokenList({
   );
   if (displayable.length === 0) {
     return (
-      <p className="text-[11px] text-[var(--vex-text-3)]">
+      <p className="text-[11px] text-ink-tertiary">
         No assets on {chainName(chainId)}
       </p>
     );
@@ -262,23 +262,23 @@ function ChainTokenList({
         return (
           <li
             key={`${chainId}:${tokenAddress ?? "x"}:${symbol ?? "—"}:${index}`}
-            className="flex items-center justify-between gap-3 border-b border-[var(--vex-line)] py-1.5 last:border-b-0"
+            className="flex items-center justify-between gap-3 border-b border-line-1 py-1.5 last:border-b-0"
           >
             <span className="flex min-w-0 flex-1 items-center gap-2">
               <TokenMark mark={mark} size={13} />
-              <span className="truncate text-[11.5px] text-[var(--vex-text-2)]">
+              <span className="truncate text-[11.5px] text-ink-secondary">
                 {symbol !== null && symbol.length > 0 ? symbol : "—"}
               </span>
             </span>
-            <span className="flex shrink-0 items-baseline gap-2 text-[11px] tabular-nums">
+            <span className="flex shrink-0 items-baseline gap-2 text-[11px] font-semibold tabular-nums">
               {quantity !== null ? (
-                <span className="text-[var(--vex-text-3)]">{quantity}</span>
+                <span className="text-ink-tertiary">{quantity}</span>
               ) : null}
               <span
                 className={
                   token.balanceUsd === null
-                    ? "text-[var(--vex-text-3)]"
-                    : "text-[var(--vex-text)]"
+                    ? "text-ink-tertiary"
+                    : "text-ink-primary"
                 }
               >
                 {formatUsd(token.balanceUsd)}

--- a/vex-app/src/renderer/features/appShell/book/ReorderableSection.tsx
+++ b/vex-app/src/renderer/features/appShell/book/ReorderableSection.tsx
@@ -265,9 +265,9 @@ export function ReorderableSection({
         // The drop indicator is a CSS-only hairline on the row's own edge — no
         // JS positioning, no injected style.
         dropEdge === "before" &&
-          "before:absolute before:inset-x-0 before:-top-1 before:h-0.5 before:rounded-full before:bg-[var(--vex-accent)]",
+          "before:absolute before:inset-x-0 before:-top-1 before:h-0.5 before:rounded-full before:bg-accent-primary",
         dropEdge === "after" &&
-          "after:absolute after:inset-x-0 after:-bottom-1 after:h-0.5 after:rounded-full after:bg-[var(--vex-accent)]",
+          "after:absolute after:inset-x-0 after:-bottom-1 after:h-0.5 after:rounded-full after:bg-accent-primary",
       )}
     >
       <button
@@ -277,7 +277,7 @@ export function ReorderableSection({
         onDragEnd={reorder.onDragEnd}
         onKeyDown={(event) => reorder.onHandleKeyDown(id, index, event)}
         aria-label={`Reorder ${BOOK_SECTION_LABEL[id]} — position ${index + 1} of ${count}`}
-        className="absolute right-2 top-2 z-10 cursor-grab rounded p-1 text-[var(--vex-text-3)] opacity-0 transition-opacity hover:text-[var(--vex-text)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)] group-hover:opacity-100"
+        className="absolute right-2 top-2 z-10 cursor-grab rounded p-1 text-ink-tertiary opacity-0 transition-opacity hover:text-ink-primary focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary group-hover:opacity-100"
       >
         <VexIcon icon={GripVerticalIcon} size={12} aria-hidden />
       </button>

--- a/vex-app/src/renderer/features/appShell/book/SessionActivityCard.tsx
+++ b/vex-app/src/renderer/features/appShell/book/SessionActivityCard.tsx
@@ -26,9 +26,8 @@ import { useMemo, type JSX, type MouseEvent } from "react";
 import type { AgentScanDto, AgentScanEntry } from "@shared/schemas/agent-scan-feed.js";
 import type { Result } from "@shared/ipc/result.js";
 import {
-  ChevronRightIcon,
-  ArrowUpRightIcon,
-  VexIcon,
+  IconChevronRight,
+  IconArrowUpRight,
 } from "../../../components/icons/index.js";
 import { useAgentScanInfinite } from "../../../lib/api/portfolio.js";
 import { useUiStore } from "../../../stores/uiStore.js";
@@ -116,10 +115,10 @@ export function SessionActivityCard({
       <button
         type="button"
         onClick={openAgentScan}
-        className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg py-1.5 text-[12px] text-[var(--vex-text-2)] transition-colors hover:bg-white/[0.05] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--vex-accent)]"
+        className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg py-1.5 text-[12px] text-ink-secondary transition-colors hover:bg-interactive-hover hover:text-ink-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-primary"
       >
         View all activity
-        <VexIcon icon={ChevronRightIcon} size={13} aria-hidden />
+        <IconChevronRight size={13} />
       </button>
     </PortfolioCard>
   );
@@ -132,7 +131,7 @@ function ActivityRow({ entry }: { readonly entry: AgentScanEntry }): JSX.Element
   const clock = entryClockText(entry.createdAt);
 
   return (
-    <li className="flex flex-col gap-0.5 border-b border-[var(--vex-line)] py-1.5 last:border-b-0 last:pb-0.5">
+    <li className="flex flex-col gap-0.5 border-b border-line-1 py-1.5 last:border-b-0 last:pb-0.5">
       <div className="flex items-center gap-1.5">
         <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
           <ProtocolMark mark={mark} size={13} />
@@ -144,30 +143,29 @@ function ActivityRow({ entry }: { readonly entry: AgentScanEntry }): JSX.Element
           statusTitle={entry.failureCode ?? undefined}
         />
       </div>
-      {/* REGISTER (C2): the dense numeric line is Instrument Sans with
-        * `tabular-nums`, NOT mono — mono is reserved for technical artifacts
-        * (code, raw JSON, addresses, tx hashes). The figures still align in a
-        * column because the tabular figure set, not the face, is what does
-        * that work. */}
-      <div className="flex items-baseline gap-1.5 overflow-hidden whitespace-nowrap pl-[20px] text-[10.5px] tabular-nums text-[var(--vex-text-2)]">
+      {/* The dense numeric line is Inter Tight with `tabular-nums`, NOT mono
+        * — mono is reserved for technical artifacts (code, raw JSON,
+        * addresses, tx hashes). The tabular figure set, not the face, keeps
+        * the column aligned. */}
+      <div className="flex items-baseline gap-1.5 overflow-hidden whitespace-nowrap pl-[20px] text-[10.5px] tabular-nums text-ink-secondary">
         <Leg
           amount={legAmountText(entry.input)}
           symbol={legSymbolText(entry.input)}
           estimated={estimated}
         />
-        <span className="shrink-0 text-[var(--vex-text-3)]">→</span>
+        <span className="shrink-0 text-ink-tertiary">→</span>
         <Leg
           amount={legAmountText(entry.output)}
           symbol={legSymbolText(entry.output)}
           estimated={estimated}
         />
         {estimated ? (
-          <span className="shrink-0 uppercase tracking-[0.14em] text-[var(--vex-text-3)]">
+          <span className="shrink-0 uppercase tracking-[0.14em] text-ink-tertiary">
             est.
           </span>
         ) : null}
         {clock !== null ? (
-          <span className="ml-auto shrink-0 text-[var(--vex-text-3)]">{clock}</span>
+          <span className="ml-auto shrink-0 text-ink-tertiary">{clock}</span>
         ) : null}
         {entry.explorerUrl !== null ? (
           <a
@@ -175,10 +173,10 @@ function ActivityRow({ entry }: { readonly entry: AgentScanEntry }): JSX.Element
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Open transaction on block explorer"
-            className="inline-flex shrink-0 items-center gap-0.5 rounded-[3px] uppercase tracking-[0.14em] text-[var(--vex-text-3)] transition-colors hover:text-[var(--vex-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)]"
+            className="inline-flex shrink-0 items-center gap-0.5 rounded-[3px] uppercase tracking-[0.14em] text-ink-tertiary transition-colors hover:text-ink-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
           >
             TX
-            <VexIcon icon={ArrowUpRightIcon} size={10} aria-hidden />
+            <IconArrowUpRight size={10} />
           </a>
         ) : null}
       </div>

--- a/vex-app/src/renderer/features/appShell/book/SessionBlock.tsx
+++ b/vex-app/src/renderer/features/appShell/book/SessionBlock.tsx
@@ -7,9 +7,19 @@
 
 import type { JSX, ReactNode } from "react";
 import { useSession } from "../../../lib/api/sessions.js";
-import { cn } from "../../../lib/utils.js";
 import { formatSessionTime, getMissionActivity } from "../sessionListModel.js";
+import {
+  StateDot,
+  type StateDotState,
+} from "../../../components/ui/state-dot.js";
 import { CardStateNote, PortfolioCard } from "./portfolio/PortfolioCard.js";
+
+/** Mission-activity tone → StateDot state (word + dot, never color alone). */
+const ACTIVITY_DOT: Record<"active" | "paused" | "stopped", StateDotState> = {
+  active: "ongoing",
+  paused: "warning",
+  stopped: "done",
+};
 
 /** Key/value row: muted label, stronger tabular value, hairline-separated. */
 function Row({
@@ -20,9 +30,9 @@ function Row({
   readonly children: ReactNode;
 }): JSX.Element {
   return (
-    <div className="flex items-baseline justify-between gap-3 border-b border-[var(--vex-line)] py-1.5 last:border-b-0 last:pb-0.5">
-      <span className="text-[10.5px] text-[var(--vex-text-3)]">{label}</span>
-      <span className="min-w-0 truncate text-right text-[11.5px] tabular-nums text-[var(--vex-text)]">
+    <div className="flex items-baseline justify-between gap-3 border-b border-line-1 py-1.5 last:border-b-0 last:pb-0.5">
+      <span className="text-[10.5px] text-ink-tertiary">{label}</span>
+      <span className="min-w-0 truncate text-right text-[11.5px] tabular-nums text-ink-primary">
         {children}
       </span>
     </div>
@@ -60,10 +70,9 @@ export function SessionBlock({
         {activity !== null ? (
           <Row label="Status">
             <span className="inline-flex items-center gap-1.5">
-              <span
-                aria-hidden
-                className={cn("h-1.5 w-1.5 rounded-full", activity.dotClass)}
-              />
+              {/* Status grammar: the word carries the meaning, the StateDot
+                * carries the motion (ongoing = pixel chase). */}
+              <StateDot state={ACTIVITY_DOT[activity.tone]} size={8} />
               {activity.label}
             </span>
           </Row>

--- a/vex-app/src/renderer/features/appShell/book/SessionRuntimeCard.tsx
+++ b/vex-app/src/renderer/features/appShell/book/SessionRuntimeCard.tsx
@@ -58,6 +58,7 @@ import {
 import { useSessionModel } from "../../../lib/api/sessions.js";
 import { CompactionApplyButton } from "../CompactionApplyButton.js";
 import { ModelBrandIcon } from "../../wizard/steps/provider/ModelBrandIcon.js";
+import { StateDot } from "../../../components/ui/state-dot.js";
 import { CardStateNote, PortfolioCard } from "./portfolio/PortfolioCard.js";
 
 export function SessionRuntimeCard({
@@ -98,7 +99,7 @@ export function SessionRuntimeCard({
         data-vex-area="runtime-status"
         role="group"
         aria-label="Session runtime status"
-        className="flex w-full flex-col gap-2.5 text-[11px] text-[var(--vex-text-3)]"
+        className="flex w-full flex-col gap-2.5 text-[11px] text-ink-tertiary"
       >
         <ModelLine model={model} />
         <UsageLine lastTurn={lastTurn} totals={totals} />
@@ -116,7 +117,7 @@ export function SessionRuntimeCard({
 }
 
 /** Muted key next to a stronger tabular value — the card's metric grammar. */
-const METRIC_LABEL = "uppercase tracking-[0.16em] text-[var(--vex-text-3)]";
+const METRIC_LABEL = "font-doto uppercase tracking-[0.16em] text-ink-tertiary";
 
 function Metric({
   label,
@@ -128,7 +129,7 @@ function Metric({
   return (
     <span className="inline-flex items-baseline gap-1">
       <span className={METRIC_LABEL}>{label}</span>
-      <span className="tabular-nums text-[var(--vex-text)]">{value}</span>
+      <span className="font-semibold tabular-nums text-ink-primary">{value}</span>
     </span>
   );
 }
@@ -168,7 +169,7 @@ function ModelLine({
         data-vex-area="session-model-indicator"
         data-state="unconfigured"
         aria-label="Model not configured"
-        className="text-[11px] text-[var(--vex-text-3)]"
+        className="text-[11px] text-ink-tertiary"
       >
         Model not configured
       </span>
@@ -184,11 +185,11 @@ function ModelLine({
     >
       <ModelBrandIcon modelId={model.modelId} size={14} />
       <span className="flex min-w-0 flex-col leading-tight">
-        <span className="min-w-0 truncate text-[12px] text-[var(--vex-text)]">
+        <span className="min-w-0 truncate text-[12px] text-ink-primary">
           {model.modelId}
         </span>
         {model.provider !== null ? (
-          <span className="truncate text-[10.5px] text-[var(--vex-text-3)]">
+          <span className="truncate text-[10.5px] text-ink-tertiary">
             via {model.provider}
           </span>
         ) : null}
@@ -222,7 +223,7 @@ function UsageLine({
   return (
     <span
       data-vex-area="usage-meter"
-      className="flex flex-wrap items-baseline gap-x-3 gap-y-1 tabular-nums text-[10.5px] text-[var(--vex-text-3)]"
+      className="flex flex-wrap items-baseline gap-x-3 gap-y-1 tabular-nums text-[10.5px] text-ink-tertiary"
       title={buildUsageTitle(lastTurn, totals)}
     >
       {lastTurn !== null ? (
@@ -244,7 +245,7 @@ function UsageLine({
       {cost !== null ? (
         <span
           aria-label="session cost"
-          className="ml-auto tabular-nums text-[var(--vex-text)]"
+          className="ml-auto tabular-nums text-ink-primary"
         >
           {fmtCost(cost)}
         </span>
@@ -312,7 +313,7 @@ function BandMarker({
     <span
       aria-hidden
       title={title}
-      className="absolute inset-y-0 w-px bg-[var(--vex-line-strong)]"
+      className="absolute inset-y-0 w-px bg-line-3"
       style={{ left: `${fraction * 100}%` }}
     />
   );
@@ -367,11 +368,11 @@ function ContextMeter({
       >
         <span className={METRIC_LABEL}>ctx</span>
         <span
-          className="relative h-1 min-w-0 flex-1 overflow-hidden rounded-full bg-white/[0.12]"
+          className="relative h-1 min-w-0 flex-1 overflow-hidden rounded-full bg-surface-skeleton"
           aria-hidden
         >
           <span
-            className="absolute inset-y-0 left-0 rounded-full bg-[var(--vex-accent)]"
+            className="absolute inset-y-0 left-0 rounded-full bg-accent-primary"
             style={{ width: `${pct}%` }}
           />
           {context.pressureWarningFraction !== undefined ? (
@@ -390,9 +391,9 @@ function ContextMeter({
             />
           ) : null}
         </span>
-        <span className="shrink-0 text-[var(--vex-text)]">{pct}%</span>
+        <span className="shrink-0 text-ink-primary">{pct}%</span>
       </div>
-      <p className="text-[10px] leading-snug text-[var(--vex-text-3)]">
+      <p className="text-[10px] leading-snug text-ink-tertiary">
         {autoCompactPct !== null ? `Auto-compact ~${autoCompactPct}% · ` : ""}
         approx, lags one turn
       </p>
@@ -436,7 +437,16 @@ function CompactionNote({
       data-state={state}
       title={`${label} · ${COMPACTION_REMOTE_NOTE}`}
       aria-label={`Compaction status: ${label}. ${COMPACTION_REMOTE_NOTE}`}
+      className="inline-flex items-center gap-1.5"
     >
+      {/* Status grammar: the word carries the meaning, the StateDot the
+        * motion (running = pixel chase). */}
+      <StateDot
+        state={
+          state === "failed" ? "error" : state === "running" ? "ongoing" : "warning"
+        }
+        size={8}
+      />
       <CardStateNote tone={state === "failed" ? "warn" : "muted"}>
         {label}
       </CardStateNote>

--- a/vex-app/src/renderer/features/appShell/book/SessionWalletsCard.tsx
+++ b/vex-app/src/renderer/features/appShell/book/SessionWalletsCard.tsx
@@ -90,15 +90,15 @@ function WalletRow({
   readonly wallet: SelectedWalletDto;
 }): JSX.Element {
   return (
-    <li className="flex flex-col gap-1.5 border-b border-[var(--vex-line)] py-2 first:pt-0.5 last:border-b-0 last:pb-1">
+    <li className="flex flex-col gap-1.5 border-b border-line-1 py-2 first:pt-0.5 last:border-b-0 last:pb-1">
       <div className="flex items-center gap-2">
         <ChainIcon chainId={chainId} size={13} />
         {wallet.label.length > 0 ? (
-          <span className="min-w-0 truncate text-[12px] text-[var(--vex-text)]">
+          <span className="min-w-0 truncate text-[12px] text-ink-primary">
             {wallet.label}
           </span>
         ) : null}
-        <span className="shrink-0 text-[10.5px] text-[var(--vex-text-3)]">
+        <span className="shrink-0 text-[10.5px] text-ink-tertiary">
           {familyCaption}
         </span>
       </div>

--- a/vex-app/src/renderer/features/appShell/book/__tests__/inspect-mode.test.tsx
+++ b/vex-app/src/renderer/features/appShell/book/__tests__/inspect-mode.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * BOOK inspect mode (A32/E13) — behavior pins for the additive tool-call
+ * view: opening swaps the rail's stack for the inspect panel WITHOUT
+ * unmounting a single card, closing restores the stack, a session switch or
+ * a foreign-session payload never renders, and hostile payloads (BigInt,
+ * circular) degrade instead of crashing. The transcript's tool row drives
+ * `openToolInspect` (board contract, 2026-08-20); this suite drives the
+ * store directly at the same seam.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+vi.mock("../../../../components/icons/VexIcon.js", () => ({
+  VexIcon: () => null,
+}));
+vi.mock("../PositionBlock.js", () => ({
+  PositionBlock: () => <div data-testid="card-position" />,
+}));
+vi.mock("../SessionWalletsCard.js", () => ({
+  SessionWalletsCard: () => <div data-testid="card-wallets" />,
+}));
+vi.mock("../portfolio/BalancesCard.js", () => ({
+  BalancesCard: () => <div data-testid="card-balances" />,
+}));
+vi.mock("../SessionActivityCard.js", () => ({
+  SessionActivityCard: () => <div data-testid="card-activity" />,
+}));
+vi.mock("../SessionRuntimeCard.js", () => ({
+  SessionRuntimeCard: () => <div data-testid="card-runtime" />,
+}));
+vi.mock("../SessionBlock.js", () => ({
+  SessionBlock: () => <div data-testid="card-session" />,
+}));
+vi.mock("../ImageLockerCard.js", () => ({
+  ImageLockerCard: () => <div data-testid="card-images" />,
+}));
+vi.mock("../../../../lib/api/sessions.js", () => ({
+  useSession: () => ({ data: undefined }),
+}));
+vi.mock("../portfolio/WelcomePortfolioPanel.js", () => ({
+  WelcomePortfolioPanel: () => <div data-testid="welcome-portfolio-panel" />,
+}));
+
+const { BookPanel } = await import("../../BookPanel.js");
+const { useUiStore } = await import("../../../../stores/uiStore.js");
+const { useToolInspectStore } = await import("../inspect/inspect-store.js");
+
+const SESSION = "00000000-0000-4000-8000-00000000dddd";
+const OTHER_SESSION = "00000000-0000-4000-8000-00000000eeee";
+
+function openCall(sessionId: string, overrides: Record<string, unknown> = {}) {
+  act(() => {
+    useToolInspectStore.getState().openToolInspect({
+      sessionId,
+      callKey: "msg-1:0",
+      toolName: "portfolio_read",
+      status: "done",
+      args: { scope: "global" },
+      result: { totalUsd: 12.5 },
+      ...overrides,
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  useUiStore.setState({ bookSectionOrder: [] });
+  act(() => useToolInspectStore.getState().closeToolInspect());
+});
+
+describe("BOOK inspect mode", () => {
+  it("opening a tool call swaps in the inspect panel while every card stays mounted", () => {
+    render(<BookPanel activeSessionId={SESSION} bookOpen onToggle={() => {}} />);
+    expect(screen.queryByLabelText(/Tool call:/)).toBeNull();
+
+    openCall(SESSION);
+
+    const panel = screen.getByLabelText("Tool call: portfolio_read");
+    expect(panel.textContent).toContain("portfolio_read");
+    expect(panel.textContent).toContain("Done");
+    expect(panel.textContent).toContain('"scope": "global"');
+    expect(panel.textContent).toContain('"totalUsd": 12.5');
+    // Additive mode: the stack hides via CSS but no card unmounts.
+    for (const card of [
+      "card-position",
+      "card-wallets",
+      "card-balances",
+      "card-activity",
+      "card-runtime",
+      "card-session",
+      "card-images",
+    ]) {
+      expect(screen.getByTestId(card)).toBeTruthy();
+    }
+    expect(screen.getByRole("list").classList.contains("hidden")).toBe(true);
+  });
+
+  it("closing returns to the card stack with nothing missing", () => {
+    render(<BookPanel activeSessionId={SESSION} bookOpen onToggle={() => {}} />);
+    openCall(SESSION);
+    fireEvent.click(screen.getByRole("button", { name: "Close inspect" }));
+    expect(screen.queryByLabelText(/Tool call:/)).toBeNull();
+    expect(screen.getByRole("list").classList.contains("hidden")).toBe(false);
+    expect(screen.getByTestId("card-position")).toBeTruthy();
+  });
+
+  it("a payload from another session never renders, and a session switch closes the view", () => {
+    const view = render(
+      <BookPanel activeSessionId={SESSION} bookOpen onToggle={() => {}} />,
+    );
+    openCall(OTHER_SESSION);
+    expect(screen.queryByLabelText(/Tool call:/)).toBeNull();
+
+    openCall(SESSION);
+    expect(screen.getByLabelText("Tool call: portfolio_read")).toBeTruthy();
+    view.rerender(
+      <BookPanel activeSessionId={OTHER_SESSION} bookOpen onToggle={() => {}} />,
+    );
+    expect(screen.queryByLabelText(/Tool call:/)).toBeNull();
+    expect(useToolInspectStore.getState().inspect).toBeNull();
+  });
+
+  it("running calls show the status word without a result section; hostile payloads degrade instead of crashing", () => {
+    render(<BookPanel activeSessionId={SESSION} bookOpen onToggle={() => {}} />);
+    const circular: Record<string, unknown> = {};
+    circular["self"] = circular;
+    openCall(SESSION, {
+      status: "running",
+      args: { amount: 10n, loop: circular },
+      result: undefined,
+    });
+    const panel = screen.getByLabelText("Tool call: portfolio_read");
+    expect(panel.textContent).toContain("Running");
+    expect(panel.textContent).toContain("Arguments");
+    expect(panel.textContent).not.toContain("Result");
+    // Circular JSON falls back to String(value); the panel still stands.
+    expect(panel.textContent).toContain("[object Object]");
+  });
+});

--- a/vex-app/src/renderer/features/appShell/book/image-locker/ImageThumb.tsx
+++ b/vex-app/src/renderer/features/appShell/book/image-locker/ImageThumb.tsx
@@ -46,7 +46,7 @@ export function ImageThumb({
   const dataUrl = result?.ok === true ? result.data.dataUrl : null;
 
   return (
-    <li className="group relative aspect-square overflow-hidden rounded-lg border border-[var(--vex-line)] bg-[var(--vex-surface-0)]">
+    <li className="group relative aspect-square overflow-hidden rounded-lg border border-line-2 bg-surface-base">
       {dataUrl !== null ? (
         <img
           src={dataUrl}
@@ -57,7 +57,7 @@ export function ImageThumb({
       ) : (
         <span
           aria-hidden
-          className="flex h-full w-full items-center justify-center font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--vex-text-3)]"
+          className="flex h-full w-full items-center justify-center font-doto text-[9px] uppercase tracking-[0.14em] text-ink-tertiary"
         >
           {hasOnchainCopy && thumb.isLoading ? "…" : "—"}
         </span>
@@ -68,7 +68,7 @@ export function ImageThumb({
       {!hasOnchainCopy ? (
         <span
           title="Too large for a Trench launch, which stores the image on-chain. Usable on pools.fun."
-          className="pointer-events-none absolute left-1 top-1 rounded-full bg-[var(--vex-surface-0)]/90 px-1.5 py-0.5 font-mono text-[8px] uppercase tracking-[0.14em] text-[var(--vex-text-3)]"
+          className="pointer-events-none absolute left-1 top-1 rounded-full bg-surface-base/90 px-1.5 py-0.5 font-doto text-[8px] uppercase tracking-[0.14em] text-ink-tertiary"
         >
           pools only
         </span>
@@ -76,7 +76,7 @@ export function ImageThumb({
 
       {/* The label rides a bottom scrim rather than a solid bar so a light
        * image stays readable without hiding what the user chose. */}
-      <span className="pointer-events-none absolute inset-x-0 bottom-0 truncate bg-gradient-to-t from-[var(--vex-surface-0)] to-transparent px-1.5 pb-1 pt-3 text-[9.5px] text-[var(--vex-text-2)]">
+      <span className="pointer-events-none absolute inset-x-0 bottom-0 truncate bg-gradient-to-t from-surface-base to-transparent px-1.5 pb-1 pt-3 text-[9.5px] text-ink-secondary">
         {image.label}
       </span>
 
@@ -87,7 +87,7 @@ export function ImageThumb({
         // Always reachable by keyboard (focus-visible), revealed on hover for
         // the mouse — a destructive control that only exists on hover is a
         // control a keyboard user does not have.
-        className="absolute right-1 top-1 rounded-full bg-[var(--vex-surface-0)]/90 p-1 text-[var(--vex-text-3)] opacity-0 transition-opacity hover:text-[var(--vex-warn-text)] focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-40"
+        className="absolute right-1 top-1 rounded-full bg-surface-base/90 p-1 text-ink-tertiary opacity-0 transition-opacity hover:text-warning-label focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-40"
         aria-label={`Remove ${image.label} from the locker`}
       >
         <VexIcon icon={Trash2Icon} size={12} aria-hidden />

--- a/vex-app/src/renderer/features/appShell/book/inspect/BookInspectPanel.tsx
+++ b/vex-app/src/renderer/features/appShell/book/inspect/BookInspectPanel.tsx
@@ -1,0 +1,118 @@
+/**
+ * BookInspectPanel — the BOOK's inspect view for one tool call (A32/E13):
+ * tool identity, status as word + StateDot, and the full arguments/result
+ * payloads. Rendered by `BookPanel` while the inspect store holds a payload;
+ * closing returns to the card stack (which stays mounted underneath).
+ * Payloads render COMPLETE — scrolling, never truncation (owner decree).
+ * The JSON view is a placeholder <pre>; it swaps to the shared JsonTree when
+ * that primitive lands (board note, transcript owner's T7).
+ */
+
+import type { JSX } from "react";
+import { IconClose } from "../../../../components/icons/index.js";
+import {
+  StateDot,
+  type StateDotState,
+} from "../../../../components/ui/state-dot.js";
+import {
+  useToolInspectStore,
+  type ToolInspectPayload,
+  type ToolInspectStatus,
+} from "./inspect-store.js";
+
+const STATUS_DOT: Record<ToolInspectStatus, StateDotState> = {
+  pending: "warning",
+  running: "ongoing",
+  done: "done",
+  error: "error",
+};
+
+const STATUS_WORD: Record<ToolInspectStatus, string> = {
+  pending: "Pending",
+  running: "Running",
+  done: "Done",
+  error: "Failed",
+};
+
+/**
+ * Pretty-print an unknown payload for the placeholder view. BigInt and
+ * circular payloads must not crash the panel — they degrade to String().
+ */
+function stringifyPayload(value: unknown): string {
+  if (value === undefined) return "—";
+  try {
+    return JSON.stringify(
+      value,
+      (_key, entry: unknown) =>
+        typeof entry === "bigint" ? entry.toString() : entry,
+      2,
+    );
+  } catch {
+    return String(value);
+  }
+}
+
+export function BookInspectPanel({
+  inspect,
+}: {
+  readonly inspect: ToolInspectPayload;
+}): JSX.Element {
+  const closeToolInspect = useToolInspectStore((s) => s.closeToolInspect);
+  return (
+    <section
+      data-vex-area="book-inspect"
+      aria-label={`Tool call: ${inspect.toolName}`}
+      className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden rounded-xl border border-line-2 bg-surface-1 p-4 shadow-lv1"
+    >
+      <header className="flex items-center justify-between gap-2">
+        <h3 className="font-doto text-[11px] font-semibold uppercase tracking-[0.16em] text-ink-tertiary">
+          Inspect
+        </h3>
+        <button
+          type="button"
+          aria-label="Close inspect"
+          onClick={closeToolInspect}
+          className="flex h-6 w-6 items-center justify-center rounded-[6px] text-ink-tertiary transition-colors hover:bg-interactive-hover hover:text-ink-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
+        >
+          <IconClose size={14} />
+        </button>
+      </header>
+
+      <div className="flex items-center justify-between gap-2">
+        <span className="min-w-0 truncate font-mono text-[12px] text-ink-primary">
+          {inspect.toolName}
+        </span>
+        <span className="inline-flex shrink-0 items-center gap-1.5 text-[11px] text-ink-secondary">
+          <StateDot state={STATUS_DOT[inspect.status]} size={8} />
+          {STATUS_WORD[inspect.status]}
+        </span>
+      </div>
+
+      <div className="vex-scroll flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
+        <PayloadSection label="Arguments" value={inspect.args} />
+        {"result" in inspect && inspect.result !== undefined ? (
+          <PayloadSection label="Result" value={inspect.result} />
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function PayloadSection({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: unknown;
+}): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="font-doto text-[9px] uppercase tracking-[0.18em] text-ink-tertiary">
+        {label}
+      </span>
+      <pre className="overflow-x-auto rounded-lg border border-line-1 p-2 font-mono text-[10.5px] leading-relaxed whitespace-pre-wrap break-words text-ink-secondary">
+        {stringifyPayload(value)}
+      </pre>
+    </div>
+  );
+}

--- a/vex-app/src/renderer/features/appShell/book/inspect/inspect-store.ts
+++ b/vex-app/src/renderer/features/appShell/book/inspect/inspect-store.ts
@@ -1,0 +1,38 @@
+/**
+ * Tool-inspect store — the BOOK panel's ADDITIVE inspect mode (A32/E13).
+ * A tool row in the transcript calls `openToolInspect` with the call it
+ * renders; the BOOK swaps its card stack for the inspect view while a
+ * payload is set and restores it on close. UI-only Zustand state, never
+ * persisted (tool args/results are session data, not preferences), and not
+ * a uiStore slot — the seam is book-local by design (board contract with
+ * the transcript owner, 2026-08-20).
+ */
+
+import { create } from "zustand";
+
+export type ToolInspectStatus = "pending" | "running" | "done" | "error";
+
+export interface ToolInspectPayload {
+  /** Session the call belongs to — a session switch closes the view. */
+  readonly sessionId: string;
+  /** Stable identity of the call row (message/tool-call key). */
+  readonly callKey: string;
+  readonly toolName: string;
+  readonly status: ToolInspectStatus;
+  /** Raw call arguments as the transcript holds them; rendered, never executed. */
+  readonly args: unknown;
+  /** Tool result when the call has one; absent while pending/running. */
+  readonly result?: unknown;
+}
+
+interface ToolInspectState {
+  readonly inspect: ToolInspectPayload | null;
+  readonly openToolInspect: (payload: ToolInspectPayload) => void;
+  readonly closeToolInspect: () => void;
+}
+
+export const useToolInspectStore = create<ToolInspectState>((set) => ({
+  inspect: null,
+  openToolInspect: (payload) => set({ inspect: payload }),
+  closeToolInspect: () => set({ inspect: null }),
+}));

--- a/vex-app/src/renderer/features/appShell/book/portfolio/BalancesCard.tsx
+++ b/vex-app/src/renderer/features/appShell/book/portfolio/BalancesCard.tsx
@@ -1,11 +1,12 @@
 /**
  * Balances — the top holdings of a portfolio read, in the shared
  * `TokenHoldingRow` grammar (address-verified marks, sanitized names, em-dash
- * unpriced convention). ONE card serves both stages:
+ * unpriced convention). ONE card serves both stages, driven by its
+ * `PortfolioCardScope` input (studio seam #3):
  *
- *  - `sessionId === null` — the welcome Portfolio tab: the five largest-USD
+ *  - global scope — the welcome Portfolio tab: the five largest-USD
  *    lines across every configured wallet.
- *  - `sessionId` a uuid — the session rail: the five largest-USD lines of
+ *  - session scope — the session rail: the five largest-USD lines of
  *    THAT session's wallet scope, flat across chains (the session DTO's
  *    `portfolio.tokens[]`; a `chainId: null` row is a real aggregate line and
  *    renders without a chain suffix, it is never dropped).
@@ -24,12 +25,15 @@
 
 import type { JSX, MouseEvent } from "react";
 import {
-  ChevronRightIcon,
-  VexIcon,
+  IconChevronRight,
 } from "../../../../components/icons/index.js";
 import { usePortfolio } from "../../../../lib/api/portfolio.js";
 import { useUiStore } from "../../../../stores/uiStore.js";
 import { CardStateNote, PortfolioCard } from "./PortfolioCard.js";
+import {
+  scopeSessionId,
+  type PortfolioCardScope,
+} from "./portfolio-scope.js";
 import {
   filterDustTokens,
   sortTokensByUsdDesc,
@@ -41,11 +45,12 @@ import {
 const TOP_TOKENS = 5;
 
 export function BalancesCard({
-  sessionId = null,
+  scope,
 }: {
-  /** `null` = the global inventory portfolio; a uuid narrows to one session. */
-  readonly sessionId?: string | null;
-} = {}): JSX.Element {
+  /** Wallet scope this card reads (studio seam #3) — never session state read inside. */
+  readonly scope: PortfolioCardScope;
+}): JSX.Element {
+  const sessionId = scopeSessionId(scope);
   const query = usePortfolio(sessionId);
   const setShellRoute = useUiStore((s) => s.setShellRoute);
   const hideDustBalances = useUiStore((s) => s.hideDustBalances);
@@ -98,10 +103,10 @@ export function BalancesCard({
           <button
             type="button"
             onClick={openAllAssets}
-            className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg py-1.5 text-[12px] text-[var(--vex-text-2)] transition-colors hover:bg-white/[0.05] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--vex-accent)]"
+            className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg py-1.5 text-[12px] text-ink-secondary transition-colors hover:bg-interactive-hover hover:text-ink-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-primary"
           >
             View all assets
-            <VexIcon icon={ChevronRightIcon} size={13} aria-hidden />
+            <IconChevronRight size={13} />
           </button>
         </>
       )}

--- a/vex-app/src/renderer/features/appShell/book/portfolio/PortfolioCard.tsx
+++ b/vex-app/src/renderer/features/appShell/book/portfolio/PortfolioCard.tsx
@@ -1,19 +1,14 @@
 /**
- * PortfolioCard — the ONE Chronos glass chrome for the welcome Portfolio
- * tab's floating cards (Portfolio Overview / Wallets / Balances): ink glass
- * matched to the current shell backdrop (`--vex-rail`) + backdrop-blur
- * (design-guard whitelisted for exactly this file), the static
- * `.vex-noise--panel` grain, a `--vex-line` hairline border, rounded-2xl.
- * Every card in the stack composes this wrapper and NO other portfolio file
- * may carry backdrop-blur (the HvZone precedent: one whitelisted wrapper
- * per glass family, so the guard stays a single conscious entry).
+ * PortfolioCard — the ONE tokens-v2 card chrome every BOOK card composes
+ * (Portfolio Overview / Wallets / Balances / the session cards): a SOLID
+ * layer-1 surface with an alpha hairline border and the lv1 elevation shadow
+ * (celeris separates by border + shadow on white; chronos by the luminance
+ * ladder + white-alpha border — both come free from the aliases). The Doto
+ * eyebrow is the card's dot-matrix signature voice.
  *
  * Each card is a `motion.section` riding the shared `cardVariants`, so the
  * panel's stack stagger (delayChildren/staggerChildren on `stackVariants`)
- * cascades the cards as one gesture without per-card wiring. `isolate`
- * guarantees a stacking context in the SETTLED state too (once the spring
- * lands, motion may drop the transform that was creating one), so the
- * `-z-10` grain always paints above the glass tint and below the content.
+ * cascades the cards as one gesture without per-card wiring.
  */
 
 import type { JSX, ReactNode } from "react";
@@ -42,21 +37,17 @@ export function PortfolioCard({
       // slice the last row ("Add wallet" / "View all assets"; owner
       // screenshot 2026-07-21). Overflow belongs to the stack's scroll, not
       // to card compression.
-      className="relative isolate shrink-0 overflow-hidden rounded-2xl border border-[var(--vex-line)] bg-[var(--vex-rail)] p-4 backdrop-blur-xl"
+      className="relative shrink-0 overflow-hidden rounded-xl border border-line-2 bg-surface-1 p-4 shadow-lv1"
     >
-      <div
-        aria-hidden
-        className="vex-noise vex-noise--panel pointer-events-none absolute inset-0 -z-10 rounded-[inherit]"
-      />
       <header className="mb-2.5 flex items-baseline justify-between gap-2">
-        {/* Landing eyebrow grammar — the same section-head voice as the
-         * session rail's BookBlock. */}
         <span className="flex min-w-0 items-center gap-2">
           {leading}
-          <h3 className="vex-eyebrow">{eyebrow}</h3>
+          <h3 className="font-doto text-[11px] font-semibold uppercase tracking-[0.16em] text-ink-tertiary">
+            {eyebrow}
+          </h3>
         </span>
         {trailing !== undefined ? (
-          <span className="font-mono text-[10px] tabular-nums text-[var(--vex-text-3)]">
+          <span className="text-[11px] tabular-nums text-ink-tertiary">
             {trailing}
           </span>
         ) : null}
@@ -69,7 +60,7 @@ export function PortfolioCard({
 /**
  * Quiet state line for a card body (loading / empty / error) — factual and
  * never louder than the content it stands in for. `loading` speaks the
- * rail's mono micro-voice; `warn` uses the token warn text; `muted` is the
+ * card's Doto micro-voice; `warn` uses the token warn label; `muted` is the
  * default informational tone (empty states phrase an invitation, not a
  * mood).
  */
@@ -82,7 +73,7 @@ export function CardStateNote({
 }): JSX.Element {
   if (tone === "loading") {
     return (
-      <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--vex-text-3)]">
+      <p className="font-doto text-[10px] uppercase tracking-[0.14em] text-ink-tertiary">
         {children}
       </p>
     );
@@ -91,8 +82,8 @@ export function CardStateNote({
     <p
       className={
         tone === "warn"
-          ? "text-[12px] text-[var(--vex-warn-text)]"
-          : "text-[12px] leading-relaxed text-[var(--vex-text-3)]"
+          ? "text-[12px] text-warning-label"
+          : "text-[12px] leading-relaxed text-ink-tertiary"
       }
     >
       {children}

--- a/vex-app/src/renderer/features/appShell/book/portfolio/PortfolioOverviewCard.tsx
+++ b/vex-app/src/renderer/features/appShell/book/portfolio/PortfolioOverviewCard.tsx
@@ -1,7 +1,7 @@
 /**
  * Portfolio Overview — the welcome tab's hero card: the Total Value figure
- * (the tab's ONE serif display number — everything else stays on the
- * sans/mono grammar), the snapshot delta in the existing solid
+ * (the tab's ONE display number, Inter Tight 600 tabular), the snapshot
+ * delta in the existing solid
  * direction-color convention (no shimmer, no washing), and the wallet-scope
  * chips: "All wallets" + one chip per configured wallet, family primaries
  * wearing the Primary badge.
@@ -32,9 +32,18 @@ import {
   flattenPortfolioWallets,
   type PortfolioWallet,
 } from "./wallet-scope.js";
+import {
+  scopeSessionId,
+  type PortfolioCardScope,
+} from "./portfolio-scope.js";
 
-export function PortfolioOverviewCard(): JSX.Element {
-  const globalQuery = usePortfolio(null);
+export function PortfolioOverviewCard({
+  scope,
+}: {
+  /** Wallet scope this card reads (studio seam #3) — never session state read inside. */
+  readonly scope: PortfolioCardScope;
+}): JSX.Element {
+  const globalQuery = usePortfolio(scopeSessionId(scope));
   const walletsQuery = useAvailableWallets();
   const inventory = walletsQuery.data?.ok ? walletsQuery.data.data : null;
   const wallets = inventory !== null ? flattenPortfolioWallets(inventory) : [];
@@ -106,21 +115,22 @@ function TotalFigure({
 }): JSX.Element {
   return (
     <div className="flex flex-col gap-1">
-      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--vex-text-3)]">
+      <span className="font-doto text-[10px] uppercase tracking-[0.14em] text-ink-tertiary">
         Total value
       </span>
-      {/* Serif is rationed to this ONE display figure (typography law). */}
-      <span className="font-serif text-[34px] leading-none tracking-[-0.01em] text-foreground">
+      {/* Display figure: Inter Tight 600 tabular — the serif retired to the
+        * gate voice (tokens v2 typography law). */}
+      <span className="font-display text-[30px] font-semibold leading-none tracking-[-0.01em] tabular-nums text-ink-primary">
         {formatUsd(portfolio?.liveTotalUsd ?? null)}
       </span>
       {portfolio !== null &&
       portfolio.snapshotTotalUsd !== null &&
       portfolio.pnlVsPrev !== null ? (
-        <span className="flex items-baseline gap-1.5 font-mono text-[11px] tabular-nums">
+        <span className="flex items-baseline gap-1.5 text-[11px] tabular-nums">
           <span className={deltaToneClass(portfolio.pnlVsPrev)}>
             {formatUsdDelta(portfolio.pnlVsPrev)}
           </span>
-          <span className="text-[var(--vex-text-3)]">vs last snapshot</span>
+          <span className="text-ink-tertiary">vs last snapshot</span>
         </span>
       ) : null}
     </div>
@@ -130,9 +140,9 @@ function TotalFigure({
 /** Solid direction colors, same convention as the rail's PnL readout
  * (`PositionBlock.pnlToneClass`): up = success, down = warn, flat = muted. */
 function deltaToneClass(pnl: number): string {
-  if (pnl > 0) return "text-[var(--color-success)]";
-  if (pnl < 0) return "text-[var(--vex-warn-text)]";
-  return "text-[var(--vex-text-3)]";
+  if (pnl > 0) return "text-success";
+  if (pnl < 0) return "text-warning-label";
+  return "text-ink-tertiary";
 }
 
 function ScopeChipRow({
@@ -194,8 +204,8 @@ function ScopeChip({
       className={cn(
         "inline-flex h-6 max-w-[150px] items-center gap-1.5 rounded-full border px-2 text-[10.5px] transition-colors",
         pressed
-          ? "border-[var(--vex-accent-border-strong)] text-[var(--vex-text)]"
-          : "border-[var(--vex-line)] text-[var(--vex-text-3)] hover:border-[var(--vex-line-strong)] hover:text-[var(--vex-text-2)]",
+          ? "border-accent-primary text-ink-primary"
+          : "border-line-2 text-ink-tertiary hover:border-line-3 hover:text-ink-secondary",
       )}
     >
       {chainId !== undefined ? <ChainIcon chainId={chainId} size={11} /> : null}

--- a/vex-app/src/renderer/features/appShell/book/portfolio/TokenHoldingRow.tsx
+++ b/vex-app/src/renderer/features/appShell/book/portfolio/TokenHoldingRow.tsx
@@ -3,7 +3,7 @@
  * BalancesCard top five and the All-assets screen's full register): the
  * address-verified `TokenMark` (`resolveTokenMark` — the security control;
  * NEVER a symbol-keyed icon), the display name with the chain in
- * parentheses ("USD Coin (Base)"), and the mono tabular amount + USD
+ * parentheses ("USD Coin (Base)"), and the tabular amount + USD
  * figures. Unpriced holdings keep the em-dash convention
  * (`formatUsd(null)`), never a fabricated $0.00.
  *
@@ -24,7 +24,7 @@
  */
 
 import type { JSX, MouseEvent } from "react";
-import { VexIcon, EyeIcon } from "../../../../components/icons/index.js";
+import { IconInspect } from "../../../../components/icons/index.js";
 import type { PositionTokenDto } from "@shared/schemas/portfolio.js";
 import { chainDisplay } from "@shared/chains/display.js";
 import { sanitizeTokenSymbol } from "@shared/token-symbol-sanitizer.js";
@@ -139,13 +139,13 @@ export function TokenHoldingRow({
   };
 
   return (
-    <li className="flex items-center justify-between gap-3 border-b border-[var(--vex-line)] py-2 last:border-b-0 last:pb-1">
+    <li className="flex items-center justify-between gap-3 border-b border-line-1 py-2 last:border-b-0 last:pb-1">
       <span className="flex min-w-0 flex-1 items-center gap-2">
         <TokenMark mark={mark} size={15} />
-        <span className="min-w-0 truncate text-[12px] leading-tight text-[var(--vex-text)]">
+        <span className="min-w-0 truncate text-[12px] leading-tight text-ink-primary">
           {name ?? "—"}
           {chainName !== null ? (
-            <span className="text-[var(--vex-text-3)]"> ({chainName})</span>
+            <span className="text-ink-tertiary"> ({chainName})</span>
           ) : null}
         </span>
         {historyIdentity !== null ? (
@@ -153,21 +153,21 @@ export function TokenHoldingRow({
             type="button"
             aria-label={`Token history: ${name ?? truncateAddress(historyIdentity.tokenAddress)}`}
             onClick={openHistory}
-            className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[4px] text-[var(--vex-text-3)] transition-colors hover:text-[var(--vex-accent-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)]"
+            className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[4px] text-ink-tertiary transition-colors hover:text-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
           >
-            <VexIcon icon={EyeIcon} size={13} aria-hidden />
+            <IconInspect size={13} />
           </button>
         ) : null}
       </span>
-      <span className="flex shrink-0 items-baseline gap-2 font-mono text-[11px] tabular-nums">
+      <span className="flex shrink-0 items-baseline gap-2 text-[11px] font-semibold tabular-nums">
         {quantity !== null ? (
-          <span className="text-[var(--vex-text-3)]">{quantity}</span>
+          <span className="text-ink-tertiary">{quantity}</span>
         ) : null}
         <span
           className={
             token.balanceUsd === null
-              ? "text-[var(--vex-text-3)]"
-              : "text-[var(--vex-text)]"
+              ? "text-ink-tertiary"
+              : "text-ink-primary"
           }
         >
           {formatUsd(token.balanceUsd)}

--- a/vex-app/src/renderer/features/appShell/book/portfolio/WalletsCard.tsx
+++ b/vex-app/src/renderer/features/appShell/book/portfolio/WalletsCard.tsx
@@ -16,7 +16,7 @@
  */
 
 import type { JSX } from "react";
-import { PlusIcon, VexIcon } from "../../../../components/icons/index.js";
+import { IconPlus } from "../../../../components/icons/index.js";
 import { useAvailableWallets } from "../../../../lib/api/wallet-inventory.js";
 import { useWalletPortfolio } from "../../../../lib/api/portfolio.js";
 import { formatUsd } from "../../../../lib/format.js";
@@ -29,8 +29,19 @@ import {
   flattenPortfolioWallets,
   type PortfolioWallet,
 } from "./wallet-scope.js";
+import type { PortfolioCardScope } from "./portfolio-scope.js";
 
-export function WalletsCard(): JSX.Element {
+export function WalletsCard({
+  scope: _scope,
+}: {
+  /**
+   * Wallet scope input (studio seam #3). The card's only wallet source today
+   * is the global inventory, so a global scope changes nothing — the prop
+   * exists so a future project scope narrows the read instead of forking the
+   * card.
+   */
+  readonly scope: PortfolioCardScope;
+}): JSX.Element {
   const walletsQuery = useAvailableWallets();
   const setShellRoute = useUiStore((s) => s.setShellRoute);
   const result = walletsQuery.data;
@@ -73,9 +84,9 @@ export function WalletsCard(): JSX.Element {
                 section: "wallets",
               });
             }}
-            className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg border border-[var(--vex-line)] py-1.5 text-[12px] text-[var(--vex-text-2)] transition-colors hover:border-[var(--vex-line-strong)] hover:bg-white/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--vex-accent)]"
+            className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg border border-line-2 py-1.5 text-[12px] text-ink-secondary transition-colors hover:border-line-3 hover:bg-interactive-hover hover:text-ink-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-primary"
           >
-            <VexIcon icon={PlusIcon} size={13} aria-hidden />
+            <IconPlus size={13} />
             Add wallet
           </button>
         </>
@@ -91,7 +102,7 @@ export function WalletsCard(): JSX.Element {
  */
 export function PrimaryBadge(): JSX.Element {
   return (
-    <span className="shrink-0 rounded-[4px] border border-[var(--vex-line)] px-1 py-px font-mono text-[8px] uppercase tracking-[0.14em] text-[var(--vex-text-3)]">
+    <span className="shrink-0 rounded-[4px] border border-line-2 px-1 py-px font-doto text-[8px] uppercase tracking-[0.14em] text-ink-tertiary">
       Primary
     </span>
   );
@@ -112,23 +123,23 @@ function WalletRow({
   const total = query.data?.ok ? query.data.data.liveTotalUsd : null;
   const { wallet } = entry;
   return (
-    <li className="flex flex-col gap-1.5 border-b border-[var(--vex-line)] py-2 first:pt-0.5 last:border-b-0 last:pb-1">
+    <li className="flex flex-col gap-1.5 border-b border-line-1 py-2 first:pt-0.5 last:border-b-0 last:pb-1">
       <div className="flex items-center gap-2">
         <ChainIcon chainId={entry.chainId} size={13} />
         {wallet.label.length > 0 ? (
-          <span className="min-w-0 truncate text-[12px] text-[var(--vex-text)]">
+          <span className="min-w-0 truncate text-[12px] text-ink-primary">
             {wallet.label}
           </span>
         ) : (
-          <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[var(--vex-text-3)]">
+          <span className="font-doto text-[9px] uppercase tracking-[0.18em] text-ink-tertiary">
             {wallet.family === "evm" ? "EVM" : "SOL"}
           </span>
         )}
         {entry.showPrimaryBadge ? <PrimaryBadge /> : null}
         <span
           className={cn(
-            "ml-auto shrink-0 font-mono text-[11px] tabular-nums",
-            total === null ? "text-[var(--vex-text-3)]" : "text-[var(--vex-text)]",
+            "ml-auto shrink-0 text-[11px] font-semibold tabular-nums",
+            total === null ? "text-ink-tertiary" : "text-ink-primary",
           )}
         >
           {formatUsd(total)}

--- a/vex-app/src/renderer/features/appShell/book/portfolio/WelcomePortfolioPanel.tsx
+++ b/vex-app/src/renderer/features/appShell/book/portfolio/WelcomePortfolioPanel.tsx
@@ -40,12 +40,13 @@
 import { useId, useState, type JSX } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import {
-  ChevronDownIcon,
+  IconChevronDown,
   VexIcon,
   WalletIcon,
 } from "../../../../components/icons/index.js";
 import { cn } from "../../../../lib/utils.js";
 import { prefersReducedMotion, stackVariants } from "./portfolio-motion.js";
+import { GLOBAL_PORTFOLIO_SCOPE } from "./portfolio-scope.js";
 import { PortfolioOverviewCard } from "./PortfolioOverviewCard.js";
 import { WalletsCard } from "./WalletsCard.js";
 import { BalancesCard } from "./BalancesCard.js";
@@ -97,9 +98,9 @@ export function WelcomePortfolioPanel({
             // origin-bottom-right = the morph's anchor at the handle below.
             className="vex-scroll pointer-events-auto mb-4 flex min-h-0 w-full origin-bottom-right flex-col gap-3 overflow-y-auto"
           >
-            <PortfolioOverviewCard />
-            <WalletsCard />
-            <BalancesCard />
+            <PortfolioOverviewCard scope={GLOBAL_PORTFOLIO_SCOPE} />
+            <WalletsCard scope={GLOBAL_PORTFOLIO_SCOPE} />
+            <BalancesCard scope={GLOBAL_PORTFOLIO_SCOPE} />
           </motion.div>
         ) : null}
       </AnimatePresence>
@@ -113,13 +114,15 @@ export function WelcomePortfolioPanel({
         // shrink-0: in the height-constrained justify-end column the button
         // must never be squashed by flex shrink (owner report 2026-07-21:
         // the stack rode over a shrunken handle).
-        className="pointer-events-auto flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-[var(--vex-line)] bg-[var(--vex-rail-strong)] text-[var(--vex-text-2)] shadow-[0_14px_32px_-16px_rgba(0,0,0,0.85)] transition-colors hover:border-[var(--vex-line-strong)] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)]"
+        className="pointer-events-auto flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-line-2 bg-[var(--vex-rail-strong)] text-ink-secondary shadow-lv2 transition-colors hover:border-line-3 hover:text-ink-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
       >
-        <VexIcon
-          icon={bookOpen ? ChevronDownIcon : WalletIcon}
-          size={17}
-          aria-hidden
-        />
+        {bookOpen ? (
+          <IconChevronDown size={17} />
+        ) : (
+          // Wallet has no glyph yet (F0 named gap) - the lucide gate covers
+          // it until the F6 icon sweep.
+          <VexIcon icon={WalletIcon} size={17} aria-hidden />
+        )}
       </button>
       </div>
     </aside>

--- a/vex-app/src/renderer/features/appShell/book/portfolio/__tests__/portfolio-scope-cards.test.tsx
+++ b/vex-app/src/renderer/features/appShell/book/portfolio/__tests__/portfolio-scope-cards.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * Characterization pins for the three scope-driven portfolio cards
+ * (Portfolio Overview / Wallets / Balances) around the vex-studio scope seam:
+ * a card's reads are a function of its scope input, never of session state
+ * read inside the card. Written against the pre-refactor behavior first and
+ * kept green across the scope-param refactor — the assertions describe
+ * observable behavior (which IPC read fires, what renders), not wiring.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { PortfolioDto } from "@shared/schemas/portfolio.js";
+import { useUiStore } from "../../../../../stores/uiStore.js";
+import { PortfolioOverviewCard } from "../PortfolioOverviewCard.js";
+import { WalletsCard } from "../WalletsCard.js";
+import { BalancesCard } from "../BalancesCard.js";
+import { GLOBAL_PORTFOLIO_SCOPE } from "../portfolio-scope.js";
+
+const readMock = vi.fn();
+const listAvailableMock = vi.fn();
+
+function installVexBridge(): void {
+  Object.defineProperty(window, "vex", {
+    configurable: true,
+    writable: true,
+    value: {
+      portfolio: { read: readMock },
+      wallets: { listAvailable: listAvailableMock },
+    },
+  });
+}
+
+function portfolio(overrides: Partial<PortfolioDto> = {}): PortfolioDto {
+  return {
+    scope: "global",
+    walletCount: 2,
+    liveTotalUsd: 1234.56,
+    snapshotTotalUsd: 1200,
+    pnlVsPrev: 34.56,
+    snapshotAt: "2026-08-20T10:00:00.000Z",
+    tokens: [],
+    chains: [],
+    ...overrides,
+  };
+}
+
+const EVM_WALLET = {
+  id: "evm-1",
+  family: "evm" as const,
+  address: "0x1111111111111111111111111111111111111111",
+  label: "Main",
+};
+const SOL_WALLET = {
+  id: "sol-1",
+  family: "solana" as const,
+  address: "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin",
+  label: "",
+};
+
+const SESSION = "00000000-0000-4000-8000-0000000000aa";
+
+function token(symbol: string, usd: number | null) {
+  return {
+    chainId: 8453,
+    symbol,
+    tokenAddress: null,
+    tokenName: null,
+    balanceUsd: usd,
+    amount: null,
+  };
+}
+
+function renderWith(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  installVexBridge();
+  readMock.mockReset();
+  listAvailableMock.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("BalancesCard scope input", () => {
+  it("a global scope reads the global portfolio, never a session one", async () => {
+    readMock.mockResolvedValue({
+      ok: true,
+      data: portfolio({ tokens: [token("ETH", 900), token("USDC", 100)] }),
+    });
+    renderWith(<BalancesCard scope={GLOBAL_PORTFOLIO_SCOPE} />);
+    await screen.findByText(/ETH/);
+    expect(readMock).toHaveBeenCalledWith({ scope: "global" });
+  });
+
+  it("a session scope narrows the read to exactly that session id", async () => {
+    readMock.mockResolvedValue({
+      ok: true,
+      data: portfolio({ scope: "session", tokens: [token("SOL", 40)] }),
+    });
+    renderWith(<BalancesCard scope={{ kind: "session", sessionId: SESSION }} />);
+    await screen.findByText(/SOL/);
+    expect(readMock).toHaveBeenCalledWith({
+      scope: "session",
+      sessionId: SESSION,
+    });
+  });
+
+  it("shows at most the top five holdings, largest USD first, dust cut before the cap", async () => {
+    // Seven priced rows: one sub-cent dust row ($0.004 < $0.005 threshold)
+    // must be dropped BEFORE the top-5 cut, so the $1 row still makes the
+    // list; the sixth-largest real row ($2) then falls off the cap.
+    readMock.mockResolvedValue({
+      ok: true,
+      data: portfolio({
+        tokens: [
+          token("DUST", 0.004),
+          token("A", 500),
+          token("B", 400),
+          token("C", 300),
+          token("D", 200),
+          token("E", 100),
+          token("F", 2),
+        ],
+      }),
+    });
+    renderWith(<BalancesCard scope={GLOBAL_PORTFOLIO_SCOPE} />);
+    await screen.findByText(/\bA\b/);
+    for (const visible of ["A", "B", "C", "D", "E"]) {
+      expect(screen.getByText(new RegExp(`\\b${visible}\\b`))).toBeTruthy();
+    }
+    expect(screen.queryByText(/\bF\b/)).toBeNull();
+    expect(screen.queryByText(/DUST/)).toBeNull();
+  });
+
+  it("the global and session empty states speak different sentences", async () => {
+    readMock.mockResolvedValue({ ok: true, data: portfolio({ tokens: [] }) });
+    renderWith(<BalancesCard scope={GLOBAL_PORTFOLIO_SCOPE} />);
+    await screen.findByText(/No balances yet/);
+    cleanup();
+    readMock.mockResolvedValue({
+      ok: true,
+      data: portfolio({ scope: "session", tokens: [] }),
+    });
+    renderWith(<BalancesCard scope={{ kind: "session", sessionId: SESSION }} />);
+    await screen.findByText(/No balances in this session/);
+  });
+});
+
+describe("PortfolioOverviewCard scope input", () => {
+  it("renders the aggregate total from the global read", async () => {
+    readMock.mockResolvedValue({ ok: true, data: portfolio() });
+    listAvailableMock.mockResolvedValue({
+      ok: true,
+      data: { evm: [EVM_WALLET], solana: [] },
+    });
+    renderWith(<PortfolioOverviewCard scope={GLOBAL_PORTFOLIO_SCOPE} />);
+    await screen.findByText("$1234.56");
+    expect(readMock).toHaveBeenCalledWith({ scope: "global" });
+  });
+
+  it("hides the wallet chip row at exactly one wallet and shows it at two", async () => {
+    readMock.mockResolvedValue({ ok: true, data: portfolio() });
+    listAvailableMock.mockResolvedValue({
+      ok: true,
+      data: { evm: [EVM_WALLET], solana: [] },
+    });
+    renderWith(<PortfolioOverviewCard scope={GLOBAL_PORTFOLIO_SCOPE} />);
+    await screen.findByText("$1234.56");
+    expect(screen.queryByRole("group", { name: "Portfolio scope" })).toBeNull();
+    cleanup();
+    listAvailableMock.mockResolvedValue({
+      ok: true,
+      data: { evm: [EVM_WALLET], solana: [SOL_WALLET] },
+    });
+    renderWith(<PortfolioOverviewCard scope={GLOBAL_PORTFOLIO_SCOPE} />);
+    await screen.findByRole("group", { name: "Portfolio scope" });
+  });
+
+  it("selecting a wallet chip narrows the read to that wallet; All wallets restores the aggregate", async () => {
+    readMock.mockImplementation((input: { walletAddress?: string }) =>
+      Promise.resolve({
+        ok: true,
+        data: portfolio(
+          input.walletAddress === undefined ? {} : { liveTotalUsd: 111.11 },
+        ),
+      }),
+    );
+    listAvailableMock.mockResolvedValue({
+      ok: true,
+      data: { evm: [EVM_WALLET], solana: [SOL_WALLET] },
+    });
+    renderWith(<PortfolioOverviewCard scope={GLOBAL_PORTFOLIO_SCOPE} />);
+    await screen.findByText("$1234.56");
+    fireEvent.click(screen.getByRole("button", { name: /Main/ }));
+    await screen.findByText("$111.11");
+    expect(readMock).toHaveBeenCalledWith({
+      scope: "global",
+      walletAddress: EVM_WALLET.address,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "All wallets" }));
+    await screen.findByText("$1234.56");
+  });
+});
+
+describe("WalletsCard scope input", () => {
+  it("renders one identity row per inventory wallet with each family's first marked Primary", async () => {
+    listAvailableMock.mockResolvedValue({
+      ok: true,
+      data: { evm: [EVM_WALLET], solana: [SOL_WALLET] },
+    });
+    readMock.mockResolvedValue({ ok: true, data: portfolio() });
+    renderWith(<WalletsCard scope={GLOBAL_PORTFOLIO_SCOPE} />);
+    await screen.findByText("Main");
+    // Both family firsts wear the badge (the labeled EVM row and the
+    // unlabeled Solana row, which falls back to the terse family caption).
+    expect(screen.getAllByText("Primary")).toHaveLength(2);
+    expect(screen.getByText("SOL")).toBeTruthy();
+  });
+
+  it("Add wallet routes to the Settings wallets section through the public store action", async () => {
+    listAvailableMock.mockResolvedValue({
+      ok: true,
+      data: { evm: [], solana: [] },
+    });
+    renderWith(<WalletsCard scope={GLOBAL_PORTFOLIO_SCOPE} />);
+    const add = await screen.findByRole("button", { name: /Add wallet/ });
+    fireEvent.click(add);
+    await waitFor(() => {
+      const route = useUiStore.getState().shellRoute;
+      expect(route?.kind).toBe("settings");
+      expect(route?.kind === "settings" ? route.section : null).toBe("wallets");
+    });
+  });
+});

--- a/vex-app/src/renderer/features/appShell/book/portfolio/portfolio-scope.ts
+++ b/vex-app/src/renderer/features/appShell/book/portfolio/portfolio-scope.ts
@@ -1,0 +1,18 @@
+/**
+ * PortfolioCardScope — the vex-studio seam (#3): the Portfolio Overview /
+ * Wallets / Balances cards take their wallet scope as an INPUT instead of
+ * reading session state inside the card. Today the members are "global"
+ * (inventory aggregate) and "session"; a future project scope becomes one
+ * more union member, never a card fork.
+ */
+
+export type PortfolioCardScope =
+  | { readonly kind: "global" }
+  | { readonly kind: "session"; readonly sessionId: string };
+
+export const GLOBAL_PORTFOLIO_SCOPE: PortfolioCardScope = { kind: "global" };
+
+/** The session id a scope narrows to; `null` = the global aggregate. */
+export function scopeSessionId(scope: PortfolioCardScope): string | null {
+  return scope.kind === "session" ? scope.sessionId : null;
+}

--- a/vex-app/src/renderer/features/appShell/market/VexTokenCardCompact.tsx
+++ b/vex-app/src/renderer/features/appShell/market/VexTokenCardCompact.tsx
@@ -32,7 +32,7 @@ import {
 } from "../../../lib/format.js";
 
 const CARD_CLASS =
-  "rounded-xl border border-[var(--vex-line)] bg-[var(--vex-surface-1)] px-3 py-2.5";
+  "rounded-xl border border-line-2 bg-surface-1 px-3 py-2.5";
 
 // The $VEX DexScreener pair — a renderer-local literal by design: the
 // market IPC schema (`@shared/schemas/market.js`) deliberately carries no
@@ -59,10 +59,10 @@ export function VexTokenCardCompact(): JSX.Element {
         <div className="flex items-center gap-2">
           <VexMark />
           <div className="flex min-w-0 flex-col">
-            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--vex-text-3)]">
+            <span className="font-doto text-[10px] uppercase tracking-[0.14em] text-ink-tertiary">
               $VEX
             </span>
-            <span className="text-[11px] text-[var(--vex-warn-text)]">
+            <span className="text-[11px] text-warning-label">
               Market data unavailable.
             </span>
           </div>
@@ -83,12 +83,12 @@ export function VexTokenCardCompact(): JSX.Element {
         <div className="flex items-center gap-2">
           <VexMark />
           <div className="flex min-w-0 flex-col gap-1.5">
-            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--vex-text-3)]">
+            <span className="font-doto text-[10px] uppercase tracking-[0.14em] text-ink-tertiary">
               $VEX
             </span>
             <span
               aria-hidden
-              className="h-4 w-20 animate-pulse rounded bg-[var(--vex-line-strong)]"
+              className="h-4 w-20 animate-pulse rounded bg-line-3"
             />
           </div>
         </div>
@@ -128,18 +128,18 @@ function CompactBody({
         aria-label="Open $VEX on DexScreener"
         className={cn(
           CARD_CLASS,
-          "block transition-colors hover:border-[var(--vex-accent-border)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)]",
+          "block transition-colors hover:border-accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary",
         )}
       >
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-2">
             <VexMark />
             <div className="flex min-w-0 flex-col gap-0.5">
-              <span className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.14em] text-[var(--vex-text-3)]">
+              <span className="flex items-center gap-1.5 font-doto text-[9px] uppercase tracking-[0.14em] text-ink-tertiary">
                 $VEX
                 {snapshot.stale ? <StaleMarker /> : null}
               </span>
-              <span className="truncate font-display text-[15px] font-extrabold leading-none tracking-[-0.02em] tabular-nums text-[var(--vex-text)]">
+              <span className="truncate font-display text-[15px] font-extrabold leading-none tracking-[-0.02em] tabular-nums text-ink-primary">
                 {priceLabel}
               </span>
             </div>
@@ -169,7 +169,7 @@ function StaleMarker(): JSX.Element {
   return (
     <span
       data-vex-area="vex-token-stale"
-      className="flex items-center gap-1 text-[var(--vex-text-3)]"
+      className="flex items-center gap-1 text-ink-tertiary"
       title="Live feed delayed — showing the last known price."
     >
       <span
@@ -206,10 +206,10 @@ function DeltaFigure({
       data-vex-area="vex-token-delta"
       data-shimmer-text={label}
       className={cn(
-        "vex-delta-shimmer inline-flex shrink-0 items-center font-mono text-[11px] font-medium tabular-nums",
-        up && "text-[var(--color-success)]",
-        down && "text-[var(--vex-warn-text)]",
-        !up && !down && "text-[var(--vex-text-3)]",
+        "vex-delta-shimmer inline-flex shrink-0 items-center text-[11px] font-semibold tabular-nums",
+        up && "text-success",
+        down && "text-warning-label",
+        !up && !down && "text-ink-tertiary",
       )}
     >
       {label}

--- a/vex-app/src/renderer/features/appShell/market/__tests__/VexTokenCardCompact.test.tsx
+++ b/vex-app/src/renderer/features/appShell/market/__tests__/VexTokenCardCompact.test.tsx
@@ -93,7 +93,7 @@ describe("VexTokenCardCompact", () => {
     expect(delta).not.toBeNull();
     expect(delta?.classList.contains("vex-delta-shimmer")).toBe(true);
     expect(delta?.getAttribute("data-shimmer-text")).toBe("+113.00%");
-    expect(delta?.className).toContain("text-[var(--color-success)]");
+    expect(delta?.className).toContain("text-success");
     expect(delta?.className).not.toContain("border");
     expect(
       container.querySelector(

--- a/vex-app/src/renderer/lib/__tests__/window-title.test.tsx
+++ b/vex-app/src/renderer/lib/__tests__/window-title.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Window-title sync (E15) + turn-complete badge (A34) — behavior pins:
+ * title composition is a pure function of (session title, unseen flag); the
+ * hook stamps document.title and restores the product title on unmount; the
+ * badge sets only for an unfocused assistant chat row of the ACTIVE session
+ * and clears on refocus. Driven through the existing transcript spine — the
+ * suite fakes only the preload bridge and focus, never a new channel.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import type { JSX } from "react";
+import { composeWindowTitle, useWindowTitleSync } from "../window-title.js";
+import { useTurnCompleteNotification } from "../turn-notification.js";
+
+type AppendListener = (event: {
+  sessionId: string;
+  role: string;
+  messageType: string | null;
+}) => void;
+
+let appendListener: AppendListener | null = null;
+const offMock = vi.fn();
+
+function installVexBridge(): void {
+  Object.defineProperty(window, "vex", {
+    configurable: true,
+    writable: true,
+    value: {
+      engine: {
+        onTranscriptAppend: (cb: AppendListener) => {
+          appendListener = cb;
+          return offMock;
+        },
+      },
+    },
+  });
+}
+
+function TitleHarness({
+  sessionId,
+  sessionTitle,
+}: {
+  readonly sessionId: string | null;
+  readonly sessionTitle: string | null;
+}): JSX.Element | null {
+  const unseen = useTurnCompleteNotification(sessionId);
+  useWindowTitleSync(sessionTitle, unseen);
+  return null;
+}
+
+const SESSION = "00000000-0000-4000-8000-00000000aaaa";
+
+function emitAssistantRow(sessionId: string, messageType: string | null = null): void {
+  act(() => {
+    appendListener?.({ sessionId, role: "assistant", messageType });
+  });
+}
+
+beforeEach(() => {
+  installVexBridge();
+  appendListener = null;
+  offMock.mockReset();
+  document.title = "Vex";
+});
+
+afterEach(cleanup);
+
+describe("composeWindowTitle", () => {
+  it("is a pure function of session title and the unseen flag", () => {
+    expect(composeWindowTitle(null, false)).toBe("Vex");
+    expect(composeWindowTitle("Fund research", false)).toBe("Fund research - Vex");
+    expect(composeWindowTitle("Fund research", true)).toBe("● Fund research - Vex");
+    expect(composeWindowTitle(null, true)).toBe("● Vex");
+    // Whitespace-only titles fall back to the bare product title.
+    expect(composeWindowTitle("   ", false)).toBe("Vex");
+  });
+});
+
+describe("useWindowTitleSync + useTurnCompleteNotification", () => {
+  it("stamps the active session into document.title and restores Vex on unmount", () => {
+    const view = render(
+      <TitleHarness sessionId={SESSION} sessionTitle="Fund research" />,
+    );
+    expect(document.title).toBe("Fund research - Vex");
+    view.unmount();
+    expect(document.title).toBe("Vex");
+  });
+
+  it("badges the title when an assistant row lands unfocused, and clears on refocus", () => {
+    const hasFocus = vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    render(<TitleHarness sessionId={SESSION} sessionTitle="Fund research" />);
+    emitAssistantRow(SESSION);
+    expect(document.title).toBe("● Fund research - Vex");
+    hasFocus.mockReturnValue(true);
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(document.title).toBe("Fund research - Vex");
+  });
+
+  it("ignores focused turns, foreign sessions, and engine marker rows", () => {
+    const hasFocus = vi.spyOn(document, "hasFocus");
+    render(<TitleHarness sessionId={SESSION} sessionTitle="Fund research" />);
+    // Focused: the user saw it — no badge.
+    hasFocus.mockReturnValue(true);
+    emitAssistantRow(SESSION);
+    expect(document.title).toBe("Fund research - Vex");
+    // Unfocused, but another session's row or an engine marker: no badge.
+    hasFocus.mockReturnValue(false);
+    emitAssistantRow("00000000-0000-4000-8000-00000000bbbb");
+    emitAssistantRow(SESSION, "compaction_marker");
+    expect(document.title).toBe("Fund research - Vex");
+  });
+
+  it("never carries an unseen badge across a session switch", () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    const view = render(
+      <TitleHarness sessionId={SESSION} sessionTitle="Fund research" />,
+    );
+    emitAssistantRow(SESSION);
+    expect(document.title).toBe("● Fund research - Vex");
+    view.rerender(
+      <TitleHarness
+        sessionId="00000000-0000-4000-8000-00000000bbbb"
+        sessionTitle="Other"
+      />,
+    );
+    expect(document.title).toBe("Other - Vex");
+  });
+});

--- a/vex-app/src/renderer/lib/turn-notification.ts
+++ b/vex-app/src/renderer/lib/turn-notification.ts
@@ -1,0 +1,49 @@
+/**
+ * Turn-complete notification (A34), title-badge form. The signal is the
+ * EXISTING transcript spine (`engine.onTranscriptAppend`): an assistant chat
+ * row for the active session landing while the window is unfocused marks an
+ * unseen turn; regaining focus clears it. The HTML5 Notification API is
+ * intentionally NOT used — main's permission policy is deny-all
+ * (`src/main/permissions.ts`), and an OS-native path would need a new IPC
+ * contract (named gap, coordinator's call); the title badge ships now on
+ * existing contracts only.
+ */
+
+import { useEffect, useState } from "react";
+
+/**
+ * True while a turn completed for `sessionId` without window focus and the
+ * user has not refocused since. Pure subscription — no render output beyond
+ * the flag; feed it to `useWindowTitleSync`.
+ */
+export function useTurnCompleteNotification(sessionId: string | null): boolean {
+  const [unseen, setUnseen] = useState(false);
+
+  // Session switch: an unseen marker never carries across sessions.
+  useEffect(() => {
+    setUnseen(false);
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (sessionId === null) return;
+    // Optional-chained like the portfolio invalidation hooks: partial test
+    // bridges (and a torn-down preload) must not crash the panel.
+    const subscribe = window.vex?.engine?.onTranscriptAppend;
+    if (subscribe === undefined) return;
+    const off = subscribe((event) => {
+      if (event.sessionId !== sessionId) return;
+      // A plain assistant chat row is the turn's answer; engine markers
+      // (compaction, memory, …) are not user-facing turn completions.
+      if (event.role !== "assistant" || event.messageType !== null) return;
+      if (!document.hasFocus()) setUnseen(true);
+    });
+    const onFocus = (): void => setUnseen(false);
+    window.addEventListener("focus", onFocus);
+    return () => {
+      off();
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [sessionId]);
+
+  return unseen;
+}

--- a/vex-app/src/renderer/lib/window-title.ts
+++ b/vex-app/src/renderer/lib/window-title.ts
@@ -1,0 +1,46 @@
+/**
+ * Window-title sync (E15): the native window title mirrors the active
+ * session through `document.title` — Electron forwards page-title updates to
+ * the BrowserWindow and main never re-stamps its static "Vex" after create,
+ * so no IPC channel is needed. The unseen-turn badge (A34 fallback) prefixes
+ * a dot while a turn finished without focus.
+ */
+
+import { useEffect } from "react";
+
+const PRODUCT_TITLE = "Vex";
+
+/** Unseen-turn marker — a plain glyph, readable in any taskbar. */
+const UNSEEN_BADGE = "● ";
+
+/** Pure title composition: `[●] {session} - Vex` / `[●] Vex`. */
+export function composeWindowTitle(
+  sessionTitle: string | null,
+  unseenTurn: boolean,
+): string {
+  const base =
+    sessionTitle !== null && sessionTitle.trim().length > 0
+      ? `${sessionTitle} - ${PRODUCT_TITLE}`
+      : PRODUCT_TITLE;
+  return unseenTurn ? `${UNSEEN_BADGE}${base}` : base;
+}
+
+/**
+ * Keep `document.title` in step with the active session and the unseen-turn
+ * badge. Mounted once by the session panel; restores the bare product title
+ * on unmount so a torn-down panel never leaves a stale session name behind.
+ */
+export function useWindowTitleSync(
+  sessionTitle: string | null,
+  unseenTurn: boolean,
+): void {
+  useEffect(() => {
+    document.title = composeWindowTitle(sessionTitle, unseenTurn);
+  }, [sessionTitle, unseenTurn]);
+  useEffect(
+    () => () => {
+      document.title = PRODUCT_TITLE;
+    },
+    [],
+  );
+}


### PR DESCRIPTION
Phase 3d, stacked on phase 1 (#95). Parallel to 3a/3b/3c with disjoint ownership.

- Full BOOK card set restyled to tokens v2, functionally unchanged (owner decision), pinned by characterization written before the refactor
- Portfolio cards take scope as an input - the vex-studio seam
- New additive inspect mode (tool-call details in the book; JsonTree swap lands with phase 3c)
- Welcome hero per the accepted mockup: Agent|Studio toggle (Studio disabled + lock), no BACKED BY footer
- Window-title sync with an unseen-turn badge on existing contracts; a real preload-bridge defect found by the full suite and fixed

Verification: lint, 5398/5401 full suite (3 real failures fixed, affected files re-run green isolated), build + artifact checks, dev smoke - green. Named gap: the final full-suite pass was substituted by isolated reruns of the two touched files under 4-builder host load.