### PR TITLE
style(vex-app): both rail toggles speak one icon language

### DIFF
--- a/vex-app/src/renderer/components/icons/__tests__/glyphs.test.tsx
+++ b/vex-app/src/renderer/components/icons/__tests__/glyphs.test.tsx
@@ -26,7 +26,10 @@ describe("icon glyphs", () => {
     // retired; a drop below this floor means a call site lost its glyph.
     // Floor 81 -> 78 (R2-A, 2026-08-21): the starter-pill glyphs IconFlame,
     // IconPercent and IconRocket retired with their last consumer.
-    expect(entries.length).toBeGreaterThanOrEqual(78);
+    // 78 -> 77 (2026-08-21): the stroke-drawn IconPanelRightOpen/Close pair
+    // merged into one mirrored filled-outline IconPanelRight, so both rail
+    // toggles speak the same drawing language.
+    expect(entries.length).toBeGreaterThanOrEqual(77);
   });
 
   it.each(entries.map(([name]) => name))("%s renders per contract", (name) => {

--- a/vex-app/src/renderer/components/icons/glyphs/navigation.tsx
+++ b/vex-app/src/renderer/components/icons/glyphs/navigation.tsx
@@ -116,22 +116,23 @@ export const IconArrowUpRight = ({ size = 16, className }: GlyphProps): JSX.Elem
   </svg>
 );
 
-/* Panel-right pair and the drag grip are drawn native on the 24 grid with a
- * 1.5 stroke, which matches the ring weight of the filled outlines above. */
+/* Panel-right toggle - the LEFT glyph's geometry mirrored, so both rail
+ * toggles speak one drawing language (the filled-outline family). One static
+ * glyph for both states, exactly like the left toggle: the open/close
+ * semantic lives in the control's aria-label, not in the picture. */
 
-export const IconPanelRightOpen = ({ size = 16, className }: GlyphProps): JSX.Element => (
-  <svg width={size} height={size} className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <rect x="3.25" y="4.25" width="17.5" height="15.5" rx="2.5" />
-    <path d="M14.75 4.25v15.5" />
-    <path d="M11 9.25 8.25 12 11 14.75" />
-  </svg>
-);
-
-export const IconPanelRightClose = ({ size = 16, className }: GlyphProps): JSX.Element => (
-  <svg width={size} height={size} className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <rect x="3.25" y="4.25" width="17.5" height="15.5" rx="2.5" />
-    <path d="M14.75 4.25v15.5" />
-    <path d="M8.25 9.25 11 12l-2.75 2.75" />
+export const IconPanelRight = ({ size = 16, className }: GlyphProps): JSX.Element => (
+  <svg width={size} height={size} className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <g transform="scale(1.5)">
+      <g transform="translate(16 0) scale(-1 1)">
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M9.67272 0.522841C10.8339 0.522841 11.76 0.522714 12.4963 0.602493C13.2453 0.683657 13.8789 0.854248 14.4264 1.25197C14.7504 1.48739 15.0355 1.77247 15.2709 2.0965C15.6686 2.64394 15.8392 3.27758 15.9204 4.02655C16.0002 4.7629 16 5.68895 16 6.85014V9.14986C16 10.3111 16.0002 11.2371 15.9204 11.9735C15.8392 12.7224 15.6686 13.3561 15.2709 13.9035C15.0355 14.2275 14.7504 14.5126 14.4264 14.748C13.8789 15.1458 13.2453 15.3163 12.4963 15.3975C11.76 15.4773 10.8339 15.4772 9.67272 15.4772H6.3273C5.16611 15.4772 4.24006 15.4773 3.50371 15.3975C2.75474 15.3163 2.1211 15.1458 1.57366 14.748C1.24963 14.5126 0.964549 14.2275 0.729131 13.9035C0.331407 13.3561 0.160817 12.7224 0.0796529 11.9735C-0.000126137 11.2371 1.25338e-09 10.3111 1.25338e-09 9.14986V6.85014C1.25329e-09 5.68895 -0.000126137 4.7629 0.0796529 4.02655C0.160817 3.27758 0.331407 2.64394 0.729131 2.0965C0.964549 1.77247 1.24963 1.48739 1.57366 1.25197C2.1211 0.854248 2.75474 0.683657 3.50371 0.602493C4.24006 0.522714 5.16611 0.522841 6.3273 0.522841H9.67272ZM5.54303 1.88715V14.1118C5.78636 14.1128 6.04709 14.1169 6.3273 14.1169H9.67272C10.8639 14.1169 11.7032 14.1164 12.3493 14.0465C12.9824 13.9779 13.3497 13.8494 13.6268 13.6482C13.8354 13.4966 14.0195 13.3125 14.1711 13.1039C14.3723 12.8268 14.5007 12.4595 14.5693 11.8264C14.6393 11.1803 14.6398 10.341 14.6398 9.14986V6.85014C14.6398 5.65896 14.6393 4.81967 14.5693 4.1736C14.5007 3.54048 14.3723 3.17318 14.1711 2.89609C14.0195 2.68747 13.8354 2.50337 13.6268 2.35179C13.3497 2.1506 12.9824 2.02212 12.3493 1.95353C11.7032 1.88358 10.8639 1.88307 9.67272 1.88307H6.3273C6.04709 1.88307 5.78636 1.8862 5.54303 1.88715ZM4.1828 1.91166C3.99125 1.9216 3.8148 1.93577 3.65076 1.95353C3.01764 2.02212 2.65034 2.1506 2.37325 2.35179C2.16463 2.50337 1.98052 2.68747 1.82895 2.89609C1.62776 3.17318 1.49928 3.54048 1.43069 4.1736C1.36074 4.81967 1.36023 5.65896 1.36023 6.85014V9.14986C1.36023 10.341 1.36074 11.1803 1.43069 11.8264C1.49928 12.4595 1.62776 12.8268 1.82895 13.1039C1.98052 13.3125 2.16463 13.4966 2.37325 13.6482C2.65034 13.8494 3.01764 13.9779 3.65076 14.0465C3.81478 14.0642 3.99127 14.0774 4.1828 14.0873V1.91166Z"
+          fill="currentColor"
+        />
+      </g>
+    </g>
   </svg>
 );
 

--- a/vex-app/src/renderer/features/appShell/BookPanel.tsx
+++ b/vex-app/src/renderer/features/appShell/BookPanel.tsx
@@ -44,8 +44,7 @@ import {
 } from "react";
 import { motion } from "motion/react";
 import {
-  IconPanelRightClose,
-  IconPanelRightOpen,
+  IconPanelRight,
 } from "../../components/icons/index.js";
 import { cn } from "../../lib/utils.js";
 import { PositionBlock } from "./book/PositionBlock.js";
@@ -139,7 +138,9 @@ export function BookPanel({
   const inspecting =
     inspect !== null && inspect.sessionId === activeSessionId;
 
-  const PanelGlyph = bookOpen ? IconPanelRightClose : IconPanelRightOpen;
+  // One static glyph for both states, like the left rail toggle - the
+  // open/close semantic lives in the aria-label.
+  const PanelGlyph = IconPanelRight;
 
   // WELCOME stage: the floating Portfolio tab replaces the rail entirely.
   if (activeSessionId === null) {


### PR DESCRIPTION
The left rail toggle uses the filled-outline glyph family while the right BOOK toggle pair was stroke-drawn with chevrons - visibly a different icon language on two mirrored controls (owner QA). The right toggle now mirrors the left glyph's exact geometry, one static glyph for both states like the left; the stroke pair retires and the glyph-count floor follows (78 -> 77). Verified: glyph contract suite + BookPanel suite (91 tests) and lint:tsc green.