### PR TITLE
Transcript tool args: whole or null, never a cut string

### DIFF
--- a/vex-app/src/main/database/__tests__/messages-redaction-whole-args.test.ts
+++ b/vex-app/src/main/database/__tests__/messages-redaction-whole-args.test.ts
@@ -1,0 +1,124 @@
+/**
+ * WHOLE-ARGS CONTRACT (owner decree: no silent content cutting).
+ *
+ * The displayed tool args are the WHOLE sanitized serialization or null,
+ * never a cut string. The reproducer here is the measured production outage
+ * of 2026-08-26: the first BoardCompose call serialized past the old
+ * 2,000-char cap, the truncation branch appended a suffix that pushed the
+ * string past the IPC schema's own bound, and the ENTIRE messages page
+ * failed output validation - the session would no longer load. Reverting the
+ * fix (any per-string, per-array, per-key, depth or whole-serialization cut)
+ * turns these red.
+ *
+ * Secret REDACTION is a different concern and must survive: it hides what
+ * the user must NOT see, and `messages-redaction-tx-hash.test.ts` plus the
+ * cases at the bottom keep it pinned.
+ */
+
+import { describe, expect, it } from "vitest";
+import { sanitizeToolArgs } from "../messages/redaction.js";
+import {
+  TOOL_ARGS_DISPLAY_CEILING,
+  toolCallDisplaySchema,
+} from "../../../shared/schemas/messages.js";
+
+/** A BoardCompose-shaped call: the real producer that exposed the outage. */
+function boardComposeSizedArgs(): Record<string, unknown> {
+  const note =
+    "Liquidity thinned out after the 14:00 candle and the pool has been " +
+    "leaning on a single maker since; treat the +60% move as unconfirmed " +
+    "until depth returns. Watch the 0.0125 shelf where the accumulation " +
+    "range from yesterday evening sat before the breakout attempt began.";
+  return {
+    title: "Robinhood Chain - Top 5 movers",
+    pools: Array.from({ length: 8 }, (_, i) => ({
+      chain: "robinhood",
+      pairAddress: `0x${String(i).repeat(40)}`,
+      caption: `${note} (pool ${i})`,
+    })),
+    notes: Array.from({ length: 6 }, () => note),
+    chart: {
+      poolIndex: 0,
+      resolution: "15m",
+      annotations: Array.from({ length: 12 }, (_, i) => ({
+        kind: "level",
+        price: `0.0${100 + i}`,
+        label: `shelf ${i}: ${note}`,
+      })),
+    },
+  };
+}
+
+describe("sanitizeToolArgs ships the WHOLE sanitized serialization", () => {
+  it("keeps a 280-char string verbatim (the old 256 cap is gone)", () => {
+    // Real prose: capitals, digits and punctuation keep it clear of the
+    // base64 and mnemonic secret heuristics, which are correct and separate.
+    const value = ("Liquidity thinned after the 14:00 candle; depth sat at 0.0125. ").repeat(5).slice(0, 280);
+    expect(value).toHaveLength(280);
+    const out = sanitizeToolArgs({ note: value });
+    expect(out).not.toBeNull();
+    expect(out).toContain(value);
+    expect(out).not.toContain("…");
+  });
+
+  it("keeps every element of a 60-item array (the old 50 cap is gone)", () => {
+    const out = sanitizeToolArgs({ items: Array.from({ length: 60 }, (_, i) => `item-${i}`) });
+    expect(out).not.toBeNull();
+    expect(out).toContain("item-0");
+    expect(out).toContain("item-59");
+  });
+
+  it("keeps all 60 keys of a wide object (the old 50-key cap is gone)", () => {
+    const wide: Record<string, unknown> = {};
+    for (let i = 0; i < 60; i += 1) wide[`field${i}`] = i;
+    const out = sanitizeToolArgs(wide);
+    expect(out).not.toBeNull();
+    expect(out).toContain("field59");
+  });
+
+  it("keeps a depth-6 branch instead of replacing it with an ellipsis marker", () => {
+    const out = sanitizeToolArgs({
+      a: { b: { c: { d: { e: { f: "deep-leaf" } } } } },
+    });
+    expect(out).not.toBeNull();
+    expect(out).toContain("deep-leaf");
+    expect(out).not.toContain("[…]");
+  });
+
+  it("round-trips a BoardCompose-sized call through the IPC display schema (the production outage class)", () => {
+    const out = sanitizeToolArgs(boardComposeSizedArgs());
+    expect(out).not.toBeNull();
+    const serialized = out as string;
+    // The old cap fired at 2,000 chars; this call is far past it and must
+    // arrive whole, with no truncation marker of any spelling.
+    expect(serialized.length).toBeGreaterThan(2000);
+    expect(serialized).not.toContain("(truncated)");
+    const parsed = toolCallDisplaySchema.safeParse({
+      toolCallId: "call_1",
+      toolName: "BoardCompose",
+      toolArgs: serialized,
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("maps a row beyond the corruption ceiling to null, never to a cut string", () => {
+    const phrase = "Corrupted row payload, far past every legitimate producer (entry 9). ";
+    const over = { blob: phrase.repeat(Math.ceil((TOOL_ARGS_DISPLAY_CEILING + 1024) / phrase.length)) };
+    expect(sanitizeToolArgs(over)).toBeNull();
+  });
+
+  it("still redacts secret-shaped values while keeping the rest whole", () => {
+    const note = ("Watch the 0.0125 shelf; yesterday's accumulation range sat there. ").repeat(5).slice(0, 280);
+    const out = sanitizeToolArgs({
+      note,
+      // Neutral key NAME so the value-shape layer is what fires: a key
+      // literally called "jwt" is dropped by name before the value is seen.
+      payload: "eyJabc.eyJdef.sig",
+      privateKey: "should be dropped by key name",
+    });
+    expect(out).not.toBeNull();
+    expect(out).toContain(note);
+    expect(out).toContain("[redacted:jwt]");
+    expect(out).not.toContain("should be dropped by key name");
+  });
+});

--- a/vex-app/src/main/database/messages/redaction.ts
+++ b/vex-app/src/main/database/messages/redaction.ts
@@ -9,11 +9,13 @@
  * tool args cross the boundary.
  */
 
+import { TOOL_ARGS_DISPLAY_CEILING } from "../../../shared/schemas/messages.js";
+
 // ── Tool-call args sanitization (renderer disclosure) ─────────────────
 // The renderer reveals the params a tool was called with. Args can carry
 // sensitive material, so this is the ONLY place they cross the boundary —
-// and only as a redacted, size-capped JSON STRING (never raw JSONB). Two
-// independent layers, defense in depth:
+// and only as a redacted, WHOLE JSON STRING (never raw JSONB, never cut).
+// Two independent layers, defense in depth:
 //   1. drop any key whose NAME indicates a secret (segment-aware so common
 //      DeFi args like `tokenAddress` / `signer` are NOT false-dropped);
 //   2. hard-redact any VALUE that looks like a secret (private key, JWT,
@@ -87,11 +89,21 @@ const JWT_RE = /^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 const BASE58_LONG_RE = /^[1-9A-HJ-NP-Za-km-z]{50,}$/; // beyond Solana addr length
 const BASE64_LONG_RE = /^[A-Za-z0-9+/=]{60,}$/;
 
-const ARG_MAX_STRING = 256;
-const ARG_MAX_ARRAY = 50;
-const ARG_MAX_KEYS = 50;
-const ARG_MAX_DEPTH = 4;
-const ARGS_MAX_SERIALIZED = 2000;
+/*
+ * NO STRUCTURAL TRUNCATION (owner decree, applied 2026-08-26).
+ *
+ * This sweep REDACTS secrets; it never cuts legitimate content. The previous
+ * per-string (256), per-array (50), per-object (50 keys), depth (4) and
+ * whole-serialization (2000) caps were silent cuts of a persisted transcript
+ * the user must see whole, and the serialization cap shipped a measured
+ * production outage: the appended "(truncated)" suffix pushed the string past
+ * the IPC schema's bound and the whole messages page failed output validation
+ * on the first tool call large enough to hit the branch (BoardCompose).
+ * Args arrive from finite acyclic JSONB, so unbounded recursion is safe; the
+ * one remaining ceiling is `TOOL_ARGS_DISPLAY_CEILING` in the shared schema,
+ * a corruption guard sitting far above every legitimate producer, and a row
+ * that somehow exceeds it maps to null rather than to a cut string.
+ */
 
 function splitKeyWords(key: string): string[] {
   return key
@@ -133,7 +145,7 @@ function redactScalarString(value: string, hashKey: boolean): string {
   if (words.length >= 12 && words.every((w) => /^[a-z]+$/.test(w))) {
     return "[redacted:mnemonic]";
   }
-  return value.length > ARG_MAX_STRING ? `${value.slice(0, ARG_MAX_STRING)}…` : value;
+  return value;
 }
 
 /**
@@ -141,23 +153,19 @@ function redactScalarString(value: string, hashKey: boolean): string {
  * It is not inherited by nested objects or array elements — a container's name
  * says nothing about what its members hold.
  */
-function redactArgValue(value: unknown, depth: number, hashKey = false): unknown {
-  if (depth > ARG_MAX_DEPTH) return "[…]";
+function redactArgValue(value: unknown, hashKey = false): unknown {
   if (typeof value === "string") return redactScalarString(value, hashKey);
   if (typeof value === "number" || typeof value === "boolean" || value === null) {
     return value;
   }
   if (Array.isArray(value)) {
-    return value.slice(0, ARG_MAX_ARRAY).map((v) => redactArgValue(v, depth + 1));
+    return value.map((v) => redactArgValue(v));
   }
   if (typeof value === "object") {
     const out: Record<string, unknown> = {};
-    let count = 0;
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      if (count >= ARG_MAX_KEYS) break;
       if (isSecretKey(k)) continue; // drop secret-named keys entirely
-      out[k] = redactArgValue(v, depth + 1, isHashKey(k));
-      count += 1;
+      out[k] = redactArgValue(v, isHashKey(k));
     }
     return out;
   }
@@ -172,7 +180,7 @@ export function sanitizeToolArgs(rawArgs: unknown): string | null {
   if (rawArgs === null || typeof rawArgs !== "object" || Array.isArray(rawArgs)) {
     return null;
   }
-  const redacted = redactArgValue(rawArgs, 0);
+  const redacted = redactArgValue(rawArgs);
   if (
     redacted === null ||
     typeof redacted !== "object" ||
@@ -186,7 +194,10 @@ export function sanitizeToolArgs(rawArgs: unknown): string | null {
   } catch {
     return null;
   }
-  return serialized.length > ARGS_MAX_SERIALIZED
-    ? `${serialized.slice(0, ARGS_MAX_SERIALIZED)}\n…(truncated)`
-    : serialized;
+  // WHOLE or nothing, never a cut string (owner decree; see the block comment
+  // above). The ceiling is the shared schema's own corruption guard: no
+  // legitimate producer can reach it (the largest, BoardCompose, refuses its
+  // own spec above 49,152 bytes), so exceeding it means a corrupted row, and
+  // a corrupted row shows no args rather than misleading partial ones.
+  return serialized.length > TOOL_ARGS_DISPLAY_CEILING ? null : serialized;
 }

--- a/vex-app/src/shared/schemas/__tests__/messages.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/messages.test.ts
@@ -8,6 +8,7 @@ import {
   messagesGetTailInputSchema,
   messagesListInputSchema,
   sessionMessageDtoSchema,
+  TOOL_ARGS_DISPLAY_CEILING,
   transcriptAppendEventSchema,
   TRANSCRIPT_APPEND_EVENT_TYPE,
 } from "../messages.js";
@@ -257,8 +258,14 @@ describe("messages schemas", () => {
     ).toBe(true);
   });
 
-  it("rejects toolArgs over the 2000-char cap (boundary size limit)", () => {
-    const parsed = sessionMessageDtoSchema.safeParse({
+  it("admits whole large toolArgs and rejects only past the corruption ceiling", () => {
+    // Contract change (owner decree, 2026-08-26): toolArgs is the WHOLE
+    // sanitized serialization, never a cut string. The first BoardCompose call
+    // in production serialized past the old 2,000-char cap and the mapper's
+    // truncation suffix pushed it past this schema, failing the entire page.
+    // The bound is now TOOL_ARGS_DISPLAY_CEILING, a corruption guard above
+    // every legitimate producer, shared with the mapper's own null guard.
+    const row = (toolArgs: string) => ({
       id: 14,
       sessionId: SESSION,
       role: "assistant",
@@ -267,9 +274,7 @@ describe("messages schemas", () => {
       createdAt: ISO,
       toolCallId: null,
       toolName: "x:y",
-      toolCalls: [
-        { toolCallId: "c", toolName: "x:y", toolArgs: "a".repeat(2001) },
-      ],
+      toolCalls: [{ toolCallId: "c", toolName: "x:y", toolArgs }],
       explorerRefs: null,
       reasoning: null,
       durationMs: null,
@@ -277,7 +282,15 @@ describe("messages schemas", () => {
       displayStatus: null,
       board: null,
     });
-    expect(parsed.success).toBe(false);
+    expect(
+      sessionMessageDtoSchema.safeParse(row("a".repeat(2001))).success,
+    ).toBe(true);
+    expect(
+      sessionMessageDtoSchema.safeParse(row("a".repeat(TOOL_ARGS_DISPLAY_CEILING))).success,
+    ).toBe(true);
+    expect(
+      sessionMessageDtoSchema.safeParse(row("a".repeat(TOOL_ARGS_DISPLAY_CEILING + 1))).success,
+    ).toBe(false);
   });
 
   it("rejects a toolCalls array over the 32-entry cap", () => {

--- a/vex-app/src/shared/schemas/messages.ts
+++ b/vex-app/src/shared/schemas/messages.ts
@@ -83,12 +83,25 @@ export type MessageCursor = z.infer<typeof messageCursorSchema>;
  * One displayable tool call extracted from a `tool_call` row's
  * `messages.tool_calls` JSONB. The mapper in `messages-db.ts` is the only
  * place this is built — `toolArgs` is a SANITIZED, pre-serialized JSON string
- * (secret-like keys dropped, secret-shaped values hard-redacted, size-capped)
+ * (secret-like keys dropped, secret-shaped values hard-redacted, never cut)
  * so the untrusted renderer receives strings only, never raw JSONB. The
  * `.max()` bounds below are enforced at the IPC boundary by the read handlers'
  * `outputSchema: messagePageSchema`, so an oversize mapper output is rejected
  * rather than shipped.
  */
+/**
+ * Ceiling on the DISPLAYED tool-args string. This is a corruption guard, not
+ * a truncation budget: the mapper ships the WHOLE sanitized serialization or
+ * `null`, never a cut string (owner decree - no silent content cutting; the
+ * previous 2,000-char cap plus a "(truncated)" suffix pushed the first large
+ * BoardCompose call past the bound and failed the whole messages page in
+ * production). The largest legitimate producer is BoardCompose, which refuses
+ * its own spec above 49,152 bytes, so 131,072 sits far above every real row;
+ * only a corrupted row can exceed it, and the mapper maps that to `null`.
+ * One declaration, both sides: the mapper's guard imports THIS constant.
+ */
+export const TOOL_ARGS_DISPLAY_CEILING = 131_072;
+
 export const toolCallDisplaySchema = z
   .object({
     /** Provider tool-call id — correlates a `tool_result` back to its call. */
@@ -100,8 +113,12 @@ export const toolCallDisplaySchema = z
      * wire name (`kyberswap__swap__quote`) before it reaches this field.
      */
     toolName: z.string().min(1).max(120),
-    /** Sanitized JSON string of the call args; `null` when there were none. */
-    toolArgs: z.string().max(2000).nullable(),
+    /**
+     * Sanitized JSON string of the call args, WHOLE (secrets redacted, content
+     * never cut); `null` when there were none or the row is corrupt beyond
+     * {@link TOOL_ARGS_DISPLAY_CEILING}.
+     */
+    toolArgs: z.string().max(TOOL_ARGS_DISPLAY_CEILING).nullable(),
   })
   .strict();
 export type ToolCallDisplay = z.infer<typeof toolCallDisplaySchema>;


### PR DESCRIPTION
Hotfix for the production outage hit during owner testing: the messages page for the board session failed IPC output validation because the first BoardCompose call serialized past the old 2,000-char args cap and the truncation suffix pushed the string past the schema bound - the session stopped loading.

Removes every structural cut from the tool-args display path per the no-silent-content-cutting decree (per-string 256, array 50, keys 50, depth 4, serialization 2000). Secret redaction untouched. One remaining bound is a named corruption guard (TOOL_ARGS_DISPLAY_CEILING = 131,072, single declaration shared by schema and mapper) far above every legitimate producer; beyond it maps to null, never to a cut string. Regressions pin the outage class end to end (BoardCompose-sized round-trip, red-on-revert per removed cap, secret-heuristic pins).

Verification: database + shared-schema suites 93 files green; tsc vex-app clean; em-dash and unsafe-escapes gates green.

Note: this branch will receive a second commit with the six final-review fixes (in progress); this hotfix merges first because it unblocks live testing.