### PR TITLE
style(vex-app): one brand-mark rule - white in chronos, brand blue in celeris

### DIFF
--- a/vex-app/src/renderer/features/appShell/SessionWelcomeHero.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionWelcomeHero.tsx
@@ -54,11 +54,10 @@ export function SessionWelcomeHero(): JSX.Element {
   return (
     <div className="relative z-10 flex w-full flex-col items-center px-8 pb-2 text-center">
       <div className="vex-rise flex flex-col items-center justify-center gap-3">
-        {/* vx script mark on currentColor ink (owner QA round 3: BLACK on the
-          * celeris day scene, not brand blue) - ink-primary is white over the
-          * chronos night photo and near-black on celeris, so one inline mark
-          * replaces the two-asset theme swap. */}
-        <span aria-hidden className="text-ink-primary">
+        {/* vx script mark on the brand-mark token (owner rule 2026-08-21:
+          * white everywhere in chronos, brand blue in celeris) - one inline
+          * mark, the theme flip lives in tokens.css. */}
+        <span aria-hidden className="text-brand-mark">
           <VexMark size={64} />
         </span>
         <span

--- a/vex-app/src/renderer/features/appShell/SidebarHomeSigil.tsx
+++ b/vex-app/src/renderer/features/appShell/SidebarHomeSigil.tsx
@@ -32,7 +32,7 @@ export function SidebarHomeSigil({
   // Height-driven size; width flows from the mark's native aspect. A light
   // rail crown (24px open / 20px collapsed), not a billboard.
   const mark = (
-    <span data-vex-home-mark className="select-none text-ink-primary">
+    <span data-vex-home-mark className="select-none text-brand-mark">
       <VexMark size={sidebarOpen ? 24 : 20} />
     </span>
   );

--- a/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
+++ b/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
@@ -98,7 +98,7 @@ function AssistantAvatar({ working = false }: { readonly working?: boolean }): J
     <span
       data-vex-agent-avatar=""
       data-vex-agent-avatar-state={working ? "working" : "settled"}
-      className="absolute left-0 top-[1px] inline-flex h-[26px] w-[26px] items-center justify-center text-ink-primary"
+      className="absolute left-0 top-[1px] inline-flex h-[26px] w-[26px] items-center justify-center text-brand-mark"
     >
       {working ? (
         <span

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionWelcomeHero.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionWelcomeHero.test.tsx
@@ -43,15 +43,15 @@ beforeEach(() => {
 
 describe("SessionWelcomeHero", () => {
   it("renders the vx mark inline on currentColor ink - no theme-swapped image pair", () => {
-    // Owner QA round 3: the celeris welcome mark is BLACK, not brand blue.
-    // One inline SVG on `text-ink-primary` gives white over the chronos night
-    // photo and near-black on celeris from the same element - no img assets,
-    // no theme attribute variants, no JS theme read.
+    // Owner rule 2026-08-21: the standalone mark is WHITE everywhere in
+    // chronos and BRAND BLUE in celeris. One inline SVG on the brand-mark
+    // token carries both - no img assets, no theme-attribute variants, no JS
+    // theme read; the flip lives in tokens.css.
     const { container } = render(<SessionWelcomeHero />);
     expect(container.querySelector("img")).toBeNull();
     const markBox = container.querySelector('span[aria-hidden="true"]');
     expect(markBox).not.toBeNull();
-    expect(markBox?.className).toContain("text-ink-primary");
+    expect(markBox?.className).toContain("text-brand-mark");
     expect(markBox?.querySelector("svg path")).not.toBeNull();
   });
 

--- a/vex-app/src/renderer/styles/global-css/tokens.css
+++ b/vex-app/src/renderer/styles/global-css/tokens.css
@@ -208,6 +208,13 @@
   /* Text painted on the theme-invariant dark chrome plates above; stays
    * white in celeris too, so it lives only on :root. */
   --vex-alias-label-on-chrome: #ffffff;
+  /* The standalone vx brand mark (owner rule, ratified 2026-08-21):
+   * WHITE everywhere in chronos, BRAND BLUE in celeris. Exceptions live
+   * at their call sites: the Chronos Gate is always white (invariant
+   * dark brand moment) and marks on blue brand discs stay white in both
+   * themes. Standalone marks consume `text-brand-mark`, never a raw
+   * color or an ink tier. */
+  --vex-alias-brand-mark: #ffffff;
 
   /* PRE-SHELL (post-gate setup stack) - the theme-aware group the
    * `[data-vex-gate="true"]` scope in chronos-gate.css re-projects onto the
@@ -302,6 +309,8 @@
   --vex-alias-accent-hover: var(--color-blue-900);
   --vex-alias-accent-brand: var(--color-blue-500);
   --vex-alias-accent-wash: var(--color-blue-100);
+  /* Standalone vx mark rides the brand blue on the light theme. */
+  --vex-alias-brand-mark: var(--color-blue-700);
 
   /* Light hover tint is BLUE-black, not neutral gray - subtle but carries
    * the cool cast. */
@@ -372,6 +381,7 @@
   --color-mask-1: var(--vex-alias-bg-mask-1);
   --color-mask-drop: var(--vex-alias-bg-mask-drop);
   --color-ink-on-chrome: var(--vex-alias-label-on-chrome);
+  --color-brand-mark: var(--vex-alias-brand-mark);
 
   --color-accent-primary: var(--vex-alias-accent-primary);
   --color-accent-hover: var(--vex-alias-accent-hover);


### PR DESCRIPTION
Owner-ratified rule superseding #103's celeris-black direction: the standalone vx mark is white everywhere in chronos and brand blue (#0000C0 family) in celeris. One owner - a brand-mark alias pair in tokens.css (+ @theme projection, verified in emitted CSS) - consumed by the welcome crown, the sidebar crown and the transcript avatar. The pre-shell white/color image pair already expressed the rule and is unchanged. Exceptions stated at the token: the Chronos Gate stays always-white (invariant dark brand moment) and marks on blue brand discs stay white in both themes. Suites: hero, sidebar sigil, transcript (63 tests) + theme-matrix, lint:tsc green.