### PR TITLE
fix: three reported bugs from 0.2.6 (Docker detection, mission dead-end, empty-round spin)

### DIFF
--- a/src/__tests__/vex-agent/engine/core/runner/agent-turn-runtime-bounds.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/agent-turn-runtime-bounds.test.ts
@@ -17,6 +17,11 @@
  *      only `iteration_limit`, so a Restricted agent that ran out of wall-clock
  *      returned `text: null` and the user saw an empty turn. Characterised
  *      first, then fixed.
+ *   4. STALL. `no_progress` is a FOURTH bound with different semantics from all
+ *      three above: it is not a budget, it is never continued (not even under
+ *      full autonomy), and it carries its own copy. The v0.2.6 report is the
+ *      reason it exists - fifty rounds that produced nothing, apologised for
+ *      with an "I reached my tool-use budget" paragraph that was false.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -115,7 +120,11 @@ const { processAgentTurn } = await import(
 const {
   ITERATION_LIMIT_REPLY,
   TIMEOUT_REPLY,
+  NO_PROGRESS_REPLY,
 } = await import("../../../../../vex-agent/engine/core/runner/shared.js");
+const { MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS } = await import(
+  "../../../../../vex-agent/engine/core/runner/unproductive-rounds.js"
+);
 const {
   FULL_AUTONOMY_MAX_ITERATIONS,
   RESTRICTED_MAX_ITERATIONS,
@@ -389,6 +398,89 @@ describe("timeout must not produce a silent turn", () => {
       expect.objectContaining({ content: TIMEOUT_REPLY }),
       expect.anything(),
     );
+  });
+});
+
+// ── 4. Model stall (`no_progress`) ─────────────────────────────
+
+describe("a stalled model is never continued and never silent", () => {
+  it("Restricted agent: persists the stall reply, not the budget apology", async () => {
+    mockRunTurnLoop.mockResolvedValue({
+      text: null, toolCallsMade: 0, pendingApprovals: [], stopReason: "no_progress",
+    });
+
+    const result = await processAgentTurn("session-1", "go");
+
+    expect(result.text).toBe(NO_PROGRESS_REPLY);
+    expect(result.stopReason).toBe("no_progress");
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      "session-1",
+      expect.objectContaining({ role: "assistant", content: NO_PROGRESS_REPLY }),
+      expect.objectContaining({
+        source: "assistant",
+        messageType: "chat",
+        visibility: "user",
+      }),
+    );
+  });
+
+  // THE regression the v0.2.6 report is about. Reusing `ITERATION_LIMIT_REPLY`
+  // here would tell the user a tool-use budget was exhausted when zero tools
+  // ran, and would invite them to say "continue" - buying another run of empty
+  // rounds. Same refusal `TIMEOUT_REPLY` was created for.
+  it("the stall reply is its own copy and never claims a budget was spent", () => {
+    expect(NO_PROGRESS_REPLY).not.toBe(ITERATION_LIMIT_REPLY);
+    expect(NO_PROGRESS_REPLY).not.toBe(TIMEOUT_REPLY);
+    expect(NO_PROGRESS_REPLY).not.toMatch(/budget/i);
+    expect(NO_PROGRESS_REPLY).toMatch(/empty responses/i);
+    // The count is derived from the bound, so the sentence cannot drift.
+    expect(NO_PROGRESS_REPLY).toContain(String(MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS));
+  });
+
+  // The reply must not promise a clean slate: the stall is only the TAIL of the
+  // turn, and rounds before it can have moved real funds.
+  it("the stall reply never claims nothing ran", () => {
+    expect(NO_PROGRESS_REPLY).not.toMatch(/nothing was executed/i);
+    expect(NO_PROGRESS_REPLY).toMatch(/transcript/i);
+  });
+
+  it("a FULL-AUTONOMY session schedules NOTHING on a stall", async () => {
+    // The decisive difference from `iteration_limit`. An unproductive round
+    // persists nothing, so a woken slice re-sends the identical request and
+    // stalls identically - a wake loop that spends input tokens forever.
+    mockHydrate.mockResolvedValue(makeHydratedSession("full"));
+    mockRunTurnLoop.mockResolvedValue({
+      text: null, toolCallsMade: 0, pendingApprovals: [], stopReason: "no_progress",
+    });
+
+    const result = await processAgentTurn("session-1", "go");
+
+    expect(mockEnqueueWake).not.toHaveBeenCalled();
+    expect(result.text).toBe(NO_PROGRESS_REPLY);
+  });
+
+  it("a partial reply is preserved on a stall (no synthesis)", async () => {
+    mockRunTurnLoop.mockResolvedValue({
+      text: "Partial progress.", toolCallsMade: 2, pendingApprovals: [], stopReason: "no_progress",
+    });
+
+    const result = await processAgentTurn("session-1", "go");
+
+    expect(result.text).toBe("Partial progress.");
+    expect(mockAddMessage).not.toHaveBeenCalledWith(
+      "session-1",
+      expect.objectContaining({ content: NO_PROGRESS_REPLY }),
+      expect.anything(),
+    );
+  });
+
+  it("the stall bound is far below the iteration budget it must pre-empt", () => {
+    // If these ever converge the detector stops being a stall detector and
+    // becomes a second budget - the exact conflation this work separated.
+    expect(MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS).toBeLessThan(
+      RESTRICTED_MAX_ITERATIONS,
+    );
+    expect(MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS).toBe(3);
   });
 });
 

--- a/src/__tests__/vex-agent/engine/core/runner/process-mission-setup-turn.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/process-mission-setup-turn.test.ts
@@ -155,7 +155,8 @@ vi.mock("@vex-agent/tools/protocols/catalog.js", () => ({
 const runnerModule = await import("../../../../../vex-agent/engine/core/runner.js");
 const { processAgentTurn, processMissionSetupTurn, startMission, resumeMissionRun } = runnerModule;
 const { MissionRunPausedError } = await import("../../../../../vex-agent/engine/types.js");
-const { ITERATION_LIMIT_REPLY } = await import("../../../../../vex-agent/engine/core/runner/shared.js");
+const { ITERATION_LIMIT_REPLY, NO_PROGRESS_REPLY } = await import("../../../../../vex-agent/engine/core/runner/shared.js");
+const { missionUpdateBus } = await import("../../../../../vex-agent/engine/runtime/mission-bus.js");
 
 function makeProvider() {
   return {
@@ -282,6 +283,69 @@ describe("runner", () => {
   // ── processMissionSetupTurn ────────────────────────────────
 
   describe("processMissionSetupTurn", () => {
+    /**
+     * The silent-stall hole. `applyMissionPatch` emits `mission_update` only
+     * when something actually changed, so a setup turn whose model output
+     * carried no patch produced NO signal at all - the host could not tell a
+     * draft that is still progressing from one that will never progress on its
+     * own, and MISSION PREPARING spun forever. These two pin the reported
+     * absence and its exclusions.
+     */
+    it("emits setup_no_progress when a setup turn writes nothing to an incomplete draft", async () => {
+      mockHydrate.mockResolvedValueOnce(makeHydratedSession({
+        sessionKind: "mission",
+        missionId: "mission-1",
+      }));
+      mockGetMission.mockResolvedValue(makeMission());
+      // The model answered in prose: no parseable mission patch at all.
+      mockRunTurnLoop.mockResolvedValueOnce({
+        text: "Which chains should this mission be allowed to touch?",
+        toolCallsMade: 0,
+        pendingApprovals: [],
+        stopReason: null,
+      });
+
+      const seen: { kind: string; sessionId: string; missionId: string | null }[] = [];
+      const off = missionUpdateBus.subscribe((e) =>
+        seen.push({ kind: e.kind, sessionId: e.sessionId, missionId: e.missionId }),
+      );
+      try {
+        await processMissionSetupTurn("session-1", "trade for me");
+      } finally {
+        off();
+      }
+
+      expect(seen).toContainEqual({
+        kind: "setup_no_progress",
+        sessionId: "session-1",
+        missionId: "mission-1",
+      });
+    });
+
+    it("does NOT call a user-stopped turn stalled - the Stop is its own explanation", async () => {
+      mockHydrate.mockResolvedValueOnce(makeHydratedSession({
+        sessionKind: "mission",
+        missionId: "mission-1",
+      }));
+      mockGetMission.mockResolvedValue(makeMission());
+      mockRunTurnLoop.mockResolvedValueOnce({
+        text: "partial",
+        toolCallsMade: 0,
+        pendingApprovals: [],
+        stopReason: "user_stopped",
+      });
+
+      const kinds: string[] = [];
+      const off = missionUpdateBus.subscribe((e) => kinds.push(e.kind));
+      try {
+        await processMissionSetupTurn("session-1", "stop");
+      } finally {
+        off();
+      }
+
+      expect(kinds).not.toContain("setup_no_progress");
+    });
+
     it("threads measurability warnings into runTurnLoop's prompt options", async () => {
       // The renew gap: warnings were computed by getMissionSetupState but
       // never forwarded, so a renewed draft's stale-denominator warning was
@@ -384,6 +448,48 @@ describe("runner", () => {
       );
       // Synthesised text must NOT be parsed/applied as a mission draft patch.
       expect(mockUpdateDraft).not.toHaveBeenCalled();
+    });
+
+    /**
+     * A stalled setup turn must not be silent. `no_progress` is deliberately
+     * NOT continuable, and this path used to ask the continuation question
+     * (`isContinuableRuntimeStop`) to decide whether the user gets a reply at
+     * all. The two questions are different, so the stall fell through both
+     * branches and the turn returned `text: null`.
+     */
+    it("synthesises the stall reply on no_progress instead of returning a silent turn", async () => {
+      mockHydrate.mockResolvedValueOnce(makeHydratedSession({
+        sessionKind: "mission",
+        missionId: "mission-1",
+      }));
+      mockGetMission.mockResolvedValue(makeMission());
+      mockRunTurnLoop.mockResolvedValueOnce({
+        text: null,
+        toolCallsMade: 0,
+        pendingApprovals: [],
+        stopReason: "no_progress",
+      });
+
+      const seen: string[] = [];
+      const off = missionUpdateBus.subscribe((e) => seen.push(e.kind));
+      let result;
+      try {
+        result = await processMissionSetupTurn("session-1", "trade for me");
+      } finally {
+        off();
+      }
+
+      expect(result.text).toBe(NO_PROGRESS_REPLY);
+      expect(result.stopReason).toBe("no_progress");
+      expect(mockAddMessage).toHaveBeenCalledWith(
+        "session-1",
+        expect.objectContaining({ role: "assistant", content: NO_PROGRESS_REPLY }),
+        expect.objectContaining({ source: "assistant", messageType: "mission_setup", visibility: "user" }),
+      );
+      expect(mockUpdateDraft).not.toHaveBeenCalled();
+      // The stall reply already explains the turn; calling it "stalled" again
+      // would be a second, contradictory account of the same event.
+      expect(seen).not.toContain("setup_no_progress");
     });
 
     it("honours a user Stop during setup — no patch applied, no not-ready notice, faithful stopReason, signal threaded to both turn-loop positions", async () => {

--- a/src/__tests__/vex-agent/engine/core/turn-loop/iteration-and-save.test.ts
+++ b/src/__tests__/vex-agent/engine/core/turn-loop/iteration-and-save.test.ts
@@ -18,6 +18,18 @@ const mockSetLastCheckpoint = vi.fn();
 // here: none of these tests exercise compaction, and the real module pulls the
 // archive/messages graph these harnesses deliberately mock. The action's own
 // behaviour lives in `turn-loop/compaction-apply-consumer.test.ts`.
+// The turn loop's structured bound reporting (rule 05) is asserted below, so
+// the logger is a real spy rather than a silent stub.
+const mockLoggerWarn = vi.fn();
+vi.mock("@utils/logger.js", () => ({
+  default: {
+    warn: (...a: unknown[]) => mockLoggerWarn(...a),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 vi.mock("@vex-agent/engine/compaction/apply/index.js", () => ({
   createCompactionApplyAction: () => ({
     name: "compaction_apply",
@@ -223,6 +235,9 @@ vi.mock("@vex-agent/tools/registry.js", async (importOriginal) => {
 });
 
 const { runTurnLoop } = await import("../../../../../vex-agent/engine/core/turn-loop.js");
+const { MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS } = await import(
+  "../../../../../vex-agent/engine/core/runner/unproductive-rounds.js"
+);
 
 describe("turn-loop", () => {
   beforeEach(() => {
@@ -322,6 +337,160 @@ describe("turn-loop", () => {
       );
 
       expect(result.stopReason).toBe("iteration_limit");
+    });
+
+    // The test above never executes the loop BODY (`maxIterations: 0`), so it
+    // proves only the post-loop fallback assignment. This one reaches the limit
+    // by actually consuming iterations: a mission run does not break on text,
+    // so a provider that always answers with text spins until the cap.
+    it("reaches the limit by consuming iterations, not by a zero budget", async () => {
+      const provider = makeProvider([{ content: "Still working..." }]);
+
+      const result = await runTurnLoop(
+        makeContext({ sessionKind: "mission", missionRunId: "run-1" }),
+        [], null, 0, provider as any, makeConfig() as any, [],
+        { ...defaultLoopConfig, maxIterations: 4 },
+      );
+
+      expect(result.stopReason).toBe("iteration_limit");
+      // Four rounds actually ran, and each was PRODUCTIVE - a working agent
+      // must reach the real budget rather than being cut short by the stall
+      // detector, whose counter every one of these rounds reset.
+      expect(provider.chatCompletion).toHaveBeenCalledTimes(4);
+      expect(result.text).toBe("Still working...");
+    });
+  });
+
+  // ── Unproductive rounds (the v0.2.6 stall) ──────────────────
+  //
+  // Before this bound existed a round with neither text nor tool calls took
+  // NEITHER dispatch branch: nothing was persisted, nothing was logged, and the
+  // `for` loop simply asked the model the identical question again - fifty
+  // times, then apologised about a "tool-use budget" that was never spent.
+  describe("a model that returns nothing stops the turn early", () => {
+    it.each([
+      ["empty string", ""],
+      ["null content", null],
+      ["whitespace only", "   \n  "],
+    ])("stops on no_progress after %s responses, well before the iteration limit", async (_label, content) => {
+      const provider = makeProvider([{ content }]);
+
+      const result = await runTurnLoop(
+        makeContext(), [], null, 0, provider as any, makeConfig() as any, [],
+        { ...defaultLoopConfig, maxIterations: 50 },
+      );
+
+      expect(result.stopReason).toBe("no_progress");
+      // The BOUND, not the budget: three rounds, not fifty. Reverting the
+      // detector makes this 50 and the stop reason `iteration_limit`.
+      expect(provider.chatCompletion).toHaveBeenCalledTimes(
+        MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS,
+      );
+      // Nothing was executed and nothing was persisted - the round produced no
+      // assistant row, which is exactly why repeating it could never help.
+      expect(result.toolCallsMade).toBe(0);
+      expect(result.text).toBe(null);
+      expect(mockAddMessage).not.toHaveBeenCalled();
+    });
+
+    it("a productive round RESETS the counter, so a long task is never cut short", async () => {
+      // Two blanks, then real work, then two blanks: five rounds, never three
+      // consecutive blanks, so the stall bound must not fire.
+      const provider = makeProvider([
+        { content: "" },
+        { content: "" },
+        { toolCalls: [{ id: "call-1", name: "web_research", arguments: { query: "x" } }] },
+        { content: "" },
+        { content: "" },
+        { content: "Finished." },
+      ]);
+      mockDispatchTool.mockResolvedValue({ success: true, output: '{"ok":true}' });
+
+      const result = await runTurnLoop(
+        makeContext(), [], null, 0, provider as any, makeConfig() as any, [],
+        { ...defaultLoopConfig, maxIterations: 50 },
+      );
+
+      expect(result.stopReason).toBe(null);
+      expect(result.text).toBe("Finished.");
+      expect(result.toolCallsMade).toBe(1);
+    });
+
+    it("counts CONSECUTIVE blanks only across the whole turn", async () => {
+      // One blank, work, then three blanks in a row: the run of three fires.
+      const provider = makeProvider([
+        { content: "" },
+        { toolCalls: [{ id: "call-1", name: "web_research", arguments: { query: "x" } }] },
+        { content: "" },
+        { content: "" },
+        { content: "" },
+        { content: "unreachable" },
+      ]);
+      mockDispatchTool.mockResolvedValue({ success: true, output: '{"ok":true}' });
+
+      const result = await runTurnLoop(
+        makeContext(), [], null, 0, provider as any, makeConfig() as any, [],
+        { ...defaultLoopConfig, maxIterations: 50 },
+      );
+
+      expect(result.stopReason).toBe("no_progress");
+      // 1 blank + 1 tool round + 3 blanks = 5 rounds; the sixth is never asked.
+      expect(provider.chatCompletion).toHaveBeenCalledTimes(5);
+      // Real work DID happen before the stall - the user-facing copy and the
+      // retry gate both depend on this count being truthful.
+      expect(result.toolCallsMade).toBe(1);
+    });
+
+    it("reports what the turn consumed when the stall bound fires", async () => {
+      const provider = makeProvider([{ content: "" }]);
+
+      await runTurnLoop(
+        makeContext({ missionRunId: "run-9" }),
+        [], null, 0, provider as any, makeConfig() as any, [],
+        { ...defaultLoopConfig, maxIterations: 50 },
+      );
+
+      // Rule 05: a bound REPORTS what it consumed. Before this the user was
+      // told "I reached my budget" with no way to learn the budget was 50 or
+      // that every one of those rounds produced nothing.
+      const stopLog = mockLoggerWarn.mock.calls.find(
+        (c) => c[0] === "engine.turn.no_progress_stop",
+      );
+      expect(stopLog).toBeDefined();
+      expect(stopLog![1]).toMatchObject({
+        sessionId: "session-1",
+        missionRunId: "run-9",
+        stopReason: "no_progress",
+        iterationsUsed: MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS,
+        maxIterations: 50,
+        consecutiveUnproductiveRounds: MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS,
+        toolCallsMade: 0,
+        producedText: false,
+      });
+    });
+
+    it("reports the same counts when the ITERATION budget is what ran out", async () => {
+      const provider = makeProvider([{ content: "Still working..." }]);
+
+      await runTurnLoop(
+        makeContext({ sessionKind: "mission", missionRunId: "run-1" }),
+        [], null, 0, provider as any, makeConfig() as any, [],
+        { ...defaultLoopConfig, maxIterations: 3 },
+      );
+
+      const stopLog = mockLoggerWarn.mock.calls.find(
+        (c) => c[0] === "engine.turn.iteration_limit_stop",
+      );
+      expect(stopLog).toBeDefined();
+      expect(stopLog![1]).toMatchObject({
+        stopReason: "iteration_limit",
+        iterationsUsed: 3,
+        maxIterations: 3,
+        // Productive rounds all the way to the cap - the two bounds are
+        // independent and the log says which one bit.
+        consecutiveUnproductiveRounds: 0,
+        producedText: true,
+      });
     });
   });
 

--- a/src/vex-agent/engine/core/runner/agent.ts
+++ b/src/vex-agent/engine/core/runner/agent.ts
@@ -429,7 +429,28 @@ export async function runAgentTurnUnderLease(
   // real assistant text itself, so nothing was saved on this path; we persist
   // the synthesised reply as a normal user-visible assistant message.
   let text = result.text;
-  if (isContinuableRuntimeStop(result.stopReason)) {
+
+  /** Persist the deterministic reply for a bound that left the turn silent. */
+  const persistSynthesisedReply = async (body: string): Promise<void> => {
+    text = body;
+    await appendMessage(
+      sessionId,
+      { role: "assistant", content: body, timestamp: new Date().toISOString() },
+      { source: "assistant", messageType: "chat", visibility: "user" },
+    );
+  };
+
+  // ── Model stall ────────────────────────────────────────────────
+  //
+  // Handled BEFORE the continuable-bound branch and deliberately outside it: a
+  // stall is not a slice that ran out of room, so it is never continued, not
+  // even under full autonomy. An unproductive round persists nothing, which
+  // means a woken slice would re-send the identical request and stall again -
+  // a wake loop that spends input tokens forever. Both permissions get the
+  // honest reply and the turn ends.
+  if (result.stopReason === "no_progress") {
+    if (!text) await persistSynthesisedReply(runtimeBoundExhaustedReply("no_progress"));
+  } else if (isContinuableRuntimeStop(result.stopReason)) {
     // The slice's own cancellation signal (a wake-driven slice carries it in
     // both positions). Handed to the scheduler, which re-reads it INSIDE the
     // scheduling transaction rather than pre-sampling it here.
@@ -443,12 +464,7 @@ export async function runAgentTurnUnderLease(
       : { scheduled: false };
 
     if (!continuation.scheduled && !text) {
-      text = runtimeBoundExhaustedReply(result.stopReason);
-      await appendMessage(
-        sessionId,
-        { role: "assistant", content: text, timestamp: new Date().toISOString() },
-        { source: "assistant", messageType: "chat", visibility: "user" },
-      );
+      await persistSynthesisedReply(runtimeBoundExhaustedReply(result.stopReason));
     }
   }
 

--- a/src/vex-agent/engine/core/runner/mission-finalize.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize.ts
@@ -345,13 +345,23 @@ export async function finalizeMissionRunStatus(
   // `updateStatus` is reserved for writes that legitimately move a run TO a
   // terminal state; a park/recovery write must never move one back out. A
   // terminal user stop outranks every other terminal state.
-  if (stopReason === "compact_unable_at_critical") {
+  // `no_progress` shares this arm's shape exactly: a run that cannot make
+  // forward progress on its own, parked for operator review with NO wake.
+  // It must NOT fall through to the `return "running"` at the bottom - that
+  // would leave the run row `running` with no wake and no lease, an orphan the
+  // operator can neither resume nor see the reason for. It is equally not a
+  // continuable stop: an unproductive round persists nothing, so a scheduled
+  // continuation would re-ask the identical question (see `stop-conditions.ts`).
+  if (stopReason === "compact_unable_at_critical" || stopReason === "no_progress") {
     // DURABLE STOP CONSUMER (see `mission-auto-retry.ts` for the full
     // rationale). Parking here reaches `paused_error` with NO wake, so this is
     // the last iteration boundary the run will ever have: a `stop_terminal`
     // request still queued at this point would be stranded until the operator
     // clicked Stop a second time. Gate + park commit together under the
     // session control lock so a Stop cannot slip between them.
+    const defaultSummary = stopReason === "no_progress"
+      ? "The model returned only empty responses - no answer and no tool call - for several consecutive rounds; operator review required."
+      : "Two consecutive forced-fallback noops at critical pressure - operator review required.";
     const { gateOnOperatorStopWithClient, withSessionControlLock } = await import(
       "../../runtime/lease-and-status.js"
     );
@@ -368,7 +378,7 @@ export async function finalizeMissionRunStatus(
         "paused_error",
         stopReason,
         {
-          summary: stopPayload?.summary ?? "Two consecutive forced-fallback noops at critical pressure — operator review required.",
+          summary: stopPayload?.summary ?? defaultSummary,
           evidence: stopPayload?.evidence,
         },
         client,
@@ -382,10 +392,11 @@ export async function finalizeMissionRunStatus(
       // THIS arm did to the mission row (nothing, on both branches), which is
       // why it is unchanged; the warn log is the record that the escalation
       // was superseded.
-      logger.warn("engine.mission.compact_unable_at_critical_after_terminal", {
+      logger.warn("engine.mission.operator_review_park_after_terminal", {
         runId,
         missionId,
         sessionId,
+        stopReason,
       });
     }
     return "running";

--- a/src/vex-agent/engine/core/runner/setup-turn.ts
+++ b/src/vex-agent/engine/core/runner/setup-turn.ts
@@ -30,8 +30,8 @@ import { resolveProvider } from "@vex-agent/inference/registry.js";
 import { appendEngineMessage, appendMessage } from "@vex-agent/engine/events/index.js";
 import logger from "@utils/logger.js";
 import { releaseLeaseAndEmitControlState } from "../../runtime/release-and-emit.js";
-import { toToolDefinitions, DEFAULT_LOOP_CONFIG, runtimeBoundExhaustedReply } from "./shared.js";
-import { isContinuableRuntimeStop } from "./runtime-continuation.js";
+import { emitMissionUpdate } from "../../runtime/mission-bus.js";
+import { toToolDefinitions, DEFAULT_LOOP_CONFIG, runtimeBoundExhaustedReply, isRuntimeBoundStop } from "./shared.js";
 
 export async function processMissionSetupTurn(
   sessionId: string,
@@ -188,8 +188,12 @@ export async function processMissionSetupTurn(
   // mission patch nor trigger the not-ready notice below. The turn-loop
   // persists real model text itself; nothing was saved on this path, so we
   // persist the synthesised reply here.
-  const capHit = isContinuableRuntimeStop(result.stopReason) && !result.text;
-  const capHitReply = isContinuableRuntimeStop(result.stopReason)
+  // `isRuntimeBoundStop`, NOT `isContinuableRuntimeStop`: a stalled turn
+  // (`no_progress`) is never auto-continued but still owes the user a reply.
+  // Asking the continuation question here is what returned `text: null` and
+  // produced a silent setup turn.
+  const boundHit = isRuntimeBoundStop(result.stopReason) && !result.text;
+  const boundHitReply = isRuntimeBoundStop(result.stopReason)
     ? runtimeBoundExhaustedReply(result.stopReason)
     : null;
   logger.info("engine.mission.setup_turn.timing", {
@@ -197,12 +201,12 @@ export async function processMissionSetupTurn(
     elapsedMs: Date.now() - startedAt,
     toolCallsMade: result.toolCallsMade,
     stopReason: result.stopReason,
-    capHit,
+    boundHit,
   });
-  if (capHit && capHitReply !== null) {
+  if (boundHit && boundHitReply !== null) {
     await appendMessage(
       sessionId,
-      { role: "assistant", content: capHitReply, timestamp: new Date().toISOString() },
+      { role: "assistant", content: boundHitReply, timestamp: new Date().toISOString() },
       { source: "assistant", messageType: "mission_setup", visibility: "user" },
     );
   }
@@ -210,10 +214,11 @@ export async function processMissionSetupTurn(
   // Apply mission patch from model response to draft (never from synthesised
   // text, never from text truncated by a user Stop — a partial patch could
   // corrupt the draft).
-  if (!capHit && result.stopReason !== "user_stopped" && result.text && missionId) {
+  let draftWasWritten = false;
+  if (!boundHit && result.stopReason !== "user_stopped" && result.text && missionId) {
     const parsed = parseModelMissionOutput(result.text);
     if (parsed) {
-      await applyMissionPatch(missionId, parsed);
+      draftWasWritten = (await applyMissionPatch(missionId, parsed)).draftWasWritten;
     }
   }
 
@@ -222,9 +227,31 @@ export async function processMissionSetupTurn(
   // mission can start unless the structured draft update made it ready.
   const latestSetupState = await getMissionSetupState(missionId);
   const missionStatus = (latestSetupState?.status ?? "draft") as MissionStatus;
-  let text = capHit ? capHitReply : result.text;
+
+  // `drafting → drafting-stalled` (see the state machine in `mission/setup.ts`).
+  // The turn ran to completion, the draft is still incomplete, and NOTHING was
+  // written - so `applyMissionPatch`'s emit-on-change stayed silent and the host
+  // would otherwise see an unchanged row it cannot distinguish from progress.
+  // Emit the absence explicitly so the mission surface can name the state and
+  // offer an escape instead of spinning forever on MISSION PREPARING.
+  //
+  // Deliberately NOT emitted for `boundHit` or `user_stopped`: those already have
+  // their own user-visible surfaces (the synthesised cap reply, the Stop the
+  // user pressed), and calling them "stalled" on top would be a second,
+  // contradictory explanation of the same event.
   if (
-    !capHit
+    !boundHit
+    && result.stopReason !== "user_stopped"
+    && !draftWasWritten
+    && latestSetupState
+    && latestSetupState.status !== "ready"
+  ) {
+    emitMissionUpdate({ sessionId, missionId, kind: "setup_no_progress" });
+  }
+
+  let text = boundHit ? boundHitReply : result.text;
+  if (
+    !boundHit
     && result.stopReason !== "user_stopped"
     && latestSetupState
     && latestSetupState.status !== "ready"

--- a/src/vex-agent/engine/core/runner/shared.ts
+++ b/src/vex-agent/engine/core/runner/shared.ts
@@ -4,7 +4,9 @@
 
 import { getOpenAITools } from "@vex-agent/tools/registry.js";
 import type { ToolDefinition } from "@vex-agent/inference/types.js";
+import type { RuntimeStopReason, StopReason } from "../../types.js";
 import type { TurnLoopConfig } from "../turn-loop.js";
+import { MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS } from "./unproductive-rounds.js";
 
 /**
  * Convert OpenAITool[] to ToolDefinition[]. Type-level identity after
@@ -72,12 +74,64 @@ export const TIMEOUT_REPLY =
   "narrow the task, or ask me something specific — and I'll pick up from here.";
 
 /**
+ * The `no_progress` sibling of `ITERATION_LIMIT_REPLY`.
+ *
+ * Reusing `ITERATION_LIMIT_REPLY` here would be the same dishonesty the
+ * `TIMEOUT_REPLY` comment above rejected, and worse: nothing was spent on tool
+ * use, no budget was exhausted, and "tell me how to proceed" invites the user
+ * to pay for another run of empty rounds. The model returned nothing, several
+ * times over. That is what this says, and it points at the two actions that can
+ * actually change the outcome.
+ *
+ * The count is derived from the bound so the sentence cannot drift from the
+ * value it claims.
+ *
+ * It deliberately does NOT claim that nothing ran. The stall is only the tail
+ * of the turn - rounds before it can have dispatched real tool calls - and a
+ * reply that promised a clean slate would be a false statement about a turn
+ * that may have moved funds. Pointing at the transcript is the honest version;
+ * the renderer's own notice gates one-click retry on the same fact.
+ */
+export const NO_PROGRESS_REPLY =
+  `I stopped this turn early: the model returned ${MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS} ` +
+  "empty responses in a row - no answer and no tool call - so continuing would " +
+  "have re-sent the same request without producing anything. Check the " +
+  "transcript above for what did run, then send the request again, or try a " +
+  "different model if it keeps happening.";
+
+/**
+ * A runtime bound that ends a turn and therefore owes the user a deterministic
+ * reply when the model produced no text.
+ *
+ * This is deliberately NOT the same set as `isContinuableRuntimeStop`, which
+ * answers a different question: whether the turn may be auto-continued.
+ * `no_progress` belongs here (a stalled turn must never be silent) but not
+ * there (auto-continuing a stall would re-send the request that just produced
+ * nothing). Conflating the two predicates is what made a stalled mission-setup
+ * turn return `text: null`.
+ */
+export type RuntimeBoundStop = Extract<
+  RuntimeStopReason,
+  "iteration_limit" | "timeout" | "no_progress"
+>;
+
+export function isRuntimeBoundStop(
+  stopReason: StopReason | null,
+): stopReason is RuntimeBoundStop {
+  return (
+    stopReason === "iteration_limit"
+    || stopReason === "timeout"
+    || stopReason === "no_progress"
+  );
+}
+
+/**
  * The deterministic reply for a turn that exhausted a runtime bound without the
  * model ever emitting text. Honest about WHICH bound fired; never a generic
  * "budget" paragraph and never a cost figure.
  */
-export function runtimeBoundExhaustedReply(
-  trigger: "iteration_limit" | "timeout",
-): string {
-  return trigger === "timeout" ? TIMEOUT_REPLY : ITERATION_LIMIT_REPLY;
+export function runtimeBoundExhaustedReply(trigger: RuntimeBoundStop): string {
+  if (trigger === "timeout") return TIMEOUT_REPLY;
+  if (trigger === "no_progress") return NO_PROGRESS_REPLY;
+  return ITERATION_LIMIT_REPLY;
 }

--- a/src/vex-agent/engine/core/runner/unproductive-rounds.ts
+++ b/src/vex-agent/engine/core/runner/unproductive-rounds.ts
@@ -1,0 +1,69 @@
+/**
+ * The consecutive-unproductive-round detector - a STALL detector, deliberately
+ * kept separate from the iteration budget.
+ *
+ * ## Why this is not the iteration budget
+ *
+ * `iteration-budget.ts` bounds how much WORK one turn may do (50 rounds
+ * restricted, 1000 under full autonomy); a round that batches six tool calls
+ * costs one unit, so the number is a backstop against a model that works
+ * forever, not a spend cap.
+ *
+ * This counter bounds something completely different: how many times in a row
+ * the model may answer with NOTHING. A round that emits neither text nor a tool
+ * call persists nothing (`saveAssistantMessage` early-returns on an empty
+ * assistant message), appends nothing to the live tape, and dispatches nothing.
+ * The next round therefore sees the SAME input the stalled round saw, so the
+ * loop is a true no-op cycle: it cannot recover by repeating, it can only burn
+ * the budget. That is exactly what the v0.2.6 report was - fifty silent rounds,
+ * zero tool calls, a "budget exhausted" apology, and roughly forty dollars of
+ * input tokens resent fifty times.
+ *
+ * Conflating the two is why a productive multi-step task died at the same
+ * threshold as a spinner. Keeping them separate, and RESETTING this one on
+ * every productive round, is the pattern VS Code's tool-calling loop uses for
+ * the same failure mode (`autopilotIterationCount = 0` on productive work,
+ * `MAX_AUTOPILOT_ITERATIONS = 3`, `toolCallingLoop.ts`).
+ *
+ * ## The bound
+ *
+ * Three consecutive unproductive rounds.
+ *
+ * Workload assumption: a healthy round emits text or at least one tool call. An
+ * empty round is a provider- or model-side defect (an empty completion, a
+ * reasoning-only response with no answer, a malformed tool call the parser
+ * dropped). One of those can be transient, so the first repeat is free. By the
+ * third consecutive blank the model has been asked the identical question three
+ * times and answered nothing three times; a fourth ask is not evidence
+ * gathering, it is spending.
+ *
+ * Cost of a false positive: a turn ends up to three rounds early with an honest
+ * "no output" message the user can retry. Cost of not having it: 50 (or 1000)
+ * rounds of full-context prompts billed for zero output.
+ */
+
+/**
+ * Consecutive rounds that may emit nothing before the turn stops with
+ * `no_progress`. Not configurable and not permission-aware: an autonomous
+ * session has no more use for a stalled model than a restricted one does.
+ */
+export const MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS = 3;
+
+/**
+ * Whether a completed inference round produced anything the turn can build on.
+ *
+ * Productive = at least one tool call to dispatch, or assistant text with at
+ * least one non-whitespace character.
+ *
+ * Reasoning is deliberately NOT productive. A reasoning-only response is
+ * discarded by the same fall-through as an empty one (the turn loop persists
+ * reasoning only alongside content or tool calls), so counting it as progress
+ * would re-open the exact hole this detector closes.
+ */
+export function isProductiveRound(round: {
+  readonly content: string | null;
+  readonly toolCalls: readonly unknown[] | null;
+}): boolean {
+  if (round.toolCalls !== null && round.toolCalls.length > 0) return true;
+  return round.content !== null && round.content.trim().length > 0;
+}

--- a/src/vex-agent/engine/core/stop-conditions.ts
+++ b/src/vex-agent/engine/core/stop-conditions.ts
@@ -39,6 +39,12 @@ const RUNTIME_PAUSES = new Set<string>([
   // any control resume path, never via a plain user chat message, so ingress
   // must not treat an incoming message as a resume.
   "plan_acceptance_required",
+  // Model stall: a run of rounds that emitted nothing at all. A runtime pause,
+  // and deliberately NOT a RESUMABLE_STOP and NOT a continuable runtime stop -
+  // an unproductive round persists nothing, so an automatic continuation would
+  // re-ask the identical question and stall identically. Only a human deciding
+  // what to do differently (retry, narrow, switch model) breaks it.
+  "no_progress",
 ]);
 
 /**

--- a/src/vex-agent/engine/core/turn-loop.ts
+++ b/src/vex-agent/engine/core/turn-loop.ts
@@ -16,6 +16,13 @@
  * Mission-run semantics: text from the model does NOT end the loop; it
  * continues until a stop condition, approval pause, or iteration limit.
  *
+ * Two INDEPENDENT bounds guard the loop and must not be conflated:
+ * - `loopConfig.maxIterations` bounds how much WORK a turn may do. A round
+ *   batching six tool calls costs one unit.
+ * - `MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS` bounds how many times in a row the
+ *   model may answer with nothing at all, and is RESET by every productive
+ *   round. See `runner/unproductive-rounds.ts`.
+ *
  * The only paths into compaction are:
  *   (a) runtime-automatic background PREPARATION at the `warning` band, forked
  *       by an iteration-boundary action. It only creates the frozen input; the
@@ -75,6 +82,10 @@ import {
   armPostCompactBridge,
   createBandObserverWithLog,
 } from "./turn-loop-state-init.js";
+import {
+  MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS,
+  isProductiveRound,
+} from "./runner/unproductive-rounds.js";
 
 /**
  * Run the turn loop.
@@ -106,6 +117,13 @@ export async function runTurnLoop(
   // stopReason stays null) from "loop exhausted without resolution" (for
   // exits via `iteration < maxIterations` becoming false → iteration_limit).
   let stoppedOnText = false;
+  // STALL detector, not a budget. Counts rounds that emitted neither text nor a
+  // tool call; reset by every productive round. See `runner/unproductive-rounds.ts`
+  // for why it must stay separate from `maxIterations` and why the bound is small.
+  let consecutiveUnproductiveRounds = 0;
+  // Rounds actually entered, so the exhaustion events can report what the turn
+  // consumed rather than only which bound fired (rule 05).
+  let iterationsUsed = 0;
   const startTime = Date.now();
   let currentTokenCount = tokenCount;
   let currentSummary = summary;
@@ -204,6 +222,8 @@ export async function runTurnLoop(
       stopReason = entryStep.stopReason;
       break;
     }
+
+    iterationsUsed = iteration + 1;
 
     // Increment iteration counter for mission runs AFTER entry guards pass.
     if (context.missionRunId) {
@@ -357,6 +377,40 @@ export async function runTurnLoop(
       break;
     }
 
+    // ── Stall detection (WP1) ───────────────────────────────────────
+    // Evaluated on the SAME `turnResult` the two dispatch branches below read,
+    // and BEFORE either of them, so the classification cannot drift from what
+    // the loop actually does with the round.
+    //
+    // An unproductive round takes neither branch: `toolCalls` is empty and
+    // `content` is `""`/`null`/whitespace, which the `if (turnResult.content)`
+    // guard treats as falsy. Before this counter existed the iteration body
+    // simply ended, the `for` continued, and the model was asked the identical
+    // question again - silently, with nothing logged and nothing persisted -
+    // until `maxIterations` ran out. That is the v0.2.6 report.
+    if (isProductiveRound(turnResult)) {
+      consecutiveUnproductiveRounds = 0;
+    } else {
+      consecutiveUnproductiveRounds += 1;
+      logger.warn("engine.turn.unproductive_round", {
+        sessionId: context.sessionId,
+        missionRunId: context.missionRunId ?? null,
+        iteration,
+        consecutiveUnproductiveRounds,
+        limit: MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS,
+        // A reasoning-only response is the common shape of this failure and is
+        // worth distinguishing in the log: the model spent output tokens, it
+        // just never answered.
+        reasoningOnly: turnResult.reasoning !== null,
+        finalRoundPromptTokens: turnResult.promptTokens,
+      });
+      if (consecutiveUnproductiveRounds >= MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS) {
+        stopReason = "no_progress";
+        break;
+      }
+      continue;
+    }
+
     if (turnResult.toolCalls && turnResult.toolCalls.length > 0) {
       const batchOutcome = await processTurnToolBatch({
         context,
@@ -430,6 +484,31 @@ export async function runTurnLoop(
   // transport can see why.
   if (!stopReason && !stoppedOnText) {
     stopReason = "iteration_limit";
+  }
+
+  // Rule 05: the owner of a bound REPORTS what was consumed when it fires.
+  // Neither of these had any structured record before - the user was told "I
+  // reached my budget" with no way to learn the budget was 50, or that all 50
+  // rounds produced nothing. Modelled on `engine.mission.deadline_enforced`
+  // above, which is the same shape for the same class of bound.
+  if (stopReason === "iteration_limit" || stopReason === "no_progress") {
+    logger.warn(
+      stopReason === "no_progress"
+        ? "engine.turn.no_progress_stop"
+        : "engine.turn.iteration_limit_stop",
+      {
+        sessionId: context.sessionId,
+        missionRunId: context.missionRunId ?? null,
+        stopReason,
+        iterationsUsed,
+        maxIterations: loopConfig.maxIterations,
+        consecutiveUnproductiveRounds,
+        unproductiveRoundLimit: MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS,
+        toolCallsMade: totalToolCalls,
+        producedText: lastText !== null,
+        elapsedMs: Date.now() - startTime,
+      },
+    );
   }
 
   return { text: lastText, toolCallsMade: totalToolCalls, pendingApprovals, stopReason };

--- a/src/vex-agent/engine/mission/setup.ts
+++ b/src/vex-agent/engine/mission/setup.ts
@@ -32,7 +32,53 @@ export interface SetupResult {
    * being written.
    */
   warnings: string[];
+  /**
+   * Whether THIS call actually wrote draft fields. False for a read
+   * (`getMissionSetupState`), for a fresh empty draft, and - the case that
+   * matters - for a setup turn whose model output carried no applicable patch.
+   *
+   * `applyMissionPatch` emits a `mission_update` only when something changed, so
+   * without this flag a setup turn that produced nothing is indistinguishable
+   * from one that is progressing. `core/runner/setup-turn.ts` reads it to emit
+   * the `setup_no_progress` signal the host UI needs to tell "still drafting"
+   * from "drafting stalled".
+   */
+  draftWasWritten: boolean;
 }
+
+/**
+ * MISSION SETUP STATE MACHINE (host-visible; see also `MissionControls.tsx`,
+ * which renders exactly these states and no others).
+ *
+ *   absent ──(first mission turn)──> drafting
+ *
+ *   drafting          the row exists, `missingFields` is non-empty, status
+ *                     `draft`. Only the model can leave this state, by calling
+ *                     `MissionDraftUpdate`; `mission.updateDraft` is a stub, so
+ *                     the host CANNOT fill these fields itself.
+ *     ├─(setup turn wrote a patch, still incomplete)──> drafting
+ *     ├─(setup turn wrote NO patch)─────────────────> drafting-stalled
+ *     └─(patch completed every required field)──────> ready
+ *
+ *   drafting-stalled  a setup turn ended without touching the draft. The row is
+ *                     unchanged and nothing will change it unless the user
+ *                     speaks again. Escapes: ask again (a new setup turn) or
+ *                     stop the mission. NOT an error state - the model may
+ *                     simply have asked a clarifying question.
+ *     └─(any later turn writes a patch)─────────────> drafting | ready
+ *
+ *   ready             every required field present, status `ready`. The host
+ *                     may now accept the contract.
+ *     ├─(host accepts)──────────────────────────────> accepted
+ *     └─(a later patch clears a field)──────────────> drafting
+ *
+ *   accepted          `accepted_contract_hash` set and matching the current
+ *                     contract. Start is live. Any contract-field edit clears
+ *                     acceptance and returns to `ready` (dirty).
+ *
+ * Transitions are decided HERE and reported over `mission_update`; the renderer
+ * never infers a transition from prose.
+ */
 
 // Detects prose that implies the mission can start while the DB draft is not
 // ready. Slash commands were removed (host now starts via the Start mission
@@ -76,6 +122,7 @@ export async function createMissionDraft(sessionId: string): Promise<SetupResult
     ],
     ready: false,
     warnings: [],
+    draftWasWritten: false,
   };
 }
 
@@ -185,6 +232,7 @@ export async function applyMissionPatch(
     missingFields: validation.missing,
     ready: validation.valid,
     warnings: assessMissionMeasurability(currentDraft).map((w) => w.message),
+    draftWasWritten,
   };
 }
 
@@ -205,5 +253,7 @@ export async function getMissionSetupState(missionId: string): Promise<SetupResu
     missingFields: validation.missing,
     ready: validation.valid,
     warnings: assessMissionMeasurability(currentDraft).map((w) => w.message),
+    // A read never writes.
+    draftWasWritten: false,
   };
 }

--- a/src/vex-agent/engine/mission/validator.ts
+++ b/src/vex-agent/engine/mission/validator.ts
@@ -16,28 +16,66 @@
 import type { Mission } from "@vex-agent/db/repos/missions.js";
 import { MISSION_DRAFT_REQUIRED_FIELDS } from "../types.js";
 
-// ── Field mapping: domain field → DB column accessor ────────────
+/**
+ * The draft values the completeness predicate reads, decoupled from ANY
+ * particular row shape.
+ *
+ * Two adapters feed it and there must never be a third predicate: the engine's
+ * `getMissingFields(Mission)` below, and the Electron main process's
+ * `mission.getDraft` mapper (`vex-app/src/main/database/missions-db.ts`), which
+ * projects the same list onto `MissionDraftDto.missingFields` so the renderer
+ * can NAME what is still missing instead of re-deriving readiness. Keeping the
+ * predicate here (rather than mirroring it main-side) is what makes the host UI
+ * structurally unable to contradict the engine's `draft → ready` decision.
+ */
+export interface MissionDraftFieldValues {
+  readonly title: string | null;
+  readonly goal: string | null;
+  /** Raw `capital_source_json` blob; `capitalSource` + `startingCapital` both read it. */
+  readonly capitalSourceJson: Record<string, unknown> | null;
+  readonly allowedWallets: readonly string[];
+  readonly allowedChains: readonly string[];
+  readonly allowedProtocols: readonly string[];
+  readonly riskProfile: string | null;
+  readonly successCriteria: readonly unknown[];
+  readonly stopConditions: readonly unknown[];
+}
 
-type FieldAccessor = (m: Mission) => unknown;
+type FieldAccessor = (v: MissionDraftFieldValues) => unknown;
 
 const FIELD_ACCESSORS: Record<string, FieldAccessor> = {
-  title: m => m.title,
-  goal: m => m.goal,
-  capitalSource: m => {
-    const src = m.capitalSourceJson;
+  title: v => v.title,
+  goal: v => v.goal,
+  capitalSource: v => {
+    const src = v.capitalSourceJson;
     return src && Object.keys(src).length > 0 ? src : null;
   },
-  startingCapital: m => {
-    const src = m.capitalSourceJson;
-    return (src as Record<string, unknown>)?.amount ?? (src as Record<string, unknown>)?.startingCapital ?? null;
+  startingCapital: v => {
+    const src = v.capitalSourceJson;
+    return src?.amount ?? src?.startingCapital ?? null;
   },
-  allowedWallets: m => m.allowedWallets.length > 0 ? m.allowedWallets : null,
-  allowedChains: m => m.allowedChains.length > 0 ? m.allowedChains : null,
-  allowedProtocols: m => m.allowedProtocols.length > 0 ? m.allowedProtocols : null,
-  riskProfile: m => m.riskProfile,
-  successCriteria: m => m.successCriteriaJson.length > 0 ? m.successCriteriaJson : null,
-  stopConditions: m => m.stopConditionsJson.length > 0 ? m.stopConditionsJson : null,
+  allowedWallets: v => v.allowedWallets.length > 0 ? v.allowedWallets : null,
+  allowedChains: v => v.allowedChains.length > 0 ? v.allowedChains : null,
+  allowedProtocols: v => v.allowedProtocols.length > 0 ? v.allowedProtocols : null,
+  riskProfile: v => v.riskProfile,
+  successCriteria: v => v.successCriteria.length > 0 ? v.successCriteria : null,
+  stopConditions: v => v.stopConditions.length > 0 ? v.stopConditions : null,
 };
+
+/** Adapt an engine mission row to the shape-agnostic predicate input. */
+function toFieldValues(mission: Mission): MissionDraftFieldValues {
+  return {
+    title: mission.title,
+    goal: mission.goal,
+    capitalSourceJson: (mission.capitalSourceJson ?? null) as Record<string, unknown> | null,
+    allowedWallets: mission.allowedWallets,
+    allowedChains: mission.allowedChains,
+    allowedProtocols: mission.allowedProtocols,
+    riskProfile: mission.riskProfile,
+    successCriteria: mission.successCriteriaJson,
+    stopConditions: mission.stopConditionsJson,
+  };
+}
 
 // ── Public API ──────────────────────────────────────────────────
 
@@ -57,6 +95,15 @@ export function validateDraft(mission: Mission): ValidationResult {
 
 /** Get list of required fields that are not yet populated. */
 export function getMissingFields(mission: Mission): string[] {
+  return getMissingDraftFields(toFieldValues(mission));
+}
+
+/**
+ * THE completeness predicate, over the row-shape-agnostic view. Everything that
+ * needs to know "what is still missing" - the engine's `draft → ready`
+ * transition and the host's `mission.getDraft` projection - goes through here.
+ */
+export function getMissingDraftFields(values: MissionDraftFieldValues): string[] {
   const missing: string[] = [];
 
   for (const field of MISSION_DRAFT_REQUIRED_FIELDS) {
@@ -66,7 +113,7 @@ export function getMissingFields(mission: Mission): string[] {
       continue;
     }
 
-    const value = accessor(mission);
+    const value = accessor(values);
     if (value === null || value === undefined || value === "") {
       missing.push(field);
     }

--- a/src/vex-agent/engine/runtime/mission-bus.ts
+++ b/src/vex-agent/engine/runtime/mission-bus.ts
@@ -33,7 +33,16 @@ export type MissionUpdateKind =
   /** The host accepted the mission contract — "Start mission" is now live. */
   | "accepted"
   /** An approval intent was enqueued and is now pending a human decision. */
-  | "approval_enqueued";
+  | "approval_enqueued"
+  /**
+   * A mission SETUP turn finished without writing anything to an incomplete
+   * draft. Nothing changed - that is precisely the point. Every other kind means
+   * "refetch, the row moved"; this one means "the row did NOT move and will not
+   * move on its own", which is the only way the host can tell a draft that is
+   * still progressing from one that has stalled. Consumers must NOT refetch the
+   * draft on it.
+   */
+  | "setup_no_progress";
 
 export interface MissionUpdateEvent {
   readonly type: typeof MISSION_UPDATE_EVENT_TYPE;

--- a/src/vex-agent/engine/types/stop-reasons.ts
+++ b/src/vex-agent/engine/types/stop-reasons.ts
@@ -34,6 +34,21 @@ export type RuntimeStopReason =
    * answers it. Sibling of `approval_required` — the call it stopped on has no
    * transcript result yet, and `resumeAgentAfterUserForm` appends the only one.
    */
-  | "user_form_required";
+  | "user_form_required"
+  /**
+   * The model produced a run of rounds that emitted NOTHING - no tool call, no
+   * text - so the turn stalled without consuming its iteration budget in any
+   * meaningful sense.
+   *
+   * Deliberately NOT `iteration_limit`. `iteration_limit` means "the agent did
+   * a lot of work and ran out of room"; this means "the agent did no work at
+   * all and kept asking". They call for different copy, different operator
+   * next steps, and different continuation policy: an exhausted budget is
+   * continuable (a fresh slice makes progress), a stall is NOT - the round that
+   * produced nothing persisted nothing, so the next round sees the identical
+   * input and would stall identically. See
+   * `runner/unproductive-rounds.ts` for the detector and its bound.
+   */
+  | "no_progress";
 
 export type StopReason = BusinessStopReason | RuntimeStopReason;

--- a/vex-app/src/main/database/__tests__/usage-db.test.ts
+++ b/vex-app/src/main/database/__tests__/usage-db.test.ts
@@ -8,13 +8,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-type QueryFn = (
-  text: string,
-  params?: readonly unknown[],
-) => Promise<{ rows: ReadonlyArray<Record<string, unknown>> }>;
-
 const mocks = vi.hoisted(() => ({
-  query: vi.fn() as QueryFn,
+  query: vi.fn(),
   connect: vi.fn(),
   end: vi.fn(),
   buildPoolConfig: vi.fn(),
@@ -187,6 +182,30 @@ describe("usage-db mapper", () => {
     expect(result.data.totalCachedSavings).toBeNull();
   });
 
+  /**
+   * `getLastTurn` reads ONE aggregate row over the turn's window. It is not a
+   * `usage_log` row mapper any more, and that is the whole point: the engine
+   * writes one row per MODEL ROUND, `runTurnLoop` runs many rounds per turn, so
+   * the old `ORDER BY created_at DESC LIMIT 1` described the last round while
+   * the panel labelled it a turn (v0.2.6: `OUT 1 / $0.0405` for fifty rounds).
+   */
+  function rollupRow(over: Record<string, unknown> = {}) {
+    return {
+      latest_prompt_tokens: "38200",
+      latest_cached_tokens: "0",
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      latest_created_at: "2026-05-21T10:00:00.000Z",
+      turn_completion_tokens: "24600",
+      turn_reasoning_tokens: "1200",
+      turn_cache_write_tokens: "0",
+      turn_cost: "0.0405",
+      turn_cached_savings: "0.0004",
+      round_count: "50",
+      ...over,
+    };
+  }
+
   it("getLastTurn returns null for empty session, never an error", async () => {
     mocks.query.mockResolvedValueOnce({ rows: [] });
     const result = await getLastTurn(SESSION, "USD");
@@ -195,64 +214,69 @@ describe("usage-db mapper", () => {
     expect(result.data).toBeNull();
   });
 
-  it("getLastTurn maps a row with mixed string/number fields", async () => {
+  // An aggregate ALWAYS returns a row; an empty window returns it with
+  // `round_count = 0`. That is "no usage yet", not a zero-round turn - the DTO
+  // cannot even express `roundCount: 0`.
+  it("getLastTurn returns null for a zero-round window, never a fabricated turn", async () => {
     mocks.query.mockResolvedValueOnce({
-      rows: [
-        {
-          session_id: SESSION,
-          prompt_tokens: "100",
-          completion_tokens: 50,
-          total_tokens: "150",
-          cached_tokens: null,
-          reasoning_tokens: "5",
-          cost: "0.001",
-          cached_savings: "0.0004",
-          cache_write_tokens: "12",
-          provider: "openrouter",
-          model: "anthropic/claude-opus-4.7",
-          currency: "USD",
-          created_at: "2026-05-21T10:00:00.000Z",
-        },
-      ],
+      rows: [rollupRow({ round_count: "0", latest_created_at: null })],
     });
     const result = await getLastTurn(SESSION, "USD");
     expect(result.ok).toBe(true);
-    if (!result.ok || result.data === null) return;
-    expect(result.data.promptTokens).toBe(100);
-    expect(result.data.completionTokens).toBe(50);
-    expect(result.data.totalTokens).toBe(150);
-    expect(result.data.cachedTokens).toBe(0);
-    expect(result.data.reasoningTokens).toBe(5);
-    expect(result.data.cost).toBeCloseTo(0.001, 6);
-    expect(result.data.cachedSavings).toBeCloseTo(0.0004, 6);
-    expect(result.data.cacheWriteTokens).toBe(12);
+    if (!result.ok) return;
+    expect(result.data).toBeNull();
   });
 
-  it("getLastTurn preserves NEGATIVE cached_savings (cache overhead) via toCost", async () => {
+  it("getLastTurn reports SUMMED output and cost against the LATEST round's input", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [rollupRow()] });
+    const result = await getLastTurn(SESSION, "USD");
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.data === null) return;
+    // Input is a snapshot: every round re-sends the whole conversation, so
+    // summing would count the same tokens fifty times.
+    expect(result.data.latestRoundPromptTokens).toBe(38_200);
+    // Output and cost are the TURN's sums - the figures the old single-row
+    // read under-reported by roughly the round count.
+    expect(result.data.turnCompletionTokens).toBe(24_600);
+    expect(result.data.turnCost).toBeCloseTo(0.0405, 6);
+    expect(result.data.turnReasoningTokens).toBe(1_200);
+    expect(result.data.roundCount).toBe(50);
+    expect(result.data.provider).toBe("openrouter");
+  });
+
+  it("getLastTurn scopes the window to the transcript, not the whole session", async () => {
+    mocks.query.mockResolvedValueOnce({ rows: [rollupRow()] });
+    await getLastTurn(SESSION, "USD");
+    const [sql, params] = mocks.query.mock.calls[0] as [string, readonly unknown[]];
+    // The turn boundary is the newest user-sourced message. `messages_archive`
+    // is unioned in because compaction moves older messages there; without it a
+    // compacted session would lose its boundary and silently widen the window
+    // to every round the session ever ran.
+    expect(sql).toContain("source = 'user'");
+    expect(sql).toContain("messages_archive");
+    expect(sql).toContain("created_at >= COALESCE");
+    expect(params).toEqual([SESSION, "USD"]);
+  });
+
+  it("getLastTurn preserves NEGATIVE summed cached_savings (cache overhead) via toCost", async () => {
     mocks.query.mockResolvedValueOnce({
-      rows: [
-        {
-          session_id: SESSION,
-          prompt_tokens: "100",
-          completion_tokens: 50,
-          total_tokens: "150",
-          cached_tokens: "20",
-          reasoning_tokens: "0",
-          cost: "0.001",
-          cached_savings: "-0.0021",
-          cache_write_tokens: "8000",
-          provider: "openrouter",
-          model: "anthropic/claude-opus-4.7",
-          currency: "USD",
-          created_at: "2026-05-21T10:00:00.000Z",
-        },
-      ],
+      rows: [rollupRow({ turn_cached_savings: "-0.0021", turn_cache_write_tokens: "8000" })],
     });
     const result = await getLastTurn(SESSION, "USD");
     expect(result.ok).toBe(true);
     if (!result.ok || result.data === null) return;
-    expect(result.data.cachedSavings).toBeCloseTo(-0.0021, 6);
-    expect(result.data.cacheWriteTokens).toBe(8000);
+    expect(result.data.turnCachedSavings).toBeCloseTo(-0.0021, 6);
+    expect(result.data.turnCacheWriteTokens).toBe(8000);
+  });
+
+  it("getLastTurn keeps an uncoercible NUMERIC cost null, never $0", async () => {
+    mocks.query.mockResolvedValueOnce({
+      rows: [rollupRow({ turn_cost: "not-a-number" })],
+    });
+    const result = await getLastTurn(SESSION, "USD");
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.data === null) return;
+    expect(result.data.turnCost).toBeNull();
   });
 
   it("getContextWindow returns null when the session row is missing/deleted/out-of-scope", async () => {

--- a/vex-app/src/main/database/missions-db.ts
+++ b/vex-app/src/main/database/missions-db.ts
@@ -33,6 +33,7 @@ import type {
   MissionGetDraftResult,
   MissionGetRenewableSourceResult,
 } from "@shared/schemas/mission.js";
+import { getMissingDraftFields } from "@vex-agent/engine/mission/validator.js";
 import { buildPoolConfig } from "./db-config.js";
 import { log } from "../logger/index.js";
 import {
@@ -121,10 +122,42 @@ const LEGACY_V2_CONTRACT_HASH_VERSION = 2;
 
 function toDraftDto(row: MissionRow): MissionDraftDto {
   const acceptance = projectAcceptance(row);
+  const status = normaliseStatus(row.status);
+  const successCriteria = normaliseStringList(
+    row.success_criteria_json,
+    "success_criteria_json",
+  );
+  const stopConditions = normaliseStringList(
+    row.stop_conditions_json,
+    "stop_conditions_json",
+  );
+  const allowedChains = normalisePgArray(row.allowed_chains, "allowed_chains", 64);
+  const allowedProtocols = normalisePgArray(
+    row.allowed_protocols,
+    "allowed_protocols",
+    64,
+  );
+  const allowedWallets = normalisePgArray(row.allowed_wallets, "allowed_wallets", 128);
+  // THE engine predicate, CALLED - not mirrored. `missions-db-normalize.ts`
+  // hand-copies `DEPLOYED_CAPITAL_BOUNDS` because those values are frozen into
+  // acceptance hashes, where a drift is unfixable. Readiness is the opposite
+  // case: a live decision that must never disagree with the engine's own
+  // `draft → ready` transition, so it is imported rather than restated.
+  const missingFields = getMissingDraftFields({
+    title: row.title,
+    goal: row.goal,
+    capitalSourceJson: (row.capital_source_json ?? null) as Record<string, unknown> | null,
+    allowedWallets,
+    allowedChains,
+    allowedProtocols,
+    riskProfile: row.risk_profile,
+    successCriteria,
+    stopConditions,
+  });
   return {
     missionId: row.id,
     sessionId: row.root_session_id,
-    status: normaliseStatus(row.status),
+    status,
     title: row.title,
     goal: row.goal,
     constraints: normaliseConstraints(row.constraints_json),
@@ -142,26 +175,12 @@ function toDraftDto(row: MissionRow): MissionDraftDto {
     ...(acceptance !== null && acceptance.contractHashVersion === LEGACY_V2_CONTRACT_HASH_VERSION
       ? { hyperliquidRisk: normaliseHyperliquidMissionRisk(row.constraints_json) }
       : {}),
-    successCriteria: normaliseStringList(
-      row.success_criteria_json,
-      "success_criteria_json",
-    ),
-    stopConditions: normaliseStringList(
-      row.stop_conditions_json,
-      "stop_conditions_json",
-    ),
+    successCriteria,
+    stopConditions,
     riskProfile: row.risk_profile,
-    allowedChains: normalisePgArray(row.allowed_chains, "allowed_chains", 64),
-    allowedProtocols: normalisePgArray(
-      row.allowed_protocols,
-      "allowed_protocols",
-      64,
-    ),
-    allowedWallets: normalisePgArray(
-      row.allowed_wallets,
-      "allowed_wallets",
-      128,
-    ),
+    allowedChains,
+    allowedProtocols,
+    allowedWallets,
     createdAt: toIso(row.created_at),
     updatedAt: toIso(row.updated_at),
     approvedAt: toIsoOrNull(row.approved_at),
@@ -171,6 +190,13 @@ function toDraftDto(row: MissionRow): MissionDraftDto {
     // which is itself meaningful (it is what suppresses measurability warnings).
     deployedCapital: normaliseDeployedCapital(row.capital_source_json),
     renewedFromMissionId: row.renewed_from_mission_id ?? null,
+    missingFields,
+    // The capability answer, decided HERE so no renderer surface re-derives it.
+    // `ready` is exactly the status `commit-start.ts` requires: accepting a
+    // `draft`-status contract is permitted by `engine/mission/acceptance.ts` but
+    // then refused at start with `not_ready`, which would only relocate the dead
+    // end this projection exists to remove.
+    canAcceptContract: status === "ready",
   };
 }
 

--- a/vex-app/src/main/database/usage-db.ts
+++ b/vex-app/src/main/database/usage-db.ts
@@ -17,6 +17,11 @@
  * surcharge) and can legitimately be NEGATIVE (first request of an
  * explicit-cache prefix writes more than it reads) — mapped via `toCost`,
  * never clamped.
+ *
+ * ONE ROW IS ONE MODEL ROUND, NOT ONE TURN. `runTurnLoop` performs many rounds
+ * per turn and `executeTurn` logs each of them, so any per-turn figure must
+ * aggregate (`getLastTurn`); reading the newest row alone under-reports a
+ * multi-round turn by roughly the round count.
  */
 
 import { Client, type ClientConfig } from "pg";
@@ -26,7 +31,6 @@ import {
   type ContextWindowResult,
   type LastTurnUsageResult,
   type SessionUsageTotalsDto,
-  type TurnUsageDto,
 } from "@shared/schemas/usage.js";
 import { VEX_APP_SESSION_SCOPE } from "@shared/schemas/sessions.js";
 import { buildPoolConfig } from "./db-config.js";
@@ -99,20 +103,24 @@ async function withClient<T>(
   }
 }
 
-interface UsageRow {
-  readonly session_id: string;
-  readonly prompt_tokens: number | string;
-  readonly completion_tokens: number | string;
-  readonly total_tokens: number | string;
-  readonly cached_tokens: number | string | null;
-  readonly reasoning_tokens: number | string | null;
-  readonly cost: number | string | null;
-  readonly cached_savings: number | string | null;
-  readonly cache_write_tokens: number | string | null;
+/**
+ * The single aggregate row `getLastTurn` reads. `latest_*` are correlated
+ * scalars from the newest round in the turn window; the rest are aggregates
+ * over the whole window. `latest_created_at` is `null` exactly when the window
+ * is empty.
+ */
+interface TurnRollupRow {
+  readonly latest_prompt_tokens: number | string | null;
+  readonly latest_cached_tokens: number | string | null;
   readonly provider: string | null;
   readonly model: string | null;
-  readonly currency: string | null;
-  readonly created_at: string | Date;
+  readonly latest_created_at: string | Date | null;
+  readonly turn_completion_tokens: number | string | null;
+  readonly turn_reasoning_tokens: number | string | null;
+  readonly turn_cache_write_tokens: number | string | null;
+  readonly turn_cost: number | string | null;
+  readonly turn_cached_savings: number | string | null;
+  readonly round_count: number | string;
 }
 
 interface UsageTotalsRow {
@@ -153,25 +161,6 @@ function toCost(value: number | string | null | undefined): number | null {
   }
   const parsed = Number.parseFloat(value);
   return Number.isFinite(parsed) ? parsed : null;
-}
-
-function toTurnDto(row: UsageRow): TurnUsageDto {
-  return {
-    sessionId: row.session_id,
-    promptTokens: toInt(row.prompt_tokens),
-    completionTokens: toInt(row.completion_tokens),
-    totalTokens: toInt(row.total_tokens),
-    cachedTokens: toInt(row.cached_tokens),
-    reasoningTokens: toInt(row.reasoning_tokens),
-    cost: toCost(row.cost),
-    // NET savings — NUMERIC, can be negative; `toCost` preserves the sign.
-    cachedSavings: toCost(row.cached_savings),
-    cacheWriteTokens: toInt(row.cache_write_tokens),
-    currency: row.currency ?? USAGE_DEFAULT_CURRENCY,
-    provider: row.provider,
-    model: row.model,
-    createdAt: toIso(row.created_at),
-  };
 }
 
 export async function getSessionTotals(
@@ -217,7 +206,7 @@ export async function getSessionTotals(
         totalTokens: toInt(row.total_total),
         totalCachedTokens: toInt(row.total_cached_tokens),
         totalCost: toCost(row.total_cost),
-        // NET savings sum — can be negative; sign preserved.
+        // NET savings sum - can be negative; sign preserved.
         totalCachedSavings: toCost(row.total_cached_savings),
         currency,
         requestCount: toInt(row.request_count),
@@ -229,27 +218,103 @@ export async function getSessionTotals(
   });
 }
 
+/**
+ * Usage for the session's most recent TURN - every model round since the user
+ * last spoke, not just the newest `usage_log` row.
+ *
+ * ## The turn boundary
+ *
+ * `usage_log` carries no turn identifier, so the window is derived from the
+ * transcript: rows written at or after the newest message with `source =
+ * 'user'`. That is exactly what a turn is here - `processAgentTurn` appends the
+ * user message as its FIRST state mutation and then runs the whole loop, so
+ * every round of the turn lands after it. `messages_archive` is unioned in
+ * because compaction moves older messages there; without it a fully compacted
+ * session would lose its boundary and the window would silently widen to the
+ * whole session.
+ *
+ * A session with no user-sourced message at all (a mission run driven entirely
+ * by the engine) has no boundary to find; the window then covers the session's
+ * rows, and `roundCount` says so rather than the number pretending to be one
+ * exchange.
+ *
+ * ## Aggregation
+ *
+ * Input is a SNAPSHOT of the newest round, output/cost/savings are SUMS. The
+ * DTO's doc comment carries the full rationale and is the contract; do not
+ * re-derive the split at a call site.
+ */
 export async function getLastTurn(
   sessionId: string,
   currency: string,
 ): Promise<Result<LastTurnUsageResult, VexError>> {
   return withClient(async (client) => {
     try {
-      const result = await client.query<UsageRow>(
-        `SELECT session_id, prompt_tokens, completion_tokens, total_tokens,
-                cached_tokens, reasoning_tokens, cost, cached_savings,
-                cache_write_tokens, provider, model,
-                currency, created_at
-           FROM usage_log
-          WHERE session_id = $1
-            AND currency = $2
-          ORDER BY created_at DESC
-          LIMIT 1`,
+      const result = await client.query<TurnRollupRow>(
+        `WITH turn_start AS (
+            SELECT MAX(created_at) AS at
+              FROM (
+                SELECT created_at FROM messages
+                 WHERE session_id = $1 AND source = 'user'
+                UNION ALL
+                SELECT created_at FROM messages_archive
+                 WHERE session_id = $1 AND source = 'user'
+              ) AS user_messages
+          ),
+          turn_rows AS (
+            SELECT *
+              FROM usage_log
+             WHERE session_id = $1
+               AND currency = $2
+               AND created_at >= COALESCE(
+                     (SELECT at FROM turn_start),
+                     TIMESTAMPTZ '-infinity')
+          ),
+          latest AS (
+            SELECT prompt_tokens, cached_tokens, provider, model, created_at
+              FROM turn_rows
+             ORDER BY created_at DESC
+             LIMIT 1
+          )
+          SELECT
+            (SELECT prompt_tokens FROM latest)      AS latest_prompt_tokens,
+            (SELECT cached_tokens FROM latest)      AS latest_cached_tokens,
+            (SELECT provider      FROM latest)      AS provider,
+            (SELECT model         FROM latest)      AS model,
+            (SELECT created_at    FROM latest)      AS latest_created_at,
+            COALESCE(SUM(completion_tokens), 0)     AS turn_completion_tokens,
+            COALESCE(SUM(reasoning_tokens), 0)      AS turn_reasoning_tokens,
+            COALESCE(SUM(cache_write_tokens), 0)    AS turn_cache_write_tokens,
+            SUM(cost)                               AS turn_cost,
+            SUM(cached_savings)                     AS turn_cached_savings,
+            COUNT(*)                                AS round_count
+           FROM turn_rows`,
         [sessionId, currency],
       );
       const row = result.rows[0];
-      if (!row) return ok(null);
-      return ok(toTurnDto(row));
+      // An aggregate always returns one row; an EMPTY window returns that row
+      // with `round_count = 0` and a null `latest_created_at`. That is "no
+      // usage yet", the same `null` the renderer has always handled - never a
+      // fabricated zero-round turn.
+      if (!row || toInt(row.round_count) === 0 || row.latest_created_at === null) {
+        return ok(null);
+      }
+      return ok({
+        sessionId,
+        latestRoundPromptTokens: toInt(row.latest_prompt_tokens),
+        latestRoundCachedTokens: toInt(row.latest_cached_tokens),
+        turnCompletionTokens: toInt(row.turn_completion_tokens),
+        turnReasoningTokens: toInt(row.turn_reasoning_tokens),
+        turnCacheWriteTokens: toInt(row.turn_cache_write_tokens),
+        turnCost: toCost(row.turn_cost),
+        // NET savings sum - can be negative; sign preserved.
+        turnCachedSavings: toCost(row.turn_cached_savings),
+        roundCount: toInt(row.round_count),
+        currency,
+        provider: row.provider,
+        model: row.model,
+        latestRoundAt: toIso(row.latest_created_at),
+      });
     } catch (cause) {
       return dbError("getLastTurn query failed", cause);
     }

--- a/vex-app/src/main/docker/__tests__/cli-env.test.ts
+++ b/vex-app/src/main/docker/__tests__/cli-env.test.ts
@@ -73,9 +73,21 @@ describe("buildDockerPath", () => {
     );
   });
 
-  it("returns the Windows environment object untouched", () => {
-    const env = { Path: "C:\\Windows", PATH: "C:\\Tools", KEEP: "yes" };
-    const dirExists = vi.fn(() => true);
+  // This test previously asserted `expect(result).toBe(env)` and that
+  // `dirExists` was never called on Windows: the Windows branch returned
+  // `process.env` by identity and did no augmentation at all. That
+  // expectation encoded the reported bug, so it is replaced by the two
+  // cases below, which assert augmentation happens AND that it never
+  // creates a second key for the one case-insensitive Windows PATH.
+  it("appends existing Windows Docker CLI directories to the inherited PATH", () => {
+    const env = {
+      Path: "C:\\Windows",
+      LOCALAPPDATA: "C:\\Users\\test\\AppData\\Local",
+      KEEP: "yes",
+    };
+    const perUserBin =
+      "C:\\Users\\test\\AppData\\Local\\Programs\\DockerDesktop\\resources\\bin";
+    const dirExists = vi.fn((candidate: string) => candidate === perUserBin);
 
     const result = buildDockerPath({
       platform: "win32",
@@ -84,13 +96,58 @@ describe("buildDockerPath", () => {
       dirExists,
     });
 
-    expect(result).toBe(env);
-    expect(result).toEqual({
+    expect(result).not.toBe(env);
+    expect(result.KEEP).toBe("yes");
+    expect(result.Path).toBe(`C:\\Windows;${perUserBin}`);
+    expect(dirExists).toHaveBeenCalledWith(perUserBin);
+  });
+
+  it("writes back to the existing Windows path key instead of adding a duplicate", () => {
+    const env = {
       Path: "C:\\Windows",
-      PATH: "C:\\Tools",
-      KEEP: "yes",
+      LOCALAPPDATA: "C:\\Users\\test\\AppData\\Local",
+    };
+
+    const result = buildDockerPath({
+      platform: "win32",
+      homedir: "C:\\Users\\test",
+      env,
+      dirExists: () => true,
     });
-    expect(dirExists).not.toHaveBeenCalled();
+
+    const pathKeys = Object.keys(result).filter(
+      (key) => key.toLowerCase() === "path",
+    );
+    expect(pathKeys).toEqual(["Path"]);
+    expect(result.PATH).toBeUndefined();
+  });
+
+  it("does not duplicate a Windows candidate already on PATH, case-insensitively", () => {
+    const perUserBin =
+      "C:\\Users\\test\\AppData\\Local\\Programs\\DockerDesktop\\resources\\bin";
+    const result = buildDockerPath({
+      platform: "win32",
+      homedir: "C:\\Users\\test",
+      env: {
+        PATH: `C:\\Windows;${perUserBin.toUpperCase()}`,
+        LOCALAPPDATA: "C:\\Users\\test\\AppData\\Local",
+      },
+      dirExists: (candidate) => candidate === perUserBin,
+    });
+
+    expect(result.PATH).toBe(`C:\\Windows;${perUserBin.toUpperCase()}`);
+  });
+
+  it("keeps working when Windows has no PATH and no install-root variables", () => {
+    const result = buildDockerPath({
+      platform: "win32",
+      homedir: "C:\\Users\\test",
+      env: { KEEP: "yes" },
+      dirExists: () => true,
+    });
+
+    expect(result.KEEP).toBe("yes");
+    expect(result.PATH).toBe("");
   });
 });
 

--- a/vex-app/src/main/docker/__tests__/engine-endpoint.test.ts
+++ b/vex-app/src/main/docker/__tests__/engine-endpoint.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Error triage for the CLI-independent engine liveness probe. The contract
+ * under test is that a connection failure is classified into distinct
+ * outcomes rather than one generic failure, and that the candidate list is
+ * walked until the most informative answer is found.
+ *
+ * `connect` is injected, so no socket or named pipe is opened here.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  classifyConnectError,
+  defaultDockerEngineEndpoints,
+  probeDockerEngineEndpoint,
+  probeEngineEndpointOnce,
+  type DockerEngineReachability,
+} from "../engine-endpoint.js";
+
+describe("defaultDockerEngineEndpoints", () => {
+  it("uses the documented Windows named pipe", () => {
+    expect(
+      defaultDockerEngineEndpoints({ platform: "win32", homedir: "C:\\U" }),
+    ).toEqual(["\\\\.\\pipe\\docker_engine"]);
+  });
+
+  it("tries the per-user Docker Desktop socket before /var/run on darwin", () => {
+    expect(
+      defaultDockerEngineEndpoints({ platform: "darwin", homedir: "/Users/t" }),
+    ).toEqual(["/Users/t/.docker/run/docker.sock", "/var/run/docker.sock"]);
+  });
+
+  it("has no endpoint on an unsupported platform", () => {
+    expect(
+      defaultDockerEngineEndpoints({ platform: "aix", homedir: "/h" }),
+    ).toEqual([]);
+  });
+});
+
+describe("classifyConnectError", () => {
+  it.each(["ENOENT", "ECONNREFUSED", "ECONNRESET", "EPIPE"])(
+    "treats %s as nothing listening",
+    (code) => {
+      expect(classifyConnectError(code, "/sock")).toEqual({
+        kind: "not_running",
+      });
+    },
+  );
+
+  it.each(["EACCES", "EPERM"])(
+    "treats %s as a permission denial, carrying the endpoint",
+    (code) => {
+      expect(classifyConnectError(code, "/sock")).toEqual({
+        kind: "permission_denied",
+        endpoint: "/sock",
+      });
+    },
+  );
+
+  it("keeps an unrecognised or absent errno as unknown", () => {
+    expect(classifyConnectError("EHOSTUNREACH", "/sock")).toEqual({
+      kind: "unknown",
+      errorCode: "EHOSTUNREACH",
+    });
+    expect(classifyConnectError(null, "/sock")).toEqual({
+      kind: "unknown",
+      errorCode: null,
+    });
+  });
+});
+
+describe("probeDockerEngineEndpoint triage", () => {
+  function withConnect(
+    responses: Record<string, DockerEngineReachability>,
+  ): (endpoint: string) => Promise<DockerEngineReachability> {
+    return (endpoint) =>
+      Promise.resolve(responses[endpoint] ?? { kind: "not_running" });
+  }
+
+  it("reports reachable when an endpoint accepts the connection", async () => {
+    const result = await probeDockerEngineEndpoint({
+      platform: "linux",
+      homedir: "/home/t",
+      connect: withConnect({
+        "/var/run/docker.sock": { kind: "reachable", endpoint: "/var/run/docker.sock" },
+      }),
+    });
+    expect(result).toEqual({ kind: "reachable", endpoint: "/var/run/docker.sock" });
+  });
+
+  it("keeps permission denied distinct from not running", async () => {
+    const result = await probeDockerEngineEndpoint({
+      platform: "linux",
+      homedir: "/home/t",
+      connect: withConnect({
+        "/var/run/docker.sock": {
+          kind: "permission_denied",
+          endpoint: "/var/run/docker.sock",
+        },
+      }),
+    });
+    expect(result.kind).toBe("permission_denied");
+  });
+
+  it("stops at the first reachable endpoint instead of probing the rest", async () => {
+    const connect = vi.fn(
+      async (endpoint: string): Promise<DockerEngineReachability> =>
+        endpoint === "/Users/t/.docker/run/docker.sock"
+          ? { kind: "reachable", endpoint }
+          : { kind: "not_running" },
+    );
+    await probeDockerEngineEndpoint({
+      platform: "darwin",
+      homedir: "/Users/t",
+      connect,
+    });
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers an unknown error over not_running so a stuck endpoint is not read as absent", async () => {
+    const result = await probeDockerEngineEndpoint({
+      platform: "darwin",
+      homedir: "/Users/t",
+      connect: withConnect({
+        "/Users/t/.docker/run/docker.sock": {
+          kind: "unknown",
+          errorCode: "ETIMEDOUT",
+        },
+      }),
+    });
+    expect(result).toEqual({ kind: "unknown", errorCode: "ETIMEDOUT" });
+  });
+
+  it("reports not_running when nothing is listening anywhere", async () => {
+    const result = await probeDockerEngineEndpoint({
+      platform: "linux",
+      homedir: "/home/t",
+      connect: withConnect({}),
+    });
+    expect(result).toEqual({ kind: "not_running" });
+  });
+
+  it("has no reachable endpoint on an unsupported platform", async () => {
+    const connect = vi.fn();
+    const result = await probeDockerEngineEndpoint({
+      platform: "aix",
+      homedir: "/h",
+      connect,
+    });
+    expect(result).toEqual({ kind: "not_running" });
+    expect(connect).not.toHaveBeenCalled();
+  });
+});
+
+describe("probeEngineEndpointOnce", () => {
+  it("classifies a missing socket as not_running", async () => {
+    const result = await probeEngineEndpointOnce(
+      "/nonexistent/vex-docker-probe.sock",
+    );
+    expect(result).toEqual({ kind: "not_running" });
+  });
+
+  it("settles immediately when the caller has already cancelled", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const result = await probeEngineEndpointOnce(
+      "/nonexistent/vex-docker-probe.sock",
+      controller.signal,
+    );
+    expect(result).toEqual({ kind: "unknown", errorCode: null });
+  });
+});

--- a/vex-app/src/main/docker/__tests__/engine-state.test.ts
+++ b/vex-app/src/main/docker/__tests__/engine-state.test.ts
@@ -1,0 +1,185 @@
+/**
+ * The state union itself: `classifyEngineState` must resolve six distinct
+ * outcomes and must never let the endpoint hint contradict a successful
+ * `docker info`, plus the bounded window that is the ONLY honest source of
+ * `engine_starting`.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { classifyEngineState } from "../probe/daemon.js";
+import {
+  ENGINE_START_WINDOW_MS,
+  clearDockerEngineStartWindow,
+  isWithinEngineStartWindow,
+  markDockerEngineStartAttempt,
+} from "../engine-start-window.js";
+import { deriveDockerStatusFlags } from "@shared/schemas/docker.js";
+
+const acceptedEndpoint = {
+  accepted: true,
+  currentContext: "default",
+  dockerHostSet: false,
+  reason: null,
+  message: null,
+} as const;
+
+const baseInput = {
+  cliFound: true,
+  versionOk: true,
+  version: "27.5.1",
+  versionErrorMessage: null,
+  endpoint: acceptedEndpoint,
+  daemonRunning: false,
+  reachability: { kind: "not_running" } as const,
+  startWindowOpen: false,
+};
+
+describe("classifyEngineState", () => {
+  it("reports not_installed only when no CLI was located", () => {
+    expect(
+      classifyEngineState({ ...baseInput, cliFound: false }),
+    ).toEqual({ kind: "not_installed" });
+  });
+
+  it("reports a located-but-unusable CLI as a probe error, never as not_installed", () => {
+    const state = classifyEngineState({
+      ...baseInput,
+      versionOk: false,
+      version: null,
+      versionErrorMessage: "spawn EACCES",
+    });
+    expect(state.kind).toBe("error");
+    expect(state).toMatchObject({ reason: "probe_error" });
+  });
+
+  it("treats unparseable version output as a probe error", () => {
+    expect(
+      classifyEngineState({ ...baseInput, version: null }).kind,
+    ).toBe("error");
+  });
+
+  it("surfaces a rejected endpoint as its own error reason and message", () => {
+    const state = classifyEngineState({
+      ...baseInput,
+      endpoint: {
+        accepted: false,
+        currentContext: "remote",
+        dockerHostSet: true,
+        reason: "docker_host_unsupported",
+        message: "DOCKER_HOST points at a remote endpoint.",
+      },
+    });
+    expect(state).toEqual({
+      kind: "error",
+      reason: "endpoint_rejected",
+      message: "DOCKER_HOST points at a remote endpoint.",
+    });
+  });
+
+  it("reports ready when the daemon answered", () => {
+    expect(
+      classifyEngineState({ ...baseInput, daemonRunning: true }),
+    ).toEqual({ kind: "ready" });
+  });
+
+  it("never lets the endpoint hint contradict a successful docker info", () => {
+    // A custom Docker context puts the engine on an endpoint this probe does
+    // not know about, so `not_running` there must not override `ready`.
+    expect(
+      classifyEngineState({
+        ...baseInput,
+        daemonRunning: true,
+        reachability: { kind: "not_running" },
+      }),
+    ).toEqual({ kind: "ready" });
+  });
+
+  it("reports permission_denied with actionable text rather than a generic failure", () => {
+    const state = classifyEngineState({
+      ...baseInput,
+      reachability: { kind: "permission_denied", endpoint: "/var/run/docker.sock" },
+    });
+    expect(state.kind).toBe("permission_denied");
+    expect(state).toMatchObject({ message: expect.stringMatching(/Docker/) });
+  });
+
+  it("reports engine_starting only inside the bounded start window", () => {
+    expect(
+      classifyEngineState({ ...baseInput, startWindowOpen: true }),
+    ).toEqual({ kind: "engine_starting" });
+    expect(
+      classifyEngineState({ ...baseInput, startWindowOpen: false }),
+    ).toEqual({ kind: "engine_stopped" });
+  });
+
+  it("does not infer engine_starting from an unknown endpoint outcome", () => {
+    expect(
+      classifyEngineState({
+        ...baseInput,
+        reachability: { kind: "unknown", errorCode: "ETIMEDOUT" },
+      }),
+    ).toEqual({ kind: "engine_stopped" });
+  });
+});
+
+describe("engine start window", () => {
+  afterEach(() => {
+    clearDockerEngineStartWindow();
+  });
+
+  it("is closed until a start attempt is recorded", () => {
+    expect(isWithinEngineStartWindow()).toBe(false);
+  });
+
+  it("opens on a start attempt and expires after the bounded window", () => {
+    markDockerEngineStartAttempt(1_000);
+    expect(isWithinEngineStartWindow(1_000 + ENGINE_START_WINDOW_MS - 1)).toBe(
+      true,
+    );
+    expect(isWithinEngineStartWindow(1_000 + ENGINE_START_WINDOW_MS)).toBe(
+      false,
+    );
+  });
+
+  it("can be closed explicitly once the engine answers", () => {
+    markDockerEngineStartAttempt();
+    clearDockerEngineStartWindow();
+    expect(isWithinEngineStartWindow()).toBe(false);
+  });
+});
+
+describe("deriveDockerStatusFlags", () => {
+  it("derives every legacy boolean from one state, with no second source", () => {
+    expect(deriveDockerStatusFlags({ kind: "ready" })).toEqual({
+      present: true,
+      runtimeOK: true,
+      daemonRunning: true,
+      daemonStartable: true,
+    });
+    expect(deriveDockerStatusFlags({ kind: "engine_stopped" })).toEqual({
+      present: true,
+      runtimeOK: false,
+      daemonRunning: false,
+      daemonStartable: true,
+    });
+    expect(deriveDockerStatusFlags({ kind: "not_installed" })).toEqual({
+      present: false,
+      runtimeOK: false,
+      daemonRunning: false,
+      daemonStartable: false,
+    });
+    expect(
+      deriveDockerStatusFlags({
+        kind: "error",
+        reason: "probe_error",
+        message: "x",
+      }),
+    ).toEqual({
+      present: false,
+      runtimeOK: false,
+      daemonRunning: false,
+      daemonStartable: false,
+    });
+  });
+});

--- a/vex-app/src/main/docker/__tests__/installer-urls.test.ts
+++ b/vex-app/src/main/docker/__tests__/installer-urls.test.ts
@@ -12,12 +12,21 @@ import {
 } from "../installer-urls.js";
 
 describe("DESKTOP_INSTALLER_URLS", () => {
-  it("has exactly the three supported installer targets", () => {
+  it("has exactly the four supported installer targets", () => {
     expect(Object.keys(DESKTOP_INSTALLER_URLS).sort()).toEqual([
       "macos-arm64",
       "macos-x64",
+      "windows-arm64",
       "windows-x64",
     ]);
+  });
+
+  it("puts the architecture in the URL path, not the filename", () => {
+    const amd64 = DESKTOP_INSTALLER_URLS["windows-x64"];
+    const arm64 = DESKTOP_INSTALLER_URLS["windows-arm64"];
+    expect(new URL(amd64.url).pathname).toContain("/amd64/");
+    expect(new URL(arm64.url).pathname).toContain("/arm64/");
+    expect(arm64.filename).toBe(amd64.filename);
   });
 
   it("only references desktop.docker.com over https", () => {
@@ -34,6 +43,7 @@ describe("getInstallerForPlatform", () => {
     ["darwin", "arm64", "Docker.dmg"],
     ["darwin", "x64", "Docker.dmg"],
     ["win32", "x64", "Docker Desktop Installer.exe"],
+    ["win32", "arm64", "Docker Desktop Installer.exe"],
   ])("returns entry for %s/%s", (platform, arch, expectedFilename) => {
     const entry = getInstallerForPlatform(platform, arch);
     expect(entry).not.toBeNull();
@@ -46,8 +56,15 @@ describe("getInstallerForPlatform", () => {
   });
 
   it("returns null for unsupported combinations", () => {
-    expect(getInstallerForPlatform("win32", "arm64")).toBeNull();
     expect(getInstallerForPlatform("freebsd", "x64")).toBeNull();
+    expect(getInstallerForPlatform("linux", "x64")).toBeNull();
+  });
+
+  // Previously asserted `getInstallerForPlatform("win32", "arm64")` is null,
+  // which hard-blocked every Snapdragon-class Windows machine. Docker ships
+  // an arm64 Windows installer, so that combination now resolves.
+  it("selects the arm64 Windows installer on Windows on Arm", () => {
+    expect(getInstallerForPlatform("win32", "arm64")?.url).toContain("/arm64/");
   });
 });
 

--- a/vex-app/src/main/docker/__tests__/locate.test.ts
+++ b/vex-app/src/main/docker/__tests__/locate.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Locator contract: install directories are probed on the FILESYSTEM before
+ * PATH is consulted, and Windows environment hazards (case-insensitive
+ * PATH/Path, PATHEXT, quoted entries with spaces, missing variables, a
+ * candidate that is a directory) are handled.
+ *
+ * Every case injects `env`, `platform`, `homedir` and `fileExists`, so
+ * Windows resolution is exercised from any host OS and nothing here touches
+ * the real environment or the real filesystem.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  dockerCliDirectories,
+  dockerDesktopInstallRoots,
+  findExecutableOnPath,
+  getEnvCaseInsensitive,
+  locateDockerCli,
+  locateDockerDesktopExe,
+  resolveEnvKey,
+  type LocatorContext,
+} from "../locate.js";
+
+const LOCAL_APP_DATA = "C:\\Users\\test\\AppData\\Local";
+const PER_USER_BIN = `${LOCAL_APP_DATA}\\Programs\\DockerDesktop\\resources\\bin`;
+const PER_USER_EXE = `${PER_USER_BIN}\\docker.exe`;
+const ALL_USERS_EXE =
+  "C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe";
+
+function winContext(
+  env: NodeJS.ProcessEnv,
+  existing: ReadonlyArray<string>,
+): LocatorContext {
+  const present = new Set(existing.map((entry) => entry.toLowerCase()));
+  return {
+    platform: "win32",
+    homedir: "C:\\Users\\test",
+    env,
+    fileExists: (candidate) => present.has(candidate.toLowerCase()),
+  };
+}
+
+describe("getEnvCaseInsensitive / resolveEnvKey", () => {
+  it("reads a Windows variable through either spelling", () => {
+    expect(getEnvCaseInsensitive({ Path: "C:\\Windows" }, "PATH")).toBe(
+      "C:\\Windows",
+    );
+    expect(getEnvCaseInsensitive({ PATH: "C:\\Windows" }, "Path")).toBe(
+      "C:\\Windows",
+    );
+    expect(getEnvCaseInsensitive({}, "PATH")).toBeUndefined();
+  });
+
+  it("resolves the key spelling that already exists so no duplicate is created", () => {
+    expect(resolveEnvKey({ Path: "x" }, "PATH")).toBe("Path");
+    expect(resolveEnvKey({ PATH: "x" }, "PATH")).toBe("PATH");
+    expect(resolveEnvKey({ OTHER: "x" }, "PATH")).toBeNull();
+  });
+});
+
+describe("dockerDesktopInstallRoots", () => {
+  it("puts the per-user default first, then ProgramW6432, ProgramFiles, ProgramFiles(x86)", () => {
+    expect(
+      dockerDesktopInstallRoots({
+        LOCALAPPDATA: LOCAL_APP_DATA,
+        ProgramW6432: "C:\\Program Files",
+        ProgramFiles: "C:\\Program Files (x86)",
+        "ProgramFiles(x86)": "C:\\Program Files (x86)",
+      }),
+    ).toEqual([
+      `${LOCAL_APP_DATA}\\Programs\\DockerDesktop`,
+      "C:\\Program Files\\Docker\\Docker",
+      "C:\\Program Files (x86)\\Docker\\Docker",
+    ]);
+  });
+
+  it("skips missing and blank environment variables instead of joining undefined", () => {
+    expect(
+      dockerDesktopInstallRoots({ LOCALAPPDATA: "", ProgramFiles: undefined }),
+    ).toEqual([]);
+  });
+
+  it("reads install roots through a lowercase Windows spelling", () => {
+    expect(dockerDesktopInstallRoots({ localappdata: LOCAL_APP_DATA })).toEqual([
+      `${LOCAL_APP_DATA}\\Programs\\DockerDesktop`,
+    ]);
+  });
+});
+
+describe("dockerCliDirectories", () => {
+  it("derives the Windows CLI dirs from the install roots", () => {
+    expect(
+      dockerCliDirectories({
+        platform: "win32",
+        homedir: "C:\\Users\\test",
+        env: { LOCALAPPDATA: LOCAL_APP_DATA },
+      }),
+    ).toEqual([PER_USER_BIN]);
+  });
+
+  it("keeps the existing darwin candidate matrix", () => {
+    expect(
+      dockerCliDirectories({
+        platform: "darwin",
+        homedir: "/Users/test",
+        env: {},
+      }),
+    ).toEqual([
+      "/usr/local/bin",
+      "/opt/homebrew/bin",
+      "/Users/test/.docker/bin",
+      "/Users/test/.orbstack/bin",
+      "/Users/test/.rd/bin",
+      "/Applications/Docker.app/Contents/Resources/bin",
+    ]);
+  });
+});
+
+describe("findExecutableOnPath", () => {
+  it("expands PATHEXT on Windows, honouring the documented default", () => {
+    // Windows filenames are case-insensitive, so the returned path carries
+    // whatever casing PATHEXT used; `winContext` matches accordingly.
+    const ctx = winContext({ Path: "C:\\Tools" }, ["C:\\Tools\\docker.exe"]);
+    expect(findExecutableOnPath("docker", ctx)?.toLowerCase()).toBe(
+      "c:\\tools\\docker.exe",
+    );
+
+    // A .cmd shim is found too, because the default PATHEXT lists it.
+    const cmdShim = winContext({ Path: "C:\\Tools" }, ["C:\\Tools\\docker.cmd"]);
+    expect(findExecutableOnPath("docker", cmdShim)?.toLowerCase()).toBe(
+      "c:\\tools\\docker.cmd",
+    );
+  });
+
+  it("uses an explicit PATHEXT when the environment supplies one", () => {
+    const ctx = winContext(
+      { Path: "C:\\Tools", PATHEXT: ".bat" },
+      ["C:\\Tools\\docker.exe", "C:\\Tools\\docker.bat"],
+    );
+    expect(findExecutableOnPath("docker", ctx)).toBe("C:\\Tools\\docker.bat");
+  });
+
+  it("handles quoted PATH entries containing spaces", () => {
+    const ctx = winContext(
+      {
+        Path: '"C:\\Program Files\\Docker\\Docker\\resources\\bin";C:\\Windows',
+        PATHEXT: ".exe",
+      },
+      ["C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe"],
+    );
+    expect(findExecutableOnPath("docker", ctx)).toBe(ALL_USERS_EXE);
+  });
+
+  it("ignores relative PATH entries, which would resolve against the cwd", () => {
+    const ctx = winContext({ Path: ".;..\\bin" }, [".\\docker.exe"]);
+    expect(findExecutableOnPath("docker", ctx)).toBeNull();
+  });
+
+  it("returns null when PATH is absent or empty", () => {
+    expect(findExecutableOnPath("docker", winContext({}, []))).toBeNull();
+    expect(
+      findExecutableOnPath("docker", winContext({ Path: "   " }, [])),
+    ).toBeNull();
+  });
+
+  it("finds a posix executable without extension expansion", () => {
+    expect(
+      findExecutableOnPath("docker", {
+        platform: "linux",
+        homedir: "/home/test",
+        env: { PATH: "/opt/x/bin:/usr/bin" },
+        fileExists: (candidate) => candidate === "/usr/bin/docker",
+      }),
+    ).toBe("/usr/bin/docker");
+  });
+});
+
+describe("locateDockerCli", () => {
+  /**
+   * THE REPORTED BUG, as a regression test. A Windows user installs Docker
+   * Desktop while Vex is already running: `process.env` is a launch-time
+   * snapshot so PATH still has no Docker, yet `docker.exe` is on disk at
+   * the default per-user install location. Detection must report installed.
+   * Reverting to a PATH-only detector turns this red.
+   */
+  it("finds a Docker installed after launch, when the PATH snapshot predates it", () => {
+    const ctx = winContext(
+      { Path: "C:\\Windows;C:\\Windows\\System32", LOCALAPPDATA: LOCAL_APP_DATA },
+      [PER_USER_EXE],
+    );
+
+    expect(locateDockerCli(ctx)).toEqual({
+      executablePath: PER_USER_EXE,
+      source: "install_dir",
+    });
+  });
+
+  it("prefers the per-user install over the all-users install", () => {
+    const ctx = winContext(
+      {
+        Path: "C:\\Windows",
+        LOCALAPPDATA: LOCAL_APP_DATA,
+        ProgramFiles: "C:\\Program Files",
+      },
+      [PER_USER_EXE, ALL_USERS_EXE],
+    );
+
+    expect(locateDockerCli(ctx)?.executablePath).toBe(PER_USER_EXE);
+  });
+
+  it("probes install directories before PATH", () => {
+    const fileExists = vi.fn(
+      (candidate: string) =>
+        candidate === PER_USER_EXE || candidate === "C:\\Tools\\docker.exe",
+    );
+    const result = locateDockerCli({
+      platform: "win32",
+      homedir: "C:\\Users\\test",
+      env: { Path: "C:\\Tools", LOCALAPPDATA: LOCAL_APP_DATA },
+      fileExists,
+    });
+
+    expect(result?.executablePath).toBe(PER_USER_EXE);
+    expect(fileExists).not.toHaveBeenCalledWith("C:\\Tools\\docker.exe");
+  });
+
+  it("falls back to PATH for a custom --installation-dir install", () => {
+    const ctx = winContext(
+      {
+        Path: "D:\\Custom\\Docker\\resources\\bin",
+        PATHEXT: ".exe",
+        LOCALAPPDATA: LOCAL_APP_DATA,
+      },
+      ["D:\\Custom\\Docker\\resources\\bin\\docker.exe"],
+    );
+
+    expect(locateDockerCli(ctx)).toEqual({
+      executablePath: "D:\\Custom\\Docker\\resources\\bin\\docker.exe",
+      source: "path",
+    });
+  });
+
+  it("does not accept a candidate that is a directory", () => {
+    const ctx: LocatorContext = {
+      platform: "win32",
+      homedir: "C:\\Users\\test",
+      env: { Path: "C:\\Windows", LOCALAPPDATA: LOCAL_APP_DATA },
+      // `fileExists` is contractually "exists AND is not a directory", so a
+      // directory named docker.exe reports false and must not be located.
+      fileExists: () => false,
+    };
+
+    expect(locateDockerCli(ctx)).toBeNull();
+  });
+
+  it("returns null when nothing is installed and PATH has no Docker", () => {
+    expect(
+      locateDockerCli(
+        winContext({ Path: "C:\\Windows", LOCALAPPDATA: LOCAL_APP_DATA }, []),
+      ),
+    ).toBeNull();
+  });
+
+  it("locates the darwin CLI through the shared candidate matrix", () => {
+    expect(
+      locateDockerCli({
+        platform: "darwin",
+        homedir: "/Users/test",
+        env: { PATH: "/usr/bin" },
+        fileExists: (candidate) =>
+          candidate ===
+          "/Applications/Docker.app/Contents/Resources/bin/docker",
+      }),
+    ).toEqual({
+      executablePath:
+        "/Applications/Docker.app/Contents/Resources/bin/docker",
+      source: "install_dir",
+    });
+  });
+});
+
+describe("locateDockerDesktopExe", () => {
+  it("resolves the GUI executable from the same install roots as the CLI", () => {
+    expect(
+      locateDockerDesktopExe({
+        env: { LOCALAPPDATA: LOCAL_APP_DATA, ProgramFiles: "C:\\Program Files" },
+        fileExists: (candidate) =>
+          candidate === "C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe",
+      }),
+    ).toBe("C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe");
+  });
+
+  it("returns null when Docker Desktop is not in any known root", () => {
+    expect(
+      locateDockerDesktopExe({
+        env: { LOCALAPPDATA: LOCAL_APP_DATA },
+        fileExists: () => false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/vex-app/src/main/docker/__tests__/probe-behavior.test.ts
+++ b/vex-app/src/main/docker/__tests__/probe-behavior.test.ts
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   isModelRunnerReachable: vi.fn(),
   getAvailableDiskGB: vi.fn(),
   logWarn: vi.fn(),
+  resolveDockerCli: vi.fn(),
+  probeEngineEndpoint: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => {
@@ -42,6 +44,10 @@ vi.mock("node:child_process", () => {
   return { execFile };
 });
 vi.mock("../cli-env.js", () => ({ dockerSpawnEnv: mocks.dockerSpawnEnv }));
+vi.mock("../locate.js", () => ({ resolveDockerCli: mocks.resolveDockerCli }));
+vi.mock("../engine-endpoint.js", () => ({
+  probeDockerEngineEndpoint: mocks.probeEngineEndpoint,
+}));
 vi.mock("../endpoint-policy.js", () => ({
   inspectDockerEndpointPolicy: mocks.inspectEndpoint,
 }));
@@ -57,6 +63,9 @@ vi.mock("../../logger/index.js", () => ({
 }));
 
 import { probeDocker } from "../probe/daemon.js";
+import { clearDockerEngineStartWindow } from "../engine-start-window.js";
+
+const DOCKER_EXE = "/usr/local/bin/docker";
 
 function commandError(code: string): Error {
   return Object.assign(new Error(`docker failed (${code})`), {
@@ -98,31 +107,71 @@ describe("probeDocker engine failure taxonomy", () => {
     mocks.isPortFree.mockResolvedValue(true);
     mocks.isModelRunnerReachable.mockResolvedValue(false);
     mocks.getAvailableDiskGB.mockResolvedValue(50);
+    mocks.resolveDockerCli.mockReturnValue({
+      executablePath: DOCKER_EXE,
+      source: "install_dir",
+    });
+    mocks.probeEngineEndpoint.mockResolvedValue({ kind: "not_running" });
+    clearDockerEngineStartWindow();
   });
 
-  it("classifies ENOENT version failures as cli_not_found", async () => {
+  it("reports not_installed when the locator finds no Docker CLI at all", async () => {
+    mocks.resolveDockerCli.mockReturnValue(null);
     installExecBehavior(() => ({ error: commandError("ENOENT") }));
 
     const status = await probeDocker({ pgPort: 55432, diskTarget: "/tmp" });
 
     expect(status.engine).toEqual({
-      present: false,
+      state: { kind: "not_installed" },
       version: null,
+      cliSource: null,
+      present: false,
       runtimeOK: false,
-      failure: "cli_not_found",
     });
+    // Nothing was located, so nothing is spawned to prove it again.
+    expect(mocks.execFile).not.toHaveBeenCalled();
   });
 
-  it("classifies non-ENOENT version failures as probe_error", async () => {
+  it("classifies a located-but-unrunnable CLI as a probe error, not as missing", async () => {
     installExecBehavior(() => ({ error: commandError("EACCES") }));
 
     const status = await probeDocker({ pgPort: 55432, diskTarget: "/tmp" });
 
     expect(status.engine.present).toBe(false);
-    expect(status.engine.failure).toBe("probe_error");
+    expect(status.engine.state).toMatchObject({
+      kind: "error",
+      reason: "probe_error",
+    });
   });
 
-  it("keeps engine failure null when version succeeds but docker info fails", async () => {
+  it("spawns the located ABSOLUTE path, never the bare name", async () => {
+    installExecBehavior(() => ({ stdout: "Docker version 27.5.1, build abc\n" }));
+
+    await probeDocker({ pgPort: 55432, diskTarget: "/tmp" });
+
+    for (const call of mocks.execFile.mock.calls) {
+      expect(call[0]).toBe(DOCKER_EXE);
+    }
+  });
+
+  it("reports permission_denied when the engine endpoint refuses this process", async () => {
+    mocks.probeEngineEndpoint.mockResolvedValue({
+      kind: "permission_denied",
+      endpoint: "/var/run/docker.sock",
+    });
+    installExecBehavior((args) =>
+      args.join(" ") === "--version"
+        ? { stdout: "Docker version 27.5.1, build abc\n" }
+        : { error: commandError("EACCES") },
+    );
+
+    const status = await probeDocker({ pgPort: 55432, diskTarget: "/tmp" });
+
+    expect(status.engine.state.kind).toBe("permission_denied");
+    expect(status.daemon.running).toBe(false);
+  });
+
+  it("reports engine_stopped when the CLI works but docker info fails", async () => {
     installExecBehavior((args) => {
       const key = args.join(" ");
       if (key === "--version") {
@@ -140,11 +189,12 @@ describe("probeDocker engine failure taxonomy", () => {
     const status = await probeDocker({ pgPort: 55432, diskTarget: "/tmp" });
 
     expect(status.engine.present).toBe(true);
-    expect(status.engine.failure).toBeNull();
+    expect(status.engine.state).toEqual({ kind: "engine_stopped" });
+    expect(status.engine.cliSource).toBe("install_dir");
     expect(status.daemon.running).toBe(false);
     expect(mocks.dockerSpawnEnv).toHaveBeenCalled();
     expect(mocks.execFile).toHaveBeenCalledWith(
-      "docker",
+      DOCKER_EXE,
       expect.any(Array),
       expect.objectContaining({ env: { PATH: "/docker/path" } }),
       expect.any(Function),

--- a/vex-app/src/main/docker/__tests__/spawn-runner-options.test.ts
+++ b/vex-app/src/main/docker/__tests__/spawn-runner-options.test.ts
@@ -6,10 +6,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   spawn: vi.fn(),
   dockerSpawnEnv: vi.fn(() => ({ PATH: "/augmented/docker/path" })),
+  resolveDockerCli: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => ({ spawn: mocks.spawn }));
 vi.mock("../cli-env.js", () => ({ dockerSpawnEnv: mocks.dockerSpawnEnv }));
+vi.mock("../locate.js", () => ({ resolveDockerCli: mocks.resolveDockerCli }));
+
+const DOCKER_EXE = "/opt/docker/bin/docker";
 
 import { runSpawn } from "../spawn-runner.js";
 
@@ -42,6 +46,10 @@ describe("runSpawn environment and spawn errors", () => {
   beforeEach(() => {
     mocks.spawn.mockReset();
     mocks.dockerSpawnEnv.mockClear();
+    mocks.resolveDockerCli.mockReset().mockReturnValue({
+      executablePath: DOCKER_EXE,
+      source: "install_dir",
+    });
     mocks.spawn.mockImplementation(() => fakeChild());
   });
 
@@ -49,10 +57,35 @@ describe("runSpawn environment and spawn errors", () => {
     await runSpawn("docker", ["info"]);
 
     expect(mocks.dockerSpawnEnv).toHaveBeenCalledOnce();
+    // The bare name is resolved to the located absolute path so every
+    // Docker caller in main spawns the same executable.
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      DOCKER_EXE,
+      ["info"],
+      expect.objectContaining({ env: { PATH: "/augmented/docker/path" } }),
+    );
+  });
+
+  it("falls back to the bare name when no Docker CLI can be located", async () => {
+    mocks.resolveDockerCli.mockReturnValue(null);
+
+    await runSpawn("docker", ["info"]);
+
     expect(mocks.spawn).toHaveBeenCalledWith(
       "docker",
       ["info"],
-      expect.objectContaining({ env: { PATH: "/augmented/docker/path" } }),
+      expect.anything(),
+    );
+  });
+
+  it("does not redirect a non-docker command through the locator", async () => {
+    await runSpawn("systemctl", ["--user", "start", "docker-desktop"]);
+
+    expect(mocks.resolveDockerCli).not.toHaveBeenCalled();
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      "systemctl",
+      ["--user", "start", "docker-desktop"],
+      expect.anything(),
     );
   });
 
@@ -84,7 +117,7 @@ describe("runSpawn environment and spawn errors", () => {
 
     expect(mocks.dockerSpawnEnv).not.toHaveBeenCalled();
     expect(mocks.spawn).toHaveBeenCalledWith(
-      "docker",
+      DOCKER_EXE,
       ["info"],
       expect.objectContaining({
         env: { PATH: "/caller/path", CUSTOM: "yes" },

--- a/vex-app/src/main/docker/__tests__/start.test.ts
+++ b/vex-app/src/main/docker/__tests__/start.test.ts
@@ -9,12 +9,13 @@
  *   - Tier 2 exe resolution precedence (per-user before Program Files)
  *   - PowerShell single-quote escaping
  *
- * `runSpawn` and `node:fs.existsSync` are mocked so nothing spawns and no
- * real filesystem is touched.
+ * `runSpawn` and the locator's `isExistingFile` are mocked so nothing spawns
+ * and no real filesystem is touched. Exe resolution now delegates to
+ * `locate.ts`, which joins Windows paths with `path.win32` rather than the
+ * host's separator, so the expected paths use backslashes.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import path from "node:path";
 import type { SpawnRunnerResult } from "../spawn-runner.js";
 
 const { runSpawnMock, existsSyncMock } = vi.hoisted(() => ({
@@ -23,9 +24,9 @@ const { runSpawnMock, existsSyncMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("../spawn-runner.js", () => ({ runSpawn: runSpawnMock }));
-vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
-  return { ...actual, existsSync: existsSyncMock };
+vi.mock("../locate.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../locate.js")>();
+  return { ...actual, isExistingFile: existsSyncMock };
 });
 
 const { performStart, escapePowershellSingleQuoted, resolveDockerDesktopExe } =
@@ -80,12 +81,7 @@ describe("resolveDockerDesktopExe", () => {
   it("prefers the per-user LocalAppData install over Program Files", () => {
     existsSyncMock.mockReturnValue(true); // both present
     expect(resolveDockerDesktopExe(env)).toBe(
-      path.join(
-        "C:\\Users\\me\\AppData\\Local",
-        "Programs",
-        "DockerDesktop",
-        "Docker Desktop.exe"
-      )
+      "C:\\Users\\me\\AppData\\Local\\Programs\\DockerDesktop\\Docker Desktop.exe"
     );
   });
 
@@ -94,12 +90,7 @@ describe("resolveDockerDesktopExe", () => {
       String(p).includes("Program Files")
     );
     expect(resolveDockerDesktopExe(env)).toBe(
-      path.join(
-        "C:\\Program Files",
-        "Docker",
-        "Docker",
-        "Docker Desktop.exe"
-      )
+      "C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe"
     );
   });
 

--- a/vex-app/src/main/docker/cli-env.ts
+++ b/vex-app/src/main/docker/cli-env.ts
@@ -1,6 +1,6 @@
 import { statSync } from "node:fs";
 import { homedir as getHomedir } from "node:os";
-import { posix } from "node:path";
+import { dockerCliDirectories, resolveEnvKey } from "./locate.js";
 import { withoutManagedSecrets } from "./env-hygiene.js";
 
 export interface BuildDockerPathOptions {
@@ -10,52 +10,55 @@ export interface BuildDockerPathOptions {
   readonly dirExists: (path: string) => boolean;
 }
 
-function dockerPathCandidates(
-  platform: NodeJS.Platform,
-  homedir: string,
-): ReadonlyArray<string> {
-  if (platform === "darwin") {
-    return [
-      "/usr/local/bin",
-      "/opt/homebrew/bin",
-      posix.join(homedir, ".docker/bin"),
-      posix.join(homedir, ".orbstack/bin"),
-      posix.join(homedir, ".rd/bin"),
-      "/Applications/Docker.app/Contents/Resources/bin",
-    ];
-  }
-  if (platform === "linux") {
-    return [
-      "/usr/local/bin",
-      "/usr/bin",
-      "/snap/bin",
-      posix.join(homedir, "bin"),
-    ];
-  }
-  return [];
+function pathDelimiter(platform: NodeJS.Platform): string {
+  return platform === "win32" ? ";" : ":";
+}
+
+function comparableEntry(platform: NodeJS.Platform, entry: string): string {
+  // Windows paths are case-insensitive and a trailing separator is noise.
+  return platform === "win32"
+    ? entry.toLowerCase().replace(/[\\/]+$/, "")
+    : entry;
 }
 
 /**
  * Builds the environment used for Docker CLI processes. Existing PATH entries
  * retain priority; only present, missing candidates are appended.
  *
- * Windows is deliberately returned by identity. Rebuilding its environment
- * can collapse duplicate PATH/Path keys before Node launches the child.
+ * Windows hazard, handled explicitly: Windows environment names are
+ * case-insensitive, so `PATH` and `Path` are the SAME variable. Writing a
+ * literal `PATH` key into an environment that already carries `Path` would
+ * hand `child_process` two entries for one variable. `resolveEnvKey` finds
+ * the spelling the environment already uses and the value is written back to
+ * THAT key, so the object always carries exactly one path variable.
+ *
+ * This function used to return `process.env` by identity on Windows, which
+ * meant Windows augmentation never happened at all. It is not a substitute
+ * for `locate.ts`: augmenting a stale PATH cannot reveal an install the
+ * snapshot never saw, which is why detection resolves the CLI on the
+ * filesystem first and this only shapes the child's environment.
  */
 export function buildDockerPath(
   options: BuildDockerPathOptions,
 ): NodeJS.ProcessEnv {
   const { platform, homedir, env, dirExists } = options;
-  if (platform === "win32") return env;
-
-  const inheritedPath = env.PATH ?? "";
-  const knownEntries = new Set(inheritedPath.split(":").filter(Boolean));
-  const appended = dockerPathCandidates(platform, homedir).filter(
-    (candidate) => !knownEntries.has(candidate) && dirExists(candidate),
+  const delimiter = pathDelimiter(platform);
+  const pathKey = resolveEnvKey(env, "PATH") ?? "PATH";
+  const inheritedPath = env[pathKey] ?? "";
+  const knownEntries = new Set(
+    inheritedPath
+      .split(delimiter)
+      .filter(Boolean)
+      .map((entry) => comparableEntry(platform, entry)),
   );
-  const path = [inheritedPath, ...appended].filter(Boolean).join(":");
+  const appended = dockerCliDirectories({ platform, homedir, env }).filter(
+    (candidate) =>
+      !knownEntries.has(comparableEntry(platform, candidate)) &&
+      dirExists(candidate),
+  );
+  const path = [inheritedPath, ...appended].filter(Boolean).join(delimiter);
 
-  return { ...env, PATH: path };
+  return { ...env, [pathKey]: path };
 }
 
 function directoryExists(path: string): boolean {

--- a/vex-app/src/main/docker/endpoint-policy.ts
+++ b/vex-app/src/main/docker/endpoint-policy.ts
@@ -105,16 +105,32 @@ export function classifyDockerEndpoint(
   };
 }
 
+/**
+ * @param dockerCommand absolute path to the located Docker CLI, or `null`
+ * when no CLI was found. Passing `null` skips the spawns entirely rather
+ * than spending two ENOENT round-trips to learn what the locator already
+ * established.
+ */
 export async function inspectDockerEndpointPolicy(
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  dockerCommand: string | null = "docker"
 ): Promise<DockerEndpointPolicy> {
+  if (dockerCommand === null) {
+    return classifyDockerEndpoint({
+      dockerHost: normalizeDockerHost(process.env.DOCKER_HOST),
+      currentContext: null,
+      contextHost: null,
+      contextInspectable: false,
+      dockerCliAvailable: false,
+    });
+  }
   const [contextShow, contextHost] = await Promise.all([
-    runSpawn("docker", ["context", "show"], {
+    runSpawn(dockerCommand, ["context", "show"], {
       ...(signal !== undefined ? { signal } : {}),
       timeoutMs: CONTEXT_TIMEOUT_MS,
     }),
     runSpawn(
-      "docker",
+      dockerCommand,
       ["context", "inspect", "--format", "{{json .Endpoints.docker.Host}}"],
       {
         ...(signal !== undefined ? { signal } : {}),

--- a/vex-app/src/main/docker/engine-endpoint.ts
+++ b/vex-app/src/main/docker/engine-endpoint.ts
@@ -1,0 +1,154 @@
+/**
+ * Docker Engine liveness, probed WITHOUT the Docker CLI.
+ *
+ * `docker info` can only answer "is the daemon up" when a working CLI is
+ * already located; this connects to the engine's local endpoint directly so
+ * the two questions ("is Docker installed" and "is the engine answering")
+ * stop sharing one boolean.
+ *
+ * IMPORTANT - this is a HINT, not a decision procedure. `DOCKER_HOST` and
+ * Docker contexts can move the endpoint anywhere, so a user with a custom
+ * context will fail this probe while having a perfectly reachable engine.
+ * Callers must therefore never let `not_running` override a successful
+ * `docker info`; only `permission_denied` is used to sharpen a failure that
+ * the CLI already reported.
+ *
+ * The connection outcome is triaged into distinct states because collapsing
+ * "nothing is listening", "the socket denied us", and "something else went
+ * wrong" into one failure is exactly the error class this task exists to
+ * remove.
+ */
+
+import { createConnection, type Socket } from "node:net";
+import path from "node:path";
+
+export type DockerEngineReachability =
+  | { readonly kind: "reachable"; readonly endpoint: string }
+  | { readonly kind: "not_running" }
+  | { readonly kind: "permission_denied"; readonly endpoint: string }
+  | { readonly kind: "unknown"; readonly errorCode: string | null };
+
+const CONNECT_TIMEOUT_MS = 1_500;
+
+/**
+ * The DOCUMENTED default local endpoints, in probe order.
+ *
+ * Windows: `\\.\pipe\docker_engine` is still moby's `DefaultNamedPipe`.
+ * macOS/Linux: Docker Desktop's per-user socket is tried before
+ * `/var/run/docker.sock`, which on Desktop installs only exists when the
+ * user enabled the default-socket option.
+ */
+export function defaultDockerEngineEndpoints(ctx: {
+  readonly platform: NodeJS.Platform;
+  readonly homedir: string;
+}): ReadonlyArray<string> {
+  if (ctx.platform === "win32") return ["\\\\.\\pipe\\docker_engine"];
+  if (ctx.platform === "darwin") {
+    return [
+      path.posix.join(ctx.homedir, ".docker/run/docker.sock"),
+      "/var/run/docker.sock",
+    ];
+  }
+  if (ctx.platform === "linux") {
+    return [
+      "/var/run/docker.sock",
+      path.posix.join(ctx.homedir, ".docker/desktop/docker.sock"),
+    ];
+  }
+  return [];
+}
+
+export function classifyConnectError(
+  code: string | null,
+  endpoint: string,
+): DockerEngineReachability {
+  switch (code) {
+    // Nothing is listening: pipe/socket absent, or present but refusing.
+    case "ENOENT":
+    case "ECONNREFUSED":
+    case "ECONNRESET":
+    case "EPIPE":
+      return { kind: "not_running" };
+    // The endpoint exists and the OS refused this process.
+    case "EACCES":
+    case "EPERM":
+      return { kind: "permission_denied", endpoint };
+    default:
+      return { kind: "unknown", errorCode: code };
+  }
+}
+
+/** Connects once to a single endpoint and triages the outcome. */
+export function probeEngineEndpointOnce(
+  endpoint: string,
+  signal?: AbortSignal,
+  timeoutMs: number = CONNECT_TIMEOUT_MS,
+): Promise<DockerEngineReachability> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let socket: Socket | null = null;
+    const settle = (result: DockerEngineReachability): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      socket?.removeAllListeners();
+      socket?.destroy();
+      resolve(result);
+    };
+    const onAbort = (): void => settle({ kind: "unknown", errorCode: null });
+    const timer = setTimeout(
+      // A connect that never completes is "alive but not answering", which
+      // is neither reachable nor proof that nothing is there.
+      () => settle({ kind: "unknown", errorCode: "ETIMEDOUT" }),
+      timeoutMs,
+    );
+    if (signal?.aborted === true) {
+      settle({ kind: "unknown", errorCode: null });
+      return;
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      socket = createConnection({ path: endpoint });
+    } catch (cause) {
+      const code =
+        cause && typeof cause === "object" && "code" in cause
+          ? String((cause as { code: unknown }).code)
+          : null;
+      settle(classifyConnectError(code, endpoint));
+      return;
+    }
+    socket.once("connect", () => settle({ kind: "reachable", endpoint }));
+    socket.once("error", (cause: NodeJS.ErrnoException) => {
+      settle(classifyConnectError(cause.code ?? null, endpoint));
+    });
+  });
+}
+
+/**
+ * Probes the documented default endpoints in order and returns the most
+ * informative outcome: a reachable endpoint wins, then a permission denial,
+ * then any unknown error, and only otherwise "not running".
+ */
+export async function probeDockerEngineEndpoint(ctx: {
+  readonly platform: NodeJS.Platform;
+  readonly homedir: string;
+  readonly signal?: AbortSignal;
+  readonly connect?: (
+    endpoint: string,
+    signal?: AbortSignal,
+  ) => Promise<DockerEngineReachability>;
+}): Promise<DockerEngineReachability> {
+  const connect = ctx.connect ?? probeEngineEndpointOnce;
+  const endpoints = defaultDockerEngineEndpoints(ctx);
+  let fallback: DockerEngineReachability = { kind: "not_running" };
+  for (const endpoint of endpoints) {
+    const result = await connect(endpoint, ctx.signal);
+    if (result.kind === "reachable") return result;
+    if (result.kind === "permission_denied") return result;
+    if (result.kind === "unknown" && fallback.kind === "not_running") {
+      fallback = result;
+    }
+  }
+  return fallback;
+}

--- a/vex-app/src/main/docker/engine-start-window.ts
+++ b/vex-app/src/main/docker/engine-start-window.ts
@@ -1,0 +1,38 @@
+/**
+ * Owner of the bounded "the engine is coming up" window.
+ *
+ * There is NO documented Docker model that distinguishes "installed but not
+ * started" from "starting" from "running", and nothing documented about when
+ * the endpoint appears relative to readiness. So `engine_starting` is NOT
+ * inferred from any probe. It exists only inside a bounded window after Vex
+ * itself attempted a start, which is the one moment we can honestly claim
+ * the engine is expected to be coming up. Outside that window a
+ * non-answering engine is reported as `engine_stopped`.
+ *
+ * The window is deliberately generous: a starting daemon needs a far larger
+ * budget than a steady-state one, and Docker Desktop routinely needs tens of
+ * seconds before it answers.
+ */
+
+export const ENGINE_START_WINDOW_MS = 150_000;
+
+let lastStartAttemptAt: number | null = null;
+
+/** Called by the start action when Vex actually launched Docker. */
+export function markDockerEngineStartAttempt(now: number = Date.now()): void {
+  lastStartAttemptAt = now;
+}
+
+export function isWithinEngineStartWindow(now: number = Date.now()): boolean {
+  if (lastStartAttemptAt === null) return false;
+  if (now - lastStartAttemptAt >= ENGINE_START_WINDOW_MS) {
+    lastStartAttemptAt = null;
+    return false;
+  }
+  return true;
+}
+
+/** Closed as soon as the engine answers, and by tests between cases. */
+export function clearDockerEngineStartWindow(): void {
+  lastStartAttemptAt = null;
+}

--- a/vex-app/src/main/docker/installer-urls.ts
+++ b/vex-app/src/main/docker/installer-urls.ts
@@ -17,7 +17,8 @@ export interface InstallerUrlEntry {
 export type DesktopPlatform =
   | "macos-arm64"
   | "macos-x64"
-  | "windows-x64";
+  | "windows-x64"
+  | "windows-arm64";
 
 export const DESKTOP_INSTALLER_URLS: Readonly<
   Record<DesktopPlatform, InstallerUrlEntry>
@@ -32,6 +33,13 @@ export const DESKTOP_INSTALLER_URLS: Readonly<
   },
   "windows-x64": {
     url: "https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe",
+    filename: "Docker Desktop Installer.exe",
+  },
+  // Windows on arm64 (Snapdragon-class machines). Docker ships this build
+  // today; the architecture lives ONLY in the URL path segment, the served
+  // basename is identical to the amd64 one.
+  "windows-arm64": {
+    url: "https://desktop.docker.com/win/main/arm64/Docker%20Desktop%20Installer.exe",
     filename: "Docker Desktop Installer.exe",
   },
 };
@@ -49,6 +57,7 @@ export function getInstallerForPlatform(
   if (platform === "darwin" && arch === "arm64") return DESKTOP_INSTALLER_URLS["macos-arm64"];
   if (platform === "darwin" && arch === "x64") return DESKTOP_INSTALLER_URLS["macos-x64"];
   if (platform === "win32" && arch === "x64") return DESKTOP_INSTALLER_URLS["windows-x64"];
+  if (platform === "win32" && arch === "arm64") return DESKTOP_INSTALLER_URLS["windows-arm64"];
   return null;
 }
 

--- a/vex-app/src/main/docker/locate.ts
+++ b/vex-app/src/main/docker/locate.ts
@@ -1,0 +1,278 @@
+/**
+ * Single owner for "where is Docker installed on this machine".
+ *
+ * Why this module exists: `process.env` in the Electron main process is a
+ * snapshot taken when the app launched. Windows gives a running process no
+ * way to observe a later PATH change (the environment block is per-process
+ * and fixed at creation), so a Docker Desktop installed AFTER Vex started is
+ * invisible to any PATH-only detector until the app restarts. That is the
+ * "I installed Docker but Vex still says install Docker" report.
+ *
+ * The fix is ordering: KNOWN INSTALL DIRECTORIES ARE PROBED ON THE
+ * FILESYSTEM FIRST, and PATH is only the fallback. A filesystem probe is
+ * immune to the stale environment snapshot.
+ *
+ * Path probing is a heuristic and never a decision procedure: Docker's
+ * installer supports `--installation-dir=<path>`, so a fixed-path-only
+ * detector would report "not installed" for a perfectly working Docker.
+ * That is why PATH must remain in the chain.
+ *
+ * Everything here takes `platform`, `env`, `homedir` and `fileExists` as
+ * injected parameters so Windows resolution is testable from any host OS.
+ */
+
+import { statSync } from "node:fs";
+import { homedir as osHomedir } from "node:os";
+import path from "node:path";
+
+/** Where a located Docker CLI came from. Never carries the path itself
+ * across the process boundary - a local install path is not renderer data. */
+export type DockerCliSource = "install_dir" | "path";
+
+export interface DockerCliLocation {
+  /** Absolute path. Callers spawn THIS, never the bare name `docker`. */
+  readonly executablePath: string;
+  readonly source: DockerCliSource;
+}
+
+export interface LocatorContext {
+  readonly platform: NodeJS.Platform;
+  readonly homedir: string;
+  readonly env: NodeJS.ProcessEnv;
+  /** True only for an existing, non-directory entry. */
+  readonly fileExists: (candidate: string) => boolean;
+}
+
+/** Documented Windows default when PATHEXT is absent from the environment. */
+export const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+function pathApi(platform: NodeJS.Platform): path.PlatformPath {
+  return platform === "win32" ? path.win32 : path.posix;
+}
+
+/**
+ * Reads an environment variable by a case-insensitive key match. Windows
+ * environment names are case-insensitive and preserve first-set casing, so
+ * `PATH` and `Path` are the same variable and either spelling can be the
+ * one that actually exists.
+ */
+export function getEnvCaseInsensitive(
+  env: NodeJS.ProcessEnv,
+  key: string,
+): string | undefined {
+  const direct = env[key];
+  if (direct !== undefined) return direct;
+  const lowercaseKey = key.toLowerCase();
+  for (const name of Object.keys(env)) {
+    if (name.toLowerCase() === lowercaseKey) return env[name];
+  }
+  return undefined;
+}
+
+/**
+ * Resolves the key spelling an environment variable ALREADY uses, so a
+ * caller can write back to that same key instead of creating a second one.
+ * Assigning `PATH` to an environment that already carries `Path` produces
+ * two entries for one Windows variable and the child process may inherit
+ * the wrong one.
+ */
+export function resolveEnvKey(
+  env: NodeJS.ProcessEnv,
+  key: string,
+): string | null {
+  if (Object.prototype.hasOwnProperty.call(env, key)) return key;
+  const lowercaseKey = key.toLowerCase();
+  for (const name of Object.keys(env)) {
+    if (name.toLowerCase() === lowercaseKey) return name;
+  }
+  return null;
+}
+
+function nonEmpty(value: string | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function dedupe(values: ReadonlyArray<string>): ReadonlyArray<string> {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    const key = value.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(value);
+  }
+  return out;
+}
+
+/**
+ * Docker Desktop install roots on Windows, in probe order.
+ *
+ * Per-user (`%LOCALAPPDATA%\Programs\DockerDesktop` - the directory name has
+ * no space) is Docker's current DEFAULT install mode, so it is tried first;
+ * the all-users mode installs under `<ProgramFiles>\Docker\Docker`.
+ * `ProgramW6432` precedes `ProgramFiles` because a 32-bit host process sees
+ * the redirected `Program Files (x86)` value in `ProgramFiles`.
+ *
+ * Both the CLI (`resources\bin`) and the GUI executable (`Docker
+ * Desktop.exe`) live under these roots, which is why the probe and the
+ * daemon starter share this one list.
+ */
+export function dockerDesktopInstallRoots(
+  env: NodeJS.ProcessEnv,
+): ReadonlyArray<string> {
+  const win = path.win32;
+  const roots: string[] = [];
+  const localAppData = getEnvCaseInsensitive(env, "LOCALAPPDATA");
+  if (nonEmpty(localAppData)) {
+    roots.push(win.join(localAppData, "Programs", "DockerDesktop"));
+  }
+  for (const key of ["ProgramW6432", "ProgramFiles", "ProgramFiles(x86)"]) {
+    const base = getEnvCaseInsensitive(env, key);
+    if (nonEmpty(base)) roots.push(win.join(base, "Docker", "Docker"));
+  }
+  return dedupe(roots);
+}
+
+/**
+ * Directories that may hold the Docker CLI, in probe order.
+ *
+ * On Windows these are derived from the install roots above. Docker's
+ * documentation proves `<installroot>\resources\bin` is the CLI tools
+ * directory but does not name `docker.exe` there by path, so this is a
+ * strong candidate rather than a certainty - hence the PATH fallback.
+ */
+export function dockerCliDirectories(ctx: {
+  readonly platform: NodeJS.Platform;
+  readonly homedir: string;
+  readonly env: NodeJS.ProcessEnv;
+}): ReadonlyArray<string> {
+  const { platform, homedir, env } = ctx;
+  if (platform === "win32") {
+    const win = path.win32;
+    return dockerDesktopInstallRoots(env).map((root) =>
+      win.join(root, "resources", "bin"),
+    );
+  }
+  if (platform === "darwin") {
+    return [
+      "/usr/local/bin",
+      "/opt/homebrew/bin",
+      path.posix.join(homedir, ".docker/bin"),
+      path.posix.join(homedir, ".orbstack/bin"),
+      path.posix.join(homedir, ".rd/bin"),
+      "/Applications/Docker.app/Contents/Resources/bin",
+    ];
+  }
+  if (platform === "linux") {
+    return [
+      "/usr/local/bin",
+      "/usr/bin",
+      "/snap/bin",
+      path.posix.join(homedir, "bin"),
+    ];
+  }
+  return [];
+}
+
+/**
+ * Finds `command` on the environment's PATH and returns its absolute path.
+ *
+ * Relative PATH entries are deliberately SKIPPED. The standard algorithm
+ * resolves them against the current working directory; in a privileged main
+ * process that would let the working directory decide which binary is
+ * executed, which is not an acceptable trust boundary for a tool that will
+ * be spawned.
+ */
+export function findExecutableOnPath(
+  command: string,
+  ctx: LocatorContext,
+): string | null {
+  const { platform, env, fileExists } = ctx;
+  const p = pathApi(platform);
+  const rawPath = getEnvCaseInsensitive(env, "PATH");
+  if (!nonEmpty(rawPath)) return null;
+
+  const delimiter = platform === "win32" ? ";" : ":";
+  const names: string[] = [];
+  if (platform === "win32") {
+    const pathExt = getEnvCaseInsensitive(env, "PATHEXT") ?? DEFAULT_PATHEXT;
+    for (const ext of pathExt.split(";")) {
+      const trimmed = ext.trim();
+      if (trimmed.length > 0) names.push(`${command}${trimmed}`);
+    }
+    // Extensionless last: PATHEXT decides what Windows would actually run.
+    names.push(command);
+  } else {
+    names.push(command);
+  }
+
+  for (const rawEntry of rawPath.split(delimiter)) {
+    // Windows tolerates quoted PATH entries containing spaces.
+    const entry = rawEntry.trim().replace(/^"(.*)"$/, "$1");
+    if (entry.length === 0) continue;
+    if (!p.isAbsolute(entry)) continue;
+    for (const name of names) {
+      const candidate = p.join(entry, name);
+      if (fileExists(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Locates the Docker CLI: known install directories first, PATH second.
+ * Returns `null` when neither strategy finds a file. This function performs
+ * NO spawn - validation (running `--version` on the absolute path) is the
+ * caller's step, so an unusable candidate is reported as a probe error and
+ * never as "not installed".
+ */
+export function locateDockerCli(ctx: LocatorContext): DockerCliLocation | null {
+  const { platform, fileExists } = ctx;
+  const p = pathApi(platform);
+  const exeName = platform === "win32" ? "docker.exe" : "docker";
+
+  for (const dir of dockerCliDirectories(ctx)) {
+    const candidate = p.join(dir, exeName);
+    if (fileExists(candidate)) {
+      return { executablePath: candidate, source: "install_dir" };
+    }
+  }
+
+  const onPath = findExecutableOnPath("docker", ctx);
+  return onPath === null ? null : { executablePath: onPath, source: "path" };
+}
+
+/** Locates the Docker Desktop GUI executable under the same install roots. */
+export function locateDockerDesktopExe(ctx: {
+  readonly env: NodeJS.ProcessEnv;
+  readonly fileExists: (candidate: string) => boolean;
+}): string | null {
+  for (const root of dockerDesktopInstallRoots(ctx.env)) {
+    const candidate = path.win32.join(root, "Docker Desktop.exe");
+    if (ctx.fileExists(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Existing, non-directory entry. Mirrors what an exec would accept. */
+export function isExistingFile(candidate: string): boolean {
+  try {
+    return !statSync(candidate).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Real-environment locator. Deliberately UNCACHED: it is recomputed per
+ * probe/spawn so "Recheck" observes a Docker installed while Vex was
+ * already running. The cost is a handful of `statSync` calls.
+ */
+export function resolveDockerCli(): DockerCliLocation | null {
+  return locateDockerCli({
+    platform: process.platform,
+    homedir: osHomedir(),
+    env: process.env,
+    fileExists: isExistingFile,
+  });
+}

--- a/vex-app/src/main/docker/probe/daemon.ts
+++ b/vex-app/src/main/docker/probe/daemon.ts
@@ -21,6 +21,12 @@ import {
 import { isPortFree, isModelRunnerEndpointReachable } from "./ports.js";
 import { getAvailableDiskGB } from "./disk.js";
 import { dockerSpawnEnv } from "../cli-env.js";
+import { resolveDockerCli } from "../locate.js";
+import { probeDockerEngineEndpoint } from "../engine-endpoint.js";
+import {
+  clearDockerEngineStartWindow,
+  isWithinEngineStartWindow,
+} from "../engine-start-window.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -90,8 +96,69 @@ async function runCmd(
 
 // ── Composite probe ──────────────────────────────────────────────────
 
-import type { DockerStatus } from "@shared/schemas/docker.js";
+import {
+  deriveDockerStatusFlags,
+  type DockerEngineState,
+  type DockerStatus,
+} from "@shared/schemas/docker.js";
+import { homedir as osHomedir } from "node:os";
+import type { DockerEngineReachability } from "../engine-endpoint.js";
+import type { DockerEndpointPolicy } from "../endpoint-policy.js";
 import { inspectDockerEndpointPolicy } from "../endpoint-policy.js";
+
+interface EngineStateInput {
+  readonly cliFound: boolean;
+  readonly versionOk: boolean;
+  readonly version: string | null;
+  readonly versionErrorMessage: string | null;
+  readonly endpoint: DockerEndpointPolicy;
+  readonly daemonRunning: boolean;
+  readonly reachability: DockerEngineReachability;
+  readonly startWindowOpen: boolean;
+}
+
+/**
+ * Resolves the six engine states. Order matters and each branch is a
+ * distinct, actionable outcome - "unavailable", "denied" and "unknown" are
+ * never folded into one failure.
+ *
+ * `reachability` is only ever allowed to SHARPEN a failure the CLI already
+ * reported. It can never contradict a successful `docker info`, because a
+ * user with a custom Docker context has a reachable engine on an endpoint
+ * this probe does not know about.
+ */
+export function classifyEngineState(input: EngineStateInput): DockerEngineState {
+  if (!input.cliFound) return { kind: "not_installed" };
+  if (!input.versionOk || input.version === null) {
+    return {
+      kind: "error",
+      reason: "probe_error",
+      message:
+        input.versionErrorMessage !== null
+          ? "The Docker CLI was found but did not report a usable version."
+          : "The Docker CLI was found but its version output could not be read.",
+    };
+  }
+  if (!input.endpoint.accepted) {
+    return {
+      kind: "error",
+      reason: "endpoint_rejected",
+      message:
+        input.endpoint.message ??
+        "The active Docker endpoint is not a supported local endpoint.",
+    };
+  }
+  if (input.daemonRunning) return { kind: "ready" };
+  if (input.reachability.kind === "permission_denied") {
+    return {
+      kind: "permission_denied",
+      message:
+        "The Docker engine socket refused this process. Add your user to the Docker group (or grant socket access) and retry.",
+    };
+  }
+  if (input.startWindowOpen) return { kind: "engine_starting" };
+  return { kind: "engine_stopped" };
+}
 
 export interface DockerProbeOpts {
   readonly signal?: AbortSignal;
@@ -103,25 +170,53 @@ export interface DockerProbeOpts {
 export async function probeDocker(opts: DockerProbeOpts): Promise<DockerStatus> {
   const { signal, pgPort, modelRunnerBaseUrl, diskTarget } = opts;
 
-  const [versionRes, composeRes, endpoint, pgFree, diskGB] =
+  // Filesystem-first resolution (see `../locate.ts`). This is what makes
+  // "Recheck" work after an install: `process.env` is a launch-time snapshot
+  // and on Windows a running process can never see a later PATH change, so a
+  // PATH-only detector reports "not installed" until Vex restarts.
+  const location = resolveDockerCli();
+  const dockerCommand = location?.executablePath ?? null;
+  const notLocated: RunResult = {
+    ok: false,
+    notFound: true,
+    stdout: "",
+    stderr: "",
+    errorMessage: null,
+  };
+
+  const [versionRes, composeRes, endpoint, reachability, pgFree, diskGB] =
     await Promise.all([
-      runCmd("docker", ["--version"], signal),
-      runCmd("docker", ["compose", "version"], signal),
-      inspectDockerEndpointPolicy(signal),
+      dockerCommand === null
+        ? Promise.resolve(notLocated)
+        : runCmd(dockerCommand, ["--version"], signal),
+      dockerCommand === null
+        ? Promise.resolve(notLocated)
+        : runCmd(dockerCommand, ["compose", "version"], signal),
+      inspectDockerEndpointPolicy(signal, dockerCommand),
+      probeDockerEngineEndpoint({
+        platform: process.platform,
+        homedir: osHomedir(),
+        ...(signal !== undefined ? { signal } : {}),
+      }),
       isPortFree("127.0.0.1", pgPort, signal),
       getAvailableDiskGB(diskTarget),
     ]);
 
-  const engineVersion = versionRes.ok ? parseDockerVersion(versionRes.stdout) : null;
+  // Per the `findGit` pattern: a candidate is only accepted once spawning
+  // its ABSOLUTE path yields a parseable version.
+  const engineVersion = versionRes.ok
+    ? parseDockerVersion(versionRes.stdout)
+    : null;
+  const cliUsable = versionRes.ok && engineVersion !== null;
   const composeVersion = composeRes.ok ? parseComposeVersion(composeRes.stdout) : null;
   let modelStatus: ModelStatusKind = "unsupported";
   let daemonRunning = false;
   let mrTcp = false;
 
-  if (versionRes.ok && endpoint.accepted) {
+  if (dockerCommand !== null && cliUsable && endpoint.accepted) {
     const [modelRes, infoRes, modelRunnerTcp] = await Promise.all([
-      runCmd("docker", ["model", "status"], signal),
-      runCmd("docker", ["info", "--format", "{{json .}}"], signal),
+      runCmd(dockerCommand, ["model", "status"], signal),
+      runCmd(dockerCommand, ["info", "--format", "{{json .}}"], signal),
       isModelRunnerEndpointReachable(modelRunnerBaseUrl, signal),
     ]);
     modelStatus = parseModelStatus(modelRes.stdout, modelRes.errorMessage);
@@ -129,17 +224,30 @@ export async function probeDocker(opts: DockerProbeOpts): Promise<DockerStatus> 
     mrTcp = modelRunnerTcp;
   }
 
+  const state = classifyEngineState({
+    cliFound: dockerCommand !== null,
+    versionOk: versionRes.ok,
+    version: engineVersion,
+    versionErrorMessage: versionRes.errorMessage,
+    endpoint,
+    daemonRunning,
+    reachability,
+    startWindowOpen: isWithinEngineStartWindow(),
+  });
+  // The engine answered, so the "we just started it" window has served its
+  // purpose and must not colour a later stop as "starting".
+  if (state.kind === "ready") clearDockerEngineStartWindow();
+
+  const flags = deriveDockerStatusFlags(state);
+
   return {
     endpoint,
     engine: {
-      present: versionRes.ok,
+      state,
       version: engineVersion,
-      runtimeOK: versionRes.ok && endpoint.accepted && daemonRunning,
-      failure: versionRes.ok
-        ? null
-        : versionRes.notFound
-          ? "cli_not_found"
-          : "probe_error",
+      cliSource: location?.source ?? null,
+      present: flags.present,
+      runtimeOK: flags.runtimeOK,
     },
     compose: {
       present: composeRes.ok,
@@ -151,10 +259,10 @@ export async function probeDocker(opts: DockerProbeOpts): Promise<DockerStatus> 
       tcpReachable: mrTcp,
     },
     daemon: {
-      running: daemonRunning,
+      running: flags.daemonRunning,
       // Startable means Vex can attempt a non-privileged start. Linux Docker
       // Engine may still require user/admin action outside Vex.
-      startable: versionRes.ok,
+      startable: flags.daemonStartable,
     },
     ports: {
       vexPgFree: pgFree,

--- a/vex-app/src/main/docker/spawn-runner.ts
+++ b/vex-app/src/main/docker/spawn-runner.ts
@@ -12,6 +12,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { redact } from "../logger/redact.js";
 import { dockerSpawnEnv } from "./cli-env.js";
+import { resolveDockerCli } from "./locate.js";
 import { withoutManagedSecrets } from "./env-hygiene.js";
 
 export interface SpawnRunnerOptions {
@@ -101,6 +102,15 @@ export async function runSpawn(
     : command === "docker"
       ? dockerSpawnEnv()
       : withoutManagedSecrets(process.env);
+  // One owner decides where `docker` lives (`locate.ts`), so every caller -
+  // the probe, the endpoint policy inspector, the daemon starter - resolves
+  // to the SAME executable instead of each getting whatever a stale PATH
+  // snapshot happens to hold. Falling back to the bare name only preserves
+  // the previous ENOENT behaviour when nothing was located.
+  const spawnCommand =
+    command === "docker"
+      ? (resolveDockerCli()?.executablePath ?? command)
+      : command;
 
   return new Promise((resolve) => {
     let aborted = false;
@@ -149,7 +159,7 @@ export async function runSpawn(
       }
     };
 
-    const child: ChildProcess = spawn(command, [...args], {
+    const child: ChildProcess = spawn(spawnCommand, [...args], {
       cwd,
       env: spawnEnv,
       stdio: ["ignore", "pipe", "pipe"],

--- a/vex-app/src/main/docker/start.ts
+++ b/vex-app/src/main/docker/start.ts
@@ -11,15 +11,26 @@
  * polls `vex.docker.detect()` afterwards to verify daemon comes up.
  */
 
-import { existsSync } from "node:fs";
-import path from "node:path";
 import { runSpawn } from "./spawn-runner.js";
+import { isExistingFile, locateDockerDesktopExe } from "./locate.js";
+import { markDockerEngineStartAttempt } from "./engine-start-window.js";
 import type { StartResult } from "@shared/schemas/docker.js";
 
 export async function performStart(
   signal?: AbortSignal
 ): Promise<StartResult> {
   const platform = process.platform;
+  const result = await runStart(platform, signal);
+  // Opens the bounded window in which the probe may honestly report
+  // `engine_starting` rather than `engine_stopped`.
+  if (result.kind === "started") markDockerEngineStartAttempt();
+  return result;
+}
+
+async function runStart(
+  platform: NodeJS.Platform,
+  signal?: AbortSignal
+): Promise<StartResult> {
   if (platform === "darwin") return startMac(signal);
   if (platform === "win32") return startWindows(signal);
   if (platform === "linux") return startLinux(signal);
@@ -59,30 +70,14 @@ export function escapePowershellSingleQuoted(value: string): string {
 }
 
 /**
- * Resolve the Docker Desktop GUI executable. Per-user install first
- * (Docker's currently recommended mode → `%LOCALAPPDATA%`), then the
- * all-users `%ProgramFiles%` location. Returns null when neither exists.
+ * Resolve the Docker Desktop GUI executable from the SAME install roots the
+ * CLI locator uses (`locate.ts`), so "is Docker installed" has exactly one
+ * answer in this process instead of the probe and the starter disagreeing.
  */
 export function resolveDockerDesktopExe(
   env: NodeJS.ProcessEnv = process.env
 ): string | null {
-  const candidates: string[] = [];
-  const localAppData = env["LOCALAPPDATA"];
-  if (localAppData && localAppData.length > 0) {
-    candidates.push(
-      path.join(localAppData, "Programs", "DockerDesktop", "Docker Desktop.exe")
-    );
-  }
-  const programFiles = env["ProgramFiles"];
-  if (programFiles && programFiles.length > 0) {
-    candidates.push(
-      path.join(programFiles, "Docker", "Docker", "Docker Desktop.exe")
-    );
-  }
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate;
-  }
-  return null;
+  return locateDockerDesktopExe({ env, fileExists: isExistingFile });
 }
 
 async function startWindows(signal?: AbortSignal): Promise<StartResult> {
@@ -142,7 +137,7 @@ async function startWindows(signal?: AbortSignal): Promise<StartResult> {
     return {
       kind: "failed",
       message:
-        "Could not locate Docker Desktop.exe (looked under %LOCALAPPDATA%\\Programs\\DockerDesktop and %ProgramFiles%\\Docker\\Docker). Is Docker Desktop installed?",
+        "Could not locate Docker Desktop.exe (looked under %LOCALAPPDATA%\\Programs\\DockerDesktop, %ProgramW6432%\\Docker\\Docker, %ProgramFiles%\\Docker\\Docker and %ProgramFiles(x86)%\\Docker\\Docker). If Docker Desktop was installed to a custom directory, start it from the Start menu and then click Recheck.",
     };
   }
   const psCommand = `Start-Process -FilePath '${escapePowershellSingleQuoted(

--- a/vex-app/src/main/ipc/__tests__/ipc-handler-surface/messages-usage.test.ts
+++ b/vex-app/src/main/ipc/__tests__/ipc-handler-surface/messages-usage.test.ts
@@ -272,7 +272,42 @@ describe("usage handlers", () => {
     expect((result.data as { totalCachedSavings: number }).totalCachedSavings).toBeCloseTo(-0.0033, 6);
   });
 
-  it("getLastTurn returns a turn DTO carrying the cache-savings fields", async () => {
+  // The DTO is a TURN ROLLUP across the turn's model rounds, not one
+  // `usage_log` row: input is the latest round's snapshot, output/cost are the
+  // turn's sums, and `roundCount` says how many rounds they cover. The output
+  // schema is strict, so a stale per-row payload cannot reach the renderer.
+  it("getLastTurn returns a turn rollup carrying the summed spend and round count", async () => {
+    mocks.getLastTurn.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        sessionId: SESSION,
+        latestRoundPromptTokens: 100,
+        latestRoundCachedTokens: 30,
+        turnCompletionTokens: 50,
+        turnReasoningTokens: 0,
+        turnCacheWriteTokens: 12,
+        turnCost: 0.001,
+        turnCachedSavings: 0.0004,
+        roundCount: 4,
+        currency: "USD",
+        provider: "openrouter",
+        model: "anthropic/claude-opus-4.7",
+        latestRoundAt: "2026-05-21T10:00:00.000Z",
+      },
+    });
+    const result = await call(CH.usage.getLastTurn, {
+      sessionId: SESSION,
+      currency: "USD",
+    });
+    expect(result.ok).toBe(true);
+    expect((result.data as { turnCacheWriteTokens: number }).turnCacheWriteTokens).toBe(12);
+    expect((result.data as { roundCount: number }).roundCount).toBe(4);
+  });
+
+  it("getLastTurn rejects a stale per-ROW payload at the output boundary", async () => {
+    // The regression guard for the shape change: a main-side helper that still
+    // returned one `usage_log` row must fail loudly here rather than reach the
+    // panel and be labelled a turn.
     mocks.getLastTurn.mockResolvedValueOnce({
       ok: true,
       data: {
@@ -295,8 +330,7 @@ describe("usage handlers", () => {
       sessionId: SESSION,
       currency: "USD",
     });
-    expect(result.ok).toBe(true);
-    expect((result.data as { cacheWriteTokens: number }).cacheWriteTokens).toBe(12);
+    expect(result.ok).toBe(false);
   });
 
   it("getLastTurn rejects payload without sessionId", async () => {

--- a/vex-app/src/main/ipc/__tests__/mission/get-draft.test.ts
+++ b/vex-app/src/main/ipc/__tests__/mission/get-draft.test.ts
@@ -81,6 +81,8 @@ function draft(deployedCapital: unknown): Record<string, unknown> {
     acceptance: null,
     deployedCapital,
     renewedFromMissionId: null,
+    missingFields: [],
+    canAcceptContract: true,
   };
 }
 

--- a/vex-app/src/renderer/features/appShell/MissionContractModal.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionContractModal.tsx
@@ -56,6 +56,10 @@ import {
   type CardState,
 } from "./MissionContractModal/contract-state.js";
 import { FooterAction } from "./MissionContractModal/FooterAction.js";
+import {
+  grantMissionContractRequest,
+  refuseMissionContractRequest,
+} from "./mission-contract-request.js";
 import { LaunchCeilingsSection } from "./MissionContractModal/LaunchCeilingsSection.js";
 import {
   readPlan,
@@ -116,11 +120,21 @@ export function MissionContractModal({
         // A successful accept closes the modal so the Start mission button it
         // points at is actually reachable. Every non-`accepted` outcome (and
         // any transport failure) keeps it open for the in-modal notice.
+        // Settle any pending contract request from the COMMIT, never from the
+        // press: `granted` is reported only once the engine has answered
+        // `accepted`, which is the point the acceptance actually exists. Any
+        // other resolved outcome is a real refusal, and a rejected mutation is
+        // reported as one too. A caller waiting on this must never be told
+        // `granted` for an acceptance that did not commit.
         onSuccess: (result) => {
           if (result.ok && result.data.outcome === "accepted") {
+            grantMissionContractRequest(sessionId);
             onOpenChange(false);
+            return;
           }
+          refuseMissionContractRequest(sessionId);
         },
+        onError: () => refuseMissionContractRequest(sessionId),
       },
     );
   };

--- a/vex-app/src/renderer/features/appShell/MissionContractModal/FooterAction.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionContractModal/FooterAction.tsx
@@ -15,6 +15,7 @@ import { Button } from "../../../components/ui/button.js";
 import { DialogFooter } from "../../../components/ui/dialog.js";
 import type { CardState } from "./contract-state.js";
 import type { PlanGate } from "./plan-gate.js";
+import { MissionMissingFields } from "../MissionMissingFields.js";
 
 export interface FooterActionProps {
   readonly state: CardState | null;
@@ -38,12 +39,35 @@ export function FooterAction({
   notice,
 }: FooterActionProps): JSX.Element | null {
   if (state === null) return null;
-  const { kind, currentHash } = state;
+  const { kind, currentHash, missingFields } = state;
 
   if (kind === "setup-needed") {
+    // THE defect this rewrite fixes: the old copy read "Add a goal,
+    // constraints, and stop conditions to enable Accept." - an imperative aimed
+    // at the user for fields the user CANNOT edit. `mission.updateDraft`
+    // returns `unavailable` (the host-side draft editor is deliberately
+    // stubbed), so only the agent's `MissionDraftUpdate` tool can write them.
+    // Telling the user to do the impossible was the dead end; naming the real
+    // actor, and the exact fields, is the fix. Shape follows VS Code's
+    // Restricted Mode copy: state, consequence, next action.
     return (
-      <DialogFooter className="justify-start border-line-2 text-xs text-ink-tertiary">
-        Add a goal, constraints, and stop conditions to enable Accept.
+      <DialogFooter className="flex-col items-start gap-1 border-line-2 text-xs text-ink-tertiary sm:flex-col sm:items-start">
+        <p data-vex-state="contract-incomplete">
+          Vex is still writing this contract. Accepting unlocks once every
+          required field is set, and Vex sets them from your conversation - they
+          cannot be edited here.
+        </p>
+        {missingFields.length > 0 ? (
+          <>
+            <p>Ask Vex for what is still missing:</p>
+            <MissionMissingFields
+              fields={missingFields}
+              surface="contract-modal"
+            />
+          </>
+        ) : (
+          <p>Reading the current contract state.</p>
+        )}
       </DialogFooter>
     );
   }

--- a/vex-app/src/renderer/features/appShell/MissionContractModal/contract-state.ts
+++ b/vex-app/src/renderer/features/appShell/MissionContractModal/contract-state.ts
@@ -15,33 +15,81 @@ import type {
 import type { CardStateKind } from "../MissionContractCardSections.js";
 import type { PremiumBadgeState } from "../PremiumBadge.js";
 import type { PlanGate } from "./plan-gate.js";
+import { resolveMissionReadiness } from "../mission-readiness.js";
 
 export interface CardState {
   readonly kind: CardStateKind;
   readonly draft: MissionDraftDto;
   readonly currentHash: string | null;
+  /**
+   * The engine's own list of required contract fields still unfilled. Non-empty
+   * only in `setup-needed`, and the footer ENUMERATES it there rather than
+   * summarising - "the contract is incomplete" is not actionable.
+   */
+  readonly missingFields: readonly string[];
 }
 
 type ReadyDiff = Extract<MissionGetDiffResult, { outcome: "ready" }>;
 
+/**
+ * Project THE shared readiness selector onto the modal's card state.
+ *
+ * This used to be its own hand-rolled chain that keyed off `draft.status`, one
+ * of three copies of the same predicate. It is now a projection, so the modal
+ * cannot disagree with the header badge or the controls strip about whether the
+ * contract is acceptable. `awaiting-plan` deliberately collapses into
+ * `awaiting-acceptance` here: the footer owns the plan block itself (`planGate`)
+ * and needs the hash to render its own refusal.
+ */
 export function resolveCardState(
   draft: MissionDraftDto | null,
   diff: ReadyDiff | null,
 ): CardState | null {
   if (draft === null) return null;
-  if (draft.status === "draft") {
-    return { kind: "setup-needed", draft, currentHash: null };
+  const readiness = resolveMissionReadiness({
+    draft,
+    diff,
+    // The footer owns the plan gate; readiness here answers the CONTRACT
+    // question only, so the plan is reported as known-and-absent.
+    plan: null,
+    planKnown: true,
+    setupStalled: false,
+  });
+  switch (readiness.kind) {
+    case "none":
+      return null;
+    case "drafting":
+      return {
+        kind: "setup-needed",
+        draft,
+        currentHash: null,
+        missingFields: readiness.missingFields,
+      };
+    case "contract-loading":
+      return { kind: "setup-needed", draft, currentHash: null, missingFields: [] };
+    case "accepted":
+      return { kind: "accepted", draft, currentHash: null, missingFields: [] };
+    case "dirty-acceptance":
+      return {
+        kind: "dirty-acceptance",
+        draft,
+        currentHash: readiness.currentHash,
+        missingFields: [],
+      };
+    case "awaiting-plan":
+    case "plan-unknown":
+    case "awaiting-acceptance":
+      return {
+        kind: "awaiting-acceptance",
+        draft,
+        // The two plan states are unreachable from this call (it passes
+        // `planKnown: true` with no plan, because the FOOTER owns the plan
+        // gate), but they are handled explicitly so the switch stays exhaustive
+        // and a future widening cannot fall through to `undefined`.
+        currentHash: diff?.currentHash ?? null,
+        missingFields: [],
+      };
   }
-  if (diff === null) {
-    return { kind: "setup-needed", draft, currentHash: null };
-  }
-  if (diff.isAccepted && !diff.isDirty) {
-    return { kind: "accepted", draft, currentHash: null };
-  }
-  if (diff.isAccepted && diff.isDirty) {
-    return { kind: "dirty-acceptance", draft, currentHash: diff.currentHash };
-  }
-  return { kind: "awaiting-acceptance", draft, currentHash: diff.currentHash };
 }
 
 /**

--- a/vex-app/src/renderer/features/appShell/MissionControls.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionControls.tsx
@@ -24,9 +24,21 @@
  *    one next-step surface shows at a time: while reviewable-and-settled,
  *    this bar REPLACES the standing notice below, never stacks with it.
  *  - NO ACTIVE RUN + a contract pending acceptance (any non-accepted-clean
- *    draft, still in setup or mid-turn) → a standing muted-warn notice:
- *    on-chain actions are blocked by the runtime gate until the user accepts
- *    the contract and starts the run.
+ *    draft, still in setup or mid-turn) → a standing warn notice: on-chain
+ *    actions are blocked by the runtime gate until the user accepts the
+ *    contract and starts the run. The notice is STATE-SPECIFIC and CARRIES A
+ *    CONTROL. Previously a `draft`-status contract landed on a terminal branch
+ *    that rendered the notice ALONE - no button, no link, no next action - and
+ *    the modal the user could reach from the header then told them to "Add a
+ *    goal, constraints, and stop conditions", fields the host cannot edit
+ *    (`mission.updateDraft` is a stub; only the agent's `MissionDraftUpdate`
+ *    writes them). That was a reachable dead end. Every branch now names the
+ *    state, the consequence, the next action and WHO must take it, enumerates
+ *    the engine's own `missingFields`, and offers the contract surface.
+ *
+ * Readiness is NOT derived here. `mission-readiness.ts` owns the single
+ * predicate that this strip, `MissionRail`'s badge and the contract modal all
+ * read, so the three surfaces cannot contradict each other.
  *
  * `useMissionLiveSync` is mounted here (event-driven + 30s-fallback refresh
  * of the draft/diff queries) so a dropped `transcriptAppend` event can never
@@ -74,7 +86,13 @@ import { MissionRestartAffordance } from "./MissionRestartAffordance.js";
 import { MissionErrorAlert } from "./MissionControls/MissionErrorAlert.js";
 import { useUiStore } from "../../stores/uiStore.js";
 import { useSessionPlan } from "../../lib/api/sessions.js";
-import { planMissing } from "./MissionRail.js";
+import {
+  resolveMissionReadiness,
+  type MissionReadiness,
+} from "./mission-readiness.js";
+import { requestMissionContract } from "./mission-contract-request.js";
+import { useMissionSetupProgress } from "./MissionSetupProgress.js";
+import { MissionMissingFields } from "./MissionMissingFields.js";
 
 /**
  * Primary mission action (Start/Renew) — the landing's solid cobalt CTA:
@@ -234,6 +252,8 @@ export function MissionControls({
   // Keep the draft/diff queries fresh (event-driven + 30s fallback poll) so
   // the review bar below can never be stranded by a dropped transcript event.
   useMissionLiveSync(sessionId);
+  // Setup liveness: distinguishes "still drafting" from "drafting stalled".
+  const { stalled } = useMissionSetupProgress(sessionId);
   // Turn-gate for the review bar's reveal — see the file header comment.
   const chatSubmitting = useIsChatSubmitting(sessionId);
   const setReviewModal = useUiStore((s) => s.setReviewModal);
@@ -326,19 +346,29 @@ export function MissionControls({
   // NO ACTIVE RUN → Start an accepted/ready draft; Start wins over Renew when
   // both could apply (a freshly accepted contract is the more immediate action).
   const diff = readReadyDiff(diffQuery.data);
-  const canStart =
-    draft !== null &&
-    draft.status === "ready" &&
-    diff !== null &&
-    diff.isAccepted &&
-    !diff.isDirty;
+  // THE readiness answer (see `mission-readiness.ts`). The header badge and the
+  // contract modal read the same function, so this strip can no longer disagree
+  // with either about whether the contract is acceptable.
+  const readiness = resolveMissionReadiness({
+    draft,
+    diff,
+    plan,
+    planKnown,
+    setupStalled: stalled,
+  });
+  const canStart = readiness.kind === "accepted";
   // Contract pending acceptance (a draft exists that is not accepted-clean)
   // with no active run: the runtime prequote gate fail-closes EVERY on-chain
   // broadcast (reason `wallet_setup`), so surface that as a standing notice —
   // the user must see the block deterministically, not via a paraphrased (and
-  // possibly confabulated) agent reply to a blocked tool call.
-  const pendingAcceptance = draft !== null && !canStart;
-  if (canStart) {
+  // possibly confabulated) agent reply to a blocked tool call. The notice now
+  // CARRIES the way forward instead of only naming the block.
+  const pendingAcceptance = readiness.kind !== "none" && !canStart;
+  const raiseContract = (): void => {
+    setReviewModal("mission");
+    void requestMissionContract({ sessionId, reason: "user" });
+  };
+  if (canStart && draft !== null) {
     const missionId = draft.missionId;
     return (
       <div data-vex-area="mission-controls" className="mt-3">
@@ -346,7 +376,24 @@ export function MissionControls({
           type="button"
           disabled={disabled}
           onClick={() =>
-            void run(() => start.mutateAsync({ sessionId, missionId }))
+            void run(async () => {
+              const result = await start.mutateAsync({ sessionId, missionId });
+              // Pattern 1 (VS Code `startDebugging` → `requestWorkspaceTrust`):
+              // the blocked capability RAISES the contract surface rather than
+              // reporting a refusal the user then has to act on by guesswork.
+              // Only for refusals the contract surface can actually resolve.
+              if (
+                result.ok &&
+                CONTRACT_BLOCKED_START_OUTCOMES.has(result.data.outcome)
+              ) {
+                setReviewModal("mission");
+                void requestMissionContract({
+                  sessionId,
+                  reason: "start_blocked",
+                });
+              }
+              return result;
+            })
           }
           aria-label="Start mission"
           className={PRIMARY_KEY}
@@ -365,17 +412,16 @@ export function MissionControls({
   // never wedge the bar shut. When not yet settled (or not reviewable), fall
   // through to the pre-existing affordances below unchanged — the standing
   // notice already covers this state, so nothing regresses mid-turn.
-  // `planMissing` is MissionRail's exported readiness gate: with plan-mode on
-  // and no plan body, the rail says Preparing — the bar must agree, not lead.
-  const reviewable =
-    draft !== null && draft.status === "ready" && diff !== null && !diff.isAccepted &&
-    planKnown && !planMissing(plan);
+  // The plan gate lives inside `resolveMissionReadiness`: with legacy plan-mode
+  // on and no plan body the readiness is `awaiting-plan`, so the rail says
+  // Preparing and the bar cannot lead it.
+  const reviewable = readiness.kind === "awaiting-acceptance";
   if (reviewable && !chatSubmitting) {
     return (
       <div data-vex-area="mission-controls" className="mt-3">
         <button
           type="button"
-          onClick={() => setReviewModal("mission")}
+          onClick={raiseContract}
           aria-label="Review & accept contract"
           className={REVIEW_KEY}
         >
@@ -400,7 +446,12 @@ export function MissionControls({
     const previousMissionId = renewSource.missionId;
     return (
       <div data-vex-area="mission-controls" className="mt-3">
-        {pendingAcceptance ? <AcceptancePendingNotice /> : null}
+        {pendingAcceptance ? (
+          <AcceptancePendingNotice
+            readiness={readiness}
+            onOpenContract={raiseContract}
+          />
+        ) : null}
         <button
           type="button"
           disabled={disabled}
@@ -429,11 +480,14 @@ export function MissionControls({
   }
 
   // Contract pending acceptance with nothing else to show → the standing
-  // notice alone, so the block is visible for the whole setup phase.
+  // notice, which carries its own control so this is never a dead end.
   if (pendingAcceptance) {
     return (
       <div data-vex-area="mission-controls" className="mt-3">
-        <AcceptancePendingNotice />
+        <AcceptancePendingNotice
+          readiness={readiness}
+          onOpenContract={raiseContract}
+        />
       </div>
     );
   }
@@ -442,21 +496,120 @@ export function MissionControls({
 }
 
 /**
- * Standing muted-warn notice while a mission session's contract is pending
- * acceptance: mirrors the runtime prequote gate's `wallet_setup` fail-close
- * (no active run → every swap/bridge/send broadcast is refused), so the block
- * is visible in the UI regardless of how the agent narrates it.
+ * `mission.start` refusals the CONTRACT surface can actually resolve. A refusal
+ * outside this set (lease busy, provider unavailable, an already-active run) is
+ * not a contract problem, and raising the contract for it would be a wrong
+ * answer wearing a helpful shape.
  */
-function AcceptancePendingNotice(): JSX.Element {
+const CONTRACT_BLOCKED_START_OUTCOMES: ReadonlySet<string> = new Set([
+  "not_accepted",
+  "stale_acceptance",
+  "not_ready",
+  "plan_not_accepted",
+]);
+
+/**
+ * Standing notice while a mission session's contract is pending acceptance:
+ * mirrors the runtime prequote gate's `wallet_setup` fail-close (no active run
+ * → every swap/bridge/send broadcast is refused), so the block is visible in
+ * the UI regardless of how the agent narrates it.
+ *
+ * Every branch below follows the same shape, taken from VS Code's Restricted
+ * Mode copy: STATE → CONSEQUENCE → NEXT ACTION, with the actor NAMED. The old
+ * copy stopped after the consequence, and the modal it pointed at then told the
+ * user to "Add a goal, constraints, and stop conditions" - fields the host
+ * cannot edit at all, because `mission.updateDraft` is a stub and only the
+ * agent's `MissionDraftUpdate` tool can write them. Naming the wrong actor was
+ * the specific defect; every branch here names the right one.
+ *
+ * The block itself is UNCHANGED. This is presentation over the same fail-closed
+ * gate - nothing here grants, widens or bypasses any authority.
+ */
+function AcceptancePendingNotice({
+  readiness,
+  onOpenContract,
+}: {
+  readonly readiness: MissionReadiness;
+  readonly onOpenContract: () => void;
+}): JSX.Element | null {
+  if (readiness.kind === "none" || readiness.kind === "accepted") return null;
+
+  const blocked =
+    "On-chain actions (swaps, bridges, sends) stay blocked until the contract is accepted and the mission is started.";
+
+  let headline: string;
+  let nextAction: string;
+  let actionLabel = "Show mission contract";
+  let missingFields: readonly string[] = [];
+
+  switch (readiness.kind) {
+    case "drafting":
+      missingFields = readiness.missingFields;
+      if (readiness.stalled) {
+        headline = `Vex's last reply did not add anything to the mission contract. ${blocked}`;
+        nextAction =
+          "Nothing will change until you reply. Answer Vex in the composer below, or ask it to fill what is left:";
+      } else {
+        headline = `Vex is still writing the mission contract. ${blocked}`;
+        nextAction =
+          "Only Vex can fill these fields; you cannot edit them here. Tell Vex what is still missing:";
+      }
+      break;
+    case "contract-loading":
+      headline = `Reading the mission contract. ${blocked}`;
+      nextAction = "Open the contract to see where it stands.";
+      break;
+    case "awaiting-plan":
+      headline = `The mission contract is complete, but this session's legacy plan mode has no action plan yet. ${blocked}`;
+      nextAction =
+        "Ask Vex to write the plan, then accept the contract and the plan together.";
+      break;
+    case "plan-unknown":
+      // NOT "your plan is missing" - we have not read it. Rule 08: unknown and
+      // absent are different states and must not collapse into one message.
+      headline = `The mission contract is complete, but its legacy action-plan status has not been read yet, so accepting is unavailable. ${blocked}`;
+      nextAction = "Open the contract to see the plan status and retry the read.";
+      break;
+    case "awaiting-acceptance":
+      // Reached only MID-TURN: once the turn settles, the dedicated
+      // "Review & accept contract" bar replaces this notice. The label stays
+      // the passive "Show mission contract" on purpose - promoting the accept
+      // CTA here would re-introduce exactly the mid-turn flash the turn-gate
+      // exists to prevent, on a contract the running turn may still change.
+      headline = `The mission contract looks ready. ${blocked}`;
+      nextAction = "Vex is still replying; review and accept once it settles.";
+      break;
+    case "dirty-acceptance":
+      headline = `The mission contract changed after you accepted it. ${blocked}`;
+      nextAction =
+        "Review what changed and accept the new contract to bring the runtime back in sync.";
+      actionLabel = "Review & accept new contract";
+      break;
+  }
+
   return (
-    <p
+    <div
       role="status"
       data-vex-state="acceptance-pending"
-      className="mb-2 w-full text-xs text-warning"
+      data-vex-readiness={readiness.kind}
+      className="mb-2 flex w-full flex-col gap-1.5 text-xs text-warning"
     >
-      Mission contract not accepted - on-chain actions (swaps, bridges, sends)
-      are blocked until you accept the contract and start the mission.
-    </p>
+      <p>{headline}</p>
+      <p className="text-ink-tertiary">{nextAction}</p>
+      <MissionMissingFields fields={missingFields} surface="mission-controls" />
+      {/* The action lives on the notice itself: a standing surface that names a
+          restriction must carry the way out of it (VS Code puts the command on
+          the banner, the status bar entry and the editor alike). This notice is
+          non-dismissible, so the affordance can never be closed away; the
+          header MISSION badge carries the same action independently. */}
+      <button
+        type="button"
+        onClick={onOpenContract}
+        className="mt-0.5 inline-flex h-7 w-fit items-center rounded-full border border-[var(--vex-accent-border-strong)] px-3 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--vex-accent-text)] transition-colors hover:bg-[var(--vex-accent-fill-8)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--vex-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      >
+        {actionLabel}
+      </button>
+    </div>
   );
 }
 

--- a/vex-app/src/renderer/features/appShell/MissionMissingFields.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionMissingFields.tsx
@@ -1,0 +1,48 @@
+/**
+ * The enumerated list of contract fields the agent has not filled yet.
+ *
+ * Modelled on VS Code's Restricted Mode editor, which ENUMERATES the concrete
+ * capabilities a user loses (`workspaceTrustEditor.ts`) rather than summarising
+ * them. The list is the whole point: "the contract is incomplete" is not
+ * actionable, "goal, risk profile and stop conditions are missing" is.
+ *
+ * Rendered in BOTH places that talk about an incomplete contract - the standing
+ * notice above the composer and the contract modal's footer - from the same
+ * `draft.missingFields` the engine computed, so the two can never name
+ * different fields.
+ *
+ * The complete list is rendered. No cap, no "and N more": these are the exact
+ * things the user is waiting on.
+ */
+
+import type { JSX } from "react";
+import { missionDraftFieldLabel } from "@shared/schemas/mission.js";
+
+export interface MissionMissingFieldsProps {
+  readonly fields: readonly string[];
+  /** Marks the list for tests and for the surface that owns it. */
+  readonly surface: string;
+}
+
+export function MissionMissingFields({
+  fields,
+  surface,
+}: MissionMissingFieldsProps): JSX.Element | null {
+  if (fields.length === 0) return null;
+  return (
+    <ul
+      data-vex-state="mission-missing-fields"
+      data-vex-surface={surface}
+      className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-xs text-ink-tertiary"
+    >
+      {fields.map((field) => (
+        <li
+          key={field}
+          className="rounded-full border border-[var(--vex-line-strong)] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em]"
+        >
+          {missionDraftFieldLabel(field)}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/vex-app/src/renderer/features/appShell/MissionRail.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionRail.tsx
@@ -64,6 +64,14 @@ import { useUiStore } from "../../stores/uiStore.js";
 import { MissionContractModal } from "./MissionContractModal.js";
 import { PlanDisplayModal } from "./PlanDisplayModal.js";
 import { PremiumBadge, type PremiumBadgeState } from "./PremiumBadge.js";
+import {
+  missionReadinessBadgeState,
+  resolveMissionReadiness,
+} from "./mission-readiness.js";
+import {
+  cancelMissionContractRequest,
+  requestMissionContract,
+} from "./mission-contract-request.js";
 
 export interface MissionRailProps {
   readonly activeSessionId: string | null;
@@ -159,9 +167,21 @@ export function MissionRail({
           state={mission.state}
           shimmer={mission.shimmer}
           expanded={open === "mission"}
-          onClick={() =>
-            setReviewModal(open === "mission" ? "none" : "mission")
-          }
+          // The one NON-DISMISSIBLE surface that always carries the action.
+          // VS Code's trust banner is dismissible and persists that, but its
+          // status-bar entry has no close, so the way in is never gone; the
+          // MISSION badge is our equivalent. It participates in the same
+          // request lifecycle as every other entry point, so a blocked
+          // capability waiting on the contract settles from here too.
+          onClick={() => {
+            if (open === "mission") {
+              setReviewModal("none");
+              cancelMissionContractRequest(sessionId);
+              return;
+            }
+            setReviewModal("mission");
+            void requestMissionContract({ sessionId, reason: "user" });
+          }}
         />
       ) : null}
 
@@ -187,7 +207,13 @@ export function MissionRail({
           sessionId={sessionId}
           permission={session.permission}
           open={open === "mission"}
-          onOpenChange={(next) => setReviewModal(next ? "mission" : "none")}
+          onOpenChange={(next) => {
+            setReviewModal(next ? "mission" : "none");
+            // Dismissal without a decision is `cancelled`, the third outcome,
+            // never a silent false. The accept path settles `granted`/`refused`
+            // itself before this runs, and settle is idempotent.
+            if (!next) cancelMissionContractRequest(sessionId);
+          }}
         />
       ) : null}
       {planEnabled ? (
@@ -260,23 +286,16 @@ function deriveMissionBadge(
   if (hasActiveRun || (draft === null && hasRenewable)) {
     return { state: "accepted", shimmer: false };
   }
-  if (draft === null || draft.status === "draft" || diff === null) {
-    return { state: "preparing", shimmer: false };
-  }
-  if (diff.isAccepted && !diff.isDirty) {
-    return { state: "accepted", shimmer: false };
-  }
-  if (diff.isAccepted && diff.isDirty) {
-    return { state: "stale", shimmer: false };
-  }
-  // awaiting-acceptance. Gate "ready" on the plan when plan-mode is on:
-  // plan_missing → keep preparing; otherwise ready (shimmer).
-  if (!planKnown || planMissing(plan)) {
-    // Unknown (pending/failed read) counts as missing — never flash READY
-    // on a plan state we have not actually seen.
-    return { state: "preparing", shimmer: false };
-  }
-  return { state: "ready", shimmer: true };
+  // Below the run-level overrides, the badge is a pure projection of THE shared
+  // readiness selector, the same one `MissionControls` and the contract modal
+  // read. The previous hand-rolled chain here is what let the three surfaces
+  // drift apart. `setupStalled` is deliberately not fed in: the stall is a
+  // liveness detail of the drafting state, and the badge for drafting is
+  // Preparing either way; the notice and the modal carry the distinction.
+  const state = missionReadinessBadgeState(
+    resolveMissionReadiness({ draft, diff, plan, planKnown, setupStalled: false }),
+  );
+  return { state, shimmer: state === "ready" };
 }
 
 /**
@@ -304,13 +323,11 @@ function derivePlanBadge(
 }
 
 /**
- * Plan-mode on with an empty body → the engine's `plan_missing` block.
- * Exported as THE shared mission-readiness gate: MissionControls' review bar
- * must never claim "ready" while this rail still (correctly) says Preparing.
+ * Plan-mode on with an empty body → the engine's `plan_missing` block. The
+ * definition moved into `mission-readiness.ts` alongside the rest of the
+ * readiness predicate; re-exported here for existing importers.
  */
-export function planMissing(plan: PlanGetResult | null): boolean {
-  return plan !== null && plan.enabled && !plan.accepted && plan.planMd.length === 0;
-}
+export { planMissing } from "./mission-readiness.js";
 
 type ReadyDiff = Extract<MissionGetDiffResult, { outcome: "ready" }>;
 

--- a/vex-app/src/renderer/features/appShell/MissionSetupProgress.ts
+++ b/vex-app/src/renderer/features/appShell/MissionSetupProgress.ts
@@ -1,0 +1,95 @@
+/**
+ * MISSION SETUP LIVENESS - is the contract still being drafted, or has drafting
+ * stalled?
+ *
+ * MISSION PREPARING is not self-advancing. Only the agent can fill a mission
+ * contract (`mission.updateDraft` is a deliberate stub), so when a setup turn
+ * ends without writing anything, NOTHING will change until the user speaks
+ * again. Before this hook that state was indistinguishable from progress: the
+ * engine's `applyMissionPatch` emits `mission_update` only when something
+ * changed, so "the model produced nothing" was completely silent and the header
+ * spun on PREPARING forever.
+ *
+ * `core/runner/setup-turn.ts` now emits `setup_no_progress` for exactly that
+ * case. This hook turns that event into the host-visible `stalled` flag.
+ *
+ * THRESHOLD, NOT A SPINNER. Modelled on VS Code's `DISCONNECT_PROMPT_TIME`
+ * (`contrib/remote/browser/remote.ts`), where an indefinite external wait
+ * escalates its UI after a measured delay rather than animating forever. A
+ * no-progress turn is often just the agent asking a clarifying question, and
+ * the user is usually already typing the answer - so the escalation waits
+ * {@link MISSION_SETUP_STALL_PROMPT_MS} and is cancelled outright by any real
+ * mission update. Only a wait that outlives the threshold is called stalled.
+ */
+
+import { useEffect, useState } from "react";
+
+/**
+ * How long a no-progress setup turn must go unanswered before the mission
+ * surface escalates from "still drafting" to "drafting stalled".
+ *
+ * 45s: long enough for a user to read the agent's clarifying question and start
+ * typing (so the ordinary Q-and-A rhythm never trips it), short enough that a
+ * genuinely dead draft is named while the user is still looking at it.
+ * Exported for tests.
+ */
+export const MISSION_SETUP_STALL_PROMPT_MS = 45_000;
+
+export interface MissionSetupProgress {
+  /**
+   * The last setup turn wrote nothing and the threshold has elapsed with no
+   * mission update since. Nothing will move until the user replies.
+   */
+  readonly stalled: boolean;
+}
+
+/**
+ * Subscribe a mission session's setup liveness.
+ *
+ * Owner: this hook. It owns the subscription AND the escalation timer, and
+ * clears both on unmount, on session change, and on every real mission update -
+ * so a stall flag can never outlive the state that justified it.
+ */
+export function useMissionSetupProgress(
+  sessionId: string | null,
+): MissionSetupProgress {
+  const [stalled, setStalled] = useState(false);
+
+  useEffect(() => {
+    if (sessionId === null || sessionId.length === 0) return;
+    // A fresh session starts un-stalled regardless of what the previous one did.
+    setStalled(false);
+
+    let timer: number | null = null;
+    const clearTimer = (): void => {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    const off = window.vex.engine.onMissionUpdate((event) => {
+      if (event.sessionId !== sessionId) return;
+      if (event.kind === "setup_no_progress") {
+        // Arm the escalation. A second no-progress turn restarts the wait
+        // rather than stacking a second timer.
+        clearTimer();
+        timer = window.setTimeout(
+          () => setStalled(true),
+          MISSION_SETUP_STALL_PROMPT_MS,
+        );
+        return;
+      }
+      // Any other kind reports a committed change: drafting is moving again.
+      clearTimer();
+      setStalled(false);
+    });
+
+    return () => {
+      off();
+      clearTimer();
+    };
+  }, [sessionId]);
+
+  return { stalled };
+}

--- a/vex-app/src/renderer/features/appShell/SessionTranscript/TurnStatsLine.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionTranscript/TurnStatsLine.tsx
@@ -1,8 +1,13 @@
 /**
  * The turn-stats line under the tail of a settled turn (gap A17): the last
- * turn's usage — tokens in/out, cache-hit share, cost — in the micro-label
- * micro-stat register. Mounted only while no turn is in flight; an empty or
- * unresolved usage read renders nothing (never an error surface).
+ * TURN's usage - tokens in/out, cache-hit share, cost, and the round count when
+ * the turn ran more than one model round - in the micro-label micro-stat
+ * register. Mounted only while no turn is in flight; an empty or unresolved
+ * usage read renders nothing (never an error surface).
+ *
+ * The figures are a ROLLUP across the turn's rounds, not one `usage_log` row:
+ * input is the last round's snapshot, output and cost are turn sums. See
+ * `turnUsageRollupDtoSchema` for why the two sides are deliberately asymmetric.
  */
 
 import type { JSX } from "react";

--- a/vex-app/src/renderer/features/appShell/SessionTranscript/turnStats.ts
+++ b/vex-app/src/renderer/features/appShell/SessionTranscript/turnStats.ts
@@ -1,11 +1,24 @@
 /**
- * Pure presentation of one turn's usage row as the micro-label stats groups:
+ * Pure presentation of ONE TURN's usage rollup as the micro-label stats groups:
  * tokens (in/out compact), cache-hit percent, and cost. Display-only — this
  * never touches content going to the model. Wall time is deliberately absent:
  * the usage DTO carries no duration (named gap, board 2026-08-20).
+ *
+ * A turn is a LOOP of model rounds, so the two token figures are deliberately
+ * NOT symmetric and must not be made so:
+ *
+ *   IN  = `latestRoundPromptTokens` - a SNAPSHOT of the turn's last request.
+ *         Every round re-sends the whole conversation, so a sum would count the
+ *         same tokens N times.
+ *   OUT = `turnCompletionTokens` - a RUNNING SUM over every round, because
+ *         every round generates NEW billed tokens (tool-call arguments
+ *         included; the provider bills them as completion tokens).
+ *
+ * Cost is likewise the turn's sum. `turnUsageRollupDtoSchema` carries the full
+ * contract; this module only renders it.
  */
 
-import type { TurnUsageDto } from "@shared/schemas/usage.js";
+import type { TurnUsageRollupDto } from "@shared/schemas/usage.js";
 
 /** Compact token count: 517 / 12.2K / 517K / 1.2M (one decimal under three digits). */
 export function formatTokens(n: number): string {
@@ -20,9 +33,11 @@ export function formatTokens(n: number): string {
  * Cache-hit share of the prompt side, rounded to an integer percent;
  * null when no prompt tokens were billed (a 0/0 read is not "0% cached").
  */
-export function cacheHitPercent(usage: TurnUsageDto): number | null {
-  if (usage.promptTokens === 0) return null;
-  return Math.round((usage.cachedTokens / usage.promptTokens) * 100);
+export function cacheHitPercent(usage: TurnUsageRollupDto): number | null {
+  if (usage.latestRoundPromptTokens === 0) return null;
+  return Math.round(
+    (usage.latestRoundCachedTokens / usage.latestRoundPromptTokens) * 100,
+  );
 }
 
 /**
@@ -40,18 +55,23 @@ export function formatCost(cost: number | null, currency: string): string | null
  * The displayable stat groups for one turn, in reading order. A group whose
  * measurement is absent drops out whole rather than printing a zero.
  */
-export function turnStatGroups(usage: TurnUsageDto): readonly string[] {
+export function turnStatGroups(usage: TurnUsageRollupDto): readonly string[] {
   const groups: string[] = [];
-  if (usage.promptTokens > 0 || usage.completionTokens > 0) {
+  if (usage.latestRoundPromptTokens > 0 || usage.turnCompletionTokens > 0) {
     groups.push(
-      `${formatTokens(usage.promptTokens)} in / ${formatTokens(usage.completionTokens)} out`,
+      `${formatTokens(usage.latestRoundPromptTokens)} in / ${formatTokens(usage.turnCompletionTokens)} out`,
     );
   }
   const cacheHit = cacheHitPercent(usage);
-  if (cacheHit !== null && usage.cachedTokens > 0) {
+  if (cacheHit !== null && usage.latestRoundCachedTokens > 0) {
     groups.push(`${cacheHit}% cached`);
   }
-  const cost = formatCost(usage.cost, usage.currency);
+  const cost = formatCost(usage.turnCost, usage.currency);
   if (cost !== null) groups.push(cost);
+  // A multi-round turn SAYS it is one. Without this the reader cannot tell an
+  // aggregate from a single request, and the asymmetry above (snapshot input,
+  // summed output) is invisible - which is precisely how the old single-row
+  // read passed for a turn figure for so long.
+  if (usage.roundCount > 1) groups.push(`${usage.roundCount} rounds`);
   return groups;
 }

--- a/vex-app/src/renderer/features/appShell/__tests__/CardBodyDeployedCapital.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/CardBodyDeployedCapital.test.tsx
@@ -40,6 +40,8 @@ const BASE_DRAFT: MissionDraftDto = {
   acceptance: null,
   deployedCapital: null,
   renewedFromMissionId: null,
+  missingFields: [],
+  canAcceptContract: true,
 };
 
 const DECLARED = {

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionContractModal.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionContractModal.test.tsx
@@ -19,6 +19,12 @@ import type { ReactNode } from "react";
 import { createElement } from "react";
 
 const { MissionContractModal } = await import("../MissionContractModal.js");
+const {
+  cancelMissionContractRequest,
+  grantMissionContractRequest,
+  requestMissionContract,
+  resetMissionContractRequests,
+} = await import("../mission-contract-request.js");
 
 const SESSION = "00000000-0000-4000-8000-00000000cccc";
 const MISSION = "mission-1";
@@ -52,6 +58,8 @@ const SAMPLE_DRAFT = {
   acceptance: null,
   deployedCapital: null,
   renewedFromMissionId: null,
+  missingFields: [],
+  canAcceptContract: true,
 };
 
 const READY_DIFF = {
@@ -471,5 +479,178 @@ describe("MissionContractModal", () => {
     });
     expect(screen.queryByText(/Mission ready/i)).toBeNull();
     expect(screen.getByText(/Preparing/i)).not.toBeNull();
+  });
+
+  /**
+   * `kind === "setup-needed"` had NO coverage before this, which is how its
+   * footer copy stayed wrong: it read "Add a goal, constraints, and stop
+   * conditions to enable Accept." - an imperative aimed at the user for fields
+   * only the agent can write (`mission.updateDraft` returns `unavailable`).
+   */
+  describe("incomplete contract (setup-needed)", () => {
+    const SETUP_DRAFT = {
+      ...SAMPLE_DRAFT,
+      status: "draft" as const,
+      canAcceptContract: false,
+      missingFields: ["goal", "riskProfile", "stopConditions"],
+    };
+
+    it("names the AGENT as the actor and enumerates the missing fields, with no Accept offered", async () => {
+      mockBridge.getDraft.mockResolvedValue({ ok: true, data: SETUP_DRAFT });
+      mockBridge.getDiff.mockResolvedValue({ ok: true, data: READY_DIFF });
+      renderModal();
+
+      const footerNote = await screen.findByText(/Vex is still writing this contract/i);
+      // The actor. This is the regression this test exists to catch: if the
+      // copy ever tells the USER to fill the fields again, this fails.
+      expect(footerNote.textContent).toMatch(/Vex sets them from your conversation/i);
+      expect(footerNote.textContent).toMatch(/cannot be edited here/i);
+      expect(
+        screen.queryByText(/Add a goal, constraints, and stop conditions/i),
+      ).toBeNull();
+
+      // Enumerated, complete, human-labelled.
+      const list = document.querySelector(
+        '[data-vex-state="mission-missing-fields"][data-vex-surface="contract-modal"]',
+      );
+      expect(list).not.toBeNull();
+      expect(list?.querySelectorAll("li")).toHaveLength(3);
+      expect(list?.textContent).toMatch(/Goal/);
+      expect(list?.textContent).toMatch(/Risk profile/);
+      expect(list?.textContent).toMatch(/Stop conditions/);
+
+      // Accept is still correctly withheld: the engine refuses the START of a
+      // `draft`-status contract with `not_ready`, so offering Accept here would
+      // only move the dead end downstream.
+      expect(screen.queryByRole("button", { name: /Accept contract/i })).toBeNull();
+    });
+
+    it("falls back honestly when the contract state is not readable yet", async () => {
+      mockBridge.getDraft.mockResolvedValue({ ok: true, data: SAMPLE_DRAFT });
+      // No usable diff → contract-loading, which must NOT claim fields are
+      // missing (we have not read them), only that the state is being read.
+      mockBridge.getDiff.mockResolvedValue({
+        ok: true,
+        data: { outcome: "not_found" },
+      });
+      renderModal();
+
+      await screen.findByText(/Reading the current contract state/i);
+      expect(
+        document.querySelector('[data-vex-state="mission-missing-fields"]'),
+      ).toBeNull();
+    });
+  });
+
+  /**
+   * WP3: the request a blocked capability raises. Single-flight, joinable,
+   * tri-state, and NEVER resolved ahead of the commit.
+   */
+  describe("contract request lifecycle", () => {
+    afterEach(() => resetMissionContractRequests());
+
+    it("resolves granted ONLY after the acceptance commits", async () => {
+      mockBridge.getDraft.mockResolvedValue({ ok: true, data: SAMPLE_DRAFT });
+      mockBridge.getDiff.mockResolvedValue({ ok: true, data: READY_DIFF });
+      let settleAccept!: (v: unknown) => void;
+      mockBridge.acceptContract.mockReturnValue(
+        new Promise((resolve) => {
+          settleAccept = resolve;
+        }),
+      );
+      let outcome: string | null = null;
+      void requestMissionContract({
+        sessionId: SESSION,
+        reason: "start_blocked",
+      }).then((o) => {
+        outcome = o;
+      });
+      renderModal();
+
+      fireEvent.click(
+        await screen.findByRole("button", { name: /^Accept contract$/i }),
+      );
+      // In flight: the engine has not committed, so nothing may be reported.
+      await Promise.resolve();
+      expect(outcome).toBeNull();
+
+      settleAccept({ ok: true, data: { outcome: "accepted" } });
+      await waitFor(() => expect(outcome).toBe("granted"));
+    });
+
+    it("resolves refused when the engine rejects the acceptance", async () => {
+      mockBridge.getDraft.mockResolvedValue({ ok: true, data: SAMPLE_DRAFT });
+      mockBridge.getDiff.mockResolvedValue({ ok: true, data: READY_DIFF });
+      mockBridge.acceptContract.mockResolvedValue({
+        ok: true,
+        data: { outcome: "hash_mismatch" },
+      });
+      const pending = requestMissionContract({
+        sessionId: SESSION,
+        reason: "start_blocked",
+      });
+      renderModal();
+      fireEvent.click(
+        await screen.findByRole("button", { name: /^Accept contract$/i }),
+      );
+      await expect(pending).resolves.toBe("refused");
+    });
+
+    it("resolves refused when the accept call itself fails", async () => {
+      mockBridge.getDraft.mockResolvedValue({ ok: true, data: SAMPLE_DRAFT });
+      mockBridge.getDiff.mockResolvedValue({ ok: true, data: READY_DIFF });
+      mockBridge.acceptContract.mockRejectedValue(new Error("transport down"));
+      const pending = requestMissionContract({
+        sessionId: SESSION,
+        reason: "start_blocked",
+      });
+      renderModal();
+      fireEvent.click(
+        await screen.findByRole("button", { name: /^Accept contract$/i }),
+      );
+      await expect(pending).resolves.toBe("refused");
+    });
+
+    it("resolves cancelled when the surface is dismissed without a decision", async () => {
+      const pending = requestMissionContract({
+        sessionId: SESSION,
+        reason: "start_blocked",
+      });
+      cancelMissionContractRequest(SESSION);
+      await expect(pending).resolves.toBe("cancelled");
+    });
+
+    it("is single-flight and joinable: a second request settles with the first", async () => {
+      const a = requestMissionContract({ sessionId: SESSION, reason: "user" });
+      const b = requestMissionContract({
+        sessionId: SESSION,
+        reason: "start_blocked",
+      });
+      grantMissionContractRequest(SESSION);
+      await expect(a).resolves.toBe("granted");
+      await expect(b).resolves.toBe("granted");
+    });
+
+    it("cancels a stale request when a different session raises one", async () => {
+      const OTHER = "00000000-0000-4000-8000-0000000000ff";
+      const stale = requestMissionContract({ sessionId: SESSION, reason: "user" });
+      const fresh = requestMissionContract({ sessionId: OTHER, reason: "user" });
+      await expect(stale).resolves.toBe("cancelled");
+      grantMissionContractRequest(OTHER);
+      await expect(fresh).resolves.toBe("granted");
+    });
+
+    it("ignores a settle aimed at a session that is not the pending one", async () => {
+      const pending = requestMissionContract({ sessionId: SESSION, reason: "user" });
+      grantMissionContractRequest("00000000-0000-4000-8000-0000000000ee");
+      let settled = false;
+      void pending.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      cancelMissionContractRequest(SESSION);
+      await expect(pending).resolves.toBe("cancelled");
+    });
   });
 });

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
@@ -22,6 +22,8 @@ import { createElement, type ReactNode } from "react";
 import { useSubmitChat } from "../../../lib/api/chat.js";
 import { useUiStore } from "../../../stores/uiStore.js";
 import { MissionControls } from "../MissionControls.js";
+import { MISSION_SETUP_STALL_PROMPT_MS } from "../MissionSetupProgress.js";
+import { resetMissionContractRequests } from "../mission-contract-request.js";
 
 const SESSION = "00000000-0000-4000-8000-0000000000d1";
 const MISSION = "mission-1";
@@ -43,6 +45,11 @@ const renewMock = vi.fn();
 const chatSubmitMock = vi.fn();
 const getPlanMock = vi.fn();
 const onTranscriptAppendMock = vi.fn(() => vi.fn());
+import type { MissionUpdateEvent } from "@shared/schemas/mission-update.js";
+type MissionUpdateListener = (event: MissionUpdateEvent) => void;
+const onMissionUpdateMock = vi.fn(
+  (_cb: MissionUpdateListener): (() => void) => vi.fn(),
+);
 
 function setVex(): void {
   Object.defineProperty(window, "vex", {
@@ -65,6 +72,7 @@ function setVex(): void {
       chat: { submit: chatSubmitMock },
       engine: makeEngineBridgeStub({
         onTranscriptAppend: onTranscriptAppendMock,
+        onMissionUpdate: onMissionUpdateMock,
       }),
     },
   });
@@ -88,7 +96,25 @@ function runtimeState(over: Record<string, unknown>) {
 }
 
 function draftReady() {
-  return ok({ missionId: MISSION, status: "ready" });
+  return ok({
+    missionId: MISSION,
+    status: "ready",
+    // The OWNER's capability answer, carried on the DTO. The renderer no longer
+    // re-derives acceptability from `status`, so a stub that omits it is not a
+    // valid `mission.getDraft` response.
+    canAcceptContract: true,
+    missingFields: [],
+  });
+}
+
+/** A contract the agent is still writing - the state the dead end lived in. */
+function draftInSetup(missingFields: readonly string[] = ["goal", "stopConditions"]) {
+  return {
+    missionId: MISSION,
+    status: "draft",
+    canAcceptContract: false,
+    missingFields,
+  };
 }
 
 function diffAccepted(isAccepted: boolean, isDirty = false) {
@@ -146,6 +172,9 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  // Any request left pending by a test settles as `cancelled` - never leaks
+  // into the next test, and never resolves as anything but the truth.
+  resetMissionContractRequests();
   useUiStore.setState({ reviewModal: "none" });
   // @ts-expect-error — test cleanup
   delete window.vex;
@@ -164,7 +193,7 @@ describe("MissionControls", () => {
     const startBtn = await screen.findByRole("button", { name: "Start mission" });
     // Accepted-clean contract → the acceptance-pending notice AND the review
     // bar must be gone (the Start CTA is the deterministic signal from here).
-    expect(screen.queryByText(/Mission contract not accepted/i)).toBeNull();
+    expect(screen.queryByText(/stay blocked until the contract is accepted/i)).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Review & accept contract" }),
     ).toBeNull();
@@ -183,7 +212,7 @@ describe("MissionControls", () => {
     const reviewBtn = await screen.findByRole("button", {
       name: "Review & accept contract",
     });
-    expect(screen.queryByText(/Mission contract not accepted/i)).toBeNull();
+    expect(screen.queryByText(/stay blocked until the contract is accepted/i)).toBeNull();
     expect(screen.queryByRole("button", { name: "Start mission" })).toBeNull();
     // Store wiring: clicking the bar opens the mission dialog via uiStore.
     expect(useUiStore.getState().reviewModal).toBe("none");
@@ -198,7 +227,7 @@ describe("MissionControls", () => {
     getPlanMock.mockImplementation(() => new Promise(() => {})); // never settles
     renderControls();
 
-    await screen.findByText(/Mission contract not accepted/i);
+    await screen.findByText(/stay blocked until the contract is accepted/i);
     expect(
       screen.queryByRole("button", { name: "Review & accept contract" }),
     ).toBeNull();
@@ -214,7 +243,7 @@ describe("MissionControls", () => {
     });
     renderControls();
 
-    await screen.findByText(/Mission contract not accepted/i);
+    await screen.findByText(/stay blocked until the contract is accepted/i);
     expect(
       screen.queryByRole("button", { name: "Review & accept contract" }),
     ).toBeNull();
@@ -231,23 +260,156 @@ describe("MissionControls", () => {
     renderControls();
 
     // The standing notice (the pre-existing affordance) stays instead.
-    await screen.findByText(/Mission contract not accepted/i);
+    await screen.findByText(/stay blocked until the contract is accepted/i);
     expect(
       screen.queryByRole("button", { name: "Review & accept contract" }),
     ).toBeNull();
   });
 
-  it("shows the standing acceptance-pending notice while the draft is still in setup", async () => {
+  /**
+   * DELIBERATE EXPECTATION CHANGE. This test previously read:
+   *
+   *   it("shows the standing acceptance-pending notice while the draft is
+   *      still in setup", ...)
+   *     await screen.findByText(/stay blocked until the contract is accepted/i);
+   *     expect(screen.queryByRole("button", { name: "Start mission" })).toBeNull();
+   *     expect(
+   *       screen.queryByRole("button", { name: "Review & accept contract" }),
+   *     ).toBeNull();
+   *
+   * It asserted that in the setup state the surface offers NO control at all -
+   * it codified the reported dead end as intended behaviour. Start and Review &
+   * accept must still be absent (the contract genuinely is not acceptable yet,
+   * and offering Accept on a `draft`-status contract would only relocate the
+   * dead end to `commit-start`'s `not_ready`), but "no next action" is exactly
+   * the bug. The notice now names the state, the blocked consequence, the actor
+   * who must act, the exact missing fields, and carries a control.
+   */
+  it("names the state, the actor and the missing fields, and carries a control, while the draft is still in setup", async () => {
     getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
-    getDraftMock.mockResolvedValue(ok({ missionId: MISSION, status: "draft" }));
+    getDraftMock.mockResolvedValue(ok(draftInSetup(["goal", "stopConditions"])));
     getDiffMock.mockResolvedValue(diffAccepted(false));
     renderControls();
 
-    await screen.findByText(/Mission contract not accepted/i);
+    const notice = await screen.findByRole("status");
+    expect(notice.getAttribute("data-vex-readiness")).toBe("drafting");
+    // State + consequence.
+    expect(notice.textContent).toMatch(/Vex is still writing the mission contract/i);
+    expect(notice.textContent).toMatch(
+      /On-chain actions \(swaps, bridges, sends\) stay blocked/i,
+    );
+    // The actor: NOT the user. This is the specific defect being fixed.
+    expect(notice.textContent).toMatch(/Only Vex can fill these fields/i);
+    // The concrete losses, enumerated - not summarised.
+    const missing = notice.querySelector(
+      '[data-vex-state="mission-missing-fields"]',
+    );
+    expect(missing).not.toBeNull();
+    expect(missing?.textContent).toMatch(/Goal/);
+    expect(missing?.textContent).toMatch(/Stop conditions/);
+    // The way forward. Keyboard-reachable and correctly named.
+    const control = screen.getByRole("button", { name: "Show mission contract" });
+    expect((control as HTMLButtonElement).disabled).toBe(false);
+    control.focus();
+    expect(document.activeElement).toBe(control);
+    fireEvent.click(control);
+    expect(useUiStore.getState().reviewModal).toBe("mission");
+
+    // Still correctly withheld: the contract is not acceptable or startable yet.
     expect(screen.queryByRole("button", { name: "Start mission" })).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Review & accept contract" }),
     ).toBeNull();
+  });
+
+  it("escalates to the stalled copy after a setup turn that wrote nothing", async () => {
+    vi.useFakeTimers();
+    try {
+      getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+      getDraftMock.mockResolvedValue(ok(draftInSetup(["goal"])));
+      getDiffMock.mockResolvedValue(diffAccepted(false));
+      let emit: MissionUpdateListener | null = null;
+      onMissionUpdateMock.mockImplementation((cb: MissionUpdateListener) => {
+        emit = cb;
+        return vi.fn();
+      });
+      renderControls();
+      await vi.waitFor(() =>
+        expect(
+          document.querySelector('[data-vex-readiness="drafting"]'),
+        ).not.toBeNull(),
+      );
+      expect(screen.getByRole("status").textContent).toMatch(
+        /Vex is still writing the mission contract/i,
+      );
+
+      // The engine reports a setup turn that produced no patch.
+      act(() => {
+        emit?.({
+          type: "engine.mission.update" as const,
+          sessionId: SESSION,
+          missionId: MISSION,
+          kind: "setup_no_progress",
+          occurredAt: new Date().toISOString(),
+        });
+      });
+      // A threshold, not a spinner: nothing escalates before it elapses, so an
+      // ordinary clarifying question the user is already answering never trips.
+      expect(screen.getByRole("status").textContent).not.toMatch(
+        /did not add anything/i,
+      );
+      act(() => {
+        vi.advanceTimersByTime(MISSION_SETUP_STALL_PROMPT_MS);
+      });
+      expect(screen.getByRole("status").textContent).toMatch(
+        /Vex's last reply did not add anything to the mission contract/i,
+      );
+      // The escape hatch is named explicitly.
+      expect(screen.getByRole("status").textContent).toMatch(
+        /Nothing will change until you reply/i,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the stalled state when a later mission update reports real progress", async () => {
+    vi.useFakeTimers();
+    try {
+      getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
+      getDraftMock.mockResolvedValue(ok(draftInSetup(["goal"])));
+      getDiffMock.mockResolvedValue(diffAccepted(false));
+      let emit: MissionUpdateListener | null = null;
+      onMissionUpdateMock.mockImplementation((cb: MissionUpdateListener) => {
+        emit = cb;
+        return vi.fn();
+      });
+      renderControls();
+      await vi.waitFor(() =>
+        expect(
+          document.querySelector('[data-vex-readiness="drafting"]'),
+        ).not.toBeNull(),
+      );
+
+      const update = (kind: MissionUpdateEvent["kind"]): MissionUpdateEvent => ({
+        type: "engine.mission.update",
+        sessionId: SESSION,
+        missionId: MISSION,
+        kind,
+        occurredAt: new Date().toISOString(),
+      });
+      act(() => emit?.(update("setup_no_progress")));
+      act(() => emit?.(update("draft_updated")));
+      act(() => {
+        vi.advanceTimersByTime(MISSION_SETUP_STALL_PROMPT_MS * 2);
+      });
+      // The armed escalation was cancelled by the real change.
+      expect(screen.getByRole("status").textContent).not.toMatch(
+        /did not add anything/i,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("holds the review bar until the chat turn settles, revealing it only once chatSubmitting goes false (no mid-turn flash)", async () => {
@@ -281,7 +443,7 @@ describe("MissionControls", () => {
 
     // Turn still in flight → the bar is HELD; the pre-existing standing
     // notice covers this state instead (never both at once).
-    await screen.findByText(/Mission contract not accepted/i);
+    await screen.findByText(/stay blocked until the contract is accepted/i);
     expect(
       screen.queryByRole("button", { name: "Review & accept contract" }),
     ).toBeNull();
@@ -460,12 +622,12 @@ describe("MissionControls", () => {
     // must NOT linger — else it looks like it "did nothing" and each extra click
     // clones another duplicate draft. The fresh draft's acceptance UI wins.
     getStateMock.mockResolvedValue(runtimeState({ hasActiveRun: false }));
-    getDraftMock.mockResolvedValue(ok({ missionId: MISSION, status: "draft" }));
+    getDraftMock.mockResolvedValue(ok(draftInSetup()));
     getDiffMock.mockResolvedValue(diffAccepted(false));
     getRenewableMock.mockResolvedValue(ok({ missionId: "m-done" }));
     renderControls();
 
-    await screen.findByText(/Mission contract not accepted/i);
+    await screen.findByText(/stay blocked until the contract is accepted/i);
     expect(screen.queryByRole("button", { name: "Renew mission" })).toBeNull();
   });
 

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionRail.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionRail.test.tsx
@@ -103,6 +103,8 @@ const READY_DRAFT: MissionDraftDto = {
   approvedAt: null,
   acceptance: null,
   renewedFromMissionId: null,
+  missingFields: [],
+  canAcceptContract: true,
 } as unknown as MissionDraftDto;
 
 function diff(over: Partial<Extract<MissionGetDiffResult, { outcome: "ready" }>> = {}) {
@@ -252,7 +254,7 @@ describe("MissionRail badge derivation", () => {
   it("Mission badge is Preparing while the draft is not ready", () => {
     mockUseSession.mockReturnValue({ data: ok(sessionRow({ mode: "mission" })) });
     mockUseMissionDraft.mockReturnValue({
-      data: ok({ ...READY_DRAFT, status: "draft" }),
+      data: ok({ ...READY_DRAFT, status: "draft", canAcceptContract: false, missingFields: ["goal", "stopConditions"] }),
     });
     rail();
     expect(screen.getByText("Preparing")).not.toBeNull();
@@ -348,7 +350,7 @@ describe("MissionRail badge derivation", () => {
     // must derive normally, NOT be masked "accepted" by the stale source.
     mockUseSession.mockReturnValue({ data: ok(sessionRow({ mode: "mission" })) });
     mockUseMissionDraft.mockReturnValue({
-      data: ok({ ...READY_DRAFT, status: "draft" }),
+      data: ok({ ...READY_DRAFT, status: "draft", canAcceptContract: false, missingFields: ["goal", "stopConditions"] }),
     });
     mockUseRuntimeState.mockReturnValue({ data: runtime(false) });
     mockUseRenewableMissionSource.mockReturnValue({ data: renewable(MISSION) });

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionTranscript/turn-stats-line.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionTranscript/turn-stats-line.test.tsx
@@ -17,24 +17,25 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render } from "@testing-library/react";
 import { createElement } from "react";
 import { TurnStatsLine } from "../../SessionTranscript/TurnStatsLine.js";
-import type { TurnUsageDto } from "@shared/schemas/usage.js";
+import type { TurnUsageRollupDto } from "@shared/schemas/usage.js";
 
 const useLastTurnUsage = vi.hoisted(() => vi.fn());
 vi.mock("../../../../lib/api/usage.js", () => ({ useLastTurnUsage }));
 
-function usage(over: Partial<TurnUsageDto> = {}): TurnUsageDto {
+function usage(over: Partial<TurnUsageRollupDto> = {}): TurnUsageRollupDto {
   return {
-    promptTokens: 88_100,
-    completionTokens: 554,
-    cachedTokens: 0,
-    cost: 0.1493,
+    latestRoundPromptTokens: 88_100,
+    latestRoundCachedTokens: 0,
+    turnCompletionTokens: 554,
+    turnCost: 0.1493,
+    roundCount: 1,
     currency: "USD",
     ...over,
-  } as TurnUsageDto;
+  } as TurnUsageRollupDto;
 }
 
 /** The hook's success envelope; `data: null` = no settled turn to report. */
-function resolved(data: TurnUsageDto | null): unknown {
+function resolved(data: TurnUsageRollupDto | null): unknown {
   return { data: { ok: true, data } };
 }
 
@@ -68,7 +69,7 @@ describe("TurnStatsLine", () => {
   });
 
   it("paints the separator dot in a tier that is actually visible", () => {
-    useLastTurnUsage.mockReturnValue(resolved(usage({ cachedTokens: 44_050 })));
+    useLastTurnUsage.mockReturnValue(resolved(usage({ latestRoundCachedTokens: 44_050 })));
     const { container } = render(
       createElement(TurnStatsLine, { sessionId: "s1" }),
     );

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionTranscript/turnStats.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionTranscript/turnStats.test.ts
@@ -1,10 +1,12 @@
 /**
- * Pure presentation of one turn's usage as micro-label stat groups — boundary seams
- * of the compact formatters and the drop-out rules for absent measurements.
+ * Pure presentation of one turn's usage ROLLUP as micro-label stat groups -
+ * boundary seams of the compact formatters, the drop-out rules for absent
+ * measurements, and the snapshot-input / summed-output asymmetry that makes the
+ * displayed figures describe the whole turn instead of its last round.
  */
 
 import { describe, expect, it } from "vitest";
-import type { TurnUsageDto } from "@shared/schemas/usage.js";
+import type { TurnUsageRollupDto } from "@shared/schemas/usage.js";
 import {
   cacheHitPercent,
   formatCost,
@@ -12,21 +14,21 @@ import {
   turnStatGroups,
 } from "../../SessionTranscript/turnStats.js";
 
-function usage(overrides: Partial<TurnUsageDto> = {}): TurnUsageDto {
+function usage(overrides: Partial<TurnUsageRollupDto> = {}): TurnUsageRollupDto {
   return {
     sessionId: "6b1c1a58-0000-4000-8000-000000000000",
-    promptTokens: 12_400,
-    completionTokens: 830,
-    totalTokens: 13_230,
-    cachedTokens: 9_920,
-    reasoningTokens: 0,
-    cost: 0.0042,
-    cachedSavings: null,
-    cacheWriteTokens: 0,
+    latestRoundPromptTokens: 12_400,
+    latestRoundCachedTokens: 9_920,
+    turnCompletionTokens: 830,
+    turnReasoningTokens: 0,
+    turnCacheWriteTokens: 0,
+    turnCost: 0.0042,
+    turnCachedSavings: null,
+    roundCount: 1,
     currency: "USD",
     provider: null,
     model: null,
-    createdAt: "2026-08-20T12:00:00.000Z",
+    latestRoundAt: "2026-08-20T12:00:00.000Z",
     ...overrides,
   };
 }
@@ -48,13 +50,13 @@ describe("formatTokens compacts counts exactly at the unit seams", () => {
 
 describe("cacheHitPercent refuses a 0/0 read", () => {
   it("is null with zero prompt tokens (a 0/0 read is not 0% cached)", () => {
-    expect(cacheHitPercent(usage({ promptTokens: 0, cachedTokens: 0 }))).toBe(
+    expect(cacheHitPercent(usage({ latestRoundPromptTokens: 0, latestRoundCachedTokens: 0 }))).toBe(
       null,
     );
   });
   it("rounds the share to an integer percent", () => {
     expect(
-      cacheHitPercent(usage({ promptTokens: 12_400, cachedTokens: 9_920 })),
+      cacheHitPercent(usage({ latestRoundPromptTokens: 12_400, latestRoundCachedTokens: 9_920 })),
     ).toBe(80);
   });
 });
@@ -81,13 +83,13 @@ describe("turnStatGroups drops absent measurements out whole", () => {
     ]);
   });
   it("omits the cache group when nothing was cached", () => {
-    expect(turnStatGroups(usage({ cachedTokens: 0 }))).toEqual([
+    expect(turnStatGroups(usage({ latestRoundCachedTokens: 0 }))).toEqual([
       "12.4K in / 830 out",
       "$0.0042",
     ]);
   });
   it("omits the cost group when cost is unknown", () => {
-    expect(turnStatGroups(usage({ cost: null }))).toEqual([
+    expect(turnStatGroups(usage({ turnCost: null }))).toEqual([
       "12.4K in / 830 out",
       "80% cached",
     ]);
@@ -96,13 +98,59 @@ describe("turnStatGroups drops absent measurements out whole", () => {
     expect(
       turnStatGroups(
         usage({
-          promptTokens: 0,
-          completionTokens: 0,
-          totalTokens: 0,
-          cachedTokens: 0,
-          cost: null,
+          latestRoundPromptTokens: 0,
+          latestRoundCachedTokens: 0,
+          turnCompletionTokens: 0,
+          turnCost: null,
         }),
       ),
     ).toEqual([]);
+  });
+});
+
+/**
+ * The regression this pins: the panel used to read ONE `usage_log` row and
+ * label it a turn. The engine writes one row per model round, so a fifty-round
+ * turn displayed the fiftieth round's output and cost - the v0.2.6 report's
+ * `OUT 1 / $0.0405`. `turnStatGroups` must read the SUMMED output and the
+ * SUMMED cost, and must read input from the latest-round snapshot (summing
+ * input would count the resent conversation N times).
+ */
+describe("a multi-round turn reports the turn, not its last round", () => {
+  it("prints summed output and summed cost against the latest-round input", () => {
+    expect(
+      turnStatGroups(
+        usage({
+          // The last round of the turn resent a 38.2K-token conversation and
+          // produced almost nothing; the turn as a whole generated 24.6K
+          // output tokens and cost four cents.
+          latestRoundPromptTokens: 38_200,
+          latestRoundCachedTokens: 0,
+          turnCompletionTokens: 24_600,
+          turnCost: 0.0405,
+          roundCount: 50,
+        }),
+      ),
+    ).toEqual(["38.2K in / 24.6K out", "$0.0405", "50 rounds"]);
+  });
+
+  it("says how many rounds the figures cover, and stays silent for a single round", () => {
+    expect(turnStatGroups(usage({ roundCount: 2 }))).toContain("2 rounds");
+    expect(turnStatGroups(usage({ roundCount: 1 })).join("|")).not.toContain("round");
+  });
+
+  it("cache share divides the SAME round's cached and prompt tokens", () => {
+    // Not the turn's summed cache writes against one round's prompt - that
+    // ratio would exceed 100% on any cached multi-round turn.
+    expect(
+      cacheHitPercent(
+        usage({
+          latestRoundPromptTokens: 1_000,
+          latestRoundCachedTokens: 250,
+          turnCacheWriteTokens: 40_000,
+          roundCount: 40,
+        }),
+      ),
+    ).toBe(25);
   });
 });

--- a/vex-app/src/renderer/features/appShell/__tests__/composer-helpers.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/composer-helpers.test.ts
@@ -24,10 +24,23 @@ describe("composer outcome copy", () => {
     ["iteration_limit", "action limit"],
     ["timeout", "timed out"],
     ["system_error", "internal error"],
+    ["no_progress", "only empty responses"],
   ] as const)("marks %s as an incomplete retryable turn", (stopReason, copy) => {
     const notice = submitFailureNotice(outcome({ stopReason }));
     expect(notice?.retryable).toBe(true);
     expect(notice?.text).toContain(copy);
+  });
+
+  // A stall is only the TAIL of a turn: rounds before it can have dispatched
+  // real, money-moving tool calls. The notice must therefore go through the
+  // SAME `toolCallsMade` gate as every other incomplete reason - a blanket
+  // "safe to retry" would blindly replay a turn that already took an action.
+  it("gates one-click retry on a stall exactly like every other incomplete turn", () => {
+    const notice = submitFailureNotice(
+      outcome({ stopReason: "no_progress", toolCallsMade: 3 }),
+    );
+    expect(notice?.retryable).toBe(false);
+    expect(notice?.text).toContain("earlier steps may have completed");
   });
 
   it("blocks blind retry after tool activity and warns that earlier steps may have completed", () => {

--- a/vex-app/src/renderer/features/appShell/composer-helpers.ts
+++ b/vex-app/src/renderer/features/appShell/composer-helpers.ts
@@ -126,6 +126,17 @@ export function submitFailureNotice(
         data,
         "Vex stopped before completing the task after reaching this turn's action limit.",
       );
+    case "no_progress":
+      // Routed through `incompleteTurnNotice` like the other incomplete-turn
+      // reasons, and for the same reason: the STALL is only the tail of the
+      // turn. Rounds before it can have dispatched real tool calls, so retry
+      // stays gated on `toolCallsMade` exactly as everywhere else. Only when
+      // the count is zero - the reported v0.2.6 shape - is one-click retry
+      // offered, and there it is genuinely safe: nothing ran.
+      return incompleteTurnNotice(
+        data,
+        "Vex stopped early because the model returned only empty responses.",
+      );
     case "timeout":
       return incompleteTurnNotice(
         data,

--- a/vex-app/src/renderer/features/appShell/mission-contract-request.ts
+++ b/vex-app/src/renderer/features/appShell/mission-contract-request.ts
@@ -1,0 +1,153 @@
+/**
+ * MISSION CONTRACT REQUEST - the blocked capability raises the contract
+ * surface instead of dead-ending on a notice.
+ *
+ * Modelled on VS Code's workspace-trust request
+ * (`src/vs/workbench/services/workspaces/common/workspaceTrust.ts`), where a
+ * capability that cannot run (`startDebugging`, task execution) BEGINS by
+ * awaiting a trust request rather than reporting a refusal the user cannot act
+ * on. Three properties transfer, and one deliberately does not.
+ *
+ * TRANSFERRED:
+ *   1. Single-flight and joinable. A second blocked capability joins the first
+ *      request instead of stacking a second surface; both callers settle from
+ *      the same decision.
+ *   2. Tri-state result: `granted` | `refused` | `cancelled`. Cancellation is a
+ *      real third outcome, never a silent `false`.
+ *   3. Never resolve ahead of the commit. `granted` is settled ONLY from the
+ *      `mission.acceptContract` success path, after the engine reports
+ *      `outcome: "accepted"` - the same point VS Code waits for a real state
+ *      change via `Event.once` rather than resolving on the button press.
+ *
+ * NOT TRANSFERRED, and it must never be: workspace trust is a boolean the user
+ * flips at will and it then stands. Mission acceptance authorizes real fund
+ * movement. This module grants NOTHING. It opens a surface; the acceptance it
+ * may lead to still goes through `mission.acceptContract`, still binds to the
+ * exact contract hash under review, and is still revalidated at start
+ * (`engine/mission/commit-start.ts`). A `granted` result is a REPORT that an
+ * acceptance committed, not a permission this module holds, hands on, or can
+ * replay. Nothing here may ever be cached, reused across missions, or consulted
+ * in place of the engine's own gate.
+ *
+ * Lifetime: renderer-session ephemeral. Requests are keyed by session and
+ * cleared on settle; a pending request whose session is left behind is
+ * cancelled by `cancelMissionContractRequest`, which every dismissal path calls.
+ */
+
+import { create } from "zustand";
+
+/**
+ * Why the contract surface was raised. Purely for the copy shown on the
+ * surface - it never widens or narrows what may be accepted.
+ */
+export type MissionContractRequestReason =
+  /** The user asked to see the contract (badge, notice control). */
+  | "user"
+  /** `mission.start` was refused because the contract is not accepted or not ready. */
+  | "start_blocked";
+
+export type MissionContractRequestOutcome =
+  /** An acceptance actually committed for this session. */
+  | "granted"
+  /** The engine refused the acceptance (a non-`accepted` outcome, or a failure). */
+  | "refused"
+  /** The user dismissed the surface without a decision. */
+  | "cancelled";
+
+interface PendingRequest {
+  readonly sessionId: string;
+  readonly reason: MissionContractRequestReason;
+}
+
+interface MissionContractRequestState {
+  /** The one in-flight request, or null. Single-flight by construction. */
+  readonly pending: PendingRequest | null;
+}
+
+export const useMissionContractRequestStore = create<MissionContractRequestState>(
+  () => ({ pending: null }),
+);
+
+/**
+ * Joiners of the CURRENT request. Kept outside the store because resolvers are
+ * functions: rule 08 keeps non-serialisable callbacks out of rendered state,
+ * and nothing renders from this list.
+ */
+let joiners: ((outcome: MissionContractRequestOutcome) => void)[] = [];
+
+function settle(outcome: MissionContractRequestOutcome): void {
+  const waiting = joiners;
+  joiners = [];
+  useMissionContractRequestStore.setState({ pending: null });
+  for (const resolve of waiting) resolve(outcome);
+}
+
+/**
+ * Raise the mission contract surface and wait for the decision.
+ *
+ * Single-flight: a request while one is pending for the SAME session joins it
+ * and settles together. A request for a DIFFERENT session cancels the stale one
+ * first - its surface is no longer reachable, so leaving its callers hanging
+ * would be a leak, and reporting anything but `cancelled` would be a lie.
+ *
+ * The caller must open the surface itself (the modal lives in `MissionRail`,
+ * driven by `uiStore.reviewModal`); this owns only the request's lifetime and
+ * its outcome.
+ */
+export function requestMissionContract(input: {
+  readonly sessionId: string;
+  readonly reason: MissionContractRequestReason;
+}): Promise<MissionContractRequestOutcome> {
+  const { pending } = useMissionContractRequestStore.getState();
+  if (pending !== null && pending.sessionId !== input.sessionId) {
+    settle("cancelled");
+  } else if (pending !== null) {
+    // Join: same session, same surface, one decision for both callers.
+    return new Promise((resolve) => {
+      joiners.push(resolve);
+    });
+  }
+  useMissionContractRequestStore.setState({
+    pending: { sessionId: input.sessionId, reason: input.reason },
+  });
+  return new Promise((resolve) => {
+    joiners.push(resolve);
+  });
+}
+
+/**
+ * Report that an acceptance COMMITTED for this session. Call only from the
+ * `mission.acceptContract` success path with `outcome === "accepted"` - never
+ * from the button press, never optimistically.
+ */
+export function grantMissionContractRequest(sessionId: string): void {
+  const { pending } = useMissionContractRequestStore.getState();
+  if (pending === null || pending.sessionId !== sessionId) return;
+  settle("granted");
+}
+
+/** The engine refused the acceptance, or the accept call failed. */
+export function refuseMissionContractRequest(sessionId: string): void {
+  const { pending } = useMissionContractRequestStore.getState();
+  if (pending === null || pending.sessionId !== sessionId) return;
+  settle("refused");
+}
+
+/**
+ * The surface was dismissed without a decision (Escape, backdrop, badge
+ * toggle-closed, unmount). Idempotent: a second call after settle is a no-op.
+ */
+export function cancelMissionContractRequest(sessionId?: string): void {
+  const { pending } = useMissionContractRequestStore.getState();
+  if (pending === null) return;
+  if (sessionId !== undefined && pending.sessionId !== sessionId) return;
+  settle("cancelled");
+}
+
+/** Test seam: drop any pending request without resolving observers twice. */
+export function resetMissionContractRequests(): void {
+  if (useMissionContractRequestStore.getState().pending !== null) {
+    settle("cancelled");
+  }
+  joiners = [];
+}

--- a/vex-app/src/renderer/features/appShell/mission-readiness.ts
+++ b/vex-app/src/renderer/features/appShell/mission-readiness.ts
@@ -1,0 +1,139 @@
+/**
+ * THE mission contract readiness selector.
+ *
+ * Before this module the same predicate was re-derived in three places -
+ * `MissionRail.deriveMissionBadge`, `MissionControls`' `canStart`/`reviewable`,
+ * and `MissionContractModal/contract-state.resolveCardState` - kept in sync by
+ * convention and comments. They disagreed in exactly the way convention always
+ * disagrees: a `draft`-status contract fell to a terminal branch in
+ * `MissionControls` that rendered a warning and NO control, while the modal
+ * that warning pointed at rendered an imperative ("Add a goal, constraints, and
+ * stop conditions") for fields the host cannot edit at all. All three now read
+ * this one function, so they are structurally unable to contradict each other.
+ *
+ * The capability answer itself is NOT computed here. `draft.canAcceptContract`
+ * is decided by the owner (main, from the mission row) and merely consumed -
+ * the same split VS Code draws between `isWorkspaceTrusted()` and
+ * `canSetWorkspaceTrust()`, where the UI asks the service whether an affordance
+ * is offerable instead of re-deriving it from state.
+ *
+ * Pure: no hooks, no IPC, no store. Inputs are the already-unwrapped query
+ * reads; the caller owns the reads.
+ */
+
+import type {
+  MissionDraftDto,
+  MissionGetDiffResult,
+} from "@shared/schemas/mission.js";
+import type { PlanGetResult } from "@shared/schemas/session-plan.js";
+import type { PremiumBadgeState } from "./PremiumBadge.js";
+
+type ReadyDiff = Extract<MissionGetDiffResult, { outcome: "ready" }>;
+
+/**
+ * Contract-readiness states, in the order a mission passes through them. These
+ * mirror the engine's setup state machine (see the header comment of
+ * `src/vex-agent/engine/mission/setup.ts`); run-level states (running, paused,
+ * terminal) are NOT here - they are the runtime's, and `MissionRail` overlays
+ * them on top of this result.
+ */
+export type MissionReadiness =
+  /** No mission row for this session - nothing to surface. */
+  | { readonly kind: "none" }
+  /**
+   * The agent is still writing the contract. `missingFields` is the engine's
+   * own complete list of what it still has to fill. `stalled` means the last
+   * setup turn ended without touching the draft, so nothing is in motion.
+   */
+  | {
+      readonly kind: "drafting";
+      readonly missingFields: readonly string[];
+      readonly stalled: boolean;
+    }
+  /** Contract complete, but its diff has not been read yet. Transient. */
+  | { readonly kind: "contract-loading" }
+  /** Contract complete; a legacy plan-mode session still owes an action plan. */
+  | { readonly kind: "awaiting-plan" }
+  /**
+   * Contract complete, but the plan read has not succeeded (pending or failed),
+   * so plan state is UNKNOWN. Distinct from `awaiting-plan` on purpose: rule 08
+   * forbids collapsing unavailable/unknown into a definite answer, and telling a
+   * user their plan is missing when we merely have not read it is exactly that.
+   * Both block acceptance identically; only the copy differs.
+   */
+  | { readonly kind: "plan-unknown" }
+  /** Complete and reviewable - the host may accept this exact hash now. */
+  | { readonly kind: "awaiting-acceptance"; readonly currentHash: string }
+  /** Accepted earlier, then edited - the accepted hash no longer matches. */
+  | { readonly kind: "dirty-acceptance"; readonly currentHash: string }
+  /** Accepted and clean. Start is the next step. */
+  | { readonly kind: "accepted" };
+
+export interface MissionReadinessInput {
+  readonly draft: MissionDraftDto | null;
+  readonly diff: ReadyDiff | null;
+  readonly plan: PlanGetResult | null;
+  /**
+   * Whether the plan read actually SUCCEEDED. Pending or failed is UNKNOWN, and
+   * unknown must read as not-ready: collapsing it to `null` would make
+   * `planMissing(null)` vacuously false and flash a ready state during loading.
+   */
+  readonly planKnown: boolean;
+  /** Last setup turn produced no patch - see `MissionUpdateKind.setup_no_progress`. */
+  readonly setupStalled: boolean;
+}
+
+export function resolveMissionReadiness(
+  input: MissionReadinessInput,
+): MissionReadiness {
+  const { draft, diff, plan, planKnown, setupStalled } = input;
+  if (draft === null) return { kind: "none" };
+  // The owner's capability answer, not `status === "ready"` restated.
+  if (!draft.canAcceptContract) {
+    return {
+      kind: "drafting",
+      missingFields: draft.missingFields,
+      stalled: setupStalled,
+    };
+  }
+  if (diff === null) return { kind: "contract-loading" };
+  if (diff.isAccepted && !diff.isDirty) return { kind: "accepted" };
+  if (diff.isAccepted && diff.isDirty) {
+    return { kind: "dirty-acceptance", currentHash: diff.currentHash };
+  }
+  // Awaiting acceptance, gated on the plan: a legacy plan-mode session with no
+  // authored plan is refused by the engine (`plan_missing`), so the UI must not
+  // invite the accept.
+  if (!planKnown) return { kind: "plan-unknown" };
+  if (planMissing(plan)) return { kind: "awaiting-plan" };
+  return { kind: "awaiting-acceptance", currentHash: diff.currentHash };
+}
+
+/**
+ * Plan-mode on with an empty body - the engine's `plan_missing` block.
+ * Historically exported from `MissionRail`; it belongs with the rest of the
+ * readiness predicate and is re-exported there for existing importers.
+ */
+export function planMissing(plan: PlanGetResult | null): boolean {
+  return plan !== null && plan.enabled && !plan.accepted && plan.planMd.length === 0;
+}
+
+/** The one mapping from readiness to the header/modal badge. */
+export function missionReadinessBadgeState(
+  readiness: MissionReadiness,
+): PremiumBadgeState {
+  switch (readiness.kind) {
+    case "none":
+    case "drafting":
+    case "contract-loading":
+    case "awaiting-plan":
+    case "plan-unknown":
+      return "preparing";
+    case "awaiting-acceptance":
+      return "ready";
+    case "dirty-acceptance":
+      return "stale";
+    case "accepted":
+      return "accepted";
+  }
+}

--- a/vex-app/src/renderer/features/docker/BootstrapPanel.tsx
+++ b/vex-app/src/renderer/features/docker/BootstrapPanel.tsx
@@ -10,21 +10,22 @@
  * the body components in `bootstrap/branches/`. Shared visual
  * primitives (SetupStatusCard, DocsLink) live in `components/onboarding/`.
  *
- * State machine (unchanged):
- *   loading     — Docker probe in flight, OR engine missing + platform
+ * State machine, driven by the `engine.state` discriminated union rather
+ * than by collapsed booleans:
+ *   loading     - Docker probe in flight, OR engine missing + platform
  *                 still resolving (data wins when platform irrelevant).
- *   A           — engine + daemon running → ReadyBody + Continue.
- *   B           — engine present + daemon stopped → DaemonStoppedBody;
+ *   A           - state `ready` → ReadyBody + Continue.
+ *   B           - state `engine_stopped` / `engine_starting` → DaemonStoppedBody;
  *                 per-platform copy (Linux shows `sudo systemctl start`
  *                 because the main process only attempts the user-mode
  *                 Docker Desktop unit, never sudo).
- *   C-desktop   — mac/win, Docker CLI missing → DesktopInstallBody (in-app
- *                 installer download via LicenseNotice — the license
+ *   C-desktop   - mac/win, state `not_installed` → DesktopInstallBody (in-app
+ *                 installer download via LicenseNotice - the license
  *                 dialog ALWAYS precedes any download IPC).
- *   C-linux     — linux, engine missing → LinuxInstallBody (auto-fetch
+ *   C-linux     - linux, state `not_installed` → LinuxInstallBody (auto-fetch
  *                 `linux_manual_instructions` IPC).
- *   D           — IPC/Result error, endpoint rejected, or version probe
- *                 failure → FailureBody.
+ *   D           - IPC/Result error, endpoint rejected, engine socket
+ *                 permission denied, or probe error → FailureBody.
  *
  * Recheck (footer, always visible non-A) calls `dockerStatus.refetch()`
  * so the user never has to restart the app after fixing Docker.
@@ -72,6 +73,9 @@ export function BootstrapPanel(): JSX.Element {
 
   const platform = systemHealth.data?.ok
     ? systemHealth.data.data.os.platform
+    : null;
+  const engineState = dockerStatus.data?.ok
+    ? dockerStatus.data.data.engine.state
     : null;
   const branch = decideBranch(
     dockerStatus.data,
@@ -206,7 +210,13 @@ export function BootstrapPanel(): JSX.Element {
           ) : branch === "B" ? (
             <DaemonStoppedBody
               platform={platform}
-              starting={startMutation.isPending}
+              // The engine also counts as starting inside the bounded
+              // window after Vex launched Docker, not only while the start
+              // IPC is still in flight.
+              starting={
+                startMutation.isPending ||
+                engineState?.kind === "engine_starting"
+              }
               startMessage={
                 startMutation.data?.ok
                   ? startMutation.data.data.message ?? null
@@ -264,6 +274,12 @@ export function BootstrapPanel(): JSX.Element {
   );
 }
 
+/**
+ * Maps the authoritative `engine.state` union onto a rendered branch.
+ * Branching on the union (rather than on `present` + `daemon.running`) is
+ * what lets "not installed", "stopped", "starting" and "denied" reach
+ * different screens instead of sharing one.
+ */
 function decideBranch(
   result: ReturnType<typeof useDockerStatus>["data"],
   platform: string | null,
@@ -273,23 +289,30 @@ function decideBranch(
   if (!result.ok) return "D";
   const status = result.data;
   if (!status.endpoint.accepted) return "D";
-  if (!status.engine.present && status.engine.failure === "probe_error") {
-    return "D";
-  }
 
-  // A — data wins when platform irrelevant; don't flicker to loading
-  // while the health probe is pending (codex round 11 SHOULD-FIX #2).
-  if (status.engine.present && status.daemon.running) return "A";
-
-  // Below: platform matters (B copy varies by OS; C dispatches per OS).
-  if (status.engine.present && !status.daemon.running) {
-    if (platformPending) return "loading";
-    return "B";
+  const state = status.engine.state;
+  switch (state.kind) {
+    // A - data wins when platform irrelevant; don't flicker to loading
+    // while the health probe is pending (codex round 11 SHOULD-FIX #2).
+    case "ready":
+      return "A";
+    case "error":
+    case "permission_denied":
+      return "D";
+    // Below: platform matters (B copy varies by OS; C dispatches per OS).
+    case "engine_stopped":
+    case "engine_starting":
+      return platformPending ? "loading" : "B";
+    case "not_installed": {
+      if (platformPending) return "loading";
+      if (platform === "darwin" || platform === "win32") return "C-desktop";
+      if (platform === "linux") return "C-linux";
+      return "D";
+    }
+    default: {
+      const exhaustive: never = state;
+      void exhaustive;
+      return "D";
+    }
   }
-  if (!status.engine.present) {
-    if (platformPending) return "loading";
-    if (platform === "darwin" || platform === "win32") return "C-desktop";
-    if (platform === "linux") return "C-linux";
-  }
-  return "D";
 }

--- a/vex-app/src/renderer/features/docker/__tests__/BootstrapPanel.test.tsx
+++ b/vex-app/src/renderer/features/docker/__tests__/BootstrapPanel.test.tsx
@@ -34,13 +34,26 @@ vi.mock("../../../lib/api/system.js", () => ({
   useSystemHealth: mockHooks.useSystemHealth,
 }));
 
+import {
+  deriveDockerStatusFlags,
+  type DockerEngineState,
+} from "@shared/schemas/docker.js";
+
 import { BootstrapPanel } from "../BootstrapPanel.js";
 
 function statusResult(opts: {
   enginePresent: boolean;
   daemonRunning: boolean;
-  failure?: "cli_not_found" | "probe_error" | null;
+  state?: DockerEngineState;
 }) {
+  const state: DockerEngineState =
+    opts.state ??
+    (opts.daemonRunning
+      ? { kind: "ready" }
+      : opts.enginePresent
+        ? { kind: "engine_stopped" }
+        : { kind: "not_installed" });
+  const flags = deriveDockerStatusFlags(state);
   return {
     isPending: false,
     isFetching: false,
@@ -55,11 +68,11 @@ function statusResult(opts: {
           message: null,
         },
         engine: {
-          present: opts.enginePresent,
+          state,
           version: opts.enginePresent ? "27.5.1" : null,
-          runtimeOK: opts.daemonRunning,
-          failure:
-            opts.failure ?? (opts.enginePresent ? null : "cli_not_found"),
+          cliSource: opts.enginePresent ? ("install_dir" as const) : null,
+          present: flags.present,
+          runtimeOK: flags.runtimeOK,
         },
         compose: {
           present: opts.enginePresent,
@@ -71,8 +84,8 @@ function statusResult(opts: {
           tcpReachable: true,
         },
         daemon: {
-          running: opts.daemonRunning,
-          startable: opts.enginePresent,
+          running: flags.daemonRunning,
+          startable: flags.daemonStartable,
         },
         ports: { vexPgFree: true },
         disk: { availableGB: 50 },
@@ -261,7 +274,12 @@ describe("BootstrapPanel branch matrix", () => {
       statusResult({
         enginePresent: false,
         daemonRunning: false,
-        failure: "probe_error",
+        state: {
+          kind: "error",
+          reason: "probe_error",
+          message:
+            "The Docker CLI was found but did not report a usable version.",
+        },
       }),
     );
     mockHooks.useSystemHealth.mockReturnValue(healthResult("darwin"));
@@ -381,6 +399,55 @@ describe("BootstrapPanel branch matrix", () => {
     expect(getByText(/Docker IPC probe rejected/)).toBeDefined();
     clickLogs(getByRole);
     expect(getByRole("button", { name: /Recheck/i })).toBeDefined();
+  });
+
+  it("branch D: engine socket permission denial names its real cause", () => {
+    mockHooks.useDockerStatus.mockReturnValue(
+      statusResult({
+        enginePresent: true,
+        daemonRunning: false,
+        state: {
+          kind: "permission_denied",
+          message:
+            "The Docker engine socket refused this process. Add your user to the Docker group (or grant socket access) and retry.",
+        },
+      }),
+    );
+    mockHooks.useSystemHealth.mockReturnValue(healthResult("linux"));
+    const { getByText, queryByRole } = render(<BootstrapPanel />);
+    expect(getByText(/^Docker denied access$/i)).toBeDefined();
+    expect(getByText(/refused this process/i)).toBeDefined();
+    // A denial is not an install prompt and not a "start Docker" prompt.
+    expect(queryByRole("button", { name: /Download installer/i })).toBeNull();
+    expect(queryByRole("button", { name: /^Start Docker$/i })).toBeNull();
+  });
+
+  it("branch B: engine_starting renders the daemon branch in its starting state", () => {
+    mockHooks.useDockerStatus.mockReturnValue(
+      statusResult({
+        enginePresent: true,
+        daemonRunning: false,
+        state: { kind: "engine_starting" },
+      }),
+    );
+    mockHooks.useSystemHealth.mockReturnValue(healthResult("win32"));
+    const { getByRole } = render(<BootstrapPanel />);
+    const startButton = getByRole("button", { name: /Starting/i });
+    expect(startButton).toBeDefined();
+    expect(startButton.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("branch C-desktop: a Windows install that PATH cannot see is NOT reported as missing", () => {
+    // Regression guard for the reported bug at the branch level: once the
+    // locator finds Docker on disk the state is engine_stopped, so the user
+    // gets "start Docker", never "install Docker" again.
+    mockHooks.useDockerStatus.mockReturnValue(
+      statusResult({ enginePresent: true, daemonRunning: false }),
+    );
+    mockHooks.useSystemHealth.mockReturnValue(healthResult("win32"));
+    const { getByRole, queryByRole } = render(<BootstrapPanel />);
+    expect(getByRole("button", { name: /^Start Docker$/i })).toBeDefined();
+    expect(queryByRole("button", { name: /Download installer/i })).toBeNull();
   });
 
   it("branch loading: when dockerStatus has no data yet", () => {

--- a/vex-app/src/renderer/features/docker/bootstrap/branches/FailureBody.tsx
+++ b/vex-app/src/renderer/features/docker/bootstrap/branches/FailureBody.tsx
@@ -1,11 +1,13 @@
 /**
- * Branch D — Docker check did not complete. Two sources of failure:
- *   1) `dockerStatus.data.ok === false` — IPC/Result error
- *   2) `dockerStatus.data.data.endpoint.accepted === false` — endpoint
- *      rejected (context misconfigured, socket access denied, etc.)
+ * Branch D - Docker check did not complete. Sources of failure:
+ *   1) `dockerStatus.data.ok === false` - IPC/Result error
+ *   2) `engine.state.kind === "permission_denied"` - the engine socket
+ *      exists and refused this process
+ *   3) `engine.state.kind === "error"` - probe error, or endpoint rejected
+ *      (context misconfigured, remote context, …)
  *
- * Either way: surface the message, suggest the common fixes, and link
- * the canonical install docs. Recheck lives in the orchestrator footer.
+ * Each case states its own real cause and remediation; none is reduced to
+ * "unexpected error". Recheck lives in the orchestrator footer.
  */
 
 import { SetupStatusCard } from "../../../../components/onboarding/SetupStatusCard.js";
@@ -23,19 +25,26 @@ interface FailureBodyProps {
 }
 
 export function FailureBody({ status }: FailureBodyProps): JSX.Element {
+  const engineState = status?.ok === true ? status.data.engine.state : null;
+  const denied = engineState?.kind === "permission_denied";
   const probeFailed =
-    status?.ok === true && status.data.engine.failure === "probe_error";
-  const title = probeFailed
-    ? "Docker probe failed"
-    : "Docker check did not complete";
-  const message =
-    probeFailed
-      ? "Docker probe failed - open the logs folder for details."
-      : status?.ok === false
-      ? status.error.message
-      : status?.ok && !status.data.endpoint.accepted
-        ? (status.data.endpoint.message ?? "Docker endpoint rejected.")
-        : "Docker check did not complete.";
+    engineState?.kind === "error" && engineState.reason === "probe_error";
+  const title = denied
+    ? "Docker denied access"
+    : probeFailed
+      ? "Docker probe failed"
+      : "Docker check did not complete";
+  const message = denied
+    ? engineState.message
+    : probeFailed
+      ? `${engineState.message} Open the logs folder for details.`
+      : engineState?.kind === "error"
+        ? engineState.message
+        : status?.ok === false
+          ? status.error.message
+          : status?.ok === true && !status.data.endpoint.accepted
+            ? (status.data.endpoint.message ?? "Docker endpoint rejected.")
+            : "Docker check did not complete.";
   return (
     <div className="flex flex-col gap-4">
       <SetupStatusCard tone="error" title={title} detail={message} />

--- a/vex-app/src/renderer/features/docker/bootstrap/branches/ReadyBody.tsx
+++ b/vex-app/src/renderer/features/docker/bootstrap/branches/ReadyBody.tsx
@@ -12,15 +12,16 @@ interface ReadyBodyProps {
 }
 
 export function ReadyBody({ status }: ReadyBodyProps): JSX.Element {
+  const state = status?.engine.state ?? null;
   const engine =
-    status?.engine.present && status.engine.version
+    state !== null && state.kind !== "not_installed" && status?.engine.version
       ? `Engine ${status.engine.version}`
       : "Engine detected";
   const compose =
     status?.compose.present && status.compose.version
       ? `Compose ${status.compose.version}`
       : "Compose plugin present";
-  const daemon = status?.daemon.running ? "Daemon up" : "Daemon idle";
+  const daemon = state?.kind === "ready" ? "Daemon up" : "Daemon idle";
   return (
     <SetupStatusCard
       tone="ok"

--- a/vex-app/src/renderer/lib/api/mission.ts
+++ b/vex-app/src/renderer/lib/api/mission.ts
@@ -208,6 +208,11 @@ export function useMissionUpdateLiveSync(sessionId: string | null): void {
 
     const off = window.vex.engine.onMissionUpdate((event) => {
       if (event.sessionId !== sessionId) return;
+      // `setup_no_progress` reports that NOTHING changed - it exists precisely
+      // so a stalled draft is distinguishable from a progressing one.
+      // Refetching on it would spend IPC round-trips re-reading a row the
+      // engine has just said is unchanged. `useMissionSetupProgress` consumes it.
+      if (event.kind === "setup_no_progress") return;
       if (event.kind === "approval_enqueued") {
         void queryClient.invalidateQueries({
           queryKey: approvalsKeys.pending(sessionId),

--- a/vex-app/src/shared/schemas/__tests__/docker.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/docker.test.ts
@@ -21,10 +21,11 @@ const validStatus: DockerStatus = {
     message: null,
   },
   engine: {
-    present: true,
+    state: { kind: "ready" },
     version: "27.5.1",
+    cliSource: "install_dir",
+    present: true,
     runtimeOK: true,
-    failure: null,
   },
   compose: { present: true, version: "v2.32.4" },
   modelRunner: { present: true, status: "active", tcpReachable: true },
@@ -42,10 +43,11 @@ describe("dockerStatusSchema", () => {
     const status: DockerStatus = {
       ...validStatus,
       engine: {
-        present: false,
+        state: { kind: "not_installed" },
         version: null,
+        cliSource: null,
+        present: false,
         runtimeOK: false,
-        failure: "cli_not_found",
       },
     };
     expect(dockerStatusSchema.safeParse(status).success).toBe(true);

--- a/vex-app/src/shared/schemas/__tests__/mission.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/mission.test.ts
@@ -69,6 +69,8 @@ describe("mission schemas", () => {
       acceptance: null,
       deployedCapital: null,
       renewedFromMissionId: null,
+      missingFields: [],
+      canAcceptContract: false,
     });
     expect(parsed.success).toBe(true);
   });
@@ -93,6 +95,8 @@ describe("mission schemas", () => {
       acceptance: null,
       deployedCapital: null,
       renewedFromMissionId: null,
+      missingFields: [],
+      canAcceptContract: false,
     });
     expect(parsed.success).toBe(false);
   });
@@ -122,6 +126,8 @@ describe("mission schemas", () => {
       },
       deployedCapital: null,
       renewedFromMissionId: "mission-source",
+      missingFields: [],
+      canAcceptContract: false,
     });
     expect(parsed.success).toBe(true);
   });
@@ -197,6 +203,8 @@ describe("mission schemas", () => {
         approvedAt: null,
         acceptance: null,
         renewedFromMissionId: null,
+        missingFields: [],
+        canAcceptContract: false,
       };
       expect(
         missionDraftDtoSchema.safeParse({ ...base, deployedCapital: VALID })

--- a/vex-app/src/shared/schemas/__tests__/usage.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/usage.test.ts
@@ -4,7 +4,7 @@ import {
   contextWindowResultSchema,
   lastTurnUsageResultSchema,
   sessionUsageTotalsDtoSchema,
-  turnUsageDtoSchema,
+  turnUsageRollupDtoSchema,
   usageInputSchema,
   USAGE_DEFAULT_CURRENCY,
 } from "../usage.js";
@@ -17,18 +17,18 @@ describe("usage schemas", () => {
   function turnFixture(overrides: Record<string, unknown> = {}) {
     return {
       sessionId: SESSION,
-      promptTokens: 100,
-      completionTokens: 50,
-      totalTokens: 150,
-      cachedTokens: 10,
-      reasoningTokens: 5,
-      cost: 0.001,
-      cachedSavings: 0.0004,
-      cacheWriteTokens: 12,
+      latestRoundPromptTokens: 100,
+      latestRoundCachedTokens: 10,
+      turnCompletionTokens: 50,
+      turnReasoningTokens: 5,
+      turnCacheWriteTokens: 12,
+      turnCost: 0.001,
+      turnCachedSavings: 0.0004,
+      roundCount: 3,
       currency: "USD",
       provider: "openrouter",
       model: "anthropic/claude-opus-4.7",
-      createdAt: ISO,
+      latestRoundAt: ISO,
       ...overrides,
     };
   }
@@ -49,62 +49,55 @@ describe("usage schemas", () => {
     };
   }
 
-  it("turnUsageDtoSchema accepts a typical row with USD currency", () => {
-    const parsed = turnUsageDtoSchema.safeParse(turnFixture());
-    expect(parsed.success).toBe(true);
+  it("turnUsageRollupDtoSchema accepts a typical multi-round rollup", () => {
+    expect(turnUsageRollupDtoSchema.safeParse(turnFixture()).success).toBe(true);
   });
 
-  it("turnUsageDtoSchema requires the cache fields (missing cachedSavings/cacheWriteTokens fails)", () => {
-    const { cachedSavings: _s, cacheWriteTokens: _w, ...withoutCacheFields } = turnFixture();
-    expect(turnUsageDtoSchema.safeParse(withoutCacheFields).success).toBe(false);
+  it("turnUsageRollupDtoSchema requires the cache fields", () => {
+    const { turnCachedSavings: _s, turnCacheWriteTokens: _w, ...without } = turnFixture();
+    expect(turnUsageRollupDtoSchema.safeParse(without).success).toBe(false);
   });
 
-  it("turnUsageDtoSchema accepts NEGATIVE cachedSavings (net cache overhead is real - no .min(0))", () => {
-    const parsed = turnUsageDtoSchema.safeParse(
-      turnFixture({ cachedSavings: -0.0021, cacheWriteTokens: 8000 }),
+  it("turnUsageRollupDtoSchema accepts NEGATIVE turnCachedSavings (net cache overhead is real - no .min(0))", () => {
+    const parsed = turnUsageRollupDtoSchema.safeParse(
+      turnFixture({ turnCachedSavings: -0.0021, turnCacheWriteTokens: 8000 }),
     );
     expect(parsed.success).toBe(true);
   });
 
-  it("turnUsageDtoSchema rejects negative cacheWriteTokens (int ≥ 0)", () => {
+  it("turnUsageRollupDtoSchema rejects negative turnCacheWriteTokens (int >= 0)", () => {
     expect(
-      turnUsageDtoSchema.safeParse(turnFixture({ cacheWriteTokens: -1 })).success,
+      turnUsageRollupDtoSchema.safeParse(turnFixture({ turnCacheWriteTokens: -1 })).success,
     ).toBe(false);
   });
 
-  it("turnUsageDtoSchema rejects unknown keys (strict)", () => {
+  it("turnUsageRollupDtoSchema rejects unknown keys (strict)", () => {
     expect(
-      turnUsageDtoSchema.safeParse(turnFixture({ extraKey: true })).success,
+      turnUsageRollupDtoSchema.safeParse(turnFixture({ extraKey: true })).success,
     ).toBe(false);
   });
 
-  it("turnUsageDtoSchema rejects negative token counts", () => {
-    const parsed = turnUsageDtoSchema.safeParse(
-      turnFixture({
-        promptTokens: -1,
-        completionTokens: 0,
-        totalTokens: 0,
-        cachedTokens: 0,
-        reasoningTokens: 0,
-        cost: null,
-        provider: null,
-        model: null,
-      }),
-    );
-    expect(parsed.success).toBe(false);
+  it("turnUsageRollupDtoSchema rejects negative token counts", () => {
+    expect(
+      turnUsageRollupDtoSchema.safeParse(turnFixture({ latestRoundPromptTokens: -1 })).success,
+    ).toBe(false);
+    expect(
+      turnUsageRollupDtoSchema.safeParse(turnFixture({ turnCompletionTokens: -1 })).success,
+    ).toBe(false);
   });
 
-  it("turnUsageDtoSchema permits nullable provider/model/cost/cachedSavings for legacy rows", () => {
-    const parsed = turnUsageDtoSchema.safeParse(
+  // A rollup describes at least one model round by construction: `getLastTurn`
+  // returns `null`, never a zero-round DTO, for an empty window. Pinning
+  // `min(1)` keeps "no usage yet" from being expressible as a fake turn.
+  it("turnUsageRollupDtoSchema rejects roundCount below 1", () => {
+    expect(turnUsageRollupDtoSchema.safeParse(turnFixture({ roundCount: 0 })).success).toBe(false);
+  });
+
+  it("turnUsageRollupDtoSchema permits nullable provider/model/cost/savings for legacy rows", () => {
+    const parsed = turnUsageRollupDtoSchema.safeParse(
       turnFixture({
-        promptTokens: 0,
-        completionTokens: 0,
-        totalTokens: 0,
-        cachedTokens: 0,
-        reasoningTokens: 0,
-        cost: null,
-        cachedSavings: null,
-        cacheWriteTokens: 0,
+        turnCost: null,
+        turnCachedSavings: null,
         provider: null,
         model: null,
       }),
@@ -152,23 +145,10 @@ describe("usage schemas", () => {
     if (parsed.success) expect(parsed.data.currency).toBe(USAGE_DEFAULT_CURRENCY);
   });
 
-  it("lastTurnUsageResultSchema accepts null (empty session) and a turn DTO", () => {
+  it("lastTurnUsageResultSchema accepts null (empty session) and a turn rollup", () => {
     expect(lastTurnUsageResultSchema.safeParse(null).success).toBe(true);
     expect(
-      lastTurnUsageResultSchema.safeParse(
-        turnFixture({
-          promptTokens: 1,
-          completionTokens: 1,
-          totalTokens: 2,
-          cachedTokens: 0,
-          reasoningTokens: 0,
-          cost: 0,
-          cachedSavings: 0,
-          cacheWriteTokens: 0,
-          provider: null,
-          model: null,
-        }),
-      ).success,
+      lastTurnUsageResultSchema.safeParse(turnFixture({ roundCount: 1 })).success,
     ).toBe(true);
   });
 

--- a/vex-app/src/shared/schemas/chat.ts
+++ b/vex-app/src/shared/schemas/chat.ts
@@ -117,6 +117,7 @@ export const chatStopReasonSchema = z.enum([
   "user_paused",
   "plan_acceptance_required",
   "user_form_required",
+  "no_progress",
 ]);
 export type ChatStopReason = z.infer<typeof chatStopReasonSchema>;
 

--- a/vex-app/src/shared/schemas/docker.ts
+++ b/vex-app/src/shared/schemas/docker.ts
@@ -146,15 +146,87 @@ export const dockerEndpointPolicySchema = z
   .strict();
 export type DockerEndpointPolicy = z.infer<typeof dockerEndpointPolicySchema>;
 
+/**
+ * The authoritative Docker engine state.
+ *
+ * Replaces the old `present` + `daemon.running` + `failure` booleans, which
+ * could not tell "not installed" apart from "installed but the engine is
+ * stopped", had no representation at all for "starting", and collapsed a
+ * permission denial into a generic failure.
+ *
+ * - `not_installed`      no Docker CLI was found in any install directory or on PATH.
+ * - `engine_stopped`     the CLI is usable, the engine is not answering.
+ * - `engine_starting`    the engine is expected to be coming up because Vex
+ *                        just started it. This is NOT inferred from a probe;
+ *                        see `main/docker/engine-start-window.ts`.
+ * - `ready`              the CLI is usable and the daemon answered.
+ * - `permission_denied`  the engine endpoint exists and refused this process.
+ * - `error`              the check itself could not complete.
+ */
+export const dockerEngineStateSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("not_installed") }).strict(),
+  z.object({ kind: z.literal("engine_stopped") }).strict(),
+  z.object({ kind: z.literal("engine_starting") }).strict(),
+  z.object({ kind: z.literal("ready") }).strict(),
+  z
+    .object({ kind: z.literal("permission_denied"), message: z.string() })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("error"),
+      reason: z.enum(["probe_error", "endpoint_rejected"]),
+      message: z.string(),
+    })
+    .strict(),
+]);
+export type DockerEngineState = z.infer<typeof dockerEngineStateSchema>;
+
+export const dockerCliSourceSchema = z.enum(["install_dir", "path"]);
+export type DockerCliSource = z.infer<typeof dockerCliSourceSchema>;
+
+export interface DockerStatusFlags {
+  readonly present: boolean;
+  readonly runtimeOK: boolean;
+  readonly daemonRunning: boolean;
+  readonly daemonStartable: boolean;
+}
+
+/**
+ * The one place the legacy booleans are derived from `engine.state`.
+ *
+ * They remain on the wire for consumers that have not migrated yet
+ * (`renderer/features/systemCheck/**`, `renderer/features/setup/
+ * useSetupOrchestrator.ts`) and are removed once those read `state`. New
+ * code must branch on `engine.state`, never on these.
+ */
+export function deriveDockerStatusFlags(
+  state: DockerEngineState,
+): DockerStatusFlags {
+  const installed =
+    state.kind !== "not_installed" && state.kind !== "error";
+  const ready = state.kind === "ready";
+  return {
+    present: installed,
+    runtimeOK: ready,
+    daemonRunning: ready,
+    daemonStartable: installed,
+  };
+}
+
 export const dockerStatusSchema = z
   .object({
     endpoint: dockerEndpointPolicySchema,
     engine: z
       .object({
-        present: z.boolean(),
+        state: dockerEngineStateSchema,
         version: z.string().nullable(),
+        /** Which strategy located the CLI. The path itself never crosses
+         * the process boundary. */
+        cliSource: dockerCliSourceSchema.nullable(),
+        /** Derived from `state` - see `deriveDockerStatusFlags`. */
+        present: z.boolean(),
+        /** Derived from `state` - see `deriveDockerStatusFlags`. */
         runtimeOK: z.boolean(),
-        failure: z.enum(["cli_not_found", "probe_error"]).nullable(),
       })
       .strict(),
     compose: z
@@ -172,7 +244,9 @@ export const dockerStatusSchema = z
       .strict(),
     daemon: z
       .object({
+        /** Derived from `engine.state` - see `deriveDockerStatusFlags`. */
         running: z.boolean(),
+        /** Derived from `engine.state` - see `deriveDockerStatusFlags`. */
         startable: z.boolean(),
       })
       .strict(),

--- a/vex-app/src/shared/schemas/mission-update.ts
+++ b/vex-app/src/shared/schemas/mission-update.ts
@@ -33,6 +33,15 @@ export const missionUpdateKindSchema = z.enum([
   "readiness_changed",
   "accepted",
   "approval_enqueued",
+  /**
+   * A mission SETUP turn finished without writing anything to an incomplete
+   * draft. The ONLY kind that reports an ABSENCE of change: every other kind
+   * means "refetch, the row moved", this one means "the row did NOT move and
+   * will not move on its own". `useMissionUpdateLiveSync` therefore does not
+   * invalidate on it; `useMissionSetupProgress` records it so the mission
+   * surface can escalate from "still drafting" to "drafting stalled".
+   */
+  "setup_no_progress",
 ]);
 export type MissionUpdateKind = z.infer<typeof missionUpdateKindSchema>;
 

--- a/vex-app/src/shared/schemas/mission/draft.ts
+++ b/vex-app/src/shared/schemas/mission/draft.ts
@@ -147,6 +147,32 @@ export const missionDeployedCapitalSchema = z
   .strict();
 export type MissionDeployedCapital = z.infer<typeof missionDeployedCapitalSchema>;
 
+/**
+ * Human labels for the engine's `MISSION_DRAFT_REQUIRED_FIELDS`
+ * (`src/vex-agent/engine/types/mission-draft.ts`). The engine names fields in
+ * its own camelCase vocabulary; the host must never show `allowedProtocols` to
+ * a person. Any field id absent from this map renders verbatim, so a new
+ * required field degrades to an ugly-but-honest label rather than disappearing
+ * from the list the user is told to wait for.
+ */
+export const MISSION_DRAFT_FIELD_LABELS: Readonly<Record<string, string>> = {
+  title: "Mission title",
+  goal: "Goal",
+  capitalSource: "Capital source",
+  startingCapital: "Starting capital",
+  allowedWallets: "Allowed wallets",
+  allowedChains: "Allowed chains",
+  allowedProtocols: "Allowed protocols",
+  riskProfile: "Risk profile",
+  successCriteria: "Success criteria",
+  stopConditions: "Stop conditions",
+};
+
+/** Render one required-field id for a person. */
+export function missionDraftFieldLabel(field: string): string {
+  return MISSION_DRAFT_FIELD_LABELS[field] ?? field;
+}
+
 export const missionDraftDtoSchema = z
   .object({
     missionId: z.string(),
@@ -180,6 +206,33 @@ export const missionDraftDtoSchema = z
     deployedCapital: missionDeployedCapitalSchema.nullable(),
     /** `/mission-renew` lineage — id of the mission this one was renewed from. */
     renewedFromMissionId: z.string().nullable(),
+    /**
+     * Required contract fields the draft still lacks, as the ENGINE's own
+     * completeness predicate reports them
+     * (`engine/mission/validator.ts#getMissingDraftFields`). Empty iff the draft
+     * is complete.
+     *
+     * COMPLETE, never a sample: the host renders the whole list, because the
+     * whole list is what the user is waiting on. Bounded at 32 by the number of
+     * required fields that can exist, not by a display budget.
+     *
+     * Whose problem it is matters: `mission.updateDraft` is a deliberate stub,
+     * so the HOST CANNOT fill these. Only the agent can, via `MissionDraftUpdate`.
+     * Any copy built from this list must name the agent as the actor.
+     */
+    missingFields: z.array(z.string().max(64)).max(32),
+    /**
+     * THE capability answer, decided by the owner (main) rather than re-derived
+     * from `status` by each renderer surface - the same split VS Code draws
+     * between `isWorkspaceTrusted()` and `canSetWorkspaceTrust()`.
+     *
+     * True iff the host may accept this contract right now. It is NOT a grant
+     * and NOT durable permission: acceptance still goes through
+     * `mission.acceptContract`, still binds to the exact contract hash, and is
+     * still revalidated at start. A renderer that shows Accept when this is
+     * false is offering an action the engine will refuse.
+     */
+    canAcceptContract: z.boolean(),
   })
   .strict();
 export type MissionDraftDto = z.infer<typeof missionDraftDtoSchema>;

--- a/vex-app/src/shared/schemas/usage.ts
+++ b/vex-app/src/shared/schemas/usage.ts
@@ -16,39 +16,6 @@ import { z } from "zod";
 export const USAGE_DEFAULT_CURRENCY = "USD";
 
 /**
- * One row from `usage_log` mapped for the renderer. All token counts
- * are non-negative integers; `cost` is a JS number (DB column is
- * `NUMERIC` — the mapper parses safely or drops to `null` on overflow,
- * keeping JSON-serializable shape).
- */
-export const turnUsageDtoSchema = z
-  .object({
-    sessionId: z.string().uuid(),
-    promptTokens: z.number().int().min(0),
-    completionTokens: z.number().int().min(0),
-    totalTokens: z.number().int().min(0),
-    cachedTokens: z.number().int().min(0),
-    reasoningTokens: z.number().int().min(0),
-    /** `null` when the DB `NUMERIC` could not be coerced to a finite JS number. */
-    cost: z.number().nullable(),
-    /**
-     * NET cache savings (read savings − write surcharge) for this turn.
-     * Deliberately NO `.min(0)` — a write-heavy explicit-cache request
-     * yields a real NEGATIVE net, and clamping it would turn every read of
-     * such a session into a contract violation. `null` when the NUMERIC
-     * could not be coerced.
-     */
-    cachedSavings: z.number().nullable(),
-    cacheWriteTokens: z.number().int().min(0),
-    currency: z.string().min(1).max(8),
-    provider: z.string().nullable(),
-    model: z.string().nullable(),
-    createdAt: z.string().datetime({ offset: true }),
-  })
-  .strict();
-export type TurnUsageDto = z.infer<typeof turnUsageDtoSchema>;
-
-/**
  * Aggregated totals for one session, filtered by currency. The DB query
  * sums per-row counts/cost and returns `requestCount` + the latest
  * `created_at`. Empty sessions resolve to all-zero counts with
@@ -65,7 +32,7 @@ export const sessionUsageTotalsDtoSchema = z
     totalCost: z.number().nullable(),
     /**
      * Session-summed NET cache savings. NO `.min(0)` (negative net is
-     * real — see `turnUsageDtoSchema.cachedSavings`).
+     * real - see `turnUsageRollupDtoSchema.turnCachedSavings`).
      */
     totalCachedSavings: z.number().nullable(),
     currency: z.string().min(1).max(8),
@@ -84,12 +51,90 @@ export const usageInputSchema = z
 export type UsageInput = z.infer<typeof usageInputSchema>;
 
 /**
+ * Usage for ONE TURN, aggregated across every model round that turn ran.
+ *
+ * ## Why this is not a `usage_log` row
+ *
+ * A "turn" in this engine is a LOOP: `runTurnLoop` performs up to
+ * `maxIterations` model round-trips and `executeTurn` writes one `usage_log`
+ * row per round. Reading the newest row therefore describes the LAST ROUND, not
+ * the turn, and under-reported a real multi-round turn by roughly the round
+ * count - the reported v0.2.6 case displayed `OUT 1 / $0.0405` for a turn that
+ * had run fifty rounds. Rule 90 forbids shipping a false money figure on a
+ * user-facing surface, so the panel aggregates.
+ *
+ * ## What each number means, and why the two sides differ
+ *
+ * INPUT is a SNAPSHOT of the newest round. Every round re-sends the whole
+ * growing conversation, so summing prompt tokens across rounds would count the
+ * same conversation repeatedly and produce a number that means nothing.
+ * `latestRound*` is the honest input measurement: the size of the last request
+ * this turn issued.
+ *
+ * OUTPUT, COST and cache savings are RUNNING SUMS across the turn's rounds.
+ * Each round's completion tokens are new tokens actually generated and actually
+ * billed, and tool-call arguments are part of them (the provider bills them as
+ * completion tokens; this code has never had a separate bucket for them), so
+ * summing is the only correct answer for what the turn spent.
+ *
+ * Same split VS Code's chat model uses (`chatModel.ts`: `promptTokens`
+ * latest-call, `completionTokens` running total).
+ *
+ * `roundCount` makes the aggregation legible rather than implicit: the reader
+ * can see the figures cover N rounds, not one.
+ */
+export const turnUsageRollupDtoSchema = z
+  .object({
+    sessionId: z.string().uuid(),
+    /** SNAPSHOT: prompt tokens of the turn's most recent round. Never summed. */
+    latestRoundPromptTokens: z.number().int().min(0),
+    /**
+     * SNAPSHOT: cached prompt tokens of that SAME round. Cache-hit share is a
+     * property of one request's prompt, so it must come from the same round as
+     * `latestRoundPromptTokens` or the percentage divides two unrelated
+     * measurements.
+     */
+    latestRoundCachedTokens: z.number().int().min(0),
+    /** RUNNING SUM: completion tokens generated across every round of the turn. */
+    turnCompletionTokens: z.number().int().min(0),
+    /** RUNNING SUM: reasoning tokens across every round of the turn. */
+    turnReasoningTokens: z.number().int().min(0),
+    /** RUNNING SUM: cache-write tokens across every round of the turn. */
+    turnCacheWriteTokens: z.number().int().min(0),
+    /**
+     * RUNNING SUM of every round's cost. `null` when the DB `NUMERIC` could not
+     * be coerced to a finite JS number - a missing measurement is never printed
+     * as `$0`.
+     */
+    turnCost: z.number().nullable(),
+    /**
+     * RUNNING SUM of NET cache savings (read savings − write surcharge).
+     * Deliberately NO `.min(0)`: a write-heavy explicit-cache turn yields a real
+     * negative net, and clamping would make honest data a contract violation.
+     */
+    turnCachedSavings: z.number().nullable(),
+    /** How many model round-trips these figures cover. Always >= 1. */
+    roundCount: z.number().int().min(1),
+    currency: z.string().min(1).max(8),
+    /** Provider/model of the most recent round (a turn can fail over mid-run). */
+    provider: z.string().nullable(),
+    model: z.string().nullable(),
+    /** `created_at` of the most recent round in the turn. */
+    latestRoundAt: z.string().datetime({ offset: true }),
+  })
+  .strict();
+export type TurnUsageRollupDto = z.infer<typeof turnUsageRollupDtoSchema>;
+
+/**
  * Result for `usage.getLastTurn` — `null` when the session has no
  * usage rows yet (mission setup hasn't produced a turn, or all rows
  * were reaped by retention). The renderer renders an empty chip then,
  * not an error toast.
+ *
+ * The channel name is unchanged and is now ACCURATE: it returns the last TURN,
+ * where it used to return the last round.
  */
-export const lastTurnUsageResultSchema = turnUsageDtoSchema.nullable();
+export const lastTurnUsageResultSchema = turnUsageRollupDtoSchema.nullable();
 export type LastTurnUsageResult = z.infer<typeof lastTurnUsageResultSchema>;
 
 /**


### PR DESCRIPTION
Fixes three bugs reported against 0.2.6. Each has a confirmed root cause in code, a fix modelled on how VS Code solves the same class of problem, and a test that goes red when the fix is reverted.

## 1. Docker gate never passes on Windows

> "I updated Windows and downloaded it, but it keeps asking me to install it." / "on my MacBook, I downloaded and installed it first, and then it asked me to log in and continue. It seems different on Windows."

`buildDockerPath` returned `process.env` unchanged on win32, and detection was `docker --version` through PATH only. That environment is a snapshot taken at app launch, and Windows gives a running process no way to observe a later PATH change, so a Docker installed after Vex started stayed invisible until restart. macOS worked because it appended candidate directories re-checked on every spawn.

The fix is ordering, taken from the Git extension's `findGitWin32` (`extensions/git/src/git.ts:151-157`): known install directories are probed on the filesystem **first**, PATH is the fallback. A filesystem probe is immune to the stale snapshot. Per-user `%LOCALAPPDATA%\Programs\DockerDesktop` is tried first because it is Docker's current default install mode.

PATH stays in the chain on purpose: `--installation-dir` is a supported installer flag, so path probing is a heuristic and never a decision procedure.

Also in this commit:

- Engine liveness moved off the CLI onto the named pipe with error-code triage, so "engine not running" is no longer reported as "not installed". `\\.\pipe\docker_engine` is confirmed current in moby source; `GET /_ping` is a documented liveness endpoint.
- `engine.present`/`failure` booleans became a six-state union. "Starting" is only entered from an explicit start, never inferred from a probe.
- The probe and `docker desktop start` now share one locator. They previously answered "is Docker installed" two different ways and routinely disagreed on Windows.
- Relative PATH entries are deliberately skipped. The standard algorithm resolves them against the working directory, which in a privileged main process lets cwd decide which binary gets executed.
- Windows arm64 installer URL added. Docker ships that build today, and `getInstallerForPlatform("win32", "arm64")` previously returned `unsupported`. Scope note, because it is narrower than it looks: the selector reads `process.arch`, the architecture of the *process*, so this unblocks a **native arm64 build** of Vex (which `electron-builder.yml` produces) rather than every ARM machine. `electron-builder.release.yml` still ships `x64` only, and an ARM user running that build under emulation reports `x64` and is served the amd64 installer, which is the wrong build for their hardware. Serving them the arm64 installer would mean detecting the host architecture rather than the process one, via `PROCESSOR_ARCHITEW6432` (the pattern VS Code uses in five places, e.g. `terminalProfiles.ts:84`). That is not done here: it cannot be verified from a Linux host, and shipping Windows arm64 is an open release decision.

## 2. Mission setup dead-ends with no way forward

The session showed "Mission contract not accepted - on-chain actions are blocked until you accept the contract" while offering nothing that could accept it. Accept only rendered at `ready`, which needs ten fields only the model can write, and the modal footer told the user in the imperative to "Add a goal, constraints, and stop conditions" when the host-side editor is stubbed and they cannot.

Modelled on Workspace Trust: the owner answers `canAcceptContract` rather than the UI re-deriving readiness (`workspaceTrust.ts:41-67`), the concrete losses are enumerated rather than summarised (`workspaceTrustEditor.ts:1008-1016`), and the request is single-flight, joinable and tri-state, settling only after the commit (`workspaceTrust.ts:856-875`).

`missingFields` was already computed every turn and discarded at the IPC boundary; it now reaches the renderer. Three hand-rolled readiness predicates collapse into one shared selector.

Accept is still **not** offered on a `draft` contract. The engine would take it but `commit-start` would refuse with `not_ready`, which moves the dead end rather than removing it.

MISSION PREPARING gains liveness: a setup turn that writes nothing to an incomplete draft now emits `setup_no_progress`, because `applyMissionPatch` only emits on change and a stalled draft was indistinguishable from a progressing one.

No authority changed. Acceptance still binds to the exact contract hash and is still revalidated at commit.

## 3. Fifty empty rounds reported as a budget exhaustion

> "I reached my tool-use budget for this turn before producing a final answer..." with `IN 38.2k / OUT 1` and nothing done.

This was never a budget problem. When a model round returns neither text nor tool calls, `turn-loop` took neither dispatch branch (`content` defaults to `""`, which is falsy). The iteration ended, nothing persisted, nothing logged, and the loop went round again with input identical to what it had just answered nothing to. Fifty times. Every round re-sent the full prompt and was billed.

The pattern is VS Code's, at `toolCallingLoop.ts:1483-1486`: keep the stall counter **separate** from the round budget and **reset it on productive work**. A budget and a stall detector are different instruments; conflating them is why a long productive task would die at the same threshold as a spinner. The iteration budget is untouched, because raising it would only buy 1000 empty rounds instead of 50.

`no_progress` is its own stop reason with its own copy. Reusing the iteration-limit text would repeat a dishonesty the timeout reply already rejected: no budget was exhausted, and "tell me how to proceed" would invite paying for another run of nothing. The reply deliberately does not claim nothing ran, because earlier rounds in the same turn may have moved funds.

**The cost panel was also wrong, independently.** `getLastTurn` read a single `usage_log` row, so a 50-round turn displayed the last round alone. That is exactly how a full turn of tool calling showed `OUT 1`. It now aggregates the turn window, following `chatModel.ts:1584-1618`: input stays a snapshot of the latest round (summing would count the resent conversation N times), output and cost are summed, and the round count is shown so the aggregation is visible. Validated against a live Postgres: the same turn reads `out 901` windowed versus `out 1 / $0.0005` from the single row.

## Verification

| Gate | Result |
|---|---|
| `pnpm test` | 1067 files, 14215 tests passed |
| `pnpm vex:test` | 517 files, 5798 tests passed |
| `pnpm vex:lint` | tsc clean, ratchet green at 337, boundaries passed |
| `pnpm check:em-dash` | passed |

Red-on-revert proven for all three: the Docker locator test fails against a PATH-only detector, five turn-loop tests fail without the stall block, and the setup-turn stall test returns `null` instead of the reply.

Three tests encoded the bugs and were changed deliberately, each with the old expectation recorded in the diff:

- `cli-env.test.ts` asserted the Windows env was returned by identity and no directory was ever probed.
- `MissionControls.test.tsx` asserted the setup state offers no control at all.
- `iteration-and-save.test.ts` reached the iteration limit with `maxIterations: 0`, so the loop body never executed.

## Not verified, and known gaps

- **Real Windows behavior is unverifiable from Linux.** The strongest residual risk is whether `resources\bin\docker.exe` is the true on-disk path: Docker's docs prove that directory holds the CLI tools but name only `kubectl.exe` there by path. If that candidate misses, detection falls through to PATH and the bug survives for a post-launch install. This needs one manual Windows 11 pass. It is also why PATH remains in the chain.
- Docker documents nothing about whether its installer writes machine PATH, user PATH, or neither. The path-first design deliberately does not depend on the answer.
- `pnpm test:integration` was not run; it needs a live embedding stack. The only new SQL was instead validated against a real Postgres directly.
- No E2E run; that needs a built app.
- **The on-chain block does not yet raise the contract surface.** The request service is complete and is raised by the notice, the header badge and a `mission.start` refusal, but wiring the actual swap/bridge/send gate needs a new engine event from the enforcement sites, which were out of scope for this branch. Until then the tri-state result has no production consumer.
- The stalled-state escape is the composer rather than a control. A setup-phase mission has no run to stop, so a real "discard this draft" affordance needs new IPC and is a separate product decision.

## Deliberately out of scope

- The installer **download** path: the 10-minute wall-clock abort on a 630 MB transfer, the absent single-flight, the write straight to the final executable path, and the missing integrity check. Docker publishes SHA-256 checksums at a derivable URL, so that check can be made real; `installer-urls.ts` currently carries a comment claiming an integrity check that does not exist. Only the URL table and arch selection were touched here.
- Token discovery collapsing onto Virtuals Trenches. The prompt-level fix was landed and deliberately reverted by the owner (ruling D19), and the deeper cause is a tool-surface gap: on EVM the only tools that answer an open "what should I buy" are launchpad browsers, since `dexscreener.search` requires a query. Reopening that needs a product decision, not a bugfix.
