### PR TITLE
style(vex-app): model chip shows the bare model name

### DIFF
--- a/vex-app/src/renderer/features/appShell/SessionComposer/ComposerSeats.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionComposer/ComposerSeats.tsx
@@ -35,6 +35,22 @@ const PlanDisplayModal = lazy(async () => ({
 const SEAT_CHIP =
   "inline-flex h-7 min-w-0 items-center gap-1.5 rounded-md px-2 text-[13px] font-medium leading-5 text-ink-secondary transition-colors duration-100 hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary";
 
+/**
+ * DISPLAY-ONLY trim of the routing prefix: `deepseek/deepseek-v4-pro` reads
+ * as `deepseek-v4-pro` on the chip (owner QA round 3 follow-up). The brand
+ * icon already names the provider, so the prefix was pure duplication eating
+ * the chip's 160px. Only the FIRST segment is cut - an id with no `/` passes
+ * through, and a variant suffix (`:free`) survives. The FULL id stays the
+ * source of truth everywhere else: the accessible name, the tooltip, the
+ * settings screen, and every request path.
+ */
+export function modelDisplayName(modelId: string): string {
+  const slash = modelId.indexOf("/");
+  return slash > 0 && slash < modelId.length - 1
+    ? modelId.slice(slash + 1)
+    : modelId;
+}
+
 export function ComposerModelChip({
   modelId,
 }: {
@@ -43,7 +59,7 @@ export function ComposerModelChip({
   const setShellRoute = useUiStore((s) => s.setShellRoute);
   if (modelId === null) return null;
   return (
-    <Tooltip label="Runtime model - change it in Settings" side="top" delayMs={300}>
+    <Tooltip label={`${modelId} - change it in Settings`} side="top" delayMs={300}>
       <button
         type="button"
         data-vex-area="composer-model-chip"
@@ -58,7 +74,7 @@ export function ComposerModelChip({
           <ModelBrandIcon modelId={modelId} size={14} />
         </span>
         <span data-vex-model-label className="min-w-0 max-w-40 flex-1 truncate">
-          {modelId}
+          {modelDisplayName(modelId)}
         </span>
       </button>
     </Tooltip>

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-toolbar-row.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-toolbar-row.test.tsx
@@ -185,6 +185,35 @@ describe("composer toolbar - the shrink chain (Bug 3)", () => {
     expect(glyphBox.className).toContain("shrink-0");
   });
 
+  it("the chip shows the bare model name; the full routed id stays the accessible name", () => {
+    // Display-only trim (owner QA round 3 follow-up): the brand glyph already
+    // names the provider, so `deepseek/deepseek-v4-pro` reads as
+    // `deepseek-v4-pro` on the chip. The FULL id must survive everywhere the
+    // identity matters: here, the aria-label.
+    models = [{ modelId: "deepseek/deepseek-v4-pro", reasoning: null }];
+    const { container } = mountDocked();
+    const label = container.querySelector(
+      "[data-vex-model-label]",
+    ) as HTMLElement;
+    expect(label.textContent).toBe("deepseek-v4-pro");
+    const chip = container.querySelector(
+      '[data-vex-area="composer-model-chip"]',
+    ) as HTMLElement;
+    expect(chip.getAttribute("aria-label")).toContain(
+      "deepseek/deepseek-v4-pro",
+    );
+  });
+
+  it("an unrouted model id passes through the display trim untouched", () => {
+    // Only the FIRST provider segment is cut; a bare id has nothing to cut,
+    // and a variant suffix after the model name must survive.
+    models = [{ modelId: "vex-local-model", reasoning: null }];
+    const { container } = mountDocked();
+    expect(
+      container.querySelector("[data-vex-model-label]")?.textContent,
+    ).toBe("vex-local-model");
+  });
+
   it("the reasoning placeholder carries no width FLOOR that the row cannot reclaim", () => {
     const { container } = mountDocked();
     const placeholder = container.querySelector(


### PR DESCRIPTION
Owner QA follow-up: the composer's model chip showed the full routed id (deepseek/deepseek-v4-pro), which truncated at the chip's width while the brand glyph already names the provider. Display-only trim of the first provider segment - deepseek-v4-pro on the chip; the full id stays the accessible name, moves into the tooltip, and request paths are untouched. An unrouted id passes through; a variant suffix survives. Verified: toolbar-row + composer-console suites (41 tests) and lint:tsc green.