### PR TITLE
style(vex-app): welcome mark rides currentColor ink - black on celeris

### DIFF
--- a/vex-app/src/renderer/features/appShell/SessionWelcomeHero.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionWelcomeHero.tsx
@@ -10,6 +10,7 @@
 
 import { useState, type JSX } from "react";
 import { IconLock } from "../../components/icons/index.js";
+import { VexMark } from "../../components/common/VexMark.js";
 import { pickGreeting } from "../../lib/greeting.js";
 import { useUserProfile } from "../../lib/api/user-profile.js";
 import { cn } from "../../lib/utils.js";
@@ -53,21 +54,13 @@ export function SessionWelcomeHero(): JSX.Element {
   return (
     <div className="relative z-10 flex w-full flex-col items-center px-8 pb-2 text-center">
       <div className="vex-rise flex flex-col items-center justify-center gap-3">
-        {/* vx script mark - white over the chronos night photo, brand blue on
-          * the celeris day scene (arbitrary parent variant on the theme
-          * attribute; no JS theme read). */}
-        <img
-          src="/brand/vex-mark-white.svg"
-          alt=""
-          aria-hidden
-          className="h-16 w-auto [[data-vex-theme=celeris]_&]:hidden"
-        />
-        <img
-          src="/brand/vex-mark-color.svg"
-          alt=""
-          aria-hidden
-          className="hidden h-16 w-auto [[data-vex-theme=celeris]_&]:block"
-        />
+        {/* vx script mark on currentColor ink (owner QA round 3: BLACK on the
+          * celeris day scene, not brand blue) - ink-primary is white over the
+          * chronos night photo and near-black on celeris, so one inline mark
+          * replaces the two-asset theme swap. */}
+        <span aria-hidden className="text-ink-primary">
+          <VexMark size={64} />
+        </span>
         <span
           className="vex-micro-label vex-micro-label--wide uppercase text-ink-secondary"
           title={PREVIEW_TITLE}

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionWelcomeHero.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionWelcomeHero.test.tsx
@@ -42,21 +42,17 @@ beforeEach(() => {
 });
 
 describe("SessionWelcomeHero", () => {
-  it("renders the vx mark pair: white for chronos, brand color revealed only under the celeris theme attribute", () => {
+  it("renders the vx mark inline on currentColor ink - no theme-swapped image pair", () => {
+    // Owner QA round 3: the celeris welcome mark is BLACK, not brand blue.
+    // One inline SVG on `text-ink-primary` gives white over the chronos night
+    // photo and near-black on celeris from the same element - no img assets,
+    // no theme attribute variants, no JS theme read.
     const { container } = render(<SessionWelcomeHero />);
-    const marks = Array.from(container.querySelectorAll("img"));
-    expect(marks.map((img) => img.getAttribute("src"))).toEqual([
-      "/brand/vex-mark-white.svg",
-      "/brand/vex-mark-color.svg",
-    ]);
-    // Theme selection is pure CSS on the html attribute — the white mark
-    // hides under celeris, the color mark shows only there. No JS theme read.
-    expect(marks[0]?.className).toContain("[[data-vex-theme=celeris]_&]:hidden");
-    expect(marks[1]?.className).toContain("hidden");
-    expect(marks[1]?.className).toContain("[[data-vex-theme=celeris]_&]:block");
-    for (const mark of marks) {
-      expect(mark.getAttribute("aria-hidden")).toBe("true");
-    }
+    expect(container.querySelector("img")).toBeNull();
+    const markBox = container.querySelector('span[aria-hidden="true"]');
+    expect(markBox).not.toBeNull();
+    expect(markBox?.className).toContain("text-ink-primary");
+    expect(markBox?.querySelector("svg path")).not.toBeNull();
   });
 
   it("speaks the date in the micro-label eyebrow and keeps the honest preview disclosure as its tooltip", () => {


### PR DESCRIPTION
Owner QA follow-up: the welcome crown's vx mark should be black in celeris, not brand blue. The theme-swapped white/color image pair collapses into the inline VexMark SVG on text-ink-primary - white over the chronos night photo, near-black on the celeris day scene, one element with no theme-attribute variants and no JS theme read. Hero suite 10/10 and lint:tsc green. Pre-shell screens keep their existing mark pair (unchanged).