### PR TITLE
fix(dexscreener): absorb provider drift - latest profiles feed dropped updatedAt

### DIFF
--- a/src/__tests__/vex-agent/tools/dexscreener-handlers.test.ts
+++ b/src/__tests__/vex-agent/tools/dexscreener-handlers.test.ts
@@ -157,8 +157,19 @@ describe("dexscreener handlers", () => {
     expect(typeof data.returned).toBe("number");
     expect(typeof data.totalMatched).toBe("number");
     expect(Array.isArray(data.rows)).toBe(true);
-    // The two fields this feed used to parse and discard.
-    expect(typeof data.rows[0].updatedAt).toBe("string");
+    // The two fields this feed used to parse and discard. `updatedAt` is
+    // `string | null` BY CONTRACT (feed-row.ts) and null in practice here:
+    // the provider dropped the field from /token-profiles/latest/v1
+    // (measured live 2026-08-21: 0/30 rows carry it on this feed while
+    // recent-updates still sends it 30/30). A live pin asserts the canonical
+    // union and that any value parses - never the provider's mood.
+    expect(data.rows[0]).toHaveProperty("updatedAt");
+    for (const row of data.rows) {
+      if (row.updatedAt !== null) {
+        expect(typeof row.updatedAt).toBe("string");
+        expect(Number.isNaN(Date.parse(row.updatedAt))).toBe(false);
+      }
+    }
     expect(data.rows[0]).toHaveProperty("communityTakeover");
   });
 

--- a/src/vex-agent/tools/protocols/dexscreener/feed-list/feed-row.ts
+++ b/src/vex-agent/tools/protocols/dexscreener/feed-list/feed-row.ts
@@ -30,12 +30,16 @@
  *
  * TWO FIELDS WE HAVE BEEN PAYING FOR AND THROWING AWAY
  *
- * Both profile feeds send `updatedAt` and `cto` on 30/30 rows (re-verified live
- * 2026-07-27), and `validation/profiles.ts` discarded both on
- * `/token-profiles/latest/v1`. `updatedAt` is the ONLY field in either feed from
- * which freshness can be computed at all, and `cto` says whether the project went
- * through a community takeover — which we deleted while maintaining a separate
- * `communityTakeovers` tool to answer the same question.
+ * Both profile feeds sent `updatedAt` and `cto` on 30/30 rows when this card
+ * landed (live 2026-07-27), and `validation/profiles.ts` discarded both on
+ * `/token-profiles/latest/v1`. PROVIDER DRIFT, re-measured live 2026-08-21:
+ * `/token-profiles/latest/v1` no longer sends `updatedAt` at all (0/30 rows;
+ * `cto` still 30/30), while `/token-profiles/recent-updates/v1` still sends
+ * both on 30/30. The `string | null` contract below absorbs the drift; the
+ * recent-updates feed is now the only source of profile freshness. `cto` says
+ * whether the project went through a community takeover — which we deleted
+ * while maintaining a separate `communityTakeovers` tool to answer the same
+ * question.
  *
  * `openGraph` also arrives on 30/30 rows of three feeds and is emitted NOWHERE,
  * by decision rather than oversight: its value is
@@ -87,7 +91,11 @@ export type FeedSourceRow = FeedRowIdentity &
   (
     | {
         readonly kind: "profile";
-        /** ISO 8601, as the provider sends it. 30/30 rows on BOTH profile feeds. */
+        /**
+         * ISO 8601, as the provider sends it. Provider drift measured live
+         * 2026-08-21: 30/30 rows on recent-updates, 0/30 on latest (the field
+         * vanished there) - hence nullable, never assumed.
+         */
         readonly updatedAt: string | null;
         readonly communityTakeover: boolean | null;
       }

--- a/src/vex-agent/tools/protocols/dexscreener/manifests/feed-list-params.ts
+++ b/src/vex-agent/tools/protocols/dexscreener/manifests/feed-list-params.ts
@@ -139,9 +139,13 @@ export const FEED_CHAIN_FILTER_PARAM: ProtocolParamDef = {
 /**
  * Freshness on the two PROFILE feeds.
  *
- * Both feeds send `updatedAt` on 30/30 rows, which is the only field in either
- * from which freshness is computable — and it was being discarded on the `latest`
- * feed until this card.
+ * `updatedAt` is the only field in either feed from which freshness is
+ * computable. Provider drift, measured live 2026-08-21: the recent-updates
+ * feed still sends it 30/30; the latest feed stopped sending it entirely
+ * (0/30), so this filter there excludes every row into
+ * droppedByFilter.unknownEventAge - honest, but empty. The param stays on
+ * both feeds because the filter semantics are identical and the provider may
+ * restore the field; the description steers the model to the feed that works.
  */
 export const PROFILE_FRESHNESS_PARAMS: readonly ProtocolParamDef[] = [
   {
@@ -151,9 +155,10 @@ export const PROFILE_FRESHNESS_PARAMS: readonly ProtocolParamDef[] = [
       "Keep profiles updated within this many seconds, computed from updatedAt against asOfMs and "
       + "reported as eventAgeSeconds on every row. Rows with no updatedAt are excluded and counted "
       + "in droppedByFilter.unknownEventAge — 'we cannot tell when' is a different answer from 'too "
-      + "old'. Measured on a live window: the recent-updates feed spanned 23-180 seconds old, the "
-      + "latest-profiles feed 64 seconds to 81 minutes. Every response is edge-cached about 30s, so "
-      + "nothing here is real-time. Whole number.",
+      + "old'. The latest-profiles feed currently sends no updatedAt at all (provider drift, "
+      + "measured 2026-08-21), so this filter there drops every row - use dexscreener.profiles.recent "
+      + "for freshness. Every response is edge-cached about 30s, so nothing here is real-time. "
+      + "Whole number.",
   },
   {
     key: "ctoOnly",

--- a/src/vex-agent/tools/protocols/dexscreener/manifests/trending.ts
+++ b/src/vex-agent/tools/protocols/dexscreener/manifests/trending.ts
@@ -33,10 +33,11 @@ export const TRENDING_TOOLS: readonly ProtocolToolManifest[] = [
     lifecycle: "active",
     description:
       "Get the latest token PROFILE METADATA on DEX Screener - icons, descriptions, social links, "
-      + "and each profile's updatedAt timestamp. A profile update is NOT token creation: this is "
-      + "not a new-token or new-listing feed, and updatedAt says when marketing text changed, not "
-      + "when anything launched. Keep one or more chains with chainIds and bound "
-      + "freshness with updatedWithinSeconds. "
+      + "and the community-takeover flag. A profile update is NOT token creation: this is "
+      + "not a new-token or new-listing feed. The provider currently sends no updatedAt on THIS "
+      + "feed (drift measured 2026-08-21), so updatedWithinSeconds here drops every row - for "
+      + "timestamps and freshness use dexscreener.profiles.recent. Keep one or more chains with "
+      + "chainIds. "
       + FEED_DESCRIPTION_WINDOW_CLAUSE + " " + SOURCE_OBSERVATION_CLAUSE,
     mutating: false,
     actionKind: "read",


### PR DESCRIPTION
Main CI has been red since the provider removed updatedAt from /token-profiles/latest/v1 (measured live 2026-08-21: 0/30 rows carry it; cto still 30/30; recent-updates still sends both on 30/30). The canonical adapter contract (string | null with nullifying projection) already absorbed the drift - the live test's strict string pin and the measured docs were stale.

- The live profiles case now asserts the canonical union: property present on every row, any non-null value is an ISO-parseable string.
- updatedWithinSeconds and the dexscreener.profiles description state honestly that the latest feed currently yields no timestamps (the filter there drops every row into droppedByFilter.unknownEventAge) and steer freshness to dexscreener.profiles.recent.
- feed-row measurement notes re-verified 2026-08-21.

Verified: the targeted root suites (dexscreener-handlers incl. the live cases, dexscreener-manifest, feed-list-params) pass - 135/135.