### PR TITLE
feat(agent): wallet transfers land in agent_activity via staged capture

### DIFF
--- a/src/__tests__/integration/agent-scan/wallet-transfer-vocabulary-schema.int.test.ts
+++ b/src/__tests__/integration/agent-scan/wallet-transfer-vocabulary-schema.int.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Migration 084 vocabulary - `agent_activity` admits an agent WALLET SEND,
+ * against a REAL local Postgres with 044+045+...+084 applied (the
+ * `_fixtures.ts` contract). These invariants genuinely live in SQL, so a mocked
+ * client would prove nothing, and the migration RUNNING at all is half of what
+ * this file establishes.
+ *
+ * Pins:
+ *   - the `transfer` kind and the `wallet_transfer` role exist, on BOTH chain
+ *     families - a send is the one lane with an eip155 and a Solana producer
+ *     writing the same role;
+ *   - the `transfer` arm of `agent_activity_kind_role_binding` carries exactly
+ *     that one role;
+ *   - NEGATIVE: no other role rides `transfer`, and `wallet_transfer` rides no
+ *     other kind. A binding that leaked either way would let a send be filed as
+ *     a trade, or a trade as a send;
+ *   - NEGATIVE: a second leg is refused (053/082's allowlist was deliberately
+ *     NOT restated by 084, and this asserts that omission was the right one);
+ *   - the 045/049 staging invariants still apply to a transfer row: an EVM
+ *     staged row needs its nonce, a Solana row must not have one, and a staged
+ *     Solana row needs its blockhash evidence. Those three CHECKs are exactly
+ *     why the wallet writer signs before it submits, so a transfer that could
+ *     not satisfy them would mean the staged split does not actually work.
+ *   - REGRESSION: every kind and role that existed before 084 is still
+ *     writable. The three CHECKs are DROPped and re-ADDed whole, so a
+ *     restatement that lost a member would make those rows unwritable - the
+ *     failure mode the migration's own comment warns about.
+ */
+import { afterEach, describe, it, expect } from "vitest";
+
+import { execute, query } from "../../../vex-agent/db/client.js";
+import { SOLANA_SYNTHETIC_CHAIN_ID } from "../../../constants/solana-chain.js";
+import { seedIntent, cleanupSeeded } from "./_fixtures.js";
+
+afterEach(async () => {
+  await cleanupSeeded();
+});
+
+async function expectReject(fn: () => Promise<unknown>): Promise<void> {
+  await expect(fn()).rejects.toThrow();
+}
+
+const WALLET = "0xWALLETSEND";
+const BASE_CHAIN_ID = 8453;
+// The repo-canonical synthetic id, NOT Solana's cluster id. The 049
+// `agent_activity_kind_family_binding` CHECK is written against this value, so a
+// literal here would both misfile transfers and make the prediction regression
+// case below fail for the wrong reason.
+const SOLANA_CHAIN_ID = SOLANA_SYNTHETIC_CHAIN_ID;
+
+const INSERT_ACTIVITY = `INSERT INTO agent_activity
+  (protocol_execution_id, event_index, event_role, kind, protocol, chain_id, wallet_address, chain_family)
+  VALUES ($1, $2, $3, $4, 'wallet', $5, $6, $7)`;
+
+describe("migration 084 - wallet transfer vocabulary", () => {
+  it("admits a transfer row on BOTH chain families", async () => {
+    for (const [chainId, family] of [[BASE_CHAIN_ID, "eip155"], [SOLANA_CHAIN_ID, "solana"]] as const) {
+      const seeded = await seedIntent();
+      const rows = await query(
+        `${INSERT_ACTIVITY} RETURNING id`,
+        [seeded.protocolExecutionId, 0, "wallet_transfer", "transfer", chainId, WALLET, family],
+      );
+      expect(rows).toHaveLength(1);
+    }
+  });
+
+  it("carries the INPUT leg a send actually has", async () => {
+    const seeded = await seedIntent();
+    const rows = await query(
+      `INSERT INTO agent_activity
+         (protocol_execution_id, event_index, event_role, kind, protocol, chain_id, wallet_address,
+          chain_family, token_in_address, token_in_symbol, token_in_decimals, amount_in_human, amount_in_raw)
+       VALUES ($1, 0, 'wallet_transfer', 'transfer', 'wallet', $2, $3, 'eip155',
+               '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', 'ETH', 18, '0.5', '500000000000000000')
+       RETURNING id`,
+      [seeded.protocolExecutionId, BASE_CHAIN_ID, WALLET],
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  it("NEGATIVE: no other role rides the transfer arm", async () => {
+    for (const role of ["swap", "allowance", "swap_fee", "token_launch", "pools_claim", "bridge_deposit"]) {
+      const seeded = await seedIntent();
+      await expectReject(() =>
+        execute(INSERT_ACTIVITY, [
+          seeded.protocolExecutionId, 0, role, "transfer", BASE_CHAIN_ID, WALLET, "eip155",
+        ]),
+      );
+    }
+  });
+
+  it("NEGATIVE: wallet_transfer rides no other kind", async () => {
+    for (const kind of ["swap", "lend", "yield", "launch", "claim", "wrap"]) {
+      const seeded = await seedIntent();
+      await expectReject(() =>
+        execute(INSERT_ACTIVITY, [
+          seeded.protocolExecutionId, 0, "wallet_transfer", kind, BASE_CHAIN_ID, WALLET, "eip155",
+        ]),
+      );
+    }
+  });
+
+  it("NEGATIVE: a transfer row may not carry a second leg", async () => {
+    const seeded = await seedIntent();
+    await expectReject(() =>
+      execute(
+        `INSERT INTO agent_activity
+           (protocol_execution_id, event_index, event_role, kind, protocol, chain_id, wallet_address,
+            chain_family, token_out2_address, token_out2_symbol, token_out2_decimals,
+            amount_out2_human, amount_out2_raw)
+         VALUES ($1, 0, 'wallet_transfer', 'transfer', 'wallet', $2, $3, 'eip155',
+                 '0xabc', 'X', 18, '1', '1')`,
+        [seeded.protocolExecutionId, BASE_CHAIN_ID, WALLET],
+      ),
+    );
+  });
+
+  it("045 evm_signed_leg_has_nonce still applies: a staged EVM transfer without a nonce is rejected", async () => {
+    const seeded = await seedIntent();
+    await expectReject(() =>
+      execute(
+        `INSERT INTO agent_activity
+           (protocol_execution_id, event_index, event_role, kind, protocol, chain_id, wallet_address,
+            chain_family, tx_hash, from_address, submit_attempted_at)
+         VALUES ($1, 0, 'wallet_transfer', 'transfer', 'wallet', $2, $3, 'eip155', '0xdead', $3, NOW())`,
+        [seeded.protocolExecutionId, BASE_CHAIN_ID, WALLET],
+      ),
+    );
+  });
+
+  it("a staged EVM transfer WITH its nonce is accepted - the writer stages exactly this shape", async () => {
+    const seeded = await seedIntent();
+    const rows = await query(
+      `INSERT INTO agent_activity
+         (protocol_execution_id, event_index, event_role, kind, protocol, chain_id, wallet_address,
+          chain_family, tx_hash, from_address, nonce, submit_attempted_at)
+       VALUES ($1, 0, 'wallet_transfer', 'transfer', 'wallet', $2, $3, 'eip155', '0xdead', $3, 7, NOW())
+       RETURNING id`,
+      [seeded.protocolExecutionId, BASE_CHAIN_ID, WALLET],
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  it("049 solana_staged_has_evidence still applies: a staged Solana transfer without a blockhash is rejected", async () => {
+    const seeded = await seedIntent();
+    await expectReject(() =>
+      execute(
+        `INSERT INTO agent_activity
+           (protocol_execution_id, event_index, event_role, kind, protocol, chain_id, wallet_address,
+            chain_family, tx_hash, from_address, submit_attempted_at)
+         VALUES ($1, 0, 'wallet_transfer', 'transfer', 'wallet', $2, $3, 'solana', 'sig', $3, NOW())`,
+        [seeded.protocolExecutionId, SOLANA_CHAIN_ID, WALLET],
+      ),
+    );
+  });
+
+  it("a staged Solana transfer WITH its blockhash evidence and no nonce is accepted", async () => {
+    const seeded = await seedIntent();
+    const rows = await query(
+      `INSERT INTO agent_activity
+         (protocol_execution_id, event_index, event_role, kind, protocol, chain_id, wallet_address,
+          chain_family, tx_hash, from_address, recent_blockhash, last_valid_block_height, submit_attempted_at)
+       VALUES ($1, 0, 'wallet_transfer', 'transfer', 'wallet', $2, $3, 'solana', 'sig', $3, 'hash', 4242, NOW())
+       RETURNING id`,
+      [seeded.protocolExecutionId, SOLANA_CHAIN_ID, WALLET],
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  it("045 solana_no_nonce still applies: a Solana transfer carrying a nonce is rejected", async () => {
+    const seeded = await seedIntent();
+    await expectReject(() =>
+      execute(
+        `INSERT INTO agent_activity
+           (protocol_execution_id, event_index, event_role, kind, protocol, chain_id, wallet_address,
+            chain_family, tx_hash, from_address, recent_blockhash, last_valid_block_height,
+            nonce, submit_attempted_at)
+         VALUES ($1, 0, 'wallet_transfer', 'transfer', 'wallet', $2, $3, 'solana', 'sig', $3, 'hash', 1, 7, NOW())`,
+        [seeded.protocolExecutionId, SOLANA_CHAIN_ID, WALLET],
+      ),
+    );
+  });
+
+  it("REGRESSION: every pre-084 kind/role pairing is still writable after the restatements", async () => {
+    // Bridge rows carry route endpoints (045 `agent_activity_bridge_has_route`)
+    // and the LOGICAL row additionally carries `normalized_route` (045
+    // `agent_activity_normalized_route_logical_only`, a biconditional). Those
+    // The logical fill row additionally requires a session (045
+    // `agent_activity_logical_has_session`). Those columns are supplied here so
+    // a row is rejected only if THIS migration's
+    // three restatements dropped its kind/role pairing - the single thing this
+    // test is for.
+    const pairings: ReadonlyArray<{
+      readonly kind: string;
+      readonly role: string;
+      readonly family: string;
+      readonly chainId: number;
+    }> = [
+      { kind: "swap", role: "swap", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "swap", role: "allowance", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "swap", role: "swap_fee", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "swap", role: "trench_fee", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "bridge", role: "bridge_deposit", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "bridge", role: "bridge_fill_expected", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "bridge", role: "bridge_fee", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "lend", role: "lend_deposit", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "lend", role: "allowance_reset", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "prediction", role: "predict_buy", family: "solana", chainId: SOLANA_SYNTHETIC_CHAIN_ID },
+      { kind: "wrap", role: "wrap", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "wrap", role: "unwrap", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "yield", role: "yield_pt", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "yield", role: "yield_claim", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "launch", role: "token_launch", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "launch", role: "pools_fee", family: "eip155", chainId: BASE_CHAIN_ID },
+      { kind: "claim", role: "pools_claim", family: "eip155", chainId: BASE_CHAIN_ID },
+    ];
+
+    for (const { kind, role, family, chainId } of pairings) {
+      const seeded = await seedIntent();
+      const isBridge = kind === "bridge";
+      const isLogicalFill = role === "bridge_fill_expected";
+      const rows = await query(
+        `INSERT INTO agent_activity
+           (protocol_execution_id, event_index, event_role, kind, protocol, chain_id, wallet_address,
+            chain_family, session_id, from_chain_id, to_chain_id, normalized_route)
+         VALUES ($1, 0, $2, $3, 'regression', $4, $5, $6, $7, $8, $9, $10::jsonb)
+         RETURNING id`,
+        [
+          seeded.protocolExecutionId, role, kind, chainId, WALLET, family,
+          // The logical fill row requires a session (045
+          // `agent_activity_logical_has_session`).
+          seeded.sessionId,
+          isBridge ? chainId : null,
+          isBridge ? chainId : null,
+          isLogicalFill ? JSON.stringify({ from: "a", to: "b" }) : null,
+        ],
+      );
+      expect(rows, `pre-084 pairing ${kind}/${role} became unwritable`).toHaveLength(1);
+    }
+  });
+});

--- a/src/__tests__/solana/legacy-staged-seam.test.ts
+++ b/src/__tests__/solana/legacy-staged-seam.test.ts
@@ -1,0 +1,255 @@
+/**
+ * The legacy sign/submit/confirm SEAM itself - `prepareLegacyTx`,
+ * `submitPreparedLegacyTxStaged`, `confirmStagedSignature` - exercised as REAL
+ * functions against a scripted `Connection`.
+ *
+ * WHY DIRECTLY, and not only through the wallet executor. The executor tests
+ * mock this module, so they pin how the executor REACTS to each outcome and
+ * prove nothing about which outcome these functions actually produce. The split
+ * introduced for migration 084 exists to make a durable row possible before
+ * money moves, and its load-bearing claims are all in here:
+ *
+ *   - the signature is derived from the SIGNED BYTES, so it is available before
+ *     anything is submitted, and it equals what the RPC would echo;
+ *   - the blockhash evidence the 049 CHECK requires comes back with it;
+ *   - preparing submits NOTHING;
+ *   - `signAndSubmitLegacyTxStaged` still behaves exactly as it did for its
+ *     existing (Jupiter) callers, because it is now those halves composed.
+ *
+ * The `Connection` is scripted rather than mocked at the module level: these
+ * tests are about what the real functions do with a node's answers.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import bs58 from "bs58";
+
+import {
+  prepareLegacyTx,
+  submitPreparedLegacyTxStaged,
+  confirmStagedSignature,
+  signAndSubmitLegacyTxStaged,
+} from "@tools/solana-ecosystem/shared/solana-transaction.js";
+
+vi.mock("@tools/solana-ecosystem/shared/solana-transaction/confirm.js", () => ({
+  confirmVersionedTx: (...args: unknown[]) => mockConfirm(...(args as [])),
+}));
+const mockConfirm = vi.fn<(...args: unknown[]) => Promise<void>>();
+
+const BLOCKHASH = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+const LAST_VALID_BLOCK_HEIGHT = 4242;
+
+/** Typed exactly like the method it stands in for, so `mock.calls[0]` is a real tuple. */
+type SendRawTransactionSpy = ReturnType<
+  typeof vi.fn<(raw: Uint8Array | Buffer | Array<number>, options?: unknown) => Promise<string>>
+>;
+
+/** A `Connection` with only the three methods this seam touches scripted. */
+function scriptedConnection(overrides: Partial<{
+  sendRawTransaction: SendRawTransactionSpy;
+}> = {}) {
+  const connection = Object.create(Connection.prototype) as Connection;
+  return Object.assign(connection, {
+    getLatestBlockhash: vi.fn(async () => ({
+      blockhash: BLOCKHASH,
+      lastValidBlockHeight: LAST_VALID_BLOCK_HEIGHT,
+    })),
+    sendRawTransaction:
+      overrides.sendRawTransaction
+      ?? (vi.fn(async () => "unused") as SendRawTransactionSpy),
+  });
+}
+
+function transferTx(from: Keypair, to: PublicKey): Transaction {
+  return new Transaction().add(
+    SystemProgram.transfer({ fromPubkey: from.publicKey, toPubkey: to, lamports: 1_000n }),
+  );
+}
+
+describe("prepareLegacyTx", () => {
+  it("signs locally and submits NOTHING", async () => {
+    const keypair = Keypair.generate();
+    const connection = scriptedConnection();
+
+    const prepared = await prepareLegacyTx(
+      transferTx(keypair, Keypair.generate().publicKey),
+      keypair,
+      { connection },
+    );
+
+    // The whole point of the split: nothing reached the network.
+    expect(connection.sendRawTransaction).not.toHaveBeenCalled();
+    expect(prepared.serialized.length).toBeGreaterThan(0);
+  });
+
+  it("returns the signature the SIGNED BYTES carry, so it can be staged before submission", async () => {
+    const keypair = Keypair.generate();
+    const connection = scriptedConnection();
+    const tx = transferTx(keypair, Keypair.generate().publicKey);
+
+    const prepared = await prepareLegacyTx(tx, keypair, { connection });
+
+    // A Solana transaction id IS the base58 of its first signature. Recomputing
+    // it from the transaction independently proves the derivation, rather than
+    // trusting the value the function chose to report.
+    const feePayerSignature = tx.signature;
+    if (feePayerSignature === null) throw new Error("the transaction was not signed");
+    expect(prepared.signature).toBe(bs58.encode(feePayerSignature));
+    // And it verifies against the signer, so it is a real signature over these
+    // bytes and not an identifier assembled from something else.
+    expect(tx.verifySignatures()).toBe(true);
+  });
+
+  it("returns the blockhash evidence the 049 staged-evidence CHECK requires", async () => {
+    const keypair = Keypair.generate();
+    const connection = scriptedConnection();
+
+    const prepared = await prepareLegacyTx(
+      transferTx(keypair, Keypair.generate().publicKey),
+      keypair,
+      { connection },
+    );
+
+    expect(prepared.recentBlockhash).toBe(BLOCKHASH);
+    expect(prepared.lastValidBlockHeight).toBe(LAST_VALID_BLOCK_HEIGHT);
+  });
+
+  it("signs the blockhash it reports, so the staged evidence describes the staged bytes", async () => {
+    const keypair = Keypair.generate();
+    const connection = scriptedConnection();
+    const tx = transferTx(keypair, Keypair.generate().publicKey);
+
+    const prepared = await prepareLegacyTx(tx, keypair, { connection });
+
+    expect(tx.recentBlockhash).toBe(prepared.recentBlockhash);
+    expect(tx.feePayer?.equals(keypair.publicKey)).toBe(true);
+  });
+});
+
+describe("submitPreparedLegacyTxStaged", () => {
+  it("sends the prepared bytes UNCHANGED, exactly once", async () => {
+    const keypair = Keypair.generate();
+    const sendRawTransaction = vi.fn(async () => "sig") as SendRawTransactionSpy;
+    const connection = scriptedConnection({ sendRawTransaction });
+    const prepared = await prepareLegacyTx(
+      transferTx(keypair, Keypair.generate().publicKey),
+      keypair,
+      { connection },
+    );
+    mockConfirm.mockResolvedValueOnce(undefined);
+
+    await submitPreparedLegacyTxStaged(prepared, { connection });
+
+    expect(sendRawTransaction).toHaveBeenCalledTimes(1);
+    // Byte-for-byte: re-signing or refreshing a blockhash here would invalidate
+    // the signature already persisted on the durable row.
+    expect(sendRawTransaction.mock.calls[0]?.[0]).toBe(prepared.serialized);
+  });
+
+  it("reports the PREPARED signature, not the RPC echo", async () => {
+    const keypair = Keypair.generate();
+    const connection = scriptedConnection({
+      sendRawTransaction: vi.fn(async () => "a-different-string-entirely") as SendRawTransactionSpy,
+    });
+    const prepared = await prepareLegacyTx(
+      transferTx(keypair, Keypair.generate().publicKey),
+      keypair,
+      { connection },
+    );
+    mockConfirm.mockResolvedValueOnce(undefined);
+
+    const result = await submitPreparedLegacyTxStaged(prepared, { connection });
+
+    // The staged value is the identity the durable row already holds.
+    expect(result.signature).toBe(prepared.signature);
+    expect(result.phase).toBe("confirmed");
+  });
+});
+
+describe("confirmStagedSignature", () => {
+  it("reports confirmed when the confirmation returns", async () => {
+    mockConfirm.mockResolvedValueOnce(undefined);
+    const result = await confirmStagedSignature(scriptedConnection(), "sig-1");
+    expect(result).toEqual({ signature: "sig-1", phase: "confirmed" });
+  });
+
+  it("classifies a chain failure as chain_failed, carrying the signature", async () => {
+    const { VexError, ErrorCodes } = await import("../../errors.js");
+    mockConfirm.mockRejectedValueOnce(new VexError(ErrorCodes.SOLANA_TX_FAILED, "tx failed"));
+
+    const result = await confirmStagedSignature(scriptedConnection(), "sig-2");
+
+    expect(result.phase).toBe("chain_failed");
+    expect(result.signature).toBe("sig-2");
+    // Structural label only - never the raw cause text.
+    expect(result.errorKind).toBe(ErrorCodes.SOLANA_TX_FAILED);
+  });
+
+  it("classifies a timeout as confirmation_unknown - never a failure", async () => {
+    const { VexError, ErrorCodes } = await import("../../errors.js");
+    mockConfirm.mockRejectedValueOnce(new VexError(ErrorCodes.SOLANA_TX_TIMEOUT, "timed out"));
+
+    const result = await confirmStagedSignature(scriptedConnection(), "sig-3");
+
+    expect(result.phase).toBe("confirmation_unknown");
+    expect(result.signature).toBe("sig-3");
+  });
+
+  it("defaults an UNRECOGNISED throw to confirmation_unknown rather than claiming failure", async () => {
+    mockConfirm.mockRejectedValueOnce(new Error("websocket closed"));
+
+    const result = await confirmStagedSignature(scriptedConnection(), "sig-4");
+
+    // Claiming "definitely failed" when we do not know is the exact lie the
+    // staged vocabulary exists to prevent.
+    expect(result.phase).toBe("confirmation_unknown");
+  });
+
+  it("never throws", async () => {
+    mockConfirm.mockRejectedValueOnce("a bare string, not an Error");
+    await expect(confirmStagedSignature(scriptedConnection(), "sig-5")).resolves.toBeDefined();
+  });
+});
+
+describe("signAndSubmitLegacyTxStaged (existing callers unchanged)", () => {
+  it("still signs, submits and confirms in one call, reporting the signed bytes' signature", async () => {
+    const keypair = Keypair.generate();
+    const sendRawTransaction = vi.fn(async () => "echo") as SendRawTransactionSpy;
+    const connection = scriptedConnection({ sendRawTransaction });
+    const tx = transferTx(keypair, Keypair.generate().publicKey);
+    mockConfirm.mockResolvedValueOnce(undefined);
+
+    const result = await signAndSubmitLegacyTxStaged(tx, keypair, { connection });
+
+    expect(result.phase).toBe("confirmed");
+    expect(sendRawTransaction).toHaveBeenCalledTimes(1);
+    // The signature of the bytes it signed - not the RPC's "echo" string.
+    const feePayerSignature = tx.signature;
+    if (feePayerSignature === null) throw new Error("the transaction was not signed");
+    expect(result.signature).toBe(bs58.encode(feePayerSignature));
+  });
+
+  it("still lets a send failure THROW for its existing callers", async () => {
+    const keypair = Keypair.generate();
+    const connection = scriptedConnection({
+      sendRawTransaction: vi.fn(async () => {
+        throw new Error("node refused");
+      }) as SendRawTransactionSpy,
+    });
+
+    // This throw-on-send contract is why a DB-backed caller must not use this
+    // function: it cannot tell a refusal from a lost response. The wallet send
+    // path goes through `submitPreparedTxOverRpc` instead.
+    await expect(
+      signAndSubmitLegacyTxStaged(transferTx(keypair, Keypair.generate().publicKey), keypair, {
+        connection,
+      }),
+    ).rejects.toThrow("node refused");
+  });
+});

--- a/src/__tests__/solana/solana-rpc-submit-lane.test.ts
+++ b/src/__tests__/solana/solana-rpc-submit-lane.test.ts
@@ -60,6 +60,24 @@ describe("submitPreparedTxOverRpc", () => {
     expect(options).not.toHaveProperty("maxRetries");
   });
 
+  it("passes a caller-preserved maxRetries bound through unchanged (wallet lane contract)", async () => {
+    // A lane that carried its own submit bound BEFORE adopting this module
+    // keeps it by passing maxRetries; the option must reach the RPC exactly
+    // and change nothing else about the submit options.
+    const sendRawTransaction = vi.fn().mockResolvedValue(LOCAL_SIGNATURE);
+
+    await submitPreparedTxOverRpc(preparedFixture(), {
+      connection: connectionWith(sendRawTransaction),
+      maxRetries: 2,
+    });
+
+    expect(sendRawTransaction).toHaveBeenCalledWith(expect.anything(), {
+      skipPreflight: false,
+      preflightCommitment: "confirmed",
+      maxRetries: 2,
+    });
+  });
+
   it("reports accepted when the RPC echoes the canonical local signature", async () => {
     const sendRawTransaction = vi.fn().mockResolvedValue(LOCAL_SIGNATURE);
 

--- a/src/__tests__/solana/solana-transaction-surface.test.ts
+++ b/src/__tests__/solana/solana-transaction-surface.test.ts
@@ -44,9 +44,17 @@ describe("solana-transaction façade surface", () => {
     const keys = Object.keys(txMod).sort();
     expect(keys).toEqual([
       "classifyProviderSubmitFailure",
+      "confirmStagedSignature",
       "confirmVersionedTx",
       "deserializeVersionedTx",
       "getSolanaConnection",
+      // Migration 084 split the legacy staged helper into a SIGN-ONLY half, a
+      // SUBMIT half and a CONFIRM-ONLY half, so the wallet-send writer can
+      // persist the signature plus its blockhash evidence before any bytes reach
+      // the network, and can submit through the classifying RPC lane while still
+      // reporting one confirmation vocabulary.
+      // `signAndSubmitLegacyTxStaged` stays, composed of those halves.
+      "prepareLegacyTx",
       "prepareVersionedTx",
       "resetSolanaConnection",
       "sendSignedVersionedTx",
@@ -55,6 +63,7 @@ describe("solana-transaction façade surface", () => {
       "signAndSubmitLegacyTxStaged",
       "signAndSubmitVersionedTxStaged",
       "signVersionedTx",
+      "submitPreparedLegacyTxStaged",
       "submitPreparedTxOverRpc",
     ]);
 
@@ -68,6 +77,11 @@ describe("solana-transaction façade surface", () => {
     expect(typeof txMod.resetSolanaConnection).toBe("function");
     expect(typeof txMod.signAndSendLegacyTx).toBe("function");
     expect(typeof txMod.signAndSubmitLegacyTxStaged).toBe("function");
+    expect(typeof txMod.prepareLegacyTx).toBe("function");
+    expect(typeof txMod.submitPreparedLegacyTxStaged).toBe("function");
+    // The confirm-only half, so a caller submitting through another lane still
+    // reports the same confirmation vocabulary.
+    expect(typeof txMod.confirmStagedSignature).toBe("function");
     expect(typeof txMod.prepareVersionedTx).toBe("function");
     expect(typeof txMod.submitPreparedTxOverRpc).toBe("function");
     expect(typeof txMod.classifyProviderSubmitFailure).toBe("function");

--- a/src/__tests__/vex-agent/db/repos/agent-activity-solana-staged-evidence.test.ts
+++ b/src/__tests__/vex-agent/db/repos/agent-activity-solana-staged-evidence.test.ts
@@ -323,6 +323,13 @@ describe("recoverStaleHashlessIntents", () => {
         // `pools_claim` is deliberately ABSENT - a claim is the primary
         // transaction of its own execution, not a dependent leg.
         "pools_fee",
+        // Migration 084 (agent wallet send). SHARED by both families, locally
+        // signed through the wallet send writer, and owned by no sweep. Unlike
+        // `pools_claim` - also a primary transaction, and deliberately absent -
+        // the transfer writer STAGES its hash before it submits, so a hashless
+        // transfer row is positive proof that nothing was ever sent and is
+        // therefore definitively not-attempted.
+        "wallet_transfer",
       ].sort(),
     );
   });
@@ -359,7 +366,10 @@ describe("recoverStaleHashlessIntents", () => {
     // built by `bridge-fee/solana-fee-transfer.ts`) or `family: "eip155"`, and
     // `khalani/handlers/bridge-execute.ts` picks the receiver with
     // `fromFamily === "solana" ? BRIDGE_FEE_RECEIVER_SOLANA : ..._EVM`.
-    const sharedRoles = ["swap", "bridge_deposit", "bridge_fee"];
+    // `wallet_transfer` (migration 084) is SHARED too: `wallet_send_confirm`
+    // takes an eip155 OR a solana wallet family, and both executors write the
+    // same role through the same staged writer.
+    const sharedRoles = ["swap", "bridge_deposit", "bridge_fee", "wallet_transfer"];
 
     for (const role of [...evmOnlyRoles, ...solanaOnlyRoles, ...sharedRoles]) {
       expect(allowedRoles).toContain(role);

--- a/src/__tests__/vex-agent/db/repos/token-history-kind-lockstep.test.ts
+++ b/src/__tests__/vex-agent/db/repos/token-history-kind-lockstep.test.ts
@@ -78,6 +78,20 @@ const KIND_ADMISSION: Readonly<Record<string, string | null>> = {
    * feed, which is where a user looks for it.
    */
   claim: null,
+  /**
+   * `transfer` (migration 084) is NOT carried by the token history today,
+   * recorded here rather than fixed - the same wrap/claim precedent.
+   *
+   * A send genuinely touches one token, so it has a real claim to a place in
+   * that token's history. But this view's row predicate admits by kind and its
+   * `product_type` CASE has no arm for one, and what a one-legged outflow with
+   * no counterparty renders as in a per-token ledger (a sale? a balance
+   * adjustment? neither) is a product decision, not a mechanical addition.
+   * Guessing it would put a fabricated trade side on a user's token page. Left
+   * as a declared gap: the transfer IS visible in the Agent Scan feed and in the
+   * transactions feed, which is where a user looks for it.
+   */
+  transfer: null,
 };
 
 /** The row-inclusion predicate of the agent_activity half. */

--- a/src/__tests__/vex-agent/db/repos/transactions-feed-kind-lockstep.test.ts
+++ b/src/__tests__/vex-agent/db/repos/transactions-feed-kind-lockstep.test.ts
@@ -82,6 +82,10 @@ const KIND_PRODUCT: Readonly<Record<string, string>> = {
   // assets out from a token that already exists, so filing it as a launch would
   // put a payout inside every launch view.
   claim: "claim",
+  // Migration 084. A wallet send renders as its OWN product: it moves one asset
+  // to an address with no route, price or counterparty, so the `ELSE` arm's
+  // "spot" would state a trade that never happened.
+  transfer: "transfer",
 };
 
 /** Every current user-action role per kind; plumbing roles are intentionally absent. */
@@ -101,6 +105,7 @@ const KIND_LOGICAL_ROLES: Readonly<Record<string, readonly string[]>> = {
   ],
   launch: ["token_launch"],
   claim: ["pools_claim"],
+  transfer: ["wallet_transfer"],
 };
 
 /** The activity half's row predicate, read from the source it is written in. */

--- a/src/__tests__/vex-agent/db/repos/transactions.test.ts
+++ b/src/__tests__/vex-agent/db/repos/transactions.test.ts
@@ -311,7 +311,7 @@ describe("filters", () => {
     // Bridges collapse to the logical row; swaps/lend/prediction/launch still
     // emit every row (one role per on-chain tx — no logical/leg split, R5).
     expect(activityHalf).toContain(
-      "(kind = 'swap' OR kind = 'lend' OR kind = 'prediction' OR kind = 'wrap' OR kind = 'yield' OR kind = 'launch' OR kind = 'claim' OR event_role = 'bridge_fill_expected')",
+      "(kind = 'swap' OR kind = 'lend' OR kind = 'prediction' OR kind = 'wrap' OR kind = 'yield' OR kind = 'launch' OR kind = 'claim' OR kind = 'transfer' OR event_role = 'bridge_fill_expected')",
     );
   });
 

--- a/src/__tests__/vex-agent/tools/internal/wallet/send-execute-evm.test.ts
+++ b/src/__tests__/vex-agent/tools/internal/wallet/send-execute-evm.test.ts
@@ -1,25 +1,34 @@
 /**
- * executeEvmTransfer — chain-resolution branch tests (Wave 2 batch 2b).
+ * executeEvmTransfer - chain-resolution wiring and the staged write path.
  *
  * Pins the inclusive-resolver wiring:
  *   - source:"local"  → wallet/public clients come from the LOCAL registry
  *     factory (getLocalEvmClients), Khalani factory untouched, tx params pass
- *     through unchanged (native sendTransaction + ERC-20 writeContract).
+ *     through unchanged (native value + ERC-20 transfer calldata).
  *   - source:"khalani" → byte-identical legacy path: createDynamicPublicClient/
  *     createDynamicWalletClient with (khalaniChain, khalaniChains[, pk]), local
  *     factory untouched.
+ *
+ * And, since migration 084, the ORDER in which money becomes durable: the
+ * `agent_activity` row is opened BEFORE signing, the hash is staged BEFORE
+ * submission, a stage CAS miss aborts without sending, an ambiguous outcome
+ * writes nothing terminal, and the amount signed is the amount recorded. Those
+ * are the assertions that go red if the staged split is ever collapsed back into
+ * a one-step `sendTransaction`.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   createPublicClient,
   createWalletClient,
+  decodeFunctionData,
   getAddress,
   http,
   parseUnits,
   type Account,
   type Chain,
   type PublicClient,
+  type TransactionReceipt,
   type Transport,
   type WalletClient,
 } from "viem";
@@ -53,6 +62,7 @@ function stubPublicClient() {
   return Object.assign(client, {
     waitForTransactionReceipt: vi.fn(),
     readContract: vi.fn(),
+    getBlock: vi.fn(),
   });
 }
 
@@ -94,6 +104,50 @@ vi.mock("@tools/khalani/evm-client.js", () => ({
   createDynamicWalletClient: (...args: Parameters<KhalaniEvmClientModule["createDynamicWalletClient"]>) => mockCreateDynamicWalletClient(...args),
 }));
 
+/**
+ * The staged broadcast primitive (migration 084). `executeEvmTransfer` no
+ * longer calls `sendTransaction` / `writeContract` - signing, staging and
+ * submitting are SPLIT so a durable row exists before funds can move - so the
+ * tx params these tests pin are now the ones handed to `signStageBroadcast`.
+ * That is the same assertion about the same values, read at the seam where they
+ * are now decided.
+ */
+type StagedBroadcastModule = typeof import("@tools/evm-chains/staged-broadcast.js");
+const mockSignStageBroadcast = vi.fn<StagedBroadcastModule["signStageBroadcast"]>();
+vi.mock("@tools/evm-chains/staged-broadcast.js", () => ({
+  signStageBroadcast: (...args: Parameters<StagedBroadcastModule["signStageBroadcast"]>) =>
+    mockSignStageBroadcast(...args),
+}));
+
+/**
+ * The durable writer, faked at its module boundary. These tests are about chain
+ * wiring, not persistence; the writer's own contract is exercised in
+ * `send/wallet-transfer-activity.test.ts` against the real repository seam.
+ */
+type ActivityWriterModule = typeof import("@vex-agent/tools/internal/wallet/send/activity-writer.js");
+const activityHandle = {
+  executionId: 77,
+  rowId: 42,
+  stageEvm: vi.fn(async () => {}),
+  stageSolana: vi.fn(async () => {}),
+  noteAccepted: vi.fn(async () => {}),
+  confirm: vi.fn(async () => {}),
+  fail: vi.fn(async () => {}),
+  completeExecution: vi.fn(async () => {}),
+};
+const mockOpenActivity = vi.fn<ActivityWriterModule["openWalletTransferActivity"]>(
+  async () => activityHandle,
+);
+const mockRecordPlanFailure = vi.fn<ActivityWriterModule["recordWalletTransferPlanFailure"]>(
+  async () => {},
+);
+vi.mock("@vex-agent/tools/internal/wallet/send/activity-writer.js", () => ({
+  openWalletTransferActivity: (...args: Parameters<ActivityWriterModule["openWalletTransferActivity"]>) =>
+    mockOpenActivity(...args),
+  recordWalletTransferPlanFailure: (...args: Parameters<ActivityWriterModule["recordWalletTransferPlanFailure"]>) =>
+    mockRecordPlanFailure(...args),
+}));
+
 const { executeEvmTransfer } = await import(
   "../../../../../vex-agent/tools/internal/wallet/send-execute-evm.js"
 );
@@ -108,7 +162,21 @@ const WALLET: EvmWallet = {
 };
 const TO = "0xffcf8fdee72ac11b5c542428b35eef5769c409f0";
 const ERC20 = "0x5fc5360d0400a0fd4f2af552add042d716f1d168";
-const TX_HASH = "0x" + "ab".repeat(32);
+const TX_HASH = ("0x" + "ab".repeat(32)) as `0x${string}`;
+
+/** The ERC-20 fragment the executor encodes, restated here so the test decodes what it asserts. */
+const ERC20_TRANSFER_ABI = [
+  {
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    name: "transfer",
+    outputs: [{ type: "bool" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
 
 /**
  * The REAL registry entry for Robinhood Chain (4663), not a hand-rolled stub:
@@ -154,17 +222,122 @@ function makeIntent(overrides: Partial<WalletIntent> = {}): WalletIntent {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  localWalletClient.sendTransaction.mockResolvedValue(TX_HASH);
-  localWalletClient.writeContract.mockResolvedValue(TX_HASH);
+  mockOpenActivity.mockResolvedValue(activityHandle);
   localPublicClient.readContract.mockResolvedValue(6);
-  localPublicClient.waitForTransactionReceipt.mockResolvedValue({ status: "success", blockNumber: 123n });
-  khalaniWalletClient.sendTransaction.mockResolvedValue(TX_HASH);
-  khalaniPublicClient.waitForTransactionReceipt.mockResolvedValue({ status: "success", blockNumber: 456n });
+  localPublicClient.getBlock.mockResolvedValue({ timestamp: 1_800_000_000n });
+  khalaniPublicClient.getBlock.mockResolvedValue({ timestamp: 1_800_000_000n });
+  // A confirmed receipt: the staged primitive is driven end to end by the
+  // executor, so the outcome it reports is what the executor branches on.
+  mockSignStageBroadcast.mockImplementation(async (_public, _wallet, _params, hooks) => {
+    await hooks.onHashStaged({ txHash: TX_HASH, fromAddress: WALLET.address, nonce: 7 });
+    await hooks.onAccepted();
+    return {
+      kind: "confirmed" as const,
+      txHash: TX_HASH,
+      receipt: stubReceipt("success", []),
+    };
+  });
 });
+
+/**
+ * The one `signStageBroadcast` call, asserted to exist. A missing call is a
+ * different defect from a wrong argument, and this says so instead of reading
+ * through an assertion.
+ */
+function stagedCall() {
+  const call = mockSignStageBroadcast.mock.calls[0];
+  if (call === undefined) throw new Error("signStageBroadcast was never called");
+  return call;
+}
+
+/** The `txParams` the executor handed the staged primitive. */
+function stagedTxParams() {
+  return stagedCall()[2];
+}
+
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+/**
+ * A COMPLETE `TransactionReceipt`, so the staged outcomes below are typed rather
+ * than cast through a partial shape. Only `status`, `blockNumber` and `logs`
+ * carry meaning for these tests; the rest exist because the contract says a
+ * receipt has them.
+ */
+interface StubLog {
+  readonly address: `0x${string}`;
+  readonly topics: [`0x${string}`, ...`0x${string}`[]] | [];
+  readonly data: `0x${string}`;
+}
+
+function stubReceipt(
+  status: "success" | "reverted",
+  logs: ReadonlyArray<StubLog>,
+  blockNumber = 123n,
+): TransactionReceipt {
+  return {
+    blockHash: `0x${"1".repeat(64)}`,
+    blockNumber,
+    contractAddress: null,
+    cumulativeGasUsed: 21_000n,
+    effectiveGasPrice: 1n,
+    from: WALLET.address as `0x${string}`,
+    gasUsed: 21_000n,
+    logs: logs.map((log, logIndex) => ({
+      address: log.address,
+      blockHash: `0x${"1".repeat(64)}` as `0x${string}`,
+      blockNumber,
+      data: log.data,
+      logIndex,
+      removed: false,
+      topics: log.topics,
+      transactionHash: TX_HASH,
+      transactionIndex: 0,
+    })),
+    logsBloom: `0x${"0".repeat(512)}`,
+    status,
+    to: getAddress(TO),
+    transactionHash: TX_HASH,
+    transactionIndex: 0,
+    type: "eip1559",
+  };
+}
+
+function paddedAddress(address: string): `0x${string}` {
+  return `0x000000000000000000000000${address.slice(2).toLowerCase()}`;
+}
+
+/** A well-formed ERC-20 `Transfer(WALLET -> TO, value)` log on the ERC20 fixture contract. */
+function erc20TransferLog(value: bigint): StubLog {
+  return {
+    address: getAddress(ERC20),
+    topics: [TRANSFER_TOPIC, paddedAddress(WALLET.address), paddedAddress(TO)],
+    data: `0x${value.toString(16).padStart(64, "0")}`,
+  };
+}
+
+/** Drive the staged primitive to a confirmed receipt carrying `logs`. */
+function stageWithLogs(logs: ReadonlyArray<StubLog>) {
+  mockSignStageBroadcast.mockImplementation(async (_public, _wallet, _params, hooks) => {
+    await hooks.onHashStaged({ txHash: TX_HASH, fromAddress: WALLET.address, nonce: 7 });
+    await hooks.onAccepted();
+    return {
+      kind: "confirmed" as const,
+      txHash: TX_HASH,
+      receipt: stubReceipt("success", logs),
+    };
+  });
+}
+
+/** The plan the executor handed the durable writer. */
+function openedPlan() {
+  const call = mockOpenActivity.mock.calls[0];
+  if (call === undefined) throw new Error("openWalletTransferActivity was never called");
+  return call[1];
+}
 
 // ── Local branch ────────────────────────────────────────────────
 
-describe("executeEvmTransfer — local registry branch", () => {
+describe("executeEvmTransfer - local registry branch", () => {
   beforeEach(() => {
     mockResolve.mockResolvedValue({
       source: "local",
@@ -180,50 +353,230 @@ describe("executeEvmTransfer — local registry branch", () => {
     expect(mockResolve).toHaveBeenCalledWith("robinhood");
     // Local factory got the registry config object + the signing key.
     expect(mockGetLocalEvmClients).toHaveBeenCalledWith(LOCAL_CONFIG, PRIVATE_KEY);
-    // Khalani factory untouched — no Khalani dependency on this path.
+    // Khalani factory untouched - no Khalani dependency on this path.
     expect(mockCreateDynamicPublicClient).not.toHaveBeenCalled();
     expect(mockCreateDynamicWalletClient).not.toHaveBeenCalled();
 
-    // Tx params pass through: checksummed recipient, 18-decimals value.
-    expect(localWalletClient.sendTransaction).toHaveBeenCalledWith({
+    // The LOCAL clients are the ones handed to the staged primitive.
+    expect(stagedCall()[0]).toBe(localPublicClient);
+    expect(stagedCall()[1]).toBe(localWalletClient);
+    // Tx params pass through: checksummed recipient, 18-decimals value, and a
+    // native send carries no calldata.
+    expect(stagedTxParams()).toEqual({
       to: getAddress(TO),
+      data: "0x",
       value: parseUnits("0.5", 18),
-      chain: undefined,
     });
 
     expect(outcome.kind).toBe("confirmed");
     if (outcome.kind === "confirmed") {
       expect(outcome.txHash).toBe(TX_HASH);
       expect(outcome.data.chain).toBe("Robinhood Chain");
-      const capture = outcome.data._tradeCapture as Record<string, unknown>;
-      expect(capture.chain).toBe("Robinhood Chain");
-      expect(capture.walletAddress).toBe(WALLET.address);
+      // The durable row is threaded, not a fabricated `_tradeCapture` blob.
+      expect(outcome.data._executionId).toBe(activityHandle.executionId);
+      expect(outcome.data._explorerRefs).toEqual([
+        { chain: "Robinhood Chain", txRef: TX_HASH },
+      ]);
     }
   });
 
-  it("routes ERC-20 transfers through the local clients (decimals read + writeContract)", async () => {
+  it("writes the durable row BEFORE it signs, and stages the hash before submission", async () => {
+    const order: string[] = [];
+    mockOpenActivity.mockImplementation(async () => {
+      order.push("intent");
+      return activityHandle;
+    });
+    activityHandle.stageEvm.mockImplementation(async () => {
+      order.push("stage");
+    });
+    mockSignStageBroadcast.mockImplementation(async (_p, _w, _params, hooks) => {
+      order.push("sign");
+      await hooks.onHashStaged({ txHash: TX_HASH, fromAddress: WALLET.address, nonce: 7 });
+      order.push("submit");
+      return {
+        kind: "confirmed" as const,
+        txHash: TX_HASH,
+        receipt: stubReceipt("success", []),
+      };
+    });
+
+    await executeEvmTransfer(makeIntent(), WALLET);
+
+    // The ordering IS the safety property: a crash at any point leaves a
+    // discoverable row rather than an invisible transaction.
+    expect(order).toEqual(["intent", "sign", "stage", "submit"]);
+    expect(activityHandle.confirm).toHaveBeenCalledTimes(1);
+    expect(activityHandle.completeExecution).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "confirmed", txHash: TX_HASH }),
+    );
+  });
+
+  it("records the SAME atomic amount on the row that it signs into the transaction", async () => {
+    await executeEvmTransfer(makeIntent({ amount: "0.5" }), WALLET);
+
+    const signedValue = stagedTxParams().value;
+    const plan = openedPlan();
+    // One bigint, two consumers. A float round-trip anywhere between them would
+    // separate these two numbers, which is the defect this asserts against.
+    expect(plan.amountRaw).toBe(signedValue);
+    expect(plan.amountRaw).toBe(parseUnits("0.5", 18));
+    expect(plan.amountHuman).toBe("0.5");
+    expect(plan.tokenDecimals).toBe(18);
+  });
+
+  it("aborts before submission when the stage CAS misses, and never terminalizes a second row", async () => {
+    activityHandle.stageEvm.mockRejectedValueOnce(new Error("CAS miss"));
+    let submitted = false;
+    mockSignStageBroadcast.mockImplementation(async (_p, _w, _params, hooks) => {
+      // The real primitive propagates an `onHashStaged` throw WITHOUT sending.
+      await hooks.onHashStaged({ txHash: TX_HASH, fromAddress: WALLET.address, nonce: 7 });
+      submitted = true;
+      throw new Error("unreachable");
+    });
+
+    const outcome = await executeEvmTransfer(makeIntent(), WALLET);
+
+    expect(submitted).toBe(false);
+    expect(outcome.kind).toBe("pre_broadcast_failed");
+    // The EXISTING event is finalized; a second execution row is never created.
+    expect(activityHandle.fail).toHaveBeenCalledWith(
+      expect.objectContaining({ failureCode: "broadcast_error" }),
+    );
+    expect(mockRecordPlanFailure).not.toHaveBeenCalled();
+    expect(activityHandle.completeExecution).toHaveBeenCalledWith({
+      kind: "failed_before_broadcast",
+    });
+  });
+
+  it("leaves an AMBIGUOUS outcome pending on the activity row, but still closes the tool attempt", async () => {
+    let submissions = 0;
+    mockSignStageBroadcast.mockImplementation(async (_p, _w, _params, hooks) => {
+      submissions++;
+      await hooks.onHashStaged({ txHash: TX_HASH, fromAddress: WALLET.address, nonce: 7 });
+      return {
+        kind: "ambiguous" as const, txHash: TX_HASH, stage: "send" as const, reason: "rpc timeout",
+      };
+    });
+
+    const outcome = await executeEvmTransfer(makeIntent(), WALLET);
+
+    expect(outcome.kind).toBe("confirmation_unknown");
+    if (outcome.kind === "confirmation_unknown") expect(outcome.txHash).toBe(TX_HASH);
+    // The CHAIN state stays unresolved: nothing terminal, and never a resend.
+    expect(activityHandle.fail).not.toHaveBeenCalled();
+    expect(activityHandle.confirm).not.toHaveBeenCalled();
+    expect(submissions).toBe(1);
+    // The TOOL ATTEMPT is closed. The compaction safe-moment gate selects an
+    // `execution_status = 'intent'` row independently of `agent_activity`, so
+    // leaving it open would block compaction even after the sweep resolved the
+    // activity row.
+    expect(activityHandle.completeExecution).toHaveBeenCalledWith({
+      kind: "confirmation_unknown", txHash: TX_HASH,
+    });
+  });
+
+  it("finalizes a definitive revert as failed, and completes the execution", async () => {
+    mockSignStageBroadcast.mockImplementation(async (_p, _w, _params, hooks) => {
+      await hooks.onHashStaged({ txHash: TX_HASH, fromAddress: WALLET.address, nonce: 7 });
+      return {
+        kind: "reverted" as const, txHash: TX_HASH, receipt: stubReceipt("reverted", [], 9n),
+      };
+    });
+
+    const outcome = await executeEvmTransfer(makeIntent(), WALLET);
+
+    expect(outcome.kind).toBe("chain_failed");
+    expect(activityHandle.fail).toHaveBeenCalledWith(
+      expect.objectContaining({ failureCode: "mined_revert" }),
+    );
+    expect(activityHandle.completeExecution).toHaveBeenCalledWith({
+      kind: "reverted", txHash: TX_HASH,
+    });
+    expect(activityHandle.confirm).not.toHaveBeenCalled();
+  });
+
+  it("refuses to sign when the durable row cannot be written", async () => {
+    mockOpenActivity.mockRejectedValueOnce(new Error("db down"));
+
+    const outcome = await executeEvmTransfer(makeIntent(), WALLET);
+
+    expect(outcome.kind).toBe("pre_broadcast_failed");
+    expect(mockSignStageBroadcast).not.toHaveBeenCalled();
+  });
+
+  it("routes ERC-20 transfers through the local clients (decimals read + transfer calldata)", async () => {
+    stageWithLogs([erc20TransferLog(parseUnits("25", 6))]);
     const outcome = await executeEvmTransfer(makeIntent({ token: ERC20, amount: "25" }), WALLET);
 
     // decimals read via the LOCAL public client.
     expect(localPublicClient.readContract).toHaveBeenCalledWith(
       expect.objectContaining({ address: getAddress(ERC20), functionName: "decimals" }),
     );
-    // transfer via the LOCAL wallet client, amount scaled by the read decimals.
-    expect(localWalletClient.writeContract).toHaveBeenCalledWith(
-      expect.objectContaining({
-        address: getAddress(ERC20),
-        functionName: "transfer",
-        args: [getAddress(TO), parseUnits("25", 6)],
-        chain: undefined,
-      }),
-    );
+    // The transfer travels as CALLDATA to the token contract now, with the
+    // amount scaled by the decimals that were read. Decoding it back asserts
+    // the same two values the old `writeContract` args did.
+    const params = stagedTxParams();
+    expect(params.to).toBe(getAddress(ERC20));
+    expect(params.value).toBe(0n);
+    expect(decodeFunctionData({ abi: ERC20_TRANSFER_ABI, data: params.data })).toEqual({
+      functionName: "transfer",
+      args: [getAddress(TO), parseUnits("25", 6)],
+    });
+    // The row records the same scaled amount, with the same decimals.
+    const plan = openedPlan();
+    expect(plan.amountRaw).toBe(parseUnits("25", 6));
+    expect(plan.tokenDecimals).toBe(6);
+    expect(plan.tokenAddress).toBe(getAddress(ERC20));
     expect(outcome.kind).toBe("confirmed");
+  });
+
+  it("records an ERC-20 amount as EXECUTED only when the receipt's Transfer log proves it", async () => {
+    stageWithLogs([erc20TransferLog(parseUnits("25", 6))]);
+
+    await executeEvmTransfer(makeIntent({ token: ERC20, amount: "25" }), WALLET);
+
+    expect(activityHandle.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ provenAmountRaw: parseUnits("25", 6) }),
+    );
+  });
+
+  it("proves NOTHING for an ERC-20 whose receipt carries no Transfer log", async () => {
+    // The defect: `transfer` returns `bool`, so a nonconforming token can answer
+    // `false` WITHOUT reverting. Inclusion is then not proof of movement.
+    stageWithLogs([]);
+
+    await executeEvmTransfer(makeIntent({ token: ERC20, amount: "25" }), WALLET);
+
+    expect(activityHandle.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ provenAmountRaw: null }),
+    );
+  });
+
+  it("proves NOTHING for an ERC-20 whose Transfer log carries a DIFFERENT amount", async () => {
+    // A fee-on-transfer token delivering less than requested.
+    stageWithLogs([erc20TransferLog(parseUnits("24", 6))]);
+
+    await executeEvmTransfer(makeIntent({ token: ERC20, amount: "25" }), WALLET);
+
+    expect(activityHandle.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ provenAmountRaw: null }),
+    );
+  });
+
+  it("keeps inclusion as proof for a NATIVE send - the protocol moves tx.value itself", async () => {
+    stageWithLogs([]);
+
+    await executeEvmTransfer(makeIntent(), WALLET);
+
+    expect(activityHandle.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ provenAmountRaw: parseUnits("0.5", 18) }),
+    );
   });
 });
 
 // ── Khalani branch regression ───────────────────────────────────
 
-describe("executeEvmTransfer — khalani branch (regression)", () => {
+describe("executeEvmTransfer - khalani branch (regression)", () => {
   beforeEach(() => {
     mockResolve.mockResolvedValue({
       source: "khalani",
@@ -242,10 +595,12 @@ describe("executeEvmTransfer — khalani branch (regression)", () => {
     // Local factory untouched on the Khalani path.
     expect(mockGetLocalEvmClients).not.toHaveBeenCalled();
 
-    expect(khalaniWalletClient.sendTransaction).toHaveBeenCalledWith({
+    expect(stagedCall()[0]).toBe(khalaniPublicClient);
+    expect(stagedCall()[1]).toBe(khalaniWalletClient);
+    expect(stagedTxParams()).toEqual({
       to: getAddress(TO),
+      data: "0x",
       value: parseUnits("0.5", 18),
-      chain: undefined,
     });
 
     expect(outcome.kind).toBe("confirmed");
@@ -257,7 +612,7 @@ describe("executeEvmTransfer — khalani branch (regression)", () => {
 
 // ── Resolver failure stays pre-broadcast ────────────────────────
 
-describe("executeEvmTransfer — resolver failure", () => {
+describe("executeEvmTransfer - resolver failure", () => {
   it("maps an unresolvable chain to pre_broadcast_failed (no client built, no tx)", async () => {
     mockResolve.mockRejectedValue(new Error("Unsupported chain: narnia"));
 

--- a/src/__tests__/vex-agent/tools/internal/wallet/send-execute-solana.test.ts
+++ b/src/__tests__/vex-agent/tools/internal/wallet/send-execute-solana.test.ts
@@ -1,0 +1,366 @@
+/**
+ * `executeSolanaTransfer` - the staged write path and the exact-decimal amount
+ * (migration 084).
+ *
+ * WHAT THESE PIN, and why each one is worth a test:
+ *
+ *  - THE FLOAT FIX. The lamport amount used to be
+ *    `BigInt(Math.round(Number(amount) * 1e9))`, which routes real money through
+ *    a float. The regression case below (`0.000000000123456789` scale and a
+ *    9-decimal amount past 2^53) returns a DIFFERENT number of lamports under
+ *    that expression than under exact arithmetic, so this test goes red the
+ *    moment the float is reintroduced.
+ *  - THE SAME BIGINT ON BOTH SIDES. The amount signed into the instruction and
+ *    the amount written to the durable row are asserted to be the same value.
+ *  - THE ORDERING. Sign, stage the signature plus blockhash evidence, THEN
+ *    submit. A staging failure must abort before submission.
+ *  - AMBIGUITY. A confirmation-unknown outcome writes nothing terminal and
+ *    completes no execution: the money is genuinely unresolved.
+ *
+ * The Solana RPC and the durable writer are faked at their module boundaries;
+ * the transfer's own assembly, amount arithmetic and ordering stay real, because
+ * those are the subject.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Keypair, PublicKey, SystemInstruction, SystemProgram } from "@solana/web3.js";
+import { parseUnits } from "viem";
+
+import type { SolanaWallet } from "@tools/wallet/multi-auth.js";
+import type { WalletIntent } from "@vex-agent/db/repos/wallet-intents.js";
+
+type SolanaTxModule = typeof import("@tools/solana-ecosystem/shared/solana-transaction.js");
+type ActivityWriterModule = typeof import("@vex-agent/tools/internal/wallet/send/activity-writer.js");
+
+const SIGNATURE = "5".repeat(88);
+const BLOCKHASH = "H".repeat(43);
+
+const mockGetBalance = vi.fn<() => Promise<number>>();
+const mockConnection = { getBalance: (...a: unknown[]) => mockGetBalance(...(a as [])) };
+
+const mockPrepareLegacyTx = vi.fn<SolanaTxModule["prepareLegacyTx"]>();
+/**
+ * The CLASSIFYING submit lane. The executor no
+ * longer calls `submitPreparedLegacyTxStaged`, whose throw-on-send contract
+ * cannot distinguish a node refusing the bytes from a response lost after the
+ * node took them.
+ */
+const mockSubmitOverRpc = vi.fn<SolanaTxModule["submitPreparedTxOverRpc"]>();
+const mockConfirmStaged = vi.fn<SolanaTxModule["confirmStagedSignature"]>();
+vi.mock("@tools/solana-ecosystem/shared/solana-transaction.js", () => ({
+  getSolanaConnection: () => mockConnection,
+  prepareLegacyTx: (...args: Parameters<SolanaTxModule["prepareLegacyTx"]>) => mockPrepareLegacyTx(...args),
+  submitPreparedTxOverRpc: (...args: Parameters<SolanaTxModule["submitPreparedTxOverRpc"]>) =>
+    mockSubmitOverRpc(...args),
+  confirmStagedSignature: (...args: Parameters<SolanaTxModule["confirmStagedSignature"]>) =>
+    mockConfirmStaged(...args),
+}));
+
+vi.mock("@tools/solana-ecosystem/shared/solana-validation.js", () => ({
+  solanaExplorerUrl: (sig: string) => `https://explorer.example/${sig}`,
+}));
+
+vi.mock("@tools/solana-ecosystem/jupiter/jupiter-tokens/service.js", () => ({
+  resolveJupiterToken: async () => {
+    throw new Error("no jupiter key in tests");
+  },
+}));
+
+const activityHandle = {
+  executionId: 91,
+  rowId: 13,
+  stageEvm: vi.fn(async () => {}),
+  stageSolana: vi.fn(async () => {}),
+  noteAccepted: vi.fn(async () => {}),
+  confirm: vi.fn(async () => {}),
+  fail: vi.fn(async () => {}),
+  completeExecution: vi.fn(async () => {}),
+};
+const mockOpenActivity = vi.fn<ActivityWriterModule["openWalletTransferActivity"]>(
+  async () => activityHandle,
+);
+const mockRecordPlanFailure = vi.fn<ActivityWriterModule["recordWalletTransferPlanFailure"]>(
+  async () => {},
+);
+vi.mock("@vex-agent/tools/internal/wallet/send/activity-writer.js", () => ({
+  openWalletTransferActivity: (...args: Parameters<ActivityWriterModule["openWalletTransferActivity"]>) =>
+    mockOpenActivity(...args),
+  recordWalletTransferPlanFailure: (...args: Parameters<ActivityWriterModule["recordWalletTransferPlanFailure"]>) =>
+    mockRecordPlanFailure(...args),
+}));
+
+const { executeSolanaTransfer } = await import(
+  "../../../../../vex-agent/tools/internal/wallet/send-execute-solana.js"
+);
+
+const KEYPAIR = Keypair.generate();
+const WALLET: SolanaWallet = {
+  family: "solana",
+  address: KEYPAIR.publicKey.toBase58(),
+  secretKey: KEYPAIR.secretKey,
+} as SolanaWallet;
+const TO = Keypair.generate().publicKey.toBase58();
+
+function makeIntent(overrides: Partial<WalletIntent> = {}): WalletIntent {
+  return {
+    intentId: "intent-sol-1",
+    sessionId: "session-1",
+    walletAddress: WALLET.address,
+    network: "solana" as WalletIntent["network"],
+    chainAlias: null,
+    toAddress: TO,
+    amount: "0.5",
+    token: null,
+    previewJson: {},
+    status: "pending" as WalletIntent["status"],
+    expiresAt: "2099-01-01T00:00:00.000Z",
+    consumedAt: null,
+    cancelledAt: null,
+    txHash: null,
+    failureReason: null,
+    idempotencyKey: null,
+    createdAt: "2026-07-05T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockOpenActivity.mockResolvedValue(activityHandle);
+  mockGetBalance.mockResolvedValue(Number.MAX_SAFE_INTEGER);
+  mockPrepareLegacyTx.mockResolvedValue({
+    serialized: new Uint8Array([1, 2, 3]),
+    signature: SIGNATURE,
+    recentBlockhash: BLOCKHASH,
+    lastValidBlockHeight: 4242,
+  });
+  mockSubmitOverRpc.mockResolvedValue({ kind: "accepted", signature: SIGNATURE });
+  mockConfirmStaged.mockResolvedValue({ signature: SIGNATURE, phase: "confirmed" });
+});
+
+/** The lamports the assembled SystemProgram.transfer instruction actually carries. */
+function signedLamports(): bigint {
+  const transaction = mockPrepareLegacyTx.mock.calls[0]![0];
+  const decoded = SystemInstruction.decodeTransfer(transaction.instructions[0]!);
+  return BigInt(decoded.lamports.toString());
+}
+
+describe("executeSolanaTransfer - exact decimal amounts", () => {
+  it("derives lamports by exact arithmetic, not through a float", async () => {
+    // 9-decimal SOL past 2^53 atomic units. `Number("9007199.254740993") * 1e9`
+    // cannot represent this value, so the old `Math.round(Number(...))` returns
+    // a DIFFERENT lamport count than the operator authorized.
+    const amount = "9007199.254740993";
+    // Enough lamports on hand that the balance gate is not what this measures.
+    mockGetBalance.mockResolvedValue(1e18);
+    const exact = parseUnits(amount, 9);
+    const viaFloat = BigInt(Math.round(Number(amount) * 1e9));
+    expect(viaFloat).not.toBe(exact); // the defect is real, not hypothetical
+
+    await executeSolanaTransfer(makeIntent({ amount }), WALLET);
+
+    expect(signedLamports()).toBe(exact);
+  });
+
+  it("writes the SAME bigint to the durable row that it signs into the instruction", async () => {
+    await executeSolanaTransfer(makeIntent({ amount: "0.123456789" }), WALLET);
+
+    const plan = mockOpenActivity.mock.calls[0]![1];
+    expect(plan.amountRaw).toBe(signedLamports());
+    expect(plan.amountRaw).toBe(parseUnits("0.123456789", 9));
+    expect(plan.amountHuman).toBe("0.123456789");
+    expect(plan.tokenDecimals).toBe(9);
+    expect(plan.chainFamily).toBe("solana");
+  });
+});
+
+describe("executeSolanaTransfer - staged write path", () => {
+  it("opens the row, signs, stages signature + blockhash evidence, THEN submits", async () => {
+    const order: string[] = [];
+    mockOpenActivity.mockImplementation(async () => {
+      order.push("intent");
+      return activityHandle;
+    });
+    mockPrepareLegacyTx.mockImplementation(async () => {
+      order.push("sign");
+      return {
+        serialized: new Uint8Array([1]),
+        signature: SIGNATURE,
+        recentBlockhash: BLOCKHASH,
+        lastValidBlockHeight: 4242,
+      };
+    });
+    activityHandle.stageSolana.mockImplementation(async () => {
+      order.push("stage");
+    });
+    mockSubmitOverRpc.mockImplementation(async () => {
+      order.push("submit");
+      return { kind: "accepted", signature: SIGNATURE };
+    });
+
+    const outcome = await executeSolanaTransfer(makeIntent(), WALLET);
+
+    expect(order).toEqual(["intent", "sign", "stage", "submit"]);
+    // The 049 CHECK needs both evidence fields the moment a Solana row stages.
+    expect(activityHandle.stageSolana).toHaveBeenCalledWith({
+      signature: SIGNATURE,
+      fromAddress: KEYPAIR.publicKey.toBase58(),
+      recentBlockhash: BLOCKHASH,
+      lastValidBlockHeight: 4242,
+    });
+    expect(outcome.kind).toBe("confirmed");
+    expect(activityHandle.completeExecution).toHaveBeenCalledWith({
+      kind: "confirmed", txHash: SIGNATURE,
+    });
+  });
+
+  it("aborts before submission when the stage CAS misses", async () => {
+    activityHandle.stageSolana.mockRejectedValueOnce(new Error("CAS miss"));
+
+    const outcome = await executeSolanaTransfer(makeIntent(), WALLET);
+
+    expect(mockSubmitOverRpc).not.toHaveBeenCalled();
+    expect(outcome.kind).toBe("pre_broadcast_failed");
+    // The EXISTING event is finalized - never a second execution row.
+    expect(activityHandle.fail).toHaveBeenCalledWith(
+      expect.objectContaining({ failureCode: "broadcast_error" }),
+    );
+    expect(mockRecordPlanFailure).not.toHaveBeenCalled();
+    expect(activityHandle.completeExecution).toHaveBeenCalledWith({
+      kind: "failed_before_broadcast",
+    });
+  });
+
+  it("refuses to sign when the durable row cannot be written", async () => {
+    mockOpenActivity.mockRejectedValueOnce(new Error("db down"));
+
+    const outcome = await executeSolanaTransfer(makeIntent(), WALLET);
+
+    expect(outcome.kind).toBe("pre_broadcast_failed");
+    expect(mockPrepareLegacyTx).not.toHaveBeenCalled();
+    expect(mockSubmitOverRpc).not.toHaveBeenCalled();
+  });
+
+  it("leaves an unknown confirmation PENDING on the activity row, but still closes the tool attempt", async () => {
+    mockConfirmStaged.mockResolvedValue({
+      signature: SIGNATURE, phase: "confirmation_unknown", errorKind: "VexError", errorHash: "abcd",
+    });
+
+    const outcome = await executeSolanaTransfer(makeIntent(), WALLET);
+
+    expect(outcome.kind).toBe("confirmation_unknown");
+    // The CHAIN state is unresolved: nothing terminal, and never a resend.
+    expect(activityHandle.fail).not.toHaveBeenCalled();
+    expect(activityHandle.confirm).not.toHaveBeenCalled();
+    expect(mockSubmitOverRpc).toHaveBeenCalledTimes(1);
+    // The wallet lane PRESERVES its pre-existing submit bound: adopting the
+    // shared classifier must not expand retry semantics on this money path.
+    expect(mockSubmitOverRpc.mock.calls[0]![1]).toMatchObject({ maxRetries: 2 });
+    // The TOOL ATTEMPT is over, so its execution row is closed - otherwise the
+    // compaction safe-moment gate, which selects `execution_status = 'intent'`
+    // independently of `agent_activity`, would block forever.
+    expect(activityHandle.completeExecution).toHaveBeenCalledWith({
+      kind: "confirmation_unknown", txHash: SIGNATURE,
+    });
+  });
+
+  it("does NOT terminalize a transport-uncertain submit: the bytes may already be on the network", async () => {
+    mockSubmitOverRpc.mockResolvedValue({
+      kind: "transport_uncertain", cause: new Error("socket hang up"),
+    });
+
+    const outcome = await executeSolanaTransfer(makeIntent(), WALLET);
+
+    // THE DEFECT THIS PINS: reporting a lost response as `pre_broadcast_failed`
+    // failed the activity row and returned no hash, while the staged signature
+    // could still land - a money gate clearing on a transfer that went through.
+    expect(outcome.kind).toBe("confirmation_unknown");
+    if (outcome.kind === "confirmation_unknown") expect(outcome.txHash).toBe(SIGNATURE);
+    expect(activityHandle.fail).not.toHaveBeenCalled();
+    expect(activityHandle.confirm).not.toHaveBeenCalled();
+    // Not confirmed either: the node never told us it took the bytes.
+    expect(mockConfirmStaged).not.toHaveBeenCalled();
+    expect(activityHandle.completeExecution).toHaveBeenCalledWith({
+      kind: "confirmation_unknown", txHash: SIGNATURE,
+    });
+  });
+
+  it("does NOT terminalize a signature mismatch, and keeps the STAGED signature as the identity", async () => {
+    mockSubmitOverRpc.mockResolvedValue({
+      kind: "signature_mismatch",
+      localSignature: SIGNATURE,
+      providerSignature: "some-other-signature",
+    });
+
+    const outcome = await executeSolanaTransfer(makeIntent(), WALLET);
+
+    expect(outcome.kind).toBe("confirmation_unknown");
+    // Never the provider's divergent echo: the staged value is what the durable
+    // row holds and what the sweep will resolve.
+    if (outcome.kind === "confirmation_unknown") expect(outcome.txHash).toBe(SIGNATURE);
+    expect(activityHandle.fail).not.toHaveBeenCalled();
+    expect(activityHandle.completeExecution).toHaveBeenCalledWith({
+      kind: "confirmation_unknown", txHash: SIGNATURE,
+    });
+  });
+
+  it("terminalizes ONLY a definitive node refusal", async () => {
+    mockSubmitOverRpc.mockResolvedValue({
+      kind: "rejected_before_broadcast", cause: new Error("preflight failed"),
+    });
+
+    const outcome = await executeSolanaTransfer(makeIntent(), WALLET);
+
+    // The node ANSWERED and refused, so nothing reached the network.
+    expect(outcome.kind).toBe("pre_broadcast_failed");
+    expect(activityHandle.fail).toHaveBeenCalledWith(
+      expect.objectContaining({ failureCode: "broadcast_error" }),
+    );
+    expect(activityHandle.completeExecution).toHaveBeenCalledWith({
+      kind: "failed_before_broadcast",
+    });
+  });
+
+  it("finalizes a definitive chain failure and completes the execution", async () => {
+    mockConfirmStaged.mockResolvedValue({
+      signature: SIGNATURE, phase: "chain_failed", errorKind: "VexError", errorHash: "beef",
+    });
+
+    const outcome = await executeSolanaTransfer(makeIntent(), WALLET);
+
+    expect(outcome.kind).toBe("chain_failed");
+    expect(activityHandle.fail).toHaveBeenCalledWith(
+      expect.objectContaining({ failureCode: "mined_revert" }),
+    );
+    expect(activityHandle.completeExecution).toHaveBeenCalledWith({
+      kind: "reverted", txHash: SIGNATURE,
+    });
+  });
+
+  it("writes ONE hashless terminal row when the plan cannot be resolved, and signs nothing", async () => {
+    // Insufficient balance is decided before any intent row exists.
+    mockGetBalance.mockResolvedValue(1);
+
+    const outcome = await executeSolanaTransfer(makeIntent({ amount: "5" }), WALLET);
+
+    expect(outcome.kind).toBe("pre_broadcast_failed");
+    expect(mockOpenActivity).not.toHaveBeenCalled();
+    expect(mockPrepareLegacyTx).not.toHaveBeenCalled();
+    expect(mockRecordPlanFailure).toHaveBeenCalledTimes(1);
+    expect(mockRecordPlanFailure.mock.calls[0]![1]).toEqual(
+      expect.objectContaining({ failureCode: "allowance_or_balance", chainFamily: "solana" }),
+    );
+  });
+});
+
+/** Guards the fixture itself: a wrong recipient would make every assertion above vacuous. */
+describe("executeSolanaTransfer - instruction shape", () => {
+  it("sends to the intent's recipient from the session wallet", async () => {
+    await executeSolanaTransfer(makeIntent(), WALLET);
+
+    const transaction = mockPrepareLegacyTx.mock.calls[0]![0];
+    const decoded = SystemInstruction.decodeTransfer(transaction.instructions[0]!);
+    expect(decoded.toPubkey.equals(new PublicKey(TO))).toBe(true);
+    expect(decoded.fromPubkey.equals(KEYPAIR.publicKey)).toBe(true);
+  });
+});

--- a/src/__tests__/vex-agent/tools/internal/wallet/send/transfer-settlement.test.ts
+++ b/src/__tests__/vex-agent/tools/internal/wallet/send/transfer-settlement.test.ts
@@ -1,0 +1,155 @@
+/**
+ * `send/transfer-settlement.ts` - what an EVM receipt proves a transfer moved
+ *
+ *
+ * THE DEFECT THESE GUARD AGAINST: `transfer` returns `bool`. A token that
+ * returns `false`, or a fee-on-transfer token that delivers less, does NOT
+ * revert, so `receipt.status === "success"` proves inclusion and nothing about
+ * the amount. Writing the requested amount into `executed_amount_in_raw` on that
+ * evidence records a request as settled truth.
+ *
+ * Pure functions, real log fixtures, no chain.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  proveErc20Transfer,
+  proveErc721Transfer,
+  type ReceiptLog,
+} from "@vex-agent/tools/internal/wallet/send/transfer-settlement.js";
+
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const TOKEN = "0x5fc5360d0400a0fd4f2af552add042d716f1d168";
+const FROM = "0xabcdef1234567890abcdef1234567890abcdef12";
+const TO = "0xffcf8fdee72ac11b5c542428b35eef5769c409f0";
+const OTHER = "0x1111111111111111111111111111111111111111";
+const AMOUNT = 25_000_000n;
+
+function padded(address: string): string {
+  return `0x000000000000000000000000${address.slice(2).toLowerCase()}`;
+}
+
+function amountData(value: bigint): string {
+  return `0x${value.toString(16).padStart(64, "0")}`;
+}
+
+function erc20Log(overrides: Partial<ReceiptLog> = {}): ReceiptLog {
+  return {
+    address: TOKEN,
+    topics: [TRANSFER_TOPIC, padded(FROM), padded(TO)],
+    data: amountData(AMOUNT),
+    ...overrides,
+  };
+}
+
+const erc20Input = {
+  tokenAddress: TOKEN,
+  from: FROM,
+  to: TO,
+  expectedAmountRaw: AMOUNT,
+};
+
+describe("proveErc20Transfer", () => {
+  it("proves the amount when the log matches contract, sender, recipient and amount", () => {
+    expect(proveErc20Transfer({ logs: [erc20Log()], ...erc20Input })).toBe(AMOUNT);
+  });
+
+  it("matches irrespective of address casing on either side", () => {
+    const log = erc20Log({ address: TOKEN.toUpperCase().replace("0X", "0x") });
+    expect(proveErc20Transfer({ logs: [log], ...erc20Input })).toBe(AMOUNT);
+  });
+
+  it("finds its log among unrelated ones in the same receipt", () => {
+    const noise: ReceiptLog = {
+      address: OTHER,
+      topics: [TRANSFER_TOPIC, padded(OTHER), padded(TO)],
+      data: amountData(999n),
+    };
+    expect(proveErc20Transfer({ logs: [noise, erc20Log()], ...erc20Input })).toBe(AMOUNT);
+  });
+
+  it("proves NOTHING when the receipt carries no Transfer log at all", () => {
+    // The `transfer` that returned `false` without reverting.
+    expect(proveErc20Transfer({ logs: [], ...erc20Input })).toBeNull();
+  });
+
+  it("proves NOTHING when the amount differs - a fee-on-transfer shortfall is not the requested amount", () => {
+    const short = erc20Log({ data: amountData(AMOUNT - 1n) });
+    expect(proveErc20Transfer({ logs: [short], ...erc20Input })).toBeNull();
+  });
+
+  it("proves NOTHING when the log belongs to a different token contract", () => {
+    expect(proveErc20Transfer({ logs: [erc20Log({ address: OTHER })], ...erc20Input })).toBeNull();
+  });
+
+  it("proves NOTHING when the recipient is not the one we sent to", () => {
+    const wrongTo = erc20Log({ topics: [TRANSFER_TOPIC, padded(FROM), padded(OTHER)] });
+    expect(proveErc20Transfer({ logs: [wrongTo], ...erc20Input })).toBeNull();
+  });
+
+  it("proves NOTHING when the sender is not our wallet", () => {
+    const wrongFrom = erc20Log({ topics: [TRANSFER_TOPIC, padded(OTHER), padded(TO)] });
+    expect(proveErc20Transfer({ logs: [wrongFrom], ...erc20Input })).toBeNull();
+  });
+
+  it("ignores an ERC-721 log on the same contract - a token id is not an amount", () => {
+    const erc721 = erc20Log({
+      topics: [TRANSFER_TOPIC, padded(FROM), padded(TO), amountData(AMOUNT)],
+      data: "0x",
+    });
+    expect(proveErc20Transfer({ logs: [erc721], ...erc20Input })).toBeNull();
+  });
+
+  it("proves NOTHING for empty or malformed log data rather than reading it as zero", () => {
+    for (const data of ["0x", "", "not-hex"]) {
+      expect(proveErc20Transfer({ logs: [erc20Log({ data })], ...erc20Input })).toBeNull();
+    }
+  });
+
+  it("proves a genuine zero-amount transfer when that is what the log says", () => {
+    // A zero the receipt states IS proven, and is different from unproven.
+    const zeroLog = erc20Log({ data: amountData(0n) });
+    expect(
+      proveErc20Transfer({ logs: [zeroLog], ...erc20Input, expectedAmountRaw: 0n }),
+    ).toBe(0n);
+  });
+});
+
+describe("proveErc721Transfer", () => {
+  const TOKEN_ID = 7n;
+  const input = { contractAddress: TOKEN, from: FROM, to: TO, tokenId: TOKEN_ID };
+
+  function erc721Log(overrides: Partial<ReceiptLog> = {}): ReceiptLog {
+    return {
+      address: TOKEN,
+      topics: [TRANSFER_TOPIC, padded(FROM), padded(TO), amountData(TOKEN_ID)],
+      data: "0x",
+      ...overrides,
+    };
+  }
+
+  it("proves ONE item moved when the token id matches", () => {
+    expect(proveErc721Transfer({ logs: [erc721Log()], ...input })).toBe(1n);
+  });
+
+  it("proves NOTHING for a different token id", () => {
+    const other = erc721Log({ topics: [TRANSFER_TOPIC, padded(FROM), padded(TO), amountData(8n)] });
+    expect(proveErc721Transfer({ logs: [other], ...input })).toBeNull();
+  });
+
+  it("proves NOTHING when there is no log", () => {
+    expect(proveErc721Transfer({ logs: [], ...input })).toBeNull();
+  });
+
+  it("ignores a 3-topic ERC-20 log - an amount is not a token id", () => {
+    expect(proveErc721Transfer({ logs: [erc20Log()], ...input })).toBeNull();
+  });
+
+  it("proves NOTHING when the recipient differs", () => {
+    const wrongTo = erc721Log({
+      topics: [TRANSFER_TOPIC, padded(FROM), padded(OTHER), amountData(TOKEN_ID)],
+    });
+    expect(proveErc721Transfer({ logs: [wrongTo], ...input })).toBeNull();
+  });
+});

--- a/src/__tests__/vex-agent/tools/internal/wallet/send/wallet-transfer-activity.test.ts
+++ b/src/__tests__/vex-agent/tools/internal/wallet/send/wallet-transfer-activity.test.ts
@@ -1,0 +1,367 @@
+/**
+ * `send/activity-writer.ts` - the durable contract of a wallet transfer's
+ * `agent_activity` row (migration 084).
+ *
+ * These tests own the WRITER's half: what shape reaches the repository, which
+ * repository function each arm calls, and which arms deliberately call nothing.
+ * The executors' half (ordering, chain mechanics, exact amounts) is pinned in
+ * `send-execute-evm.test.ts` / `send-execute-solana.test.ts`.
+ *
+ * The `agent-activity` repository and the session control lock are faked at
+ * their module boundaries - they are the DB boundary, not the subject. The
+ * writer's own decisions stay real.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { WalletIntent } from "@vex-agent/db/repos/wallet-intents.js";
+import type { WalletTransferPlan } from "@vex-agent/tools/internal/wallet/send/activity-writer.js";
+
+type ActivityRepo = typeof import("@vex-agent/db/repos/agent-activity.js");
+
+const mockCreateIntent = vi.fn<ActivityRepo["createAgentActivityIntent"]>();
+const mockCreatePreBroadcastFailure = vi.fn<ActivityRepo["createAgentActivityPreBroadcastFailure"]>();
+const mockMarkBroadcast = vi.fn<ActivityRepo["markActivityBroadcast"]>();
+const mockMarkSolanaBroadcast = vi.fn<ActivityRepo["markActivitySolanaBroadcast"]>();
+const mockMarkAccepted = vi.fn<ActivityRepo["markBroadcastAccepted"]>();
+const mockConfirm = vi.fn<ActivityRepo["confirmActivityEvent"]>();
+const mockFail = vi.fn<ActivityRepo["failActivityEvent"]>();
+const mockNoteBlockTime = vi.fn<ActivityRepo["noteSettledBlockTime"]>();
+
+vi.mock("@vex-agent/db/repos/agent-activity.js", () => ({
+  createAgentActivityIntent: (...a: unknown[]) => mockCreateIntent(...(a as [never])),
+  createAgentActivityPreBroadcastFailure: (...a: unknown[]) => mockCreatePreBroadcastFailure(...(a as [never])),
+  markActivityBroadcast: (...a: unknown[]) => mockMarkBroadcast(...(a as [never, never])),
+  markActivitySolanaBroadcast: (...a: unknown[]) => mockMarkSolanaBroadcast(...(a as [never, never])),
+  markBroadcastAccepted: (...a: unknown[]) => mockMarkAccepted(...(a as [never])),
+  confirmActivityEvent: (...a: unknown[]) => mockConfirm(...(a as [never, never])),
+  failActivityEvent: (...a: unknown[]) => mockFail(...(a as [never, never])),
+  noteSettledBlockTime: (...a: unknown[]) => mockNoteBlockTime(...(a as [never, never])),
+}));
+
+const mockCompleteExecution = vi.fn(async () => {});
+vi.mock("@vex-agent/db/repos/executions.js", () => ({
+  completeExecutionIntentWith: (...a: unknown[]) => mockCompleteExecution(...(a as [])),
+}));
+
+const FAKE_CLIENT = {} as never;
+vi.mock("@vex-agent/engine/runtime/lease-and-status/session-control-lock.js", () => ({
+  withSessionControlLock: async (_sessionId: string, fn: (c: never) => Promise<unknown>) => fn(FAKE_CLIENT),
+}));
+
+const writer = await import(
+  "../../../../../../vex-agent/tools/internal/wallet/send/activity-writer.js"
+);
+
+const INTENT: WalletIntent = {
+  intentId: "intent-1",
+  sessionId: "session-1",
+  walletAddress: "0xabcdef1234567890abcdef1234567890abcdef12",
+  network: "eip155" as WalletIntent["network"],
+  chainAlias: "base",
+  toAddress: "0xffcf8fdee72ac11b5c542428b35eef5769c409f0",
+  amount: "0.5",
+  token: null,
+  previewJson: {},
+  status: "pending" as WalletIntent["status"],
+  expiresAt: "2099-01-01T00:00:00.000Z",
+  consumedAt: null,
+  cancelledAt: null,
+  txHash: null,
+  failureReason: null,
+  idempotencyKey: null,
+  createdAt: "2026-07-05T00:00:00.000Z",
+};
+
+const PLAN: WalletTransferPlan = {
+  chainId: 8453,
+  chainSlug: "base",
+  chainFamily: "eip155",
+  tokenAddress: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+  tokenSymbol: "ETH",
+  tokenDecimals: 18,
+  amountRaw: 500_000_000_000_000_000n,
+  amountHuman: "0.5",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreateIntent.mockResolvedValue({ executionId: 5, events: [{ id: 42 }] } as never);
+  mockMarkBroadcast.mockResolvedValue({ applied: true, row: {} } as never);
+  mockMarkSolanaBroadcast.mockResolvedValue({ applied: true, row: {} } as never);
+  mockMarkAccepted.mockResolvedValue({ applied: true, row: {} } as never);
+  mockConfirm.mockResolvedValue({ applied: true, row: {} } as never);
+  mockFail.mockResolvedValue({ applied: true, row: {} } as never);
+  mockNoteBlockTime.mockResolvedValue(true);
+});
+
+describe("openWalletTransferActivity", () => {
+  it("creates ONE pending row with the transfer kind/role, an INPUT leg only, and no USD claim", async () => {
+    await writer.openWalletTransferActivity(INTENT, PLAN);
+
+    const input = mockCreateIntent.mock.calls[0]![0];
+    expect(input.toolId).toBe("wallet_send_confirm");
+    expect(input.namespace).toBe("wallet");
+    expect(input.events).toHaveLength(1);
+
+    const event = input.events[0]!;
+    expect(event.kind).toBe("transfer");
+    expect(event.eventRole).toBe("wallet_transfer");
+    expect(event.protocol).toBe("wallet");
+    expect(event.chainId).toBe(8453);
+    expect(event.chainFamily).toBe("eip155");
+    expect(event.sessionId).toBe(INTENT.sessionId);
+    expect(event.walletAddress).toBe(INTENT.walletAddress);
+
+    // The leg the wallet SPENT, with its scale and the raw amount beside it.
+    expect(event.tokenIn).toEqual({
+      tokenAddress: PLAN.tokenAddress,
+      tokenSymbol: "ETH",
+      tokenDecimals: 18,
+      amountHuman: "0.5",
+      amountRaw: "500000000000000000",
+    });
+    // A send has no counterparty and no second leg. Stating one would invent a
+    // trade; the kind<->role binding refuses the shape at the DB too.
+    expect(event.tokenOut).toBeUndefined();
+    expect(event.tokenIn2).toBeUndefined();
+    expect(event.tokenOut2).toBeUndefined();
+    // No venue quoted this, so no USD figure is claimed.
+    expect(event.usdInEst).toBeUndefined();
+    expect(event.usdOutEst).toBeUndefined();
+    expect(event.usdVexFeeEst).toBeUndefined();
+  });
+
+  it("does NOT record the recipient on the activity row", async () => {
+    await writer.openWalletTransferActivity(INTENT, PLAN);
+
+    const event = mockCreateIntent.mock.calls[0]![0].events[0]!;
+    // The destination lives on the local `wallet_intents` row and this
+    // execution's params; the ledger row that feeds the agent-visible feed
+    // deliberately carries no counterparty (rules/90 privacy stance).
+    expect(JSON.stringify(event)).not.toContain(INTENT.toAddress);
+  });
+
+  it("propagates a durable-write failure instead of swallowing it", async () => {
+    mockCreateIntent.mockRejectedValueOnce(new Error("db down"));
+    // The caller must not sign without a row; a resolved promise here would let
+    // it.
+    await expect(writer.openWalletTransferActivity(INTENT, PLAN)).rejects.toThrow("db down");
+  });
+});
+
+describe("staging is a hard gate", () => {
+  it("THROWS on an EVM stage CAS miss rather than letting the caller broadcast", async () => {
+    mockMarkBroadcast.mockResolvedValue({ applied: false, row: {} } as never);
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+
+    await expect(
+      activity.stageEvm({ txHash: "0xdead", fromAddress: INTENT.walletAddress, nonce: 3 }),
+    ).rejects.toThrow(/refusing to broadcast untracked/);
+  });
+
+  it("THROWS on a Solana stage CAS miss", async () => {
+    mockMarkSolanaBroadcast.mockResolvedValue({ applied: false, row: {} } as never);
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+
+    await expect(
+      activity.stageSolana({
+        signature: "sig", fromAddress: "wallet", recentBlockhash: "hash", lastValidBlockHeight: 1,
+      }),
+    ).rejects.toThrow(/refusing to broadcast untracked/);
+  });
+
+  it("stages the EVM hash together with its sender and nonce", async () => {
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+    await activity.stageEvm({ txHash: "0xdead", fromAddress: INTENT.walletAddress, nonce: 3 });
+
+    expect(mockMarkBroadcast).toHaveBeenCalledWith(42, {
+      txHash: "0xdead", fromAddress: INTENT.walletAddress, nonce: 3,
+    });
+  });
+
+  it("stages a Solana signature together with the blockhash evidence the 049 CHECK requires", async () => {
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+    await activity.stageSolana({
+      signature: "sig", fromAddress: "wallet", recentBlockhash: "hash", lastValidBlockHeight: 99,
+    });
+
+    expect(mockMarkSolanaBroadcast).toHaveBeenCalledWith(42, {
+      txHash: "sig", fromAddress: "wallet", recentBlockhash: "hash", lastValidBlockHeight: 99,
+    });
+  });
+});
+
+describe("finalization", () => {
+  it("writes the PROVEN amount as the executed one, plus the block's own time", async () => {
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+    await activity.confirm({
+      txHash: "0xdead",
+      blockTimeIso: "2026-08-21T00:00:00.000Z",
+      provenAmountRaw: PLAN.amountRaw,
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(42, {
+      executedAmountInRaw: "500000000000000000",
+      executedAmountInHuman: "0.5",
+    });
+    // The BLOCK's time, not the observation time - see settled-block-time.ts.
+    expect(mockNoteBlockTime).toHaveBeenCalledWith(42, "2026-08-21T00:00:00.000Z");
+  });
+
+  it("confirms with NO executed amount when the receipt proved none", async () => {
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+    await activity.confirm({ txHash: "0xdead", provenAmountRaw: null });
+
+    // The transaction confirmed, but WHAT IT MOVED is unproven. Writing the
+    // request here would make an unverified number look verified; the repair
+    // lane may fill one in later from its own evidence.
+    expect(mockConfirm).toHaveBeenCalledWith(42, {});
+  });
+
+  it("writes the amount the receipt PROVED even when it differs from the plan", async () => {
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+    // A fee-on-transfer token delivering less: the chain's number is the truth.
+    await activity.confirm({ txHash: "0xdead", provenAmountRaw: 499_000_000_000_000_000n });
+
+    expect(mockConfirm).toHaveBeenCalledWith(42, {
+      executedAmountInRaw: "499000000000000000",
+      executedAmountInHuman: "0.499",
+    });
+  });
+
+  it("writes no block time when none could be read", async () => {
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+    await activity.confirm({ txHash: "0xdead", provenAmountRaw: PLAN.amountRaw });
+
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    expect(mockNoteBlockTime).not.toHaveBeenCalled();
+  });
+
+  it("does not report a failed transfer when only the bookkeeping write failed", async () => {
+    mockConfirm.mockRejectedValueOnce(new Error("db down"));
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+
+    // The transaction is the truth. A confirm-write failure is logged and the
+    // repair lane reconciles the row; it must never surface as an error.
+    await expect(
+      activity.confirm({ txHash: "0xdead", provenAmountRaw: PLAN.amountRaw }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("finalizes the EXISTING event on failure - never a second pre-broadcast row", async () => {
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+    await activity.fail({ failureCode: "mined_revert", failureReason: "reverted" });
+
+    expect(mockFail).toHaveBeenCalledWith(42, {
+      failureCode: "mined_revert", failureReason: "reverted",
+    });
+    expect(mockCreatePreBroadcastFailure).not.toHaveBeenCalled();
+  });
+});
+
+describe("protocol_executions completion", () => {
+  it("settles the SAME execution row on a confirmed outcome, under the session lock", async () => {
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+    await activity.completeExecution({ kind: "confirmed", txHash: "0xdead" });
+
+    const [, completion] = mockCompleteExecution.mock.calls[0] as unknown as [unknown, {
+      executionId: number; success: boolean; externalRefs: Record<string, unknown>;
+    }];
+    expect(completion.executionId).toBe(5);
+    expect(completion.success).toBe(true);
+    expect(completion.externalRefs).toEqual({ txHash: "0xdead" });
+  });
+
+  it("settles it as unsuccessful on a revert, an unknown confirmation, and a pre-broadcast failure", async () => {
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+    await activity.completeExecution({ kind: "reverted", txHash: "0xdead" });
+    await activity.completeExecution({ kind: "confirmation_unknown", txHash: "0xdead" });
+    await activity.completeExecution({ kind: "failed_before_broadcast" });
+
+    const completions = mockCompleteExecution.mock.calls.map(
+      (call) => (call as unknown as [unknown, { success: boolean; result: { status: string } }])[1],
+    );
+    expect(completions.map((c) => c.success)).toEqual([false, false, false]);
+    // The tool attempt is CLOSED on an unknown confirmation, with a structural
+    // status that does not claim the chain settled. The activity row is what
+    // stays pending.
+    expect(completions[1]?.result.status).toBe("confirmation_unknown");
+  });
+
+  it("does not surface a completion failure as a transfer failure", async () => {
+    mockCompleteExecution.mockRejectedValueOnce(new Error("lock timeout"));
+    const activity = await writer.openWalletTransferActivity(INTENT, PLAN);
+
+    await expect(
+      activity.completeExecution({ kind: "confirmed", txHash: "0xdead" }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("recordWalletTransferPlanFailure", () => {
+  it("writes ONE hashless terminal row with no leg it could not resolve", async () => {
+    mockCreatePreBroadcastFailure.mockResolvedValue({ executionId: 9, event: { id: 1 } } as never);
+
+    await writer.recordWalletTransferPlanFailure(INTENT, {
+      failureCode: "chain_unsupported",
+      failureReason: "no chain was named",
+      chainId: 0,
+      chainFamily: "eip155",
+    });
+
+    const input = mockCreatePreBroadcastFailure.mock.calls[0]![0];
+    expect(input.event.kind).toBe("transfer");
+    expect(input.event.eventRole).toBe("wallet_transfer");
+    expect(input.event.failureCode).toBe("chain_unsupported");
+    // The plan is exactly what failed to resolve, so any token identity or
+    // amount stated here would be a guess about the thing that failed.
+    expect(input.event.tokenIn).toBeUndefined();
+    expect(input.event.tokenOut).toBeUndefined();
+    // And it never creates a pending row it would then have to finalize.
+    expect(mockCreateIntent).not.toHaveBeenCalled();
+  });
+
+  it("COMPLETES the execution row it opened - a discarded id blocks compaction forever", async () => {
+    mockCreatePreBroadcastFailure.mockResolvedValue({ executionId: 9, event: { id: 1 } } as never);
+
+    await writer.recordWalletTransferPlanFailure(INTENT, {
+      failureCode: "chain_unsupported",
+      failureReason: "no chain was named",
+      chainId: 0,
+      chainFamily: "eip155",
+    });
+
+    // `createAgentActivityPreBroadcastFailure` opens a `protocol_executions`
+    // intent alongside the activity row. Discarding that id left the execution
+    // at `execution_status = 'intent'`, which the compaction safe-moment gate
+    // selects independently of `agent_activity` - so a transfer that never even
+    // resolved a plan blocked compaction permanently.
+    const [, completion] = mockCompleteExecution.mock.calls[0] as unknown as [unknown, {
+      executionId: number; success: boolean;
+    }];
+    expect(completion.executionId).toBe(9);
+    expect(completion.success).toBe(false);
+  });
+
+  it("does not attempt a completion when the failure row itself could not be written", async () => {
+    mockCreatePreBroadcastFailure.mockRejectedValueOnce(new Error("db down"));
+
+    await writer.recordWalletTransferPlanFailure(INTENT, {
+      failureCode: "unknown", failureReason: "x", chainId: 1, chainFamily: "eip155",
+    });
+
+    // There is no execution id to complete; inventing one would be worse.
+    expect(mockCompleteExecution).not.toHaveBeenCalled();
+  });
+
+  it("swallows its own write failure - a transfer that never happened is still reported as such", async () => {
+    mockCreatePreBroadcastFailure.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(
+      writer.recordWalletTransferPlanFailure(INTENT, {
+        failureCode: "unknown", failureReason: "x", chainId: 1, chainFamily: "eip155",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/tools/solana-ecosystem/shared/solana-transaction.ts
+++ b/src/tools/solana-ecosystem/shared/solana-transaction.ts
@@ -18,6 +18,9 @@ export {
 export {
   signAndSubmitVersionedTxStaged,
   signAndSubmitLegacyTxStaged,
+  prepareLegacyTx,
+  submitPreparedLegacyTxStaged,
+  confirmStagedSignature,
   type StagedSubmissionPhase,
   type StagedSubmissionResult,
 } from "./solana-transaction/staged.js";

--- a/src/tools/solana-ecosystem/shared/solana-transaction/rpc-submit.ts
+++ b/src/tools/solana-ecosystem/shared/solana-transaction/rpc-submit.ts
@@ -27,13 +27,18 @@
  *     confirmed state before accepting. A simulation failure is thereby
  *     reported to us synchronously instead of becoming a silent disappearance.
  *
- *  3. `maxRetries` is OMITTED, so "the RPC node will retry the transaction
- *     until it is finalized or until the blockhash expires"
+ *  3. `maxRetries` is OMITTED BY DEFAULT, so "the RPC node will retry the
+ *     transaction until it is finalized or until the blockhash expires"
  *     (solana.com/developers/guides/advanced/retry). The guide's recommended
  *     alternative — `maxRetries: 0` plus an application-owned rebroadcast loop
  *     — needs a durable outbox holding signed bytes, which is explicitly out
  *     of scope this wave (design D3) and needs its own security design. Node-
  *     side retry re-sends the SAME bytes, so it cannot violate point 1.
+ *     A caller whose lane carried its own retry bound BEFORE adopting this
+ *     module (the wallet send lane, `maxRetries: 2`) passes that bound via
+ *     `options.maxRetries` so adopting the shared classifier does not
+ *     silently expand its retry semantics; protocol lanes keep the omitted
+ *     default.
  *
  *  4. A successful return does NOT mean confirmation — the docs are explicit
  *     that acceptance "does not guarantee the transaction is processed or
@@ -56,6 +61,12 @@ import type { SolanaSubmitOutcome } from "./submit-outcome.js";
 export interface SubmitPreparedTxOverRpcOptions {
   /** Defaults to the shared cached Solana connection. Inject for tests or a non-default RPC. */
   readonly connection?: Connection;
+  /**
+   * Node-side retry bound for `sendRawTransaction`. OMITTED by default
+   * (contract point 3). Pass it only to PRESERVE a lane's pre-existing
+   * bound; never to introduce new retry behavior on a money path.
+   */
+  readonly maxRetries?: number;
 }
 
 export async function submitPreparedTxOverRpc(
@@ -69,6 +80,7 @@ export async function submitPreparedTxOverRpc(
     rpcSignature = await connection.sendRawTransaction(prepared.serialized, {
       skipPreflight: false,
       preflightCommitment: "confirmed",
+      ...(options.maxRetries === undefined ? {} : { maxRetries: options.maxRetries }),
     });
   } catch (err) {
     if (err instanceof SendTransactionError) {

--- a/src/tools/solana-ecosystem/shared/solana-transaction/staged.ts
+++ b/src/tools/solana-ecosystem/shared/solana-transaction/staged.ts
@@ -4,6 +4,7 @@
 
 import { createHash } from "node:crypto";
 import { Connection, type Commitment, Keypair, Transaction } from "@solana/web3.js";
+import bs58 from "bs58";
 import { loadConfig } from "../../../../config/store.js";
 import { VexError, ErrorCodes } from "../../../../errors.js";
 import { DEFAULT_CONFIRM_TIMEOUT_MS, DEFAULT_SEND_RETRIES, DEFAULT_NETWORK_RETRIES } from "./constants.js";
@@ -11,6 +12,7 @@ import { deserializeVersionedTx } from "./deserialize.js";
 import { signVersionedTx } from "./sign.js";
 import { confirmVersionedTx } from "./confirm.js";
 import { getSolanaConnection } from "./connection.js";
+import type { PreparedSolanaTx } from "./prepare.js";
 
 function getConfiguredSolanaConnection(): Connection {
   const cfg = loadConfig();
@@ -164,6 +166,38 @@ export async function signAndSubmitLegacyTxStaged(
   opts?: { connection?: Connection },
 ): Promise<StagedSubmissionResult> {
   const connection = opts?.connection ?? getSolanaConnection();
+  const prepared = await prepareLegacyTx(transaction, keypair, { connection });
+  return submitPreparedLegacyTxStaged(prepared, { connection });
+}
+
+/**
+ * SIGN-ONLY half of `signAndSubmitLegacyTxStaged`: fetch a blockhash, sign the
+ * legacy transaction locally, and return its signature together with the
+ * blockhash EVIDENCE - WITHOUT sending anything to the network.
+ *
+ * Split out (migration 084) for the wallet-send writer, which has to persist a
+ * durable `agent_activity` row carrying `tx_hash` + `recent_blockhash` +
+ * `last_valid_block_height` BEFORE the funds can move: the 049
+ * `agent_activity_solana_staged_has_evidence` CHECK requires exactly these two
+ * fields the moment a Solana row is staged, and a writer that submits first has
+ * no way to satisfy it without a crash window in which money moved and the row
+ * is hashless.
+ *
+ * The signature is derived from the bytes that were signed, not from the RPC's
+ * reply - that is what makes it available before submission. It is the same
+ * value `sendRawTransaction` returns, by definition: a Solana transaction id IS
+ * the base58 of its first signature.
+ *
+ * Callers that do not need the split keep using `signAndSubmitLegacyTxStaged`,
+ * whose behavior is unchanged: it is now this function composed with
+ * `submitPreparedLegacyTxStaged`.
+ */
+export async function prepareLegacyTx(
+  transaction: Transaction,
+  keypair: Keypair,
+  opts?: { connection?: Connection },
+): Promise<PreparedSolanaTx> {
+  const connection = opts?.connection ?? getSolanaConnection();
 
   const { blockhash, lastValidBlockHeight } =
     await connection.getLatestBlockhash("confirmed");
@@ -172,13 +206,69 @@ export async function signAndSubmitLegacyTxStaged(
   transaction.feePayer = keypair.publicKey;
   transaction.sign(keypair);
 
+  const serialized = transaction.serialize();
+  const signature = transaction.signature;
+  if (signature === null) {
+    throw new Error("prepareLegacyTx: transaction carries no fee-payer signature after signing");
+  }
+  return {
+    serialized,
+    signature: bs58.encode(signature),
+    recentBlockhash: blockhash,
+    lastValidBlockHeight,
+  };
+}
+
+/**
+ * SUBMIT half of `signAndSubmitLegacyTxStaged`. The signed bytes are sent ONCE
+ * and the post-broadcast outcome is reported as a discriminated `phase`; a
+ * `sendRawTransaction` throw is PRE-broadcast and bubbles out, exactly as
+ * before the split.
+ *
+ * The reported `signature` is the prepared one rather than the RPC's echo, so a
+ * caller that already staged that value durably reads back the same identity it
+ * persisted.
+ */
+export async function submitPreparedLegacyTxStaged(
+  prepared: PreparedSolanaTx,
+  opts?: { connection?: Connection },
+): Promise<StagedSubmissionResult> {
+  const connection = opts?.connection ?? getSolanaConnection();
+
   // Pre-broadcast: any throw from sendRawTransaction bubbles out.
-  const signature = await connection.sendRawTransaction(
-    transaction.serialize(),
+  //
+  // THIS CONTRACT IS FOR `signAndSubmitLegacyTxStaged`'s EXISTING CALLERS ONLY.
+  // A throw here is reported as pre-broadcast, which is TRUE for a preflight
+  // rejection and FALSE for a socket timeout after the node took the bytes. A
+  // caller with a durable row must not use this function: it should submit
+  // through `submitPreparedTxOverRpc`, which classifies that difference, and
+  // then confirm through `confirmStagedSignature` below.
+  await connection.sendRawTransaction(
+    prepared.serialized,
     { skipPreflight: false, maxRetries: 2 },
   );
 
   // Broadcast happened — anything below is post-broadcast.
+  return confirmStagedSignature(connection, prepared.signature);
+}
+
+/**
+ * CONFIRM-ONLY half: await a confirmation for an already-submitted signature
+ * and classify the outcome as `confirmed` / `chain_failed` /
+ * `confirmation_unknown`.
+ *
+ * Split out (migration 084) so a caller that submits through a lane with its
+ * own outcome classification (`submitPreparedTxOverRpc`) still gets exactly the
+ * same confirmation vocabulary as `signAndSubmitLegacyTxStaged`, instead of a
+ * second copy of `classifyConfirmFailure` drifting beside this one.
+ *
+ * Never throws: a confirmation that could not be determined is
+ * `confirmation_unknown`, not a failure.
+ */
+export async function confirmStagedSignature(
+  connection: Connection,
+  signature: string,
+): Promise<StagedSubmissionResult> {
   try {
     await confirmVersionedTx(connection, signature);
     return { signature, phase: "confirmed" };

--- a/src/vex-agent/db/migrations/084_agent_activity_wallet_transfer.sql
+++ b/src/vex-agent/db/migrations/084_agent_activity_wallet_transfer.sql
@@ -1,0 +1,127 @@
+-- 084_agent_activity_wallet_transfer.sql - agent wallet sends become activity rows
+--
+-- RUNS AFTER 083.
+--
+-- WHAT THIS ADDS. One kind, `transfer`, and one role, `wallet_transfer`, so an
+-- agent wallet send (`wallet_send_prepare` / `wallet_send_confirm`) lands in
+-- `agent_activity` like every other money-moving action.
+--
+-- WHY IT WAS MISSING, and why that is a defect rather than a gap. A transfer
+-- persisted only into `wallet_intents`, which no feed reads. The transaction was
+-- real, the funds moved, and the agent's own history showed nothing - while the
+-- executors carried comments promising a capture pipeline that never ran on the
+-- internal tool route. Every other lane here (swap, bridge, lend, prediction,
+-- wrap, yield, launch, claim) writes a durable row BEFORE it signs; a transfer
+-- was the one money path with no durable record at all.
+--
+-- WHY ITS OWN KIND rather than a role on `swap`. A send has no route, no price,
+-- no slippage and no counterparty: it has ONE leg, the asset that left the
+-- wallet, and a destination that is deliberately not recorded. Filing it under
+-- `swap` would state a trade that never happened - the exact falsehood
+-- migration 051 (`wrap`) and 053 (`yield`) each record the cost of. The name
+-- `transfer` matches the on-wire ERC-20 `Transfer` semantics and the display
+-- kind the deprecated `proj_activity` lane already derived for a legacy send, so
+-- nothing a user has already seen changes its label.
+--
+-- THE `transfer` ARM CARRIES AN INPUT LEG AND NOTHING ELSE. The wallet spends
+-- the asset, so the row populates the `token_in_*` / `amount_in_*` columns. It
+-- takes no output leg (there is no asset coming back) and no second leg
+-- (`agent_activity_second_leg_roles_only`, migration 053/082, is deliberately
+-- NOT restated here - `wallet_transfer` is absent from its allowlist, which is
+-- the correct answer). An NFT send rides the same kind and role: the token
+-- identity is the CONTRACT address with `decimals = 0`, the token id travels in
+-- the symbol, and a pseudo-address is never minted.
+--
+-- CONSTRAINTS DELIBERATELY NOT RESTATED, and why each is unaffected:
+--   * `agent_activity_kind_family_binding` (079) - its predicate reads
+--     `kind NOT IN ('lend', 'prediction') OR ...`, so `transfer` satisfies it
+--     through the leading disjunct on EITHER family, exactly as `swap`, `wrap`,
+--     `yield`, `launch` and `claim` already do. A transfer arm would be a
+--     disjunct nothing needs, and restating the constraint would risk dropping
+--     079's `eip155` lend arm.
+--   * `agent_activity_evm_signed_leg_has_nonce` (045) - family-scoped, not
+--     kind-scoped. A staged EVM transfer row satisfies it because the writer
+--     signs LOCALLY first and stages the hash together with the prepared
+--     request's nonce (see `send/activity-writer.ts`), which is precisely why
+--     the writer was restructured rather than the CHECK relaxed.
+--   * `agent_activity_solana_no_nonce` (045) - family-scoped; a Solana transfer
+--     row leaves `nonce` NULL.
+--   * `agent_activity_solana_staged_has_evidence` (049) - family-scoped. A
+--     Solana transfer stages its base58 signature together with the
+--     `recent_blockhash` / `last_valid_block_height` its sign-only preparation
+--     step returns, so the evidence exists before anything is submitted.
+--   * `agent_activity_second_leg_roles_only` (053/082) - see above.
+--
+-- All three restatements below carry every existing member across byte-for-byte
+-- from migration 082 (the current state). A CHECK cannot be amended in place, so
+-- a restatement that dropped a member would make those rows unwritable.
+
+-- ── 1. The role vocabulary ────────────────────────────────────────────────
+ALTER TABLE agent_activity DROP CONSTRAINT IF EXISTS agent_activity_event_role_valid;
+ALTER TABLE agent_activity
+  ADD CONSTRAINT agent_activity_event_role_valid
+  CHECK (event_role IN (
+    'allowance_reset', 'allowance', 'swap',
+    'bridge_deposit', 'bridge_fee', 'bridge_fill_expected', 'bridge_fill_observed', 'bridge_refund',
+    'lend_deposit', 'lend_withdraw', 'lend_borrow_operate',
+    'predict_buy', 'predict_sell', 'predict_claim', 'predict_close',
+    'wrap', 'unwrap',
+    'yield_pt', 'yield_yt', 'yield_py', 'yield_lp', 'yield_sy', 'yield_claim',
+    'token_launch',
+    'trench_fee',
+    'swap_fee',
+    'pools_fee', 'pools_claim',
+    'wallet_transfer'
+  ));
+
+-- ── 2. The kind vocabulary ────────────────────────────────────────────────
+ALTER TABLE agent_activity DROP CONSTRAINT IF EXISTS agent_activity_kind_valid;
+ALTER TABLE agent_activity
+  ADD CONSTRAINT agent_activity_kind_valid
+  CHECK (kind IN ('swap', 'bridge', 'lend', 'prediction', 'wrap', 'yield', 'launch', 'claim', 'transfer'));
+
+-- ── 3. The kind <-> role binding ──────────────────────────────────────────
+--
+-- The `transfer` arm carries exactly ONE role. A send has no allowance step
+-- (a native send approves nothing, and an ERC-20 send moves the caller's own
+-- balance) and no fee leg of its own. The CHECK body itself stays comment-free
+-- and apostrophe-free, because the constraint evaluators that test these
+-- bindings parse the body as SQL rather than as prose.
+ALTER TABLE agent_activity DROP CONSTRAINT IF EXISTS agent_activity_kind_role_binding;
+ALTER TABLE agent_activity
+  ADD CONSTRAINT agent_activity_kind_role_binding
+  CHECK (
+    (kind = 'swap'   AND event_role IN ('allowance_reset', 'allowance', 'swap', 'trench_fee', 'swap_fee'))
+    OR
+    (kind = 'bridge' AND event_role IN (
+      'allowance_reset', 'allowance',
+      'bridge_deposit', 'bridge_fee',
+      'bridge_fill_expected', 'bridge_fill_observed', 'bridge_refund'
+    ))
+    OR
+    (kind = 'lend' AND event_role IN (
+      'allowance_reset', 'allowance',
+      'lend_deposit', 'lend_withdraw', 'lend_borrow_operate'
+    ))
+    OR
+    (kind = 'prediction' AND event_role IN (
+      'predict_buy', 'predict_sell', 'predict_claim', 'predict_close'
+    ))
+    OR
+    (kind = 'wrap' AND event_role IN ('wrap', 'unwrap'))
+    OR
+    (kind = 'yield' AND event_role IN (
+      'allowance_reset', 'allowance',
+      'yield_pt', 'yield_yt', 'yield_py', 'yield_lp', 'yield_sy', 'yield_claim'
+    ))
+    OR
+    (kind = 'launch' AND event_role IN (
+      'allowance_reset', 'allowance',
+      'token_launch', 'trench_fee',
+      'pools_fee'
+    ))
+    OR
+    (kind = 'claim' AND event_role IN ('pools_claim'))
+    OR
+    (kind = 'transfer' AND event_role IN ('wallet_transfer'))
+  );

--- a/src/vex-agent/db/repos/agent-activity/hashless-recovery.ts
+++ b/src/vex-agent/db/repos/agent-activity/hashless-recovery.ts
@@ -155,6 +155,18 @@ const LOCALLY_SIGNABLE_ACTIVITY_ROLES: readonly AgentActivityEventRole[] = [
   // and it aborts before broadcasting. A launch can never be double-created by
   // this interaction.
   "token_launch",
+  // Migration 084 (agent wallet send). Signed LOCALLY through the wallet send
+  // executors' staged writer (`internal/wallet/send/activity-writer.ts`), on
+  // either chain family, and no wallet-side sweep owns a hashless row: the EVM
+  // repair sweep's candidate query requires `submit_attempted_at IS NOT NULL`,
+  // which only `markActivityBroadcast` sets.
+  //
+  // Safe for the same reason `token_launch` is, plus one specific to this lane:
+  // the transfer writer stages the hash BEFORE it submits the signed bytes, so
+  // `tx_hash IS NULL` on a transfer row is proof that nothing was ever sent to
+  // the network. A crash between intent creation and staging is reaped here
+  // instead of pinning the session's money state open forever.
+  "wallet_transfer",
 ];
 
 /**

--- a/src/vex-agent/db/repos/agent-activity/types/vocabulary.ts
+++ b/src/vex-agent/db/repos/agent-activity/types/vocabulary.ts
@@ -34,7 +34,17 @@ export type AgentActivityKind =
    * it under `launch` would put a payout inside every launch feed, filter and
    * count. `pools_fee` stays on `launch`, because it IS the fee leg of one.
    */
-  | "claim";
+  | "claim"
+  /**
+   * An agent WALLET SEND (migration 084) - `wallet_send_prepare` /
+   * `wallet_send_confirm`. Its own kind rather than a `swap` role: a send has no
+   * route, no price, no slippage and no counterparty, only the one leg that left
+   * the wallet, so the `swap` arm's assertions would all describe a trade that
+   * never happened. The name matches the on-wire ERC-20 `Transfer` semantics and
+   * the display kind the deprecated `proj_activity` lane already derived for a
+   * legacy send.
+   */
+  | "transfer";
 
 /**
  * Kinds valid through the GENERIC write path (`./swap-intent.js` +
@@ -132,7 +142,15 @@ export type AgentActivityEventRole =
   // launched token and the paired asset that `collectAndClaim` returns
   // together, and it rides the `claim` KIND rather than `launch`.
   | "pools_fee"
-  | "pools_claim";
+  | "pools_claim"
+  /**
+   * Migration 084 - the whole of an agent wallet send, on either chain family.
+   * ONE role for the transaction, carrying the INPUT leg only - the asset the
+   * wallet spent. There is no output leg, because nothing comes back, and no
+   * second leg. An NFT send rides this same role with the CONTRACT address as
+   * the token identity, `tokenDecimals: 0`, and the token id in the symbol.
+   */
+  | "wallet_transfer";
 
 /** Chain family discriminator (045) — drives the nonce matrix + explorer-link resolution. */
 export type BridgeChainFamily = "eip155" | "solana";

--- a/src/vex-agent/db/repos/transactions-query-builder.ts
+++ b/src/vex-agent/db/repos/transactions-query-builder.ts
@@ -166,7 +166,7 @@ export function buildActivityHalf(
   // losses. The vocabulary-lockstep test beside this file now fails the build
   // when a migration adds a kind these feeds do not know.
   activityConds.push(
-    "(kind = 'swap' OR kind = 'lend' OR kind = 'prediction' OR kind = 'wrap' OR kind = 'yield' OR kind = 'launch' OR kind = 'claim' OR event_role = 'bridge_fill_expected')",
+    "(kind = 'swap' OR kind = 'lend' OR kind = 'prediction' OR kind = 'wrap' OR kind = 'yield' OR kind = 'launch' OR kind = 'claim' OR kind = 'transfer' OR event_role = 'bridge_fill_expected')",
   );
   // LEG roles are not feed rows. The kind↔role CHECK (migrations 050/063/066)
   // admits approval legs on the swap/yield/launch arms and Vex fee legs
@@ -193,6 +193,7 @@ export function buildActivityHalf(
   else if (productType === "yield") activityConds.push("kind = 'yield'");
   else if (productType === "launch") activityConds.push("kind = 'launch'");
   else if (productType === "claim") activityConds.push("kind = 'claim'");
+  else if (productType === "transfer") activityConds.push("kind = 'transfer'");
   else if (productType !== undefined) activityConds.push("FALSE");
   const activityKeyset = keysetPredicate(0, cursor, tsParam, rankParam, idParam);
 
@@ -215,6 +216,10 @@ export function buildActivityHalf(
         -- already exists - and it is certainly not the ELSE arm's spot trade,
         -- which would state a route, a price and a counterparty it never had.
         WHEN kind = 'claim' THEN 'claim'
+        -- A wallet SEND is its own product (migration 084). The ELSE arm would
+        -- render it as a spot trade, stating a route, a price and a
+        -- counterparty that moving your own funds to an address never had.
+        WHEN kind = 'transfer' THEN 'transfer'
         WHEN kind = 'wrap' THEN 'wrap'
         -- Pendle (migration 053) is its OWN product. The ELSE arm would state
         -- a route, a price and a counterparty that a py.mint (1 -> 2) or a

--- a/src/vex-agent/tools/internal/wallet/send-execute-evm.ts
+++ b/src/vex-agent/tools/internal/wallet/send-execute-evm.ts
@@ -1,217 +1,523 @@
 /**
- * Wallet send — EVM executor (multi-chain via Khalani).
+ * Wallet send - EVM executor (multi-chain via Khalani).
  *
- * Refactor of the pre-phase-4 `executeEvmTransfer`: `hash` lives in the
- * outer scope so a `waitForTransactionReceipt` failure can return
- * `chain_failed` / `confirmation_unknown` with the hash intact (Codex
- * puzzle-5 phase-4 review v3 acceptance).
+ * STAGED SINCE MIGRATION 084. This executor no longer calls `sendTransaction` /
+ * `writeContract`, which sign and submit in one indivisible step and therefore
+ * cannot produce a durable record before the funds move. It now:
+ *
+ *   1. resolves ONE exact plan (numeric chain id, token identity, and the atomic
+ *      amount as a single `bigint`);
+ *   2. opens the durable `agent_activity` row BEFORE anything is signed;
+ *   3. signs LOCALLY, stages the hash + sender + nonce, and only THEN submits
+ *      the signed bytes, once - through `signStageBroadcast`, the same
+ *      venue-agnostic primitive every EVM protocol handler here already uses;
+ *   4. finalizes from a DEFINITIVE receipt, and leaves the row `pending` when
+ *      the outcome is ambiguous. Nothing is ever re-sent.
+ *
+ * WHAT CHANGED ABOUT GAS, stated rather than buried: `signStageBroadcast`
+ * estimates explicitly and signs with headroom, where `sendTransaction` signed
+ * viem's bare estimate. That raises the gas LIMIT - a ceiling - and not the fee,
+ * which the chain charges on gas USED either way. It is the same treatment every
+ * other signing path in this repository already gets.
+ *
+ * `hash` still lives in the outer scope so a receipt failure can return
+ * `chain_failed` / `confirmation_unknown` with the hash intact.
  */
 
 import { createHash } from "node:crypto";
 
 import type { EvmWallet } from "@tools/wallet/multi-auth.js";
+import { NATIVE_TOKEN_ADDRESS } from "@tools/kyberswap/constants.js";
+import {
+  signStageBroadcast,
+  type StagedBroadcastOutcome,
+} from "@tools/evm-chains/staged-broadcast.js";
 
 import type { WalletIntent } from "@vex-agent/db/repos/wallet-intents.js";
+import logger from "@utils/logger.js";
 
 import {
   preBroadcastFailed,
   summarizeWalletError,
   type ExecuteOutcome,
 } from "./send-types.js";
+import {
+  proveErc20Transfer,
+  proveErc721Transfer,
+  type ReceiptLog,
+} from "./send/transfer-settlement.js";
+import {
+  openWalletTransferActivity,
+  recordWalletTransferPlanFailure,
+  type WalletTransferActivity,
+  type WalletTransferPlan,
+} from "./send/activity-writer.js";
+
+const ERC20_TRANSFER_ABI = [
+  {
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    name: "transfer",
+    outputs: [{ type: "bool" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
+
+const ERC721_SAFE_TRANSFER_ABI = [
+  {
+    inputs: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "tokenId", type: "uint256" },
+    ],
+    name: "safeTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
+
+const ERC20_DECIMALS_ABI = [
+  {
+    inputs: [],
+    name: "decimals",
+    outputs: [{ type: "uint8" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
 
 export async function executeEvmTransfer(
   intent: WalletIntent,
   wallet: EvmWallet,
 ): Promise<ExecuteOutcome> {
-  let publicClient;
-  let chainName: string;
-  let tokenSymbol: string;
-  let hash: `0x${string}`;
-  let isNftTransfer = false;
+  const resolved = await resolveEvmTransferPlan(intent, wallet);
+  if (!resolved.ok) {
+    // No intent row exists yet, so this is the ONE arm that writes a hashless
+    // terminal row. Nothing was signed and nothing was sent.
+    await recordWalletTransferPlanFailure(intent, {
+      failureCode: resolved.failureCode,
+      failureReason: resolved.failureReason,
+      chainId: resolved.chainId,
+      chainFamily: "eip155",
+    });
+    return preBroadcastFailed(resolved.cause);
+  }
 
-  // Setup + broadcast — any throw is pre-broadcast.
+  const { plan, chainName, publicClient, walletClient, txParams, proof: txProof } = resolved;
+
+  // The durable row BEFORE anything is signed. A failure here means we have no
+  // record, so we must not sign: returning pre-broadcast is the safe direction.
+  let activity: WalletTransferActivity;
   try {
-    const { parseUnits, getAddress } = await import("viem");
-    const { resolveInclusiveEvmChain } = await import(
-      "@tools/evm-chains/resolver.js"
+    activity = await openWalletTransferActivity(intent, plan);
+  } catch (cause) {
+    logger.warn("wallet.send.activity_intent_write_failed", {
+      intentId: intent.intentId, ...summarizeWalletError(cause),
+    });
+    return preBroadcastFailed(cause);
+  }
+
+  let outcome: StagedBroadcastOutcome;
+  try {
+    outcome = await signStageBroadcast(
+      publicClient,
+      walletClient,
+      txParams,
+      {
+        // Persist hash + sender + nonce BEFORE the signed bytes are sent. A CAS
+        // miss THROWS out of here, and `signStageBroadcast` has not submitted
+        // anything at that point - refusing to broadcast an untracked transfer.
+        onHashStaged: (handles) => activity.stageEvm(handles),
+        onAccepted: () => activity.noteAccepted(),
+      },
     );
+  } catch (cause) {
+    // Every throw from `signStageBroadcast` is PRE-submission (estimate,
+    // prepare, sign, or the staging hook). "Definitely not attempted" is a
+    // definitive outcome, so it finalizes the EXISTING row - never a second one.
+    const sum = summarizeWalletError(cause);
+    await activity.fail({
+      failureCode: "broadcast_error",
+      failureReason: `PreBroadcast:${sum.errorKind}:${sum.errorHash}`,
+    });
+    await activity.completeExecution({ kind: "failed_before_broadcast" });
+    return preBroadcastFailed(cause);
+  }
 
-    if (intent.chainAlias === null) {
-      return preBroadcastFailed(
-        new Error("Missing chain for eip155 transfer"),
-      );
+  if (outcome.kind === "ambiguous") {
+    // NOTHING TERMINAL, on EITHER stage. A send whose RPC reply never confirmed
+    // it reached the mempool and a receipt that could not be read are both
+    // unknown, not failed, and the transaction may be settling right now. The
+    // ACTIVITY row stays `pending` for the repair sweep, and nothing is
+    // re-sent, ever.
+    //
+    // The EXECUTION row is completed all the same: the tool attempt is over
+    // the moment this returns, and the compaction
+    // safe-moment gate selects an `execution_status = 'intent'` row on its own,
+    // so leaving it open would block compaction forever - even after the sweep
+    // resolved the activity row. `success: false` plus a structural
+    // `confirmation_unknown` records what the tool reported; the pending
+    // activity row is what still says the CHAIN state is unknown.
+    await activity.completeExecution({
+      kind: "confirmation_unknown",
+      txHash: outcome.txHash,
+    });
+    return {
+      kind: "confirmation_unknown",
+      txHash: outcome.txHash,
+      chain: chainName,
+      errorKind: "ConfirmationUnknown",
+      errorHash: createHash("sha256")
+        .update(`evm-ambiguous:${outcome.stage}:${outcome.reason}`)
+        .digest("hex")
+        .slice(0, 16),
+    };
+  }
+
+  if (outcome.kind === "reverted") {
+    await activity.fail({
+      failureCode: "mined_revert",
+      failureReason: "the transfer transaction reverted on-chain",
+    });
+    await activity.completeExecution({ kind: "reverted", txHash: outcome.txHash });
+    return {
+      kind: "chain_failed",
+      txHash: outcome.txHash,
+      chain: chainName,
+      errorKind: "ChainRevert",
+      errorHash: createHash("sha256")
+        .update(`evm-revert:${outcome.txHash}`)
+        .digest("hex")
+        .slice(0, 16),
+    };
+  }
+
+  // WHAT THE RECEIPT PROVES depends on the asset. A native send moves exactly
+  // `tx.value` by protocol rule, so inclusion is
+  // proof. An ERC-20 `transfer` returns `bool`: a nonconforming token can answer
+  // `false`, and a fee-on-transfer token can deliver less, WITHOUT reverting -
+  // so its amount is proven only by the receipt's own `Transfer` log. Unproven
+  // is recorded as unproven, never as the requested amount.
+  const provenAmountRaw = proveEvmTransferAmount(plan, txProof, outcome.receipt.logs);
+  const blockTimeIso = await readBlockTimeIso(publicClient, outcome.receipt.blockNumber);
+  await activity.confirm({
+    txHash: outcome.txHash,
+    provenAmountRaw,
+    ...(blockTimeIso === null ? {} : { blockTimeIso }),
+  });
+  await activity.completeExecution({
+    kind: "confirmed",
+    txHash: outcome.txHash,
+    ...(blockTimeIso === null ? {} : { blockTimeIso }),
+  });
+
+  return {
+    kind: "confirmed",
+    txHash: outcome.txHash,
+    data: {
+      // Curated, cross-network-normalised projection (see formatWalletSendOutput
+      // in send/finalize.ts): `txHash` + `chain` + `status` mirror the Solana
+      // executor; `blockNumber` is EVM-specific and always present on a
+      // confirmed receipt. `chain` is the human-readable network name.
+      txHash: outcome.txHash,
+      chain: chainName,
+      status: "confirmed",
+      blockNumber: Number(outcome.receipt.blockNumber),
+      // The durable record of this transfer is its own `agent_activity` row
+      // (migration 084), written by `send/activity-writer.ts` before the
+      // transaction was signed. `_executionId` names the `protocol_executions`
+      // row this path already opened AND completed itself - the internal tool
+      // route never reaches `protocols/runtime/capture.ts`, which is why the
+      // writer owns that completion. It rides here for correlation, and so that
+      // any future consumer of the standard threading contract reuses this row
+      // instead of creating a second one.
+      _executionId: activity.executionId,
+      // The explorer link, through the EXPLICIT channel the failure arms
+      // already use. It replaces the `_tradeCapture` blob this path used to
+      // emit: that blob's comment claimed it fed "the sync/activity pipeline",
+      // which never ran on the internal tool route - `deriveExplorerRefs` was
+      // its only reader, and this states the same fact without the fiction.
+      _explorerRefs: [{ chain: chainName, txRef: outcome.txHash }],
+    },
+  };
+}
+
+/** The block's own time, or `null` when the node will not give it. Never a guess. */
+async function readBlockTimeIso(
+  publicClient: { getBlock: (args: { blockNumber: bigint }) => Promise<{ timestamp: bigint }> },
+  blockNumber: bigint,
+): Promise<string | null> {
+  try {
+    const block = await publicClient.getBlock({ blockNumber });
+    return new Date(Number(block.timestamp) * 1000).toISOString();
+  } catch (cause) {
+    // Precision of a later report, never a money fact - see
+    // `agent-activity/settled-block-time.ts`.
+    logger.warn("wallet.send.block_time_read_failed", summarizeWalletError(cause));
+    return null;
+  }
+}
+
+/** The receipt evidence that settles each asset kind. See `transfer-settlement.ts`. */
+type EvmTransferProof =
+  /** Inclusion IS the proof: the protocol moves `tx.value` itself. */
+  | { readonly asset: "native" }
+  | { readonly asset: "erc20"; readonly tokenAddress: string; readonly from: string; readonly to: string }
+  | {
+      readonly asset: "erc721";
+      readonly contractAddress: string;
+      readonly from: string;
+      readonly to: string;
+      readonly tokenId: bigint;
+    };
+
+/**
+ * The amount this receipt PROVED moved, or `null` when it proved none.
+ *
+ * Native is proven by inclusion. ERC-20 and ERC-721 are proven only by a
+ * matching `Transfer` log, because neither `transfer` returning `false` nor a
+ * fee-on-transfer shortfall reverts the transaction.
+ */
+function proveEvmTransferAmount(
+  plan: WalletTransferPlan,
+  proof: EvmTransferProof,
+  logs: readonly ReceiptLog[],
+): bigint | null {
+  switch (proof.asset) {
+    case "native":
+      return plan.amountRaw;
+    case "erc20":
+      return proveErc20Transfer({
+        logs,
+        tokenAddress: proof.tokenAddress,
+        from: proof.from,
+        to: proof.to,
+        expectedAmountRaw: plan.amountRaw,
+      });
+    case "erc721":
+      return proveErc721Transfer({
+        logs,
+        contractAddress: proof.contractAddress,
+        from: proof.from,
+        to: proof.to,
+        tokenId: proof.tokenId,
+      });
+  }
+}
+
+type ResolvedEvmTransfer =
+  | {
+      readonly ok: true;
+      readonly plan: WalletTransferPlan;
+      readonly chainName: string;
+      // Typed from the primitive that consumes them, so the resolver cannot
+      // hand `signStageBroadcast` a client shape it does not accept.
+      readonly publicClient: Parameters<typeof signStageBroadcast>[0];
+      readonly walletClient: Parameters<typeof signStageBroadcast>[1];
+      readonly txParams: Parameters<typeof signStageBroadcast>[2];
+      /**
+       * What a confirmed receipt has to show before this transfer's amount may
+       * be recorded as EXECUTED. Carried from the resolver because only it knows
+       * which asset was built, and matched against the receipt's own logs at
+       * confirmation time (`proveEvmTransferAmount`).
+       */
+      readonly proof: EvmTransferProof;
     }
+  | {
+      readonly ok: false;
+      readonly cause: unknown;
+      readonly failureCode: "chain_unsupported" | "unknown";
+      readonly failureReason: string;
+      /** `0` when the chain itself is what could not be resolved - the row records that it is unknown. */
+      readonly chainId: number;
+    };
 
-    // Inclusive resolver (LOCKED correction #2): a Khalani-registered chain keeps
-    // the Khalani client path (byte-identical to before); a local-registry chain
-    // (e.g. Robinhood Chain 4663) resolves a viem wallet client with NO Khalani
-    // dependency.
+/**
+ * Resolve EXACTLY ONE unsigned transfer: chain identity, token identity, the
+ * atomic amount, and the calldata that spends it. Everything the durable row
+ * needs and everything the transaction needs, derived together from the same
+ * values, so the row can never describe a different transfer from the one that
+ * is signed.
+ */
+async function resolveEvmTransferPlan(
+  intent: WalletIntent,
+  wallet: EvmWallet,
+): Promise<ResolvedEvmTransfer> {
+  const { parseUnits, formatUnits, getAddress, encodeFunctionData } = await import("viem");
+  const { resolveInclusiveEvmChain } = await import("@tools/evm-chains/resolver.js");
+
+  if (intent.chainAlias === null) {
+    const cause = new Error("Missing chain for eip155 transfer");
+    return {
+      ok: false, cause, chainId: 0,
+      failureCode: "chain_unsupported",
+      failureReason: "no chain was named for an eip155 transfer",
+    };
+  }
+
+  let chainId = 0;
+  try {
+    // Inclusive resolver: a Khalani-registered chain keeps the Khalani client
+    // path; a local-registry chain (e.g. Robinhood Chain 4663) resolves a viem
+    // wallet client with NO Khalani dependency.
     const resolved = await resolveInclusiveEvmChain(intent.chainAlias);
+    chainId = resolved.chainId;
+
+    let publicClient;
     let walletClient;
+    let chainName: string;
+    let nativeSymbol: string;
     let nativeDecimals: number;
     if (resolved.source === "khalani") {
       const { createDynamicPublicClient, createDynamicWalletClient } =
         await import("@tools/khalani/evm-client.js");
-      publicClient = createDynamicPublicClient(
-        resolved.khalaniChain,
-        resolved.khalaniChains,
-      );
+      publicClient = createDynamicPublicClient(resolved.khalaniChain, resolved.khalaniChains);
       walletClient = createDynamicWalletClient(
         resolved.khalaniChain,
         resolved.khalaniChains,
         wallet.privateKey as `0x${string}`,
       );
       chainName = resolved.khalaniChain.name || intent.chainAlias;
-      tokenSymbol = resolved.khalaniChain.nativeCurrency.symbol;
+      nativeSymbol = resolved.khalaniChain.nativeCurrency.symbol;
       nativeDecimals = resolved.khalaniChain.nativeCurrency.decimals;
     } else {
-      const { getLocalEvmClients } = await import(
-        "@tools/evm-chains/evm-client.js"
-      );
-      const clients = getLocalEvmClients(
-        resolved.config,
-        wallet.privateKey as `0x${string}`,
-      );
+      const { getLocalEvmClients } = await import("@tools/evm-chains/evm-client.js");
+      const clients = getLocalEvmClients(resolved.config, wallet.privateKey as `0x${string}`);
       publicClient = clients.publicClient;
       walletClient = clients.walletClient;
       chainName = resolved.config.name || intent.chainAlias;
-      tokenSymbol = resolved.config.nativeCurrency.symbol;
+      nativeSymbol = resolved.config.nativeCurrency.symbol;
       nativeDecimals = resolved.config.nativeCurrency.decimals;
     }
 
-    const isNft = intent.token?.startsWith("nft:");
-    isNftTransfer = isNft === true;
-    const isNative = intent.token === null || intent.token === "native";
+    const to = getAddress(intent.toAddress);
+    const token = intent.token;
+    const isNative = token === null || token === "native";
+
+    const base = {
+      chainId,
+      chainSlug: intent.chainAlias,
+      chainFamily: "eip155",
+    } as const;
 
     if (isNative) {
-      const value = parseUnits(intent.amount, nativeDecimals);
-      hash = await walletClient.sendTransaction({
-        to: getAddress(intent.toAddress),
-        value,
-        chain: undefined,
-      });
-    } else if (isNft) {
-      const parts = intent.token!.split(":");
-      const nftContract = getAddress(parts[1]);
-      const nftTokenId = BigInt(parts[2]);
-      tokenSymbol = `NFT#${nftTokenId}`;
-      hash = await walletClient.writeContract({
-        address: nftContract,
-        abi: [
-          {
-            inputs: [
-              { name: "from", type: "address" },
-              { name: "to", type: "address" },
-              { name: "tokenId", type: "uint256" },
-            ],
-            name: "safeTransferFrom",
-            outputs: [],
-            stateMutability: "nonpayable",
-            type: "function",
-          },
-        ] as const,
-        functionName: "safeTransferFrom",
-        args: [
-          wallet.address as `0x${string}`,
-          getAddress(intent.toAddress),
-          nftTokenId,
-        ],
-        chain: undefined,
-      });
-    } else {
-      const tokenAddress = getAddress(intent.token!);
-      tokenSymbol = intent.token!;
-      const decimals = await publicClient.readContract({
-        address: tokenAddress,
-        abi: [
-          {
-            inputs: [],
-            name: "decimals",
-            outputs: [{ type: "uint8" }],
-            stateMutability: "view",
-            type: "function",
-          },
-        ] as const,
-        functionName: "decimals",
-      });
-      const value = parseUnits(intent.amount, decimals);
-      hash = await walletClient.writeContract({
-        address: tokenAddress,
-        abi: [
-          {
-            inputs: [
-              { name: "to", type: "address" },
-              { name: "amount", type: "uint256" },
-            ],
-            name: "transfer",
-            outputs: [{ type: "bool" }],
-            stateMutability: "nonpayable",
-            type: "function",
-          },
-        ] as const,
-        functionName: "transfer",
-        args: [getAddress(intent.toAddress), value],
-        chain: undefined,
-      });
-    }
-  } catch (cause) {
-    return preBroadcastFailed(cause);
-  }
-
-  // Broadcast happened — `hash` is set. Receipt-wait throws are
-  // confirmation_unknown; receipt.status !== 'success' is chain_failed.
-  try {
-    const receipt = await publicClient.waitForTransactionReceipt({ hash });
-    if (receipt.status !== "success") {
-      const errorHash = createHash("sha256")
-        .update(`evm-revert:${hash}`)
-        .digest("hex")
-        .slice(0, 16);
+      // The ONE bigint: signed as `value`, recorded as `amount_in_raw`.
+      const amountRaw = parseUnits(intent.amount, nativeDecimals);
       return {
-        kind: "chain_failed",
-        txHash: hash,
-        chain: chainName,
-        errorKind: "ChainRevert",
-        errorHash,
+        ok: true,
+        chainName,
+        publicClient,
+        walletClient,
+        txParams: { to, data: "0x", value: amountRaw },
+        proof: { asset: "native" },
+        plan: {
+          ...base,
+          // The chain-agnostic native sentinel is the right IDENTITY (one value
+          // on every chain); the chain's real symbol is the right LABEL.
+          tokenAddress: NATIVE_TOKEN_ADDRESS,
+          tokenSymbol: nativeSymbol,
+          tokenDecimals: nativeDecimals,
+          amountRaw,
+          amountHuman: formatUnits(amountRaw, nativeDecimals),
+        },
       };
     }
-    return {
-      kind: "confirmed",
-      txHash: hash,
-      data: {
-        // Curated, cross-network-normalised projection (see
-        // formatWalletSendOutput in send/finalize.ts): `txHash` + `chain` +
-        // `status` mirror the Solana executor; `blockNumber` is EVM-specific
-        // and always present on a confirmed receipt. `chain` is the
-        // human-readable network name, consistent with _tradeCapture.chain.
-        txHash: hash,
-        chain: chainName,
-        status: "confirmed",
-        blockNumber: Number(receipt.blockNumber),
-        // Full capture stays intact for the sync/activity pipeline — it keeps
-        // the dropped-from-output fields (signature, in/out token+amount,
-        // walletAddress) under _tradeCapture.
-        _tradeCapture: {
-          type: isNftTransfer ? "send" : "transfer",
-          chain: chainName,
-          status: "executed",
-          inputToken: tokenSymbol,
-          inputAmount: intent.amount,
-          outputToken: tokenSymbol,
-          outputAmount: intent.amount,
-          signature: hash,
-          walletAddress: wallet.address,
+
+    if (token.startsWith("nft:")) {
+      // `nft:<contract>:<tokenId>`. Parsed with a real check rather than three
+      // non-null assertions: a malformed identity must be refused by NAME here,
+      // not discovered as an opaque throw from `getAddress(undefined)`.
+      const [, contractPart, tokenIdPart] = token.split(":");
+      if (contractPart === undefined || tokenIdPart === undefined) {
+        throw new Error("malformed NFT token identity: expected nft:<contract>:<tokenId>");
+      }
+      const nftContract = getAddress(contractPart);
+      const nftTokenId = BigInt(tokenIdPart);
+      // ONE item, indivisible. The identity is the CONTRACT - never a
+      // synthesized `nft:contract:id` pseudo-address, which is not an address
+      // and would poison every join that reads this column - and the token id
+      // travels in the symbol, where a non-fungible identity belongs.
+      const amountRaw = 1n;
+      return {
+        ok: true,
+        chainName,
+        publicClient,
+        walletClient,
+        txParams: {
+          to: nftContract,
+          data: encodeFunctionData({
+            abi: ERC721_SAFE_TRANSFER_ABI,
+            functionName: "safeTransferFrom",
+            args: [getAddress(wallet.address), to, nftTokenId],
+          }),
+          value: 0n,
         },
+        proof: {
+          asset: "erc721",
+          contractAddress: nftContract,
+          from: getAddress(wallet.address),
+          to,
+          tokenId: nftTokenId,
+        },
+        plan: {
+          ...base,
+          tokenAddress: nftContract,
+          tokenSymbol: `NFT#${nftTokenId}`,
+          tokenDecimals: 0,
+          amountRaw,
+          amountHuman: "1",
+        },
+      };
+    }
+
+    const tokenAddress = getAddress(token);
+    const decimals = await publicClient.readContract({
+      address: tokenAddress,
+      abi: ERC20_DECIMALS_ABI,
+      functionName: "decimals",
+    });
+    const amountRaw = parseUnits(intent.amount, decimals);
+    return {
+      ok: true,
+      chainName,
+      publicClient,
+      walletClient,
+      txParams: {
+        to: tokenAddress,
+        data: encodeFunctionData({
+          abi: ERC20_TRANSFER_ABI,
+          functionName: "transfer",
+          args: [to, amountRaw],
+        }),
+        value: 0n,
+      },
+      proof: {
+        asset: "erc20",
+        tokenAddress,
+        from: getAddress(wallet.address),
+        to,
+      },
+      plan: {
+        ...base,
+        tokenAddress,
+        tokenSymbol: tokenAddress,
+        tokenDecimals: decimals,
+        amountRaw,
+        amountHuman: formatUnits(amountRaw, decimals),
       },
     };
   } catch (cause) {
     const sum = summarizeWalletError(cause);
     return {
-      kind: "confirmation_unknown",
-      txHash: hash,
-      chain: chainName,
-      errorKind: sum.errorKind,
-      errorHash: sum.errorHash,
+      ok: false,
+      cause,
+      chainId,
+      failureCode: "unknown",
+      failureReason: `PlanUnresolved:${sum.errorKind}:${sum.errorHash}`,
     };
   }
 }

--- a/src/vex-agent/tools/internal/wallet/send-execute-solana.ts
+++ b/src/vex-agent/tools/internal/wallet/send-execute-solana.ts
@@ -1,14 +1,26 @@
 /**
- * Wallet send — Solana executor.
+ * Wallet send - Solana executor.
  *
  * Inlines the validation + tx-build that previously lived in
  * `sendSol` / `sendSplToken` (`src/tools/solana-ecosystem/shared/solana-transfer.ts`)
  * so the broadcast/confirm split is visible to this caller. The shared
  * helpers stay untouched for Jupiter swap + other consumers.
  *
- * Codex puzzle-5 phase-4 review v3 acceptance: tx hash arrives via
- * `StagedSubmissionResult.signature` post-broadcast; the caller never
- * extracts it heuristically from an opaque throw.
+ * STAGED SINCE MIGRATION 084, and the amount arithmetic is EXACT. Two changes,
+ * both of them corrections:
+ *
+ *   1. Signing and submitting are SPLIT (`prepareLegacyTx` then
+ *      `submitPreparedLegacyTxStaged`), so the durable `agent_activity` row
+ *      carries the signature AND the blockhash evidence BEFORE the funds can
+ *      move. `signAndSubmitLegacyTxStaged` did both in one step, leaving a
+ *      window in which a crash meant money moved against a hashless row.
+ *   2. The atomic amount is derived ONCE with exact decimal arithmetic
+ *      (`parseUnits`) instead of `BigInt(Math.round(Number(amount) * 10 ** d))`.
+ *      That expression routed a token amount through a float: it rounds
+ *      silently, and above 2^53 atomic units - one SOL is 10^9, a 9-decimal SPL
+ *      balance reaches it easily - it loses precision outright. The same bigint
+ *      now feeds the transaction and the activity row, so the two cannot
+ *      disagree about how much money moved.
  */
 
 import {
@@ -24,21 +36,40 @@ import {
   getAssociatedTokenAddress,
   getMint,
 } from "@solana/spl-token";
+import { formatUnits, parseUnits } from "viem";
 
 import type { SolanaWallet } from "@tools/wallet/multi-auth.js";
 import {
   getSolanaConnection,
-  signAndSubmitLegacyTxStaged,
+  prepareLegacyTx,
+  submitPreparedTxOverRpc,
+  confirmStagedSignature,
 } from "@tools/solana-ecosystem/shared/solana-transaction.js";
 import { solanaExplorerUrl } from "@tools/solana-ecosystem/shared/solana-validation.js";
 import { resolveJupiterToken } from "@tools/solana-ecosystem/jupiter/jupiter-tokens/service.js";
+import { SOL_DECIMALS, SOL_MINT } from "@tools/solana-ecosystem/shared/solana-constants.js";
+// The repo-canonical synthetic id every Solana `agent_activity` row carries. The
+// 049 `agent_activity_kind_family_binding` CHECK is written against this value,
+// so a locally-invented literal (101, Solana's cluster id) would file transfers
+// under a chain nothing else in this database uses.
+import { SOLANA_SYNTHETIC_CHAIN_ID } from "../../../../constants/solana-chain.js";
 
 import type { WalletIntent } from "@vex-agent/db/repos/wallet-intents.js";
+import logger from "@utils/logger.js";
 
 import {
   preBroadcastFailed,
+  summarizeWalletError,
   type ExecuteOutcome,
 } from "./send-types.js";
+import {
+  openWalletTransferActivity,
+  recordWalletTransferPlanFailure,
+  type WalletTransferActivity,
+  type WalletTransferPlan,
+} from "./send/activity-writer.js";
+
+const SOLANA_CHAIN_SLUG = "solana";
 
 async function safeResolveSolanaToken(
   token: string,
@@ -55,16 +86,244 @@ export async function executeSolanaTransfer(
   intent: WalletIntent,
   wallet: SolanaWallet,
 ): Promise<ExecuteOutcome> {
-  // Pre-broadcast build phase — validation + tx assembly. Any throw here
-  // returns `pre_broadcast_failed` (no signature exists).
-  let transaction: Transaction;
-  let keypair: Keypair;
-  let tokenSymbol: string;
-  let connection;
+  const resolved = await resolveSolanaTransferPlan(intent, wallet);
+  if (!resolved.ok) {
+    // No intent row exists yet, so this is the ONE arm that writes a hashless
+    // terminal row. Nothing was signed and nothing was sent.
+    await recordWalletTransferPlanFailure(intent, {
+      failureCode: resolved.failureCode,
+      failureReason: resolved.failureReason,
+      chainId: SOLANA_SYNTHETIC_CHAIN_ID,
+      chainFamily: "solana",
+    });
+    return preBroadcastFailed(resolved.cause);
+  }
 
+  const { plan, transaction, keypair, connection } = resolved;
+
+  // The durable row BEFORE anything is signed.
+  let activity: WalletTransferActivity;
   try {
-    keypair = Keypair.fromSecretKey(wallet.secretKey);
-    connection = getSolanaConnection();
+    activity = await openWalletTransferActivity(intent, plan);
+  } catch (cause) {
+    logger.warn("wallet.send.activity_intent_write_failed", {
+      intentId: intent.intentId, ...summarizeWalletError(cause),
+    });
+    return preBroadcastFailed(cause);
+  }
+
+  // SIGN ONLY. Nothing has reached the network yet.
+  let prepared;
+  try {
+    prepared = await prepareLegacyTx(transaction, keypair, { connection });
+  } catch (cause) {
+    const sum = summarizeWalletError(cause);
+    await activity.fail({
+      failureCode: "broadcast_error",
+      failureReason: `PreSign:${sum.errorKind}:${sum.errorHash}`,
+    });
+    await activity.completeExecution({ kind: "failed_before_broadcast" });
+    return preBroadcastFailed(cause);
+  }
+
+  // STAGE the signature together with the blockhash evidence the 049
+  // `agent_activity_solana_staged_has_evidence` CHECK requires. A CAS miss
+  // throws, and NOTHING has been submitted at that point.
+  try {
+    await activity.stageSolana({
+      signature: prepared.signature,
+      fromAddress: keypair.publicKey.toBase58(),
+      recentBlockhash: prepared.recentBlockhash,
+      lastValidBlockHeight: prepared.lastValidBlockHeight,
+    });
+  } catch (cause) {
+    const sum = summarizeWalletError(cause);
+    await activity.fail({
+      failureCode: "broadcast_error",
+      failureReason: `SignedNotBroadcast:${sum.errorKind}:${sum.errorHash}`,
+    });
+    await activity.completeExecution({ kind: "failed_before_broadcast" });
+    return preBroadcastFailed(cause);
+  }
+
+  // SUBMIT the exact signed bytes, once, through the CLASSIFYING lane.
+  //
+  // `submitPreparedLegacyTxStaged` reports every send throw as pre-broadcast,
+  // which is true for a preflight rejection and FALSE for a socket timeout after
+  // the node already took the bytes. Terminalizing that second case would fail
+  // the activity row, complete the execution, and hand back a hashless
+  // `pre_broadcast_failed` while the staged signature was still landing - money
+  // gates clearing on a transfer that in fact went through.
+  //
+  // `submitPreparedTxOverRpc` is the repository's existing owner of exactly this
+  // distinction (`solana-landing-lanes-design.md` D2/D4): a `SendTransactionError`
+  // means the node ANSWERED and refused, anything else is ambiguous, and it also
+  // validates the RPC's echoed signature against the one we staged. Reused
+  // rather than mirrored, so the classification cannot drift in two places.
+  //
+  // `maxRetries: 2` PRESERVES this lane's pre-existing submit bound. Adopting
+  // the shared classifier must not silently expand retry semantics on a money
+  // path; the classifier's own omitted-default stays for protocol lanes.
+  const submitOutcome = await submitPreparedTxOverRpc(prepared, { connection, maxRetries: 2 });
+
+  if (submitOutcome.kind === "rejected_before_broadcast") {
+    // DEFINITIVE. The node parsed the bytes and refused them (preflight,
+    // simulation, or signature verification), so nothing reached the network.
+    const sum = summarizeWalletError(submitOutcome.cause);
+    await activity.fail({
+      failureCode: "broadcast_error",
+      failureReason: `SubmitRejected:${sum.errorKind}:${sum.errorHash}`,
+    });
+    await activity.completeExecution({ kind: "failed_before_broadcast" });
+    return preBroadcastFailed(submitOutcome.cause);
+  }
+
+  if (submitOutcome.kind === "transport_uncertain" || submitOutcome.kind === "signature_mismatch") {
+    // NOT DEFINITIVE, so NOTHING TERMINAL. The bytes may already be on the
+    // network. The activity row stays `pending` carrying the signature we staged
+    // - which is the canonical one for these bytes, never replaced by a
+    // divergent RPC echo - and the repair sweep owns its fate. The execution
+    // attempt is completed so the compaction gate is not blocked forever
+    // (finding 2b). Nothing is re-sent, ever.
+    if (submitOutcome.kind === "signature_mismatch") {
+      logger.warn("wallet.send.solana_signature_mismatch", {
+        rowId: activity.rowId,
+        // The staged (canonical) signature only. The provider's divergent value
+        // is deliberately not persisted anywhere it could be mistaken for truth.
+        stagedSignature: submitOutcome.localSignature,
+      });
+    }
+    const sum = summarizeWalletError(
+      submitOutcome.kind === "transport_uncertain"
+        ? submitOutcome.cause
+        : new Error("Solana RPC echoed a signature that does not match the staged transaction."),
+    );
+    await activity.completeExecution({
+      kind: "confirmation_unknown",
+      txHash: prepared.signature,
+    });
+    return {
+      kind: "confirmation_unknown",
+      txHash: prepared.signature,
+      chain: SOLANA_CHAIN_SLUG,
+      errorKind: sum.errorKind,
+      errorHash: sum.errorHash,
+    };
+  }
+
+  await activity.noteAccepted();
+
+  // Accepted by the node. Confirmation is a SEPARATE question, answered by the
+  // shared confirm-only classifier so this lane reports the same vocabulary as
+  // `signAndSubmitLegacyTxStaged`.
+  const submission = await confirmStagedSignature(connection, prepared.signature);
+
+  if (submission.phase === "chain_failed") {
+    await activity.fail({
+      failureCode: "mined_revert",
+      failureReason: "the transfer transaction failed on-chain",
+    });
+    await activity.completeExecution({ kind: "reverted", txHash: submission.signature });
+    return {
+      kind: "chain_failed",
+      txHash: submission.signature,
+      chain: SOLANA_CHAIN_SLUG,
+      errorKind: submission.errorKind ?? "Unknown",
+      errorHash: submission.errorHash ?? "0000000000000000",
+    };
+  }
+
+  if (submission.phase === "confirmation_unknown") {
+    // NOTHING TERMINAL. The transaction may be settling right now, and the row
+    // is already staged with the blockhash evidence the repair sweep needs to
+    // resolve it. Nothing is re-sent, ever.
+    //
+    // The EXECUTION attempt is completed all the same (finding 2b): the tool is
+    // returning, and an `execution_status = 'intent'` row is selected by the
+    // compaction safe-moment gate on its own, so leaving it open would block
+    // compaction even after the sweep resolved the activity row.
+    await activity.completeExecution({
+      kind: "confirmation_unknown",
+      txHash: submission.signature,
+    });
+    return {
+      kind: "confirmation_unknown",
+      txHash: submission.signature,
+      chain: SOLANA_CHAIN_SLUG,
+      errorKind: submission.errorKind ?? "Unknown",
+      errorHash: submission.errorHash ?? "0000000000000000",
+    };
+  }
+
+  // Confirmation PROVES the amount on this family: `SystemProgram.transfer`
+  // debits exactly its `lamports`, and `transferChecked` moves exactly its
+  // amount and additionally verifies the mint's decimals on-chain - neither can
+  // succeed having moved something else. That is why no log decoding is needed
+  // here, unlike the EVM ERC-20 path, where `transfer` returns a `bool` a token
+  // may set to `false` without reverting.
+  //
+  // No `settled_block_time` is written on this family: the Solana confirm
+  // helper reports success without a slot, so there is no block to read a time
+  // from here. A missing block time is the normal state that module documents,
+  // and it degrades a later report's precision rather than any money fact -
+  // reporting an OBSERVATION time as a settlement time is the thing that must
+  // not happen, and this avoids it.
+  await activity.confirm({ txHash: submission.signature, provenAmountRaw: plan.amountRaw });
+  await activity.completeExecution({ kind: "confirmed", txHash: submission.signature });
+
+  return {
+    kind: "confirmed",
+    txHash: submission.signature,
+    data: {
+      // Curated, cross-network-normalised projection (see formatWalletSendOutput
+      // in send/finalize.ts): emit `txHash` (not the Solana-only `signature`),
+      // `chain`, `status`, and `explorerUrl`.
+      txHash: submission.signature,
+      chain: SOLANA_CHAIN_SLUG,
+      status: "confirmed",
+      explorerUrl: solanaExplorerUrl(submission.signature),
+      // The durable record of this transfer is its own `agent_activity` row
+      // (migration 084). `_executionId` names the `protocol_executions` row this
+      // path already opened AND completed itself - the internal tool route never
+      // reaches `protocols/runtime/capture.ts`, which is why the writer owns
+      // that completion. It rides here for correlation.
+      _executionId: activity.executionId,
+      // The explorer link, through the EXPLICIT channel the failure arms
+      // already use - replacing the `_tradeCapture` blob whose comment claimed
+      // it fed a sync/activity pipeline that never ran on the internal route.
+      _explorerRefs: [{ chain: SOLANA_CHAIN_SLUG, txRef: submission.signature }],
+    },
+  };
+}
+
+type ResolvedSolanaTransfer =
+  | {
+      readonly ok: true;
+      readonly plan: WalletTransferPlan;
+      readonly transaction: Transaction;
+      readonly keypair: Keypair;
+      readonly connection: ReturnType<typeof getSolanaConnection>;
+    }
+  | {
+      readonly ok: false;
+      readonly cause: unknown;
+      readonly failureCode: "allowance_or_balance" | "route_not_found" | "unknown";
+      readonly failureReason: string;
+    };
+
+/**
+ * Resolve EXACTLY ONE unsigned transfer: token identity, the atomic amount, and
+ * the instructions that spend it. The amount is derived ONCE, by exact decimal
+ * arithmetic, and the SAME bigint reaches both the instruction and the durable
+ * row.
+ */
+async function resolveSolanaTransferPlan(
+  intent: WalletIntent,
+  wallet: SolanaWallet,
+): Promise<ResolvedSolanaTransfer> {
+  try {
+    const keypair = Keypair.fromSecretKey(wallet.secretKey);
+    const connection = getSolanaConnection();
     const toPubkey = new PublicKey(intent.toAddress);
 
     if (
@@ -72,150 +331,133 @@ export async function executeSolanaTransfer(
       || intent.token === "native"
       || intent.token.toUpperCase() === "SOL"
     ) {
-      const lamports = BigInt(Math.round(Number(intent.amount) * 1e9));
+      // EXACT. `parseUnits` is string arithmetic; the float round-trip this
+      // replaced could return a different number of lamports than the operator
+      // authorized.
+      const lamports = parseUnits(intent.amount, SOL_DECIMALS);
       const balance = await connection.getBalance(keypair.publicKey);
       if (BigInt(balance) < lamports) {
-        return preBroadcastFailed(
-          new Error("Insufficient SOL balance for transfer"),
-        );
+        return {
+          ok: false,
+          cause: new Error("Insufficient SOL balance for transfer"),
+          failureCode: "allowance_or_balance",
+          failureReason: "insufficient SOL balance for the requested transfer",
+        };
       }
-      transaction = new Transaction().add(
-        SystemProgram.transfer({
-          fromPubkey: keypair.publicKey,
-          toPubkey,
-          lamports,
-        }),
+      const transaction = new Transaction().add(
+        SystemProgram.transfer({ fromPubkey: keypair.publicKey, toPubkey, lamports }),
       );
-      tokenSymbol = "SOL";
-    } else {
-      const tokenMeta = await safeResolveSolanaToken(intent.token);
-      if (!tokenMeta) {
-        return preBroadcastFailed(
-          new Error(`Token not found: ${intent.token}`),
-        );
-      }
-      const mintPubkey = new PublicKey(tokenMeta.address);
+      return {
+        ok: true,
+        transaction,
+        keypair,
+        connection,
+        plan: {
+          chainId: SOLANA_SYNTHETIC_CHAIN_ID,
+          chainSlug: SOLANA_CHAIN_SLUG,
+          chainFamily: "solana",
+          // The wrapped-SOL mint is the identity every other Solana row in this
+          // database uses for native value, so a send joins the same asset as a
+          // swap of the same asset instead of forking a second name for SOL.
+          tokenAddress: SOL_MINT,
+          tokenSymbol: "SOL",
+          tokenDecimals: SOL_DECIMALS,
+          amountRaw: lamports,
+          amountHuman: formatUnits(lamports, SOL_DECIMALS),
+        },
+      };
+    }
 
-      // Compute destination ATA address without creating it. If the ATA
-      // doesn't exist on-chain we PREPEND the create instruction to our
-      // staged transfer transaction so both ops broadcast under one
-      // signature — Codex puzzle-5 phase-4 final review point 2: hidden
-      // on-chain side effects (getOrCreateAssociatedTokenAccount can
-      // broadcast its own tx) MUST NOT escape the staged ExecuteOutcome.
-      const destinationAtaAddress = await getAssociatedTokenAddress(
-        mintPubkey,
-        toPubkey,
-      );
-      let destinationAtaExists: boolean;
-      try {
-        await getAccount(connection, destinationAtaAddress);
-        destinationAtaExists = true;
-      } catch {
-        // getAccount throws when the ATA hasn't been initialised. Treat
-        // any failure as "needs creation"; the staged transaction below
-        // will atomically create + transfer.
-        destinationAtaExists = false;
-      }
+    const tokenMeta = await safeResolveSolanaToken(intent.token);
+    if (!tokenMeta) {
+      return {
+        ok: false,
+        cause: new Error(`Token not found: ${intent.token}`),
+        failureCode: "route_not_found",
+        failureReason: "the SPL token could not be resolved to a mint",
+      };
+    }
+    const mintPubkey = new PublicKey(tokenMeta.address);
 
-      const sourceAtaAddress = await getAssociatedTokenAddress(
-        mintPubkey,
-        keypair.publicKey,
-      );
-      const sourceAccount = await getAccount(connection, sourceAtaAddress);
-      const atomicAmount = BigInt(
-        Math.round(Number(intent.amount) * 10 ** tokenMeta.decimals),
-      );
-      if (sourceAccount.amount < atomicAmount) {
-        return preBroadcastFailed(
-          new Error(`Insufficient token balance for ${intent.token}`),
-        );
-      }
-      const mintInfo = await getMint(connection, mintPubkey);
-      const decimals = tokenMeta.decimals || mintInfo.decimals;
+    // Compute destination ATA address without creating it. If the ATA doesn't
+    // exist on-chain we PREPEND the create instruction to our staged transfer
+    // transaction so both ops broadcast under one signature - a hidden on-chain
+    // side effect (getOrCreateAssociatedTokenAccount can broadcast its own tx)
+    // MUST NOT escape the staged outcome.
+    const destinationAtaAddress = await getAssociatedTokenAddress(mintPubkey, toPubkey);
+    let destinationAtaExists: boolean;
+    try {
+      await getAccount(connection, destinationAtaAddress);
+      destinationAtaExists = true;
+    } catch {
+      // getAccount throws when the ATA hasn't been initialised. Treat any
+      // failure as "needs creation"; the staged transaction below will
+      // atomically create + transfer.
+      destinationAtaExists = false;
+    }
 
-      transaction = new Transaction();
-      if (!destinationAtaExists) {
-        transaction.add(
-          createAssociatedTokenAccountInstruction(
-            keypair.publicKey, // payer
-            destinationAtaAddress,
-            toPubkey, // owner
-            mintPubkey,
-          ),
-        );
-      }
+    const sourceAtaAddress = await getAssociatedTokenAddress(mintPubkey, keypair.publicKey);
+    const sourceAccount = await getAccount(connection, sourceAtaAddress);
+    const mintInfo = await getMint(connection, mintPubkey);
+    // The MINT is the authority on scale. Jupiter's metadata is a label source;
+    // when the two disagree the chain's own value is the one the instruction is
+    // checked against, and `transferChecked` rejects a mismatch outright.
+    const decimals = mintInfo.decimals;
+    const atomicAmount = parseUnits(intent.amount, decimals);
+    if (sourceAccount.amount < atomicAmount) {
+      return {
+        ok: false,
+        cause: new Error(`Insufficient token balance for ${intent.token}`),
+        failureCode: "allowance_or_balance",
+        failureReason: "insufficient SPL token balance for the requested transfer",
+      };
+    }
+
+    const transaction = new Transaction();
+    if (!destinationAtaExists) {
       transaction.add(
-        createTransferCheckedInstruction(
-          sourceAtaAddress,
-          mintPubkey,
+        createAssociatedTokenAccountInstruction(
+          keypair.publicKey, // payer
           destinationAtaAddress,
-          keypair.publicKey,
-          atomicAmount,
-          decimals,
+          toPubkey, // owner
+          mintPubkey,
         ),
       );
-      tokenSymbol = tokenMeta.symbol;
     }
-  } catch (cause) {
-    return preBroadcastFailed(cause);
-  }
+    transaction.add(
+      createTransferCheckedInstruction(
+        sourceAtaAddress,
+        mintPubkey,
+        destinationAtaAddress,
+        keypair.publicKey,
+        atomicAmount,
+        decimals,
+      ),
+    );
 
-  // Broadcast + confirm staged. `signAndSubmitLegacyTxStaged` only throws
-  // for pre-broadcast (sendRawTransaction failed); all post-broadcast
-  // branches return a StagedSubmissionResult with `signature` set.
-  let submission: Awaited<ReturnType<typeof signAndSubmitLegacyTxStaged>>;
-  try {
-    submission = await signAndSubmitLegacyTxStaged(transaction, keypair, {
+    return {
+      ok: true,
+      transaction,
+      keypair,
       connection,
-    });
-  } catch (cause) {
-    return preBroadcastFailed(cause);
-  }
-
-  if (submission.phase === "chain_failed") {
-    return {
-      kind: "chain_failed",
-      txHash: submission.signature,
-      chain: "solana",
-      errorKind: submission.errorKind ?? "Unknown",
-      errorHash: submission.errorHash ?? "0000000000000000",
-    };
-  }
-  if (submission.phase === "confirmation_unknown") {
-    return {
-      kind: "confirmation_unknown",
-      txHash: submission.signature,
-      chain: "solana",
-      errorKind: submission.errorKind ?? "Unknown",
-      errorHash: submission.errorHash ?? "0000000000000000",
-    };
-  }
-
-  return {
-    kind: "confirmed",
-    txHash: submission.signature,
-    data: {
-      // Curated, cross-network-normalised projection (see
-      // formatWalletSendOutput in send/finalize.ts): emit `txHash` (not the
-      // Solana-only `signature`), `chain`, `status`, and `explorerUrl`.
-      txHash: submission.signature,
-      chain: "solana",
-      status: "confirmed",
-      explorerUrl: solanaExplorerUrl(submission.signature),
-      // Full capture stays intact for the sync/activity pipeline — it keeps
-      // the dropped-from-output fields (signature, in/out token+amount,
-      // walletAddress) under _tradeCapture.
-      _tradeCapture: {
-        type: "transfer",
-        chain: "solana",
-        status: "executed",
-        inputToken: tokenSymbol,
-        inputAmount: intent.amount,
-        outputToken: tokenSymbol,
-        outputAmount: intent.amount,
-        signature: submission.signature,
-        walletAddress: intent.walletAddress,
+      plan: {
+        chainId: SOLANA_SYNTHETIC_CHAIN_ID,
+        chainSlug: SOLANA_CHAIN_SLUG,
+        chainFamily: "solana",
+        tokenAddress: tokenMeta.address,
+        tokenSymbol: tokenMeta.symbol,
+        tokenDecimals: decimals,
+        amountRaw: atomicAmount,
+        amountHuman: formatUnits(atomicAmount, decimals),
       },
-    },
-  };
+    };
+  } catch (cause) {
+    const sum = summarizeWalletError(cause);
+    return {
+      ok: false,
+      cause,
+      failureCode: "unknown",
+      failureReason: `PlanUnresolved:${sum.errorKind}:${sum.errorHash}`,
+    };
+  }
 }

--- a/src/vex-agent/tools/internal/wallet/send/activity-writer.ts
+++ b/src/vex-agent/tools/internal/wallet/send/activity-writer.ts
@@ -1,0 +1,434 @@
+/**
+ * The durable `agent_activity` writer for an agent wallet send (migration 084).
+ *
+ * WHY THIS EXISTS. Until 084 a transfer persisted only into `wallet_intents`,
+ * which no feed reads, and both executors carried comments promising a capture
+ * pipeline that never runs on the internal tool route. The transaction was real,
+ * the funds moved, and the agent's own history showed nothing.
+ *
+ * WHAT IT OWNS, and what it deliberately does not. This module owns the DURABLE
+ * state of a transfer: the `protocol_executions` intent row, the
+ * `agent_activity` event row, their staging, their finalization, and the
+ * execution completion. The executors keep owning the CHAIN mechanics - which
+ * client, which calldata, which signature. Splitting them this way is what lets
+ * the ordering below be stated once instead of twice.
+ *
+ * THE ORDERING IS THE POINT. Every step exists to close a specific window:
+ *
+ *   1. Resolve ONE exact plan - numeric chain id, token identity, and the ATOMIC
+ *      amount as a `bigint` derived once by exact decimal arithmetic. The SAME
+ *      bigint feeds the transaction and the row, so the two can never disagree.
+ *   2. A plan that cannot be resolved gets ONE hashless terminal row
+ *      (`recordWalletTransferPlanFailure`). That is the only arm using the
+ *      pre-broadcast-failure API, because it is the only arm where no intent
+ *      exists yet.
+ *   3. `openWalletTransferActivity` creates the pending row BEFORE anything is
+ *      signed.
+ *   4. The executor signs LOCALLY and calls `stageEvm` / `stageSolana` with the
+ *      hash (or signature plus blockhash evidence) BEFORE submitting. A CAS miss
+ *      THROWS, which aborts the send: refusing to broadcast an untracked
+ *      transfer is the whole reason the writer is shaped this way.
+ *   5. Only then are the signed bytes submitted, once.
+ *   6. `confirm` / `fail` finalize from DEFINITIVE chain evidence only. An
+ *      ambiguous outcome calls NEITHER - the row stays `pending` for the repair
+ *      sweep, and nothing is ever re-sent. Ambiguity never terminalizes
+ *      (rules/90; plan section 11.1 / FIX-SPINE C1).
+ *   7. `completeExecution` settles the `protocol_executions` row on EVERY path
+ *      by which the tool returns, ambiguity included.
+ *
+ * THE TWO ROWS ANSWER DIFFERENT QUESTIONS, and conflating them strands money
+ * state. `protocol_executions` records the TOOL
+ * ATTEMPT: opened when the attempt starts, finished when the tool returns,
+ * whatever it returns. `agent_activity` records the CHAIN OUTCOME, and only it
+ * is allowed to stay `pending` while a transaction's fate is unknown.
+ *
+ * The compaction safe-moment gate reads BOTH independently
+ * (`db/repos/approval-intents/money-state.ts`), and it selects an
+ * `execution_status = 'intent'` row on its OWN - so an execution left at
+ * `intent` for an ambiguous send would block compaction forever, even after the
+ * repair sweep resolved the activity row. Completing the attempt with
+ * `success: false` and a structural `confirmation_unknown` status does NOT claim
+ * the chain state is settled: the still-`pending` activity row is what keeps the
+ * gate honest about that, and it is the row the sweep owns.
+ *
+ * The internal wallet route never enters `protocols/runtime/capture.ts`, so
+ * unlike a protocol handler NOTHING ELSE will complete these rows. That includes
+ * the hashless plan-failure arm, which completes its own execution too.
+ *
+ * ONE ROW PER SEND, EVER. A failure after step 3 finalizes the EXISTING event
+ * through `fail`; it never creates a second execution.
+ *
+ * Bookkeeping is best-effort by design: the transaction is the truth, and a
+ * write failure here is logged structurally and never converted into a claim
+ * that the transfer failed. The one exception is staging, which is a hard gate.
+ */
+
+import { formatUnits } from "viem";
+
+import type { WalletIntent } from "@vex-agent/db/repos/wallet-intents.js";
+import {
+  createAgentActivityIntent,
+  createAgentActivityPreBroadcastFailure,
+  markActivityBroadcast,
+  markActivitySolanaBroadcast,
+  markBroadcastAccepted,
+  confirmActivityEvent,
+  failActivityEvent,
+  noteSettledBlockTime,
+  type AgentActivityFailureCode,
+  type BridgeChainFamily,
+} from "@vex-agent/db/repos/agent-activity.js";
+import { completeExecutionIntentWith } from "@vex-agent/db/repos/executions.js";
+import { withSessionControlLock } from "@vex-agent/engine/runtime/lease-and-status/session-control-lock.js";
+import logger from "@utils/logger.js";
+
+import { summarizeWalletError } from "../send-types.js";
+
+/** The tool whose durable execution a transfer belongs to. */
+const TOOL_ID = "wallet_send_confirm";
+const NAMESPACE = "wallet";
+/** `agent_activity.protocol` - a send belongs to no venue. */
+const PROTOCOL = "wallet";
+
+/**
+ * ONE resolved, exact, unsigned transfer. Everything the durable row needs, and
+ * everything the transaction needs, resolved together so they cannot diverge.
+ *
+ * `amountRaw` is the atomic amount as a `bigint`, derived ONCE from the intent's
+ * decimal text by exact string arithmetic (`viem`'s `parseUnits`). It is the
+ * value that is signed AND the value that is recorded. Never a float: a token
+ * amount through `Number` silently loses precision above 2^53 atomic units and
+ * rounds below it, which on this path is a wrong amount of real money.
+ */
+export interface WalletTransferPlan {
+  readonly chainId: number;
+  readonly chainSlug: string;
+  readonly chainFamily: BridgeChainFamily;
+  /**
+   * The token's IDENTITY. For an EVM native leg, the chain-agnostic native
+   * sentinel; for SOL, the wrapped-SOL mint that every other Solana row in this
+   * database uses for native value; for an ERC-20 / SPL token, its contract or
+   * mint address; for an NFT, the CONTRACT address - never a synthesized
+   * `nft:contract:id` pseudo-address, which is not an address and would poison
+   * every join and every per-token view that reads this column.
+   */
+  readonly tokenAddress: string;
+  /** The label. An NFT carries its token id here, which is where a non-fungible identity belongs. */
+  readonly tokenSymbol: string;
+  /** An NFT is indivisible: `0`, so `amountRaw` of `1n` reads as one item. */
+  readonly tokenDecimals: number;
+  readonly amountRaw: bigint;
+  /** `formatUnits(amountRaw, tokenDecimals)` - derived from the raw amount, never re-parsed from user text. */
+  readonly amountHuman: string;
+}
+
+/**
+ * How the TOOL ATTEMPT ended, for the `protocol_executions` record.
+ *
+ * `confirmation_unknown` is a real member, not an omission: the attempt is over
+ * the moment the tool returns, even though the CHAIN outcome is not. The
+ * `agent_activity` row carries that unresolved chain state; this union carries
+ * only "what did the tool end up telling the caller".
+ */
+export type WalletTransferSettlement =
+  | { readonly kind: "confirmed"; readonly txHash: string; readonly blockTimeIso?: string }
+  | { readonly kind: "reverted"; readonly txHash: string }
+  | { readonly kind: "confirmation_unknown"; readonly txHash: string }
+  | { readonly kind: "failed_before_broadcast" };
+
+export interface WalletTransferActivity {
+  readonly executionId: number;
+  readonly rowId: number;
+  /** EVM staging. THROWS on a CAS miss - the caller must abort before submitting. */
+  stageEvm(handles: { txHash: string; fromAddress: string; nonce: number }): Promise<void>;
+  /** Solana staging, carrying the blockhash evidence the 049 CHECK requires. THROWS on a CAS miss. */
+  stageSolana(handles: {
+    signature: string;
+    fromAddress: string;
+    recentBlockhash: string;
+    lastValidBlockHeight: number;
+  }): Promise<void>;
+  /** Best-effort `broadcast_at` bookkeeping once the RPC accepted the submission. */
+  noteAccepted(): Promise<void>;
+  /**
+   * CAS-finalize `confirmed` from a DEFINITIVE receipt. Best-effort.
+   *
+   * `provenAmountRaw` is the amount the receipt PROVED moved, or `null` when it
+   * proved none. `null` confirms the row WITHOUT an executed amount rather than
+   * recording the request as settled truth - see the doc on the implementation.
+   */
+  confirm(settlement: {
+    readonly txHash: string;
+    readonly blockTimeIso?: string;
+    readonly provenAmountRaw: bigint | null;
+  }): Promise<void>;
+  /** CAS-finalize `definitively_failed`. Best-effort. NEVER called for an ambiguous outcome. */
+  fail(input: { failureCode: AgentActivityFailureCode; failureReason: string }): Promise<void>;
+  /**
+   * Settle the `protocol_executions` row: the TOOL ATTEMPT completes on every
+   * outcome the tool can name, `confirmation_unknown` included. Only the
+   * `agent_activity` row may stay pending; the chain outcome is its concern.
+   */
+  completeExecution(settlement: WalletTransferSettlement): Promise<void>;
+}
+
+function intentParamsOf(intent: WalletIntent): Record<string, unknown> {
+  return {
+    intentId: intent.intentId,
+    network: intent.network,
+    chain: intent.chainAlias,
+    to: intent.toAddress,
+    amount: intent.amount,
+    token: intent.token,
+  };
+}
+
+/**
+ * Create the pending `agent_activity` row and its `protocol_executions` intent,
+ * atomically and under the session control lock, BEFORE anything is signed.
+ *
+ * Throws if the durable write fails. That is deliberate and it is the safe
+ * direction: with no row, the caller must not sign.
+ */
+export async function openWalletTransferActivity(
+  intent: WalletIntent,
+  plan: WalletTransferPlan,
+): Promise<WalletTransferActivity> {
+  const started = Date.now();
+  const created = await createAgentActivityIntent({
+    toolId: TOOL_ID,
+    namespace: NAMESPACE,
+    intentParams: intentParamsOf(intent),
+    events: [
+      {
+        eventIndex: 0,
+        eventRole: "wallet_transfer",
+        kind: "transfer",
+        protocol: PROTOCOL,
+        chainId: plan.chainId,
+        chainSlug: plan.chainSlug,
+        chainFamily: plan.chainFamily,
+        walletAddress: intent.walletAddress,
+        sessionId: intent.sessionId,
+        // INPUT LEG ONLY. The asset left the wallet; nothing comes back, so an
+        // output leg would invent a counterparty. The DESTINATION is
+        // deliberately absent from the row (rules/90 privacy stance) - it lives
+        // on the local `wallet_intents` row and in this execution's params.
+        tokenIn: {
+          tokenAddress: plan.tokenAddress,
+          tokenSymbol: plan.tokenSymbol,
+          tokenDecimals: plan.tokenDecimals,
+          amountHuman: plan.amountHuman,
+          amountRaw: plan.amountRaw.toString(),
+        },
+        // usd_* stay NULL. A send has no venue quote and no price this path
+        // fetched; a number invented here would be a valuation nobody made.
+      },
+    ],
+  });
+  // Exactly one event was requested above, so exactly one comes back. Checked
+  // rather than asserted: without a row id there is nothing to stage against,
+  // and the caller must not sign.
+  const event = created.events[0];
+  if (event === undefined) {
+    throw new Error("agent_activity: transfer intent returned no event row");
+  }
+  return makeHandle(intent.sessionId, created.executionId, event.id, plan, started);
+}
+
+function makeHandle(
+  sessionId: string,
+  executionId: number,
+  rowId: number,
+  plan: WalletTransferPlan,
+  startedAtMs: number,
+): WalletTransferActivity {
+  return {
+    executionId,
+    rowId,
+
+    async stageEvm(handles) {
+      const res = await markActivityBroadcast(rowId, handles);
+      if (!res.applied) {
+        // Refusing to broadcast an untracked transfer. Nothing has been sent.
+        throw new Error(
+          `agent_activity: markActivityBroadcast CAS miss for event ${rowId} - refusing to broadcast untracked`,
+        );
+      }
+    },
+
+    async stageSolana(handles) {
+      const res = await markActivitySolanaBroadcast(rowId, {
+        txHash: handles.signature,
+        fromAddress: handles.fromAddress,
+        recentBlockhash: handles.recentBlockhash,
+        lastValidBlockHeight: handles.lastValidBlockHeight,
+      });
+      if (!res.applied) {
+        throw new Error(
+          `agent_activity: markActivitySolanaBroadcast CAS miss for event ${rowId} - refusing to broadcast untracked`,
+        );
+      }
+    },
+
+    async noteAccepted() {
+      try {
+        const res = await markBroadcastAccepted(rowId);
+        if (!res.applied) logger.warn("wallet.send.activity_accept_miss", { rowId });
+      } catch (err) {
+        logger.warn("wallet.send.activity_accept_failed", { rowId, ...summarizeWalletError(err) });
+      }
+    },
+
+    async confirm(settlement) {
+      try {
+        // THE EXECUTED AMOUNT IS WRITTEN ONLY WHEN IT WAS PROVEN. The caller
+        // supplies the proof: for a native send
+        // the protocol itself moves `tx.value`, so a successful receipt proves
+        // it; for an ERC-20 or an NFT the caller must have matched the receipt's
+        // own `Transfer` log, because `transfer` returns `bool` and a
+        // nonconforming token can answer `false`, or move less, without
+        // reverting.
+        //
+        // `null` means the transaction confirmed but WHAT IT MOVED is unproven.
+        // The row is then confirmed with NO executed amount at all
+        // (`confirmActivityEvent` accepts this for `wallet_transfer`: its strict
+        // both-legs guard covers only `swap`/`wrap`/`unwrap`/`token_launch`, and
+        // migration 061 dropped the corresponding DB CHECKs precisely so that
+        // `confirmed` + NULL `executed_*` is a legitimate, repairable state).
+        // Writing the REQUEST there instead would make an unverified number
+        // indistinguishable from a verified one.
+        const proven = settlement.provenAmountRaw;
+        await confirmActivityEvent(
+          rowId,
+          proven === null
+            ? {}
+            : {
+                executedAmountInRaw: proven.toString(),
+                executedAmountInHuman: formatUnits(proven, plan.tokenDecimals),
+              },
+        );
+        if (proven === null) {
+          logger.info("wallet.send.confirmed_amount_unproven", {
+            rowId, txHash: settlement.txHash, chainFamily: plan.chainFamily,
+          });
+        }
+      } catch (err) {
+        logger.warn("wallet.send.activity_confirm_failed", {
+          rowId, txHash: settlement.txHash, ...summarizeWalletError(err),
+        });
+        return;
+      }
+      if (settlement.blockTimeIso !== undefined) {
+        try {
+          await noteSettledBlockTime(rowId, settlement.blockTimeIso);
+        } catch (err) {
+          // Precision of a later report, never a money fact. See that module's doc.
+          logger.warn("wallet.send.activity_block_time_failed", { rowId, ...summarizeWalletError(err) });
+        }
+      }
+    },
+
+    async fail(input) {
+      try {
+        await failActivityEvent(rowId, input);
+      } catch (err) {
+        logger.warn("wallet.send.activity_fail_failed", { rowId, ...summarizeWalletError(err) });
+      }
+    },
+
+    async completeExecution(settlement) {
+      try {
+        await withSessionControlLock(sessionId, (client) =>
+          completeExecutionIntentWith(client, {
+            executionId,
+            // Structural only. No raw provider text, no key material, no amounts
+            // the row does not already carry under its own columns.
+            result: { status: settlement.kind, ...("txHash" in settlement ? { txHash: settlement.txHash } : {}) },
+            success: settlement.kind === "confirmed",
+            tradeCapture: null,
+            externalRefs: "txHash" in settlement ? { txHash: settlement.txHash } : {},
+            durationMs: Date.now() - startedAtMs,
+          }),
+        );
+      } catch (err) {
+        logger.warn("wallet.send.execution_complete_failed", {
+          executionId, rowId, ...summarizeWalletError(err),
+        });
+      }
+    },
+  };
+}
+
+/**
+ * A plan-resolution failure: ONE hashless, already-terminal row. This is the
+ * ONLY caller of the pre-broadcast-failure API on this path, because it is the
+ * only point at which no intent exists yet. After
+ * `openWalletTransferActivity` has run, a failure finalizes the EXISTING event
+ * through `fail` instead - a second execution row for one send would double-count
+ * the money state the compaction gate reads.
+ *
+ * IT COMPLETES ITS OWN EXECUTION ROW.
+ * `createAgentActivityPreBroadcastFailure` opens a `protocol_executions` intent
+ * alongside the activity row, and discarding that id left the execution at
+ * `execution_status = 'intent'` forever - the compaction safe-moment gate
+ * selects such a row independently of `agent_activity`, so a transfer that never
+ * even resolved a plan would have blocked compaction permanently. The activity
+ * row here is already `definitively_failed`, so completing the attempt states
+ * nothing the row does not.
+ *
+ * Best-effort: a transfer that never reached the chain must not be reported to
+ * the operator as something else because its audit row could not be written.
+ */
+export async function recordWalletTransferPlanFailure(
+  intent: WalletIntent,
+  failure: { failureCode: AgentActivityFailureCode; failureReason: string; chainId: number; chainFamily: BridgeChainFamily },
+): Promise<void> {
+  const started = Date.now();
+  let executionId: number | null = null;
+  try {
+    const created = await createAgentActivityPreBroadcastFailure({
+      toolId: TOOL_ID,
+      namespace: NAMESPACE,
+      intentParams: intentParamsOf(intent),
+      event: {
+        eventIndex: 0,
+        eventRole: "wallet_transfer",
+        kind: "transfer",
+        protocol: PROTOCOL,
+        chainId: failure.chainId,
+        chainFamily: failure.chainFamily,
+        walletAddress: intent.walletAddress,
+        sessionId: intent.sessionId,
+        // No leg: the plan is exactly what could not be resolved, so any token
+        // identity or amount stated here would be a guess about the thing that
+        // failed to resolve.
+        failureCode: failure.failureCode,
+        failureReason: failure.failureReason,
+      },
+    });
+    executionId = created.executionId;
+  } catch (err) {
+    logger.warn("wallet.send.activity_prebroadcast_write_failed", {
+      intentId: intent.intentId, ...summarizeWalletError(err),
+    });
+  }
+
+  if (executionId === null) return;
+  try {
+    await withSessionControlLock(intent.sessionId, (client) =>
+      completeExecutionIntentWith(client, {
+        executionId,
+        result: { status: "failed_before_broadcast", failureCode: failure.failureCode },
+        success: false,
+        tradeCapture: null,
+        externalRefs: {},
+        durationMs: Date.now() - started,
+      }),
+    );
+  } catch (err) {
+    logger.warn("wallet.send.prebroadcast_execution_complete_failed", {
+      intentId: intent.intentId, executionId, ...summarizeWalletError(err),
+    });
+  }
+}

--- a/src/vex-agent/tools/internal/wallet/send/finalize.ts
+++ b/src/vex-agent/tools/internal/wallet/send/finalize.ts
@@ -24,9 +24,18 @@ import { fail, failWith } from "./results.js";
  * `txHash` / `chain` / `status` are always present (both the EVM and Solana
  * executors emit them post-normalisation). `blockNumber` is EVM-specific and
  * `explorerUrl` is Solana-specific — included only when the executor supplied
- * a value of the right type. Everything else the executors carry (signature,
- * in/out token + amount, walletAddress) is deliberately dropped here; it stays
- * intact under `data._tradeCapture` for the sync/activity pipeline.
+ * a value of the right type. Everything else the executors carry
+ * (`_executionId`, `_explorerRefs`) is deliberately dropped from the
+ * model-visible `output` and stays under `data`.
+ *
+ * The durable record of a transfer is its own `agent_activity` row (migration
+ * 084), written by `send/activity-writer.ts` BEFORE the transaction is signed.
+ * It is NOT derived from anything in this projection. The `_tradeCapture` blob
+ * these executors used to emit claimed to feed "the sync/activity pipeline";
+ * that pipeline (`protocols/runtime/capture.ts`) never runs on the internal tool
+ * route, so nothing consumed it but `deriveExplorerRefs`. It was removed in 084
+ * and the explorer link now travels on the explicit `_explorerRefs` channel the
+ * failure arms below already use.
  */
 interface WalletSendOutput {
   readonly txHash: string;
@@ -66,8 +75,9 @@ function formatWalletSendOutput(
 /**
  * Metadata-only `data` payload attaching a coherent explorer ref for a
  * broadcast-but-failed transfer. `chain` is the SAME identity the confirmed
- * path's `_tradeCapture.chain` carries, so `deriveExplorerRefs` resolves both
- * paths identically. Model-invisible — it rides under `data`, never `output`.
+ * path's own `_explorerRefs` entry carries, so `deriveExplorerRefs` resolves
+ * both paths identically. Model-invisible - it rides under `data`, never
+ * `output`.
  */
 function explorerRefsData(
   chain: string,
@@ -199,9 +209,9 @@ async function finalizeConfirmed(
   }
 
   // Curate the operator-facing output: project to {txHash, chain, status,
-  // blockNumber?, explorerUrl?} instead of dumping the full capture (which
-  // would leak signature / token amounts / walletAddress into the transcript).
-  // `data` keeps the full payload — `_tradeCapture` stays intact for sync.
+  // blockNumber?, explorerUrl?} instead of dumping the executor's whole payload
+  // into the transcript. `data` keeps the rest - `_executionId` and
+  // `_explorerRefs`, both model-invisible.
   return {
     success: true,
     output: JSON.stringify(formatWalletSendOutput(outcome.txHash, outcome.data), null, 2),

--- a/src/vex-agent/tools/internal/wallet/send/transfer-settlement.ts
+++ b/src/vex-agent/tools/internal/wallet/send/transfer-settlement.ts
@@ -1,0 +1,140 @@
+/**
+ * What an EVM transfer receipt PROVES moved (migration 084).
+ *
+ * WHY THIS EXISTS. A successful receipt proves the transaction was INCLUDED and
+ * did not revert. For a NATIVE send that is the whole story: `tx.value` is the
+ * movement, enforced by the protocol itself. For an ERC-20 it is not. The
+ * standard's `transfer` returns `bool`, and a nonconforming token may return
+ * `false` - or move a different amount, as a fee-on-transfer token does by
+ * design - WITHOUT reverting. Copying the requested amount into
+ * `executed_amount_in_raw` on the strength of `status === "success"` would
+ * therefore record a REQUEST as settled truth, which is exactly the class of
+ * claim this repository's money rules forbid.
+ *
+ * WHAT IT DOES. Reads the receipt's own `Transfer` event and reports the amount
+ * only when the log matches the transfer we intended on every field that
+ * identifies it: the token contract, the sender, the recipient, and the amount.
+ * Anything else - no log, a log for another token, a different recipient, a
+ * different amount - is reported as UNPROVEN, and the caller confirms the row
+ * without an executed amount rather than writing a number it cannot support.
+ *
+ * DELIBERATELY STRICT, AND DELIBERATELY NOT A SUM. `swap-settlement.ts` nets
+ * received-minus-sent across every matching log because a swap route legitimately
+ * moves a token several times. A wallet send is ONE transfer with one intended
+ * amount; if the receipt does not contain exactly that transfer, the honest
+ * answer is "unproven", not a total assembled from other movements.
+ *
+ * Pure: receipt logs in, a verdict out. No chain access, no repository.
+ */
+
+/** `Transfer(address indexed from, address indexed to, uint256 value)` - ERC-20 and ERC-721 share this topic. */
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+export interface ReceiptLog {
+  readonly address: string;
+  readonly topics: readonly string[];
+  readonly data: string;
+}
+
+/**
+ * The amount a receipt proved moved, or `null` when it proved nothing.
+ *
+ * `null` is not an error and not a failure: the transaction confirmed. It means
+ * the row is confirmed WITHOUT an executed amount, and the repair lane may fill
+ * one in later from its own evidence.
+ */
+export type ProvenTransferAmount = bigint | null;
+
+function paddedAddress(address: string): string {
+  return `0x000000000000000000000000${address.slice(2).toLowerCase()}`;
+}
+
+function addressesEqual(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+/** `null` for malformed or empty data rather than a coerced `0n`, which would read as a proven zero. */
+function parseLogAmount(data: string): bigint | null {
+  if (typeof data !== "string" || !data.startsWith("0x") || data.length <= 2) return null;
+  try {
+    return BigInt(data);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Prove an ERC-20 send: exactly one `Transfer(from, to, value)` on the token
+ * contract, from this wallet to this recipient, carrying `expectedAmountRaw`.
+ *
+ * Returns the amount only on a full match. A fee-on-transfer token that
+ * delivered less, a token that silently returned `false` and emitted nothing,
+ * and a receipt whose logs belong to some other movement all return `null` -
+ * three different situations that share one honest answer: this receipt did not
+ * prove the amount we intended.
+ */
+export function proveErc20Transfer(input: {
+  readonly logs: readonly ReceiptLog[];
+  readonly tokenAddress: string;
+  readonly from: string;
+  readonly to: string;
+  readonly expectedAmountRaw: bigint;
+}): ProvenTransferAmount {
+  const fromPadded = paddedAddress(input.from);
+  const toPadded = paddedAddress(input.to);
+
+  for (const log of input.logs) {
+    if (!addressesEqual(log.address, input.tokenAddress)) continue;
+    if (log.topics[0] !== TRANSFER_TOPIC) continue;
+    // ERC-20 Transfer indexes from + to only; a 4-topic log is ERC-721, whose
+    // third topic is a token id and whose `data` is empty. Reading one as an
+    // amount would turn a token id into a balance.
+    if (log.topics.length !== 3) continue;
+    if (log.topics[1]?.toLowerCase() !== fromPadded) continue;
+    if (log.topics[2]?.toLowerCase() !== toPadded) continue;
+    const amount = parseLogAmount(log.data);
+    if (amount === null) continue;
+    if (amount !== input.expectedAmountRaw) continue;
+    return amount;
+  }
+  return null;
+}
+
+/**
+ * Prove an ERC-721 send: a `Transfer(from, to, tokenId)` on the contract, with
+ * the token id in the third indexed topic.
+ *
+ * A match proves ONE item moved, so the proven amount is `1n` - the same value
+ * the plan recorded, on a role whose decimals are 0.
+ */
+export function proveErc721Transfer(input: {
+  readonly logs: readonly ReceiptLog[];
+  readonly contractAddress: string;
+  readonly from: string;
+  readonly to: string;
+  readonly tokenId: bigint;
+}): ProvenTransferAmount {
+  const fromPadded = paddedAddress(input.from);
+  const toPadded = paddedAddress(input.to);
+
+  for (const log of input.logs) {
+    if (!addressesEqual(log.address, input.contractAddress)) continue;
+    if (log.topics[0] !== TRANSFER_TOPIC) continue;
+    // Exactly the opposite arity check to the ERC-20 case above: an ERC-721
+    // Transfer indexes the token id as a third topic.
+    if (log.topics.length !== 4) continue;
+    if (log.topics[1]?.toLowerCase() !== fromPadded) continue;
+    if (log.topics[2]?.toLowerCase() !== toPadded) continue;
+    const idTopic = log.topics[3];
+    if (idTopic === undefined) continue;
+    let loggedId: bigint;
+    try {
+      loggedId = BigInt(idTopic);
+    } catch {
+      continue;
+    }
+    if (loggedId !== input.tokenId) continue;
+    return 1n;
+  }
+  return null;
+}

--- a/vex-app/src/main/database/agent-activity-logical-row.ts
+++ b/vex-app/src/main/database/agent-activity-logical-row.ts
@@ -21,5 +21,6 @@ export const AGENT_ACTIVITY_LOGICAL_ROW_PREDICATE = `aa.event_role IN (
           'yield_pt', 'yield_yt', 'yield_py',
           'yield_lp', 'yield_sy', 'yield_claim',
           'token_launch',
-          'pools_claim'
+          'pools_claim',
+          'wallet_transfer'
         )`;

--- a/vex-app/src/renderer/features/appShell/ActivityBadge.tsx
+++ b/vex-app/src/renderer/features/appShell/ActivityBadge.tsx
@@ -215,6 +215,9 @@ const ROLE_LABEL: Record<AgentActivityEventRole, string | null> = {
   // A creator fee CLAIM, which pays out two assets in one transaction. The
   // badge names the act; the two legs are the row's own output legs.
   pools_claim: "CLAIM",
+  // Migration 084 - `null`, like `swap`'s own role: the kind segment already
+  // reads TRANSFER, so a second segment would print `TRANSFER·TRANSFER`.
+  wallet_transfer: null,
 };
 
 /**

--- a/vex-app/src/shared/agent-activity-vocabulary.ts
+++ b/vex-app/src/shared/agent-activity-vocabulary.ts
@@ -62,6 +62,13 @@ export const AGENT_ACTIVITY_KINDS = [
   // belongs to, spends nothing, and pays two assets out - so filing it under
   // `launch` would put a payout inside every launch feed, filter and count.
   "claim",
+  // Migration 084: an agent WALLET SEND. Until 084 this value lived here only as
+  // a LEGACY-DERIVED display kind for a deprecated `proj_activity` send row (see
+  // below); it is now a real `agent_activity.kind` too, because a transfer
+  // finally writes its own row. The spelling is deliberately the SAME one, so
+  // nothing a user has already seen changes label: the legacy derivation keeps
+  // producing it, and both now mean the same thing.
+  "transfer",
 ] as const;
 export type AgentActivityKind = (typeof AGENT_ACTIVITY_KINDS)[number];
 
@@ -73,7 +80,12 @@ export type AgentActivityKind = (typeof AGENT_ACTIVITY_KINDS)[number];
  * consumer to keep reading `productType`/`tradeSide`:
  *
  *  - `transfer` — a Vex-executed wallet send (legacy `product_type` `send` /
- *    `transfer`), which has no trade economics at all;
+ *    `transfer`), which has no trade economics at all. Since migration 084 it is
+ *    ALSO a canonical `agent_activity.kind`, and the two mean the same thing: a
+ *    new-format send row and a legacy one present identically, which is why the
+ *    canonical list reused this exact spelling rather than minting a second name
+ *    for one concept. It stays listed here because the legacy deriver still
+ *    produces it;
  *  - `activity` — the deliberate NEUTRAL fallback for a legacy product this
  *    build has no canonical name for (e.g. `perps`). It is an explicit "a
  *    thing happened, we will not claim what" — strictly better than
@@ -90,10 +102,17 @@ export const NEUTRAL_ACTIVITY_KIND = "activity";
  * Every `activityKind` a feed DTO can carry — the canonical kinds plus the
  * legacy-derived ones. This is the list a renderer keys its chips off; an
  * `activityKind` outside it is engine drift and must degrade to neutral.
+ *
+ * DEDUPED SINCE MIGRATION 084. `transfer` now appears in BOTH source lists - it
+ * is a canonical kind and it is still what the legacy deriver emits - so a bare
+ * spread of the two would list it twice. Every consumer of this list iterates it
+ * (the badge's label map, its tests), and a duplicate member there is a
+ * duplicate React key and a doubled test case, not a wider vocabulary. Only the
+ * legacy-ONLY member is appended.
  */
 export const FEED_ACTIVITY_KINDS = [
   ...AGENT_ACTIVITY_KINDS,
-  ...LEGACY_DERIVED_ACTIVITY_KINDS,
+  NEUTRAL_ACTIVITY_KIND,
 ] as const;
 export type FeedActivityKind = (typeof FEED_ACTIVITY_KINDS)[number];
 
@@ -155,6 +174,11 @@ export const AGENT_ACTIVITY_EVENT_ROLES = [
   "swap_fee",
   "pools_fee",
   "pools_claim",
+  // Migration 084: the whole of an agent wallet send, on either chain family.
+  // ONE role carrying the INPUT leg only - the asset that left the wallet. There
+  // is no output leg because nothing comes back, and the destination is
+  // deliberately not recorded.
+  "wallet_transfer",
 ] as const;
 export type AgentActivityEventRole = (typeof AGENT_ACTIVITY_EVENT_ROLES)[number];
 


### PR DESCRIPTION
## What

Agent wallet sends persisted only wallet_intents: the unified history (agent_scan views, portfolio feed, AgentScan egress) never saw them, and the executors carried comments promising a capture pipeline that never runs on the internal tool route.

- Migration 084: new agent_activity kind `transfer` + role `wallet_transfer` (all three CHECKs re-added whole, modelled on 082).
- New durable writer (`send/activity-writer.ts`): protocol_executions intent + agent_activity row opened BEFORE signing; staging (hash + sender + nonce, or signature + blockhash evidence) is a hard CAS gate BEFORE submission; finalization only from definitive chain evidence; the execution row completes as the tool attempt on every known outcome, so nothing strands at intent.
- Both executors rewritten to the staged-broadcast shape the protocol handlers already use (EVM reuses `signStageBroadcast`; Solana gains a sign-only seam split out of `signAndSubmitLegacyTxStaged`, submitting through the classifying `submitPreparedTxOverRpc` lane with its pre-existing `maxRetries: 2` bound preserved).
- Solana amounts: atomic amount derived once with exact decimal arithmetic (replaces a Number/Math.round conversion); the same bigint feeds the transaction and the row.
- ERC-20 confirm writes the executed amount only when the receipt's Transfer log proves it (contract + from + to + amount); otherwise the row confirms without executed truth.
- Readers: transactions feed arms, app logical-row predicate, ActivityBadge label, lockstep test maps; token history declares the kind as a recorded gap.
- AgentScan egress deliberately unchanged: the server contract must accept the kind first (companion branch prepared separately).

## Verification

- Full engine suite 13829/13830 (sole failure: pre-existing dexscreener live-feed test, identical on base), vex-app 5668 tests + build with the migration-mirror gate, integration suite executed for real (wallet-transfer schema 11/11, agent-scan dir 162 tests), fresh-DB migration chain 044 to 084 with cross-pair rejection checks, tsc/build/unsafe-escapes/type-ratchet clean for this change.
- Live end-to-end on Base: tx 0xc63ca647565cd6707b0d385e2d115fdf318c6c90a5ef6426b1266f46b41c080f (0.000002 ETH). wallet_intents executed, agent_activity confirmed with nonce 72 and proven executed amount, protocol execution succeeded, agent_scan renders the row.