### PR TITLE
Board final-review fix round

### DIFF
--- a/src/__tests__/vex-agent/tools/registry/fresh-model-surface-names.test.ts
+++ b/src/__tests__/vex-agent/tools/registry/fresh-model-surface-names.test.ts
@@ -24,10 +24,13 @@
  * `route-admission-subset.test.ts`.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import type { EngineContext } from "@vex-agent/engine/types.js";
-import { buildPromptStack } from "@vex-agent/engine/prompts/index.js";
+import {
+  buildPromptStack,
+  resetProtocolsPromptCache,
+} from "@vex-agent/engine/prompts/index.js";
 import { PROTOCOL_TOOLS } from "@vex-agent/tools/protocols/catalog.js";
 import { getOpenAITools } from "@vex-agent/tools/registry/openai-tools.js";
 import {
@@ -94,45 +97,131 @@ function namesTaughtIn(text: string): readonly string[] {
   return PUBLIC_NAMES.filter((name) => text.includes(name));
 }
 
+/** How MANY times `name` appears in `text`, not merely whether it does. */
+function occurrencesOf(name: string, text: string): number {
+  return text.split(name).length - 1;
+}
+
 /**
- * PRE-EXISTING INVENTORY, measured 2026-08-26, NOT a whitelist.
+ * ENV POSTURE IS PART OF THE SURFACE, so the scan enumerates it explicitly.
  *
- * The scan below found that six static prompt modules outside this change's
- * scope teach a protocol publicName to a session that cannot call it, and have
- * done so since long before D-DS9: `task-shapes.ts`, `mission-run.ts`,
- * `mission-setup.ts`, `safety-contract.ts`, `identity.ts` and `tool-model.ts`.
- * Fixing them is a prompt-doctrine decision with its own budget diff (some, like
- * `tool-model.ts`'s alias-to-protocol table, may be a deliberate teaching
- * artifact rather than a defect), so it belongs to the owner and not to this
- * task. What is NOT deferred is the measurement.
- *
- * This constant is therefore a RATCHET, and it bites in both directions: the
- * union of everything the six modes teach must EQUAL it. A seventh name added
- * anywhere fails, and removing one also fails until the constant is edited down
- * with it, so the inventory can only shrink and can never quietly grow. It is
- * the whole list, no entry is elided, and each names the exact string a model
- * would copy into a call the dispatcher then refuses.
- *
- * ZERO IS THE TARGET. Delete a line when its prompt stops teaching the name;
- * delete the constant when the list is empty.
+ * The prompt layers are env-gated line by line: `mission-run.ts` only emits its
+ * Solana research pointer when `JUPITER_API_KEY` is present. A scan run under
+ * the AMBIENT environment therefore measures ONE install's surface and calls it
+ * the surface, which is how a name taught only in the keyed posture stays
+ * invisible to the ratchet. The postures below are the same two fingerprints
+ * `promptsnaps.test.ts` freezes, produced by the same mechanism: TAVILY and
+ * RETTIWT removed for the run so the gated layers render their reduced variant
+ * in both, and JUPITER toggled. The sentinel is not a credential; the
+ * availability gate tests presence only and no handler runs here.
  */
-const PRE_EXISTING_TAUGHT_NAMES: readonly string[] = [
-  "khalani__bridge_execute",
-  "khalani__order_get",
-  "khalani__orders_list",
-  "khalani__token_balances_get",
-  "khalani__tokens_search",
-  "kyberswap__swap_quote",
-  "kyberswap__token_safety_check",
-  "pools__launch_execute",
-  "pools__launch_request_form",
-  "solana__tokens_search",
-  "trench__images_list",
-  "trench__launch_execute",
-  "trench__launch_preview",
-  "trench__launch_request_form",
-  "virtuals__agent_get",
+const GATED_KEYS = ["JUPITER_API_KEY", "TAVILY_API_KEY", "RETTIWT_API_KEY"] as const;
+const SENTINEL_VALUE = "vex-eval-sentinel-not-a-credential";
+
+interface EnvPosture {
+  readonly slug: string;
+  readonly jupiter: boolean;
+  /**
+   * PRE-EXISTING INVENTORY FOR THIS POSTURE, measured 2026-08-26, NOT a
+   * whitelist. See the ratchet contract below the postures.
+   */
+  readonly occurrences: Readonly<Record<string, number>>;
+}
+
+/**
+ * THE RATCHET CONTRACT, and it bites in every direction.
+ *
+ * Static prompt modules outside this change's scope teach protocol publicNames
+ * to sessions that cannot call them, and have done so since long before D-DS9:
+ * `task-shapes.ts`, `mission-setup.ts`, `safety-contract.ts`, `identity.ts` and
+ * `tool-model.ts`. Fixing them is a prompt-doctrine decision with its own
+ * budget diff (some, like `tool-model.ts`'s alias-to-protocol table, may be a
+ * deliberate teaching artifact rather than a defect), so it belongs to the
+ * owner and not to this task. What is NOT deferred is the measurement.
+ *
+ * Each posture's map must EQUAL what that posture teaches, name for name AND
+ * count for count. A new name fails. A SECOND OCCURRENCE of an already-listed
+ * name fails too, which is the hole a name-only ratchet left open: the doctrine
+ * "do not print a callable name on the fresh surface" is violated once per
+ * printed name, not once per distinct string, so the pin has to be the count.
+ * Removing a name or lowering a count also fails until the map is edited down
+ * with it, so the inventory can only shrink and can never quietly grow.
+ *
+ * ZERO IS THE TARGET. Delete an entry when its prompt stops teaching the name;
+ * delete the maps when they are empty.
+ */
+const ENV_POSTURES: readonly EnvPosture[] = [
+  {
+    slug: "no provider keys",
+    jupiter: false,
+    occurrences: {
+    khalani__bridge_execute: 6,
+    khalani__order_get: 6,
+    khalani__orders_list: 6,
+    khalani__token_balances_get: 6,
+    khalani__tokens_search: 12,
+    kyberswap__swap_quote: 18,
+    kyberswap__token_safety_check: 6,
+    pools__launch_execute: 6,
+    pools__launch_request_form: 6,
+    solana__tokens_search: 6,
+    trench__images_list: 4,
+    trench__launch_execute: 8,
+    trench__launch_preview: 2,
+    trench__launch_request_form: 8,
+    virtuals__agent_get: 6,
+    },
+  },
+  {
+    // Measured identical to the keyless posture only BECAUSE the Solana research
+    // pointer in `mission-run.ts`, the one line this posture adds, now names a
+    // capability reached with ToolSearch instead of a raw publicName. The two
+    // maps are written out separately so a future divergence shows up as a
+    // divergence, and so editing one down can never quietly edit the other.
+    slug: "JUPITER_API_KEY present",
+    jupiter: true,
+    occurrences: {
+    khalani__bridge_execute: 6,
+    khalani__order_get: 6,
+    khalani__orders_list: 6,
+    khalani__token_balances_get: 6,
+    khalani__tokens_search: 12,
+    kyberswap__swap_quote: 18,
+    kyberswap__token_safety_check: 6,
+    pools__launch_execute: 6,
+    pools__launch_request_form: 6,
+    solana__tokens_search: 6,
+    trench__images_list: 4,
+    trench__launch_execute: 8,
+    trench__launch_preview: 2,
+    trench__launch_request_form: 8,
+    virtuals__agent_get: 6,
+    },
+  },
 ];
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeAll(() => {
+  for (const key of GATED_KEYS) savedEnv[key] = process.env[key];
+});
+
+afterAll(() => {
+  for (const key of GATED_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  resetProtocolsPromptCache();
+});
+
+/** Put the process into `posture` and drop every prompt cache built under the old one. */
+function applyPosture(posture: EnvPosture): void {
+  delete process.env.TAVILY_API_KEY;
+  delete process.env.RETTIWT_API_KEY;
+  if (posture.jupiter) process.env.JUPITER_API_KEY = SENTINEL_VALUE;
+  else delete process.env.JUPITER_API_KEY;
+  resetProtocolsPromptCache();
+}
 
 describe("fresh model surface teaches no protocol publicName", () => {
   it("the catalog it scans against is the real, non-empty one", () => {
@@ -152,52 +241,70 @@ describe("fresh model surface teaches no protocol publicName", () => {
    * is always visible, so every session read that instruction and every session
    * that followed it was refused. Nothing is whitelisted here and nothing may be.
    */
-  for (const subject of MODES) {
-    it(`${subject.name}: no visible tool DESCRIPTION teaches a callable protocol name`, () => {
-      clearDiscoveredTools(SESSION);
-      // The premise of the whole scan: this session has discovered nothing, so
-      // NO protocol name is callable for it.
-      expect(getDiscoveredToolIds(SESSION)).toEqual([]);
+  for (const posture of ENV_POSTURES) {
+    for (const subject of MODES) {
+      it(`${posture.slug} / ${subject.name}: no visible tool DESCRIPTION teaches a callable protocol name`, () => {
+        applyPosture(posture);
+        clearDiscoveredTools(SESSION);
+        // The premise of the whole scan: this session has discovered nothing, so
+        // NO protocol name is callable for it.
+        expect(getDiscoveredToolIds(SESSION)).toEqual([]);
 
-      const offences = getOpenAITools(subject.visibility).flatMap((tool) =>
-        namesTaughtIn(tool.function.description).map(
-          (name) => `description of "${tool.function.name}" teaches "${name}"`,
-        ),
-      );
-      expect(offences).toEqual([]);
-    });
+        const offences = getOpenAITools(subject.visibility).flatMap((tool) =>
+          namesTaughtIn(tool.function.description).map(
+            (name) => `description of "${tool.function.name}" teaches "${name}"`,
+          ),
+        );
+        expect(offences).toEqual([]);
+      });
+    }
   }
 
   /**
-   * LANE 2, RATCHETED. Same scan over the static prompt layers, against the
-   * measured inventory above rather than against zero. See that constant for
-   * why the residue is deferred and why this is not a whitelist.
+   * LANE 2, RATCHETED PER POSTURE AND PER OCCURRENCE. Same scan over the static
+   * prompt layers, against the measured inventory of THIS posture rather than
+   * against zero. See `ENV_POSTURES` for why the residue is deferred, why this
+   * is not a whitelist, and why the pin is a count and not a name.
    */
-  it("the static prompt layers teach EXACTLY the pre-existing inventory, and nothing new", () => {
-    clearDiscoveredTools(SESSION);
-    const taught = new Set<string>();
-    for (const subject of MODES) {
-      for (const layer of buildPromptStack(subject.engine).staticLayers) {
-        for (const name of namesTaughtIn(layer)) taught.add(name);
+  for (const posture of ENV_POSTURES) {
+    it(`${posture.slug}: the static prompt layers teach EXACTLY the inventory of this posture, name and count`, () => {
+      applyPosture(posture);
+      clearDiscoveredTools(SESSION);
+      const taught = new Map<string, number>();
+      for (const subject of MODES) {
+        for (const layer of buildPromptStack(subject.engine).staticLayers) {
+          for (const name of namesTaughtIn(layer)) {
+            taught.set(name, (taught.get(name) ?? 0) + occurrencesOf(name, layer));
+          }
+        }
       }
-    }
-    expect([...taught].sort()).toEqual([...PRE_EXISTING_TAUGHT_NAMES].sort());
-  });
+      // Name level, unchanged: the set may shrink, never grow.
+      expect([...taught.keys()].sort()).toEqual(Object.keys(posture.occurrences).sort());
+      // Occurrence level: a SECOND printing of an already-listed name is a new
+      // violation of the same doctrine, and must fail exactly as a new name does.
+      expect(Object.fromEntries([...taught.entries()].sort())).toEqual(
+        Object.fromEntries(Object.entries(posture.occurrences).sort()),
+      );
+    });
+  }
 
-  it("no dexscreener name survives the D-DS9 revert anywhere on the fresh surface", () => {
-    // The reverted decision's own residue, pinned at zero separately from the
-    // ratchet so a re-introduction cannot hide inside a growing inventory.
-    clearDiscoveredTools(SESSION);
-    const dexNames = PUBLIC_NAMES.filter((name) => name.startsWith("dexscreener__"));
-    expect(dexNames).toHaveLength(18);
-    for (const subject of MODES) {
-      const surface = [
-        ...buildPromptStack(subject.engine).staticLayers,
-        ...getOpenAITools(subject.visibility).map((tool) => tool.function.description),
-      ].join("\n");
-      for (const name of dexNames) {
-        expect(surface, `${subject.name} teaches "${name}"`).not.toContain(name);
+  for (const posture of ENV_POSTURES) {
+    it(`${posture.slug}: no dexscreener name survives the D-DS9 revert anywhere on the fresh surface`, () => {
+      // The reverted decision's own residue, pinned at zero separately from the
+      // ratchet so a re-introduction cannot hide inside a growing inventory.
+      applyPosture(posture);
+      clearDiscoveredTools(SESSION);
+      const dexNames = PUBLIC_NAMES.filter((name) => name.startsWith("dexscreener__"));
+      expect(dexNames).toHaveLength(18);
+      for (const subject of MODES) {
+        const surface = [
+          ...buildPromptStack(subject.engine).staticLayers,
+          ...getOpenAITools(subject.visibility).map((tool) => tool.function.description),
+        ].join("\n");
+        for (const name of dexNames) {
+          expect(surface, `${subject.name} teaches "${name}"`).not.toContain(name);
+        }
       }
-    }
-  });
+    });
+  }
 });

--- a/src/vex-agent/engine/prompts/__promptsnaps__/mission-run-full.jupiter.md
+++ b/src/vex-agent/engine/prompts/__promptsnaps__/mission-run-full.jupiter.md
@@ -531,7 +531,7 @@ You are executing an active mission. Your job is to work toward the mission goal
 - Respect the mission constraints: allowed chains, protocols, wallets, risk profile
 - Deployed capital and portfolio change since this run started are given to you each turn in `# Mission Capital`. Read them there. Do not recompute them from the transcript, and never treat a balance that existed before the run started as progress. If that section is absent, say the start value is unknown instead of assuming one
 - Route research through the `### Research` task shape: it names which surface answers which token question. Use them only to advance the current mission step; each research loop must produce a shortlist, an execution candidate, a defer decision, or a contract-valid stop
-- For fresh/newly-launched Solana tokens, prefer solana__tokens_discover with category=recent (or solana__tokens_search) — Jupiter surfaces richer signal (organic score, verification, holder/audit data) than the free DexScreener feed
+- For fresh/newly-launched Solana tokens, prefer the solana namespace's recent-token discovery (its category=recent listing) or its token search, both reached with ToolSearch - Jupiter surfaces richer signal (organic score, verification, holder/audit data) than the free DexScreener feed
 - Log significant decisions with rationale for audit trail
 
 ## Token launches

--- a/src/vex-agent/engine/prompts/__promptsnaps__/mission-run-restricted.jupiter.md
+++ b/src/vex-agent/engine/prompts/__promptsnaps__/mission-run-restricted.jupiter.md
@@ -533,7 +533,7 @@ You are executing an active mission. Your job is to work toward the mission goal
 - Respect the mission constraints: allowed chains, protocols, wallets, risk profile
 - Deployed capital and portfolio change since this run started are given to you each turn in `# Mission Capital`. Read them there. Do not recompute them from the transcript, and never treat a balance that existed before the run started as progress. If that section is absent, say the start value is unknown instead of assuming one
 - Route research through the `### Research` task shape: it names which surface answers which token question. Use them only to advance the current mission step; each research loop must produce a shortlist, an execution candidate, a defer decision, or a contract-valid stop
-- For fresh/newly-launched Solana tokens, prefer solana__tokens_discover with category=recent (or solana__tokens_search) — Jupiter surfaces richer signal (organic score, verification, holder/audit data) than the free DexScreener feed
+- For fresh/newly-launched Solana tokens, prefer the solana namespace's recent-token discovery (its category=recent listing) or its token search, both reached with ToolSearch - Jupiter surfaces richer signal (organic score, verification, holder/audit data) than the free DexScreener feed
 - Log significant decisions with rationale for audit trail
 
 ## Token launches

--- a/src/vex-agent/engine/prompts/mission-run.ts
+++ b/src/vex-agent/engine/prompts/mission-run.ts
@@ -69,7 +69,10 @@ export function buildMissionRunPrompt(
   // Recommending it in an install without the key sends the model at a tool the
   // dispatcher will refuse — same availability predicate the registry uses.
   if (isProtocolNamespaceAvailable("solana")) {
-    lines.push("- For fresh/newly-launched Solana tokens, prefer solana__tokens_discover with category=recent (or solana__tokens_search) — Jupiter surfaces richer signal (organic score, verification, holder/audit data) than the free DexScreener feed");
+    // Capability + ToolSearch, never a raw protocol publicName: a FRESH session
+    // has discovered nothing, so a name printed here is one the dispatcher
+    // refuses. Same treatment `TokenFind`'s description already got.
+    lines.push("- For fresh/newly-launched Solana tokens, prefer the solana namespace's recent-token discovery (its category=recent listing) or its token search, both reached with ToolSearch - Jupiter surfaces richer signal (organic score, verification, holder/audit data) than the free DexScreener feed");
   }
   lines.push("- Log significant decisions with rationale for audit trail");
   lines.push("");

--- a/src/vex-agent/tools/internal/board/hydrate-row.ts
+++ b/src/vex-agent/tools/internal/board/hydrate-row.ts
@@ -178,10 +178,25 @@ export interface ProjectBoardRowArgs {
 /**
  * One raw provider row as the board's hydrated row.
  *
- * Never throws and never refuses: an unreadable figure becomes null, which is
- * what the row's nullable fields mean. Refusing a whole board because a pool
- * did not resolve is the CALLER's decision (compose fails closed; the live
- * loop rejects the tick), and it is taken before this function is reached.
+ * AN UNREADABLE FIGURE BECOMES NULL. That is what the row's nullable fields
+ * mean, and it is why no individual missing number is a refusal here.
+ *
+ * IT CAN STILL THROW, and the comment that used to promise otherwise was
+ * wrong. This function does not parse the provider row itself: it delegates to
+ * the surface's own `projectPairRow`, which raises when a row's SHAPE drifts
+ * from what it can read, as opposed to when a field is merely absent. Both
+ * callers must therefore treat a throw as a real outcome, and both do, with
+ * different policies because they owe the reader different things:
+ *
+ *  - COMPOSE FAILS CLOSED. The throw leaves `hydrate.ts` as a tool failure and
+ *    no durable board is written. A board is a document, and a document is
+ *    better absent than built out of rows nobody could read.
+ *  - THE LIVE LOOP REJECTS THE TICK. `board-live-service.ts` projects inside
+ *    its classified path, so the throw degrades the lease, keeps the last-good
+ *    rows and their clock, and schedules the next attempt.
+ *
+ * Refusing a whole board because a pool did not RESOLVE is a separate decision
+ * and is taken by the caller before this function is reached.
  */
 export function projectBoardRow(args: ProjectBoardRowArgs): BoardHydratedRow {
   const h24 = projectPairRow(args.source, { window: "h24", nowMs: args.nowMs });

--- a/vex-app/src/main/agent/index.ts
+++ b/vex-app/src/main/agent/index.ts
@@ -29,13 +29,16 @@ import { setupTranscriptBridge } from "./transcript-bridge.js";
 
 /**
  * Mount every agent-side bridge and return a single teardown that
- * unsubscribes all of them. Order does not matter — bridges are
- * independent subscribers on disjoint event buses. Cleanup restores
+ * unsubscribes all of them, and which the caller may await. Order does
+ * not matter BETWEEN bridges - they are independent subscribers on
+ * disjoint event buses - but it does matter INSIDE the DexScreener
+ * teardown, where the board icon service must finish draining before
+ * the bridge whose transport it borrows is disposed. Cleanup restores
  * the engine `BugReportSink` to the no-op default so test runs don't
  * inherit a stale sink from a previous main lifecycle.
  */
-export function setupAgentBridges(): () => void {
-  const teardowns: Array<() => void> = [];
+export function setupAgentBridges(): () => Promise<void> {
+  const teardowns: Array<() => void | Promise<void>> = [];
 
   teardowns.push(setupTranscriptBridge());
   teardowns.push(setupControlBridge());
@@ -95,16 +98,24 @@ export function setupAgentBridges(): () => void {
   // bridge it borrows from, so no icon fetch can outlive its transport.
   const unmountBoardIcons = mountBoardIconService(dexScreenerBridge.transport.httpGet);
 
-  teardowns.push(() => {
-    unmountBoardIcons();
+  // AWAITED, not fired and forgotten. Unmounting closes admission and drains
+  // the icon fetches that are still running ON THIS BRIDGE'S TRANSPORT; only
+  // once that drain has settled may the bridge itself be disposed. The other
+  // two steps keep their original order: unregister the transport slot before
+  // disposing the bridge behind it.
+  teardowns.push(async () => {
+    await unmountBoardIcons();
     unregisterDexScreener();
     dexScreenerBridge.dispose();
   });
 
-  return () => {
+  // Sequential rather than concurrent, because the ordering inside the teardown
+  // above is the point of it. `await` inside the try also catches a rejected
+  // async teardown, so one bad disposer still cannot poison the rest.
+  return async () => {
     for (const teardown of teardowns) {
       try {
-        teardown();
+        await teardown();
       } catch {
         // a misbehaving teardown must not poison the others
       }

--- a/vex-app/src/main/dexscreener-bridge/__tests__/ws-bridge-coalesce-scope.test.ts
+++ b/vex-app/src/main/dexscreener-bridge/__tests__/ws-bridge-coalesce-scope.test.ts
@@ -21,6 +21,9 @@
  * The fake window stands in for Chromium exactly as `ws-bridge.test.ts` does.
  */
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("electron", () => ({
@@ -385,5 +388,44 @@ describe("R14: coalesceScope isolates exchange ownership", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+/**
+ * The scope delimiter is a DIGEST INPUT, so its exact bytes are a contract.
+ *
+ * `exchangeDigest` separates the scope from the expectation string with one NUL
+ * followed by "scope:". Those seven bytes decide which callers single-flight
+ * together, and they used to be spelled with a LITERAL NUL in the source, which
+ * a reviewer cannot see and a diff cannot show. The delimiter is now written as
+ * the escape "\u0000scope:"; the emitted bytes are unchanged. This pins both
+ * halves, so a future silent change to either is caught: the byte sequence
+ * itself, and the fact that the source spells it visibly.
+ */
+describe("R14: the scope delimiter bytes are pinned", () => {
+  const SOURCE = readFileSync(
+    fileURLToPath(new URL("../ws-bridge.ts", import.meta.url)),
+    "utf8",
+  );
+
+  it("mixes in exactly NUL followed by \"scope:\"", () => {
+    expect([...Buffer.from("\u0000scope:", "utf8")]).toStrictEqual([
+      0x00, 0x73, 0x63, 0x6f, 0x70, 0x65, 0x3a,
+    ]);
+  });
+
+  it("spells that delimiter as a reviewable escape in the source", () => {
+    expect(SOURCE).toContain('hash.update("\\u0000scope:");');
+  });
+
+  it("carries no raw control byte a reader cannot see", () => {
+    // Tab, newline and carriage return are the only control characters a source
+    // file legitimately contains; anything else is an invisible literal.
+    const invisible = [...SOURCE].filter((character) => {
+      if (character === "\t" || character === "\n" || character === "\r") return false;
+      const code = character.codePointAt(0) ?? 0;
+      return code < 0x20 || code === 0x7f;
+    });
+    expect(invisible.map((character) => character.codePointAt(0))).toStrictEqual([]);
   });
 });

--- a/vex-app/src/main/dexscreener-bridge/ws-bridge.ts
+++ b/vex-app/src/main/dexscreener-bridge/ws-bridge.ts
@@ -398,7 +398,11 @@ export class DexScreenerWsBridge {
       `expect:${options.expect.binaryFrames}:${options.expect.maxTotalBytes}`
     );
     if (options.coalesceScope !== undefined) {
-      hash.update(" scope:");
+      // The delimiter is written as an ESCAPE, never as the raw byte: a literal
+      // NUL in the source is invisible in a diff and unreviewable. These are
+      // the same seven bytes the digest has always mixed in (0x00 then
+      // "scope:"), pinned by `ws-bridge-coalesce-scope.test.ts`.
+      hash.update("\u0000scope:");
       hash.update(options.coalesceScope, "utf8");
     }
     return hash.digest("hex");

--- a/vex-app/src/main/images/__tests__/board-icon-service.test.ts
+++ b/vex-app/src/main/images/__tests__/board-icon-service.test.ts
@@ -23,6 +23,7 @@ import type { TransportResponse } from "@tools/dexscreener/transport.js";
 import {
   BOARD_ICON_MAX_BYTES,
   BOARD_ICON_MAX_DIMENSION,
+  BOARD_ICON_NOT_FOUND_TTL_MS,
   createBoardIconService,
   mountBoardIconService,
   resolveBoardIcon,
@@ -442,17 +443,101 @@ describe("mountBoardIconService / resolveBoardIcon", () => {
       const outcome = await resolveBoardIcon(ID);
       expect(outcome.kind).toBe("image");
     } finally {
-      teardown();
+      await teardown();
     }
   });
 
   it("the returned teardown unmounts - a later call answers not_mounted again", async () => {
     const { fetcher } = scriptedFetcher([response(200, "image/png", pngFixture(64, 64))]);
     const teardown = mountBoardIconService(fetcher);
-    teardown();
+    await teardown();
     expect(await resolveBoardIcon(`${ID}-after-teardown`)).toEqual({
       kind: "unavailable",
       reason: "not_mounted",
     });
+  });
+
+  /**
+   * THE PRODUCTION TEARDOWN ORDER, asserted by sequence rather than by a timer.
+   *
+   * `setupAgentBridges` disposes the DexScreener bridge - Chromium session,
+   * hidden window and all - in the same teardown that unmounts this service,
+   * and icon fetches run on THAT bridge's transport. So the mounted teardown
+   * has to be awaitable and its drain has to complete before the bridge step
+   * runs. The recorded order is the whole assertion: a teardown that dropped
+   * its dispose promise would push "bridge-disposed" first, with a fetch still
+   * live on a transport that is being torn down underneath it.
+   */
+  it("the mounted teardown drains in-flight work BEFORE the caller disposes the bridge", async () => {
+    const order: string[] = [];
+    const { fetcher, pendingCount } = deferredFetcher();
+    const teardown = mountBoardIconService(fetcher);
+
+    const inFlight = resolveBoardIcon(ID).then((outcome) => {
+      order.push("icon-fetch-settled");
+      return outcome;
+    });
+    await Promise.resolve();
+    expect(pendingCount()).toBe(1);
+    expect(order).toEqual([]);
+
+    // Exactly the shape of the production teardown: await the unmount, THEN
+    // dispose the transport it borrowed.
+    await teardown();
+    order.push("bridge-disposed");
+
+    expect(order).toEqual(["icon-fetch-settled", "bridge-disposed"]);
+    expect(await inFlight).toEqual({ kind: "unavailable", reason: "transport" });
+  });
+
+  it("the mounted teardown is idempotent - a second call resolves without throwing", async () => {
+    const { fetcher } = scriptedFetcher([response(200, "image/png", pngFixture(64, 64))]);
+    const teardown = mountBoardIconService(fetcher);
+    await teardown();
+    await expect(teardown()).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * ONE NUMBER, TWO PROCESSES, AND A DRIFT GUARD RATHER THAN AN IMPORT.
+ *
+ * Main answers `not_found` out of its negative cache for
+ * `BOARD_ICON_NOT_FOUND_TTL_MS`; the renderer's query holds the same 404 for
+ * `BOARD_ICON_NOT_FOUND_STALE_MS` (`src/renderer/lib/api/board-icons.ts`). A
+ * renderer asking sooner spends an IPC round trip on an answer main already
+ * has; one asking later leaves newly published artwork undrawn for no reason.
+ *
+ * The two cannot be ONE declaration: a renderer module may not import a
+ * main-process one, and the reverse import would compile a `window`-using file
+ * into the main program. So each side asserts the literal against the SAME
+ * stated window, and the sibling assertion in
+ * `src/renderer/lib/api/__tests__/board-icons.test.ts` is the other half.
+ * Changing the window on one side alone turns one of the two red.
+ */
+describe("the 404 window main enforces", () => {
+  it("is the ten minutes the renderer's own staleness is written against", () => {
+    expect(BOARD_ICON_NOT_FOUND_TTL_MS).toBe(600_000);
+  });
+
+  it("is the window a cached 404 is actually served for", async () => {
+    vi.useFakeTimers();
+    try {
+      const { fetcher, calls } = scriptedFetcher([
+        response(404, undefined, new Uint8Array()),
+        response(200, "image/png", pngFixture(64, 64)),
+      ]);
+      const service = createBoardIconService(fetcher);
+
+      expect(await service.resolve(ID)).toEqual({ kind: "absent", reason: "not_found" });
+      vi.advanceTimersByTime(BOARD_ICON_NOT_FOUND_TTL_MS - 1);
+      expect(await service.resolve(ID)).toEqual({ kind: "absent", reason: "not_found" });
+      expect(calls).toHaveLength(1);
+
+      vi.advanceTimersByTime(2);
+      expect((await service.resolve(ID)).kind).toBe("image");
+      expect(calls).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/vex-app/src/main/images/board-icon-service.ts
+++ b/vex-app/src/main/images/board-icon-service.ts
@@ -119,8 +119,13 @@ const POSITIVE_CACHE_MAX = 64;
  * rare but not impossible, so "no such icon" is settled for a while rather than
  * forever. Transient failures are NEVER cached: caching an unknown would turn
  * one bad minute into ten minutes of missing logos.
+ *
+ * EXPORTED because the renderer holds the same window: a card that re-asks
+ * sooner spends an IPC round trip on an answer main already has in memory. The
+ * renderer cannot import a main-process module, so it declares its own copy
+ * (`BOARD_ICON_NOT_FOUND_STALE_MS`) and a test pins the two together.
  */
-const NEGATIVE_CACHE_TTL_MS = 600_000;
+export const BOARD_ICON_NOT_FOUND_TTL_MS = 600_000;
 
 /** What the caller gets back. Three families, deliberately not collapsed. */
 export type BoardIconResolution =
@@ -272,7 +277,7 @@ export function createBoardIconService(fetcher: BoardIconFetcher): BoardIconServ
   /** Turn one response into the resolution, cache side effects included. */
   function classify(iconId: string, response: TransportResponse): BoardIconResolution {
     if (response.status === 404) {
-      negativeUntil.set(iconId, Date.now() + NEGATIVE_CACHE_TTL_MS);
+      negativeUntil.set(iconId, Date.now() + BOARD_ICON_NOT_FOUND_TTL_MS);
       return { kind: "absent", reason: "not_found" };
     }
     if (response.status !== 200) {
@@ -390,13 +395,20 @@ let mounted: BoardIconService | null = null;
  * policy, and a second fetch path would be a second trust surface. The teardown
  * unmounts BEFORE disposing, so a call arriving during shutdown gets
  * `not_mounted` rather than racing a draining service.
+ *
+ * THE TEARDOWN IS ASYNC, AND ITS PROMISE IS THE POINT. `dispose()` drains what
+ * is in flight, and those fetches run on the DexScreener bridge's transport.
+ * Dropping this promise would let the caller dispose that bridge - Chromium
+ * session, hidden window and all - underneath fetches that are still running.
+ * Callers await it, and only then dispose the bridge it borrows from.
+ * Idempotent: a second call unmounts nothing and `dispose()` returns at once.
  */
-export function mountBoardIconService(fetcher: BoardIconFetcher): () => void {
+export function mountBoardIconService(fetcher: BoardIconFetcher): () => Promise<void> {
   const service = createBoardIconService(fetcher);
   mounted = service;
-  return () => {
+  return async () => {
     if (mounted === service) mounted = null;
-    void service.dispose();
+    await service.dispose();
   };
 }
 

--- a/vex-app/src/main/ipc/__tests__/board-live-ipc.test.ts
+++ b/vex-app/src/main/ipc/__tests__/board-live-ipc.test.ts
@@ -51,6 +51,8 @@ const { registerBoardLiveHandlers } = await import("../board-live.js");
 
 const REQUEST_ID = "11111111-2222-4333-8444-555555555555";
 const LEASE_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+/** The renderer's own name for one subscribe attempt. Minted before the call. */
+const CANCEL_REQUEST_ID = "99999999-8888-4777-8666-555555555555";
 const POOLS = [{ chain: "solana", pairAddress: "PairAAA" }];
 
 const SNAPSHOT = {
@@ -85,7 +87,17 @@ interface OkShape {
   readonly data: Record<string, unknown>;
 }
 
-const trustedSender = createTrustedSender({ sender: createTestWebContents() });
+/**
+ * A REAL id on the fake webContents, and that is load-bearing.
+ *
+ * The shared helper does not carry one, so an ownership assertion read through
+ * it was comparing `undefined` to `undefined` and would have passed against a
+ * handler that made the owner id up. Naming the id here makes the two
+ * ownership tests below say something.
+ */
+const TRUSTED_SENDER_ID = 4242;
+const trustedWebContents = { ...createTestWebContents(), id: TRUSTED_SENDER_ID };
+const trustedSender = createTrustedSender({ sender: trustedWebContents });
 const untrustedSender = { senderFrame: createMainFrame("https://evil.example/") };
 
 async function call(
@@ -124,7 +136,7 @@ afterEach(() => {
 
 describe("board live IPC", () => {
   it("claims a lease and returns the FIRST snapshot with it", async () => {
-    const result = await call(CH.boardLive.subscribe, { pools: POOLS });
+    const result = await call(CH.boardLive.subscribe, { pools: POOLS, requestId: CANCEL_REQUEST_ID });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     // No event race: the rows are in the response the toggle already awaited.
@@ -138,12 +150,17 @@ describe("board live IPC", () => {
     ["more pools than a board can hold", { pools: Array(9).fill(POOLS[0]) }],
     ["a pool with no address", { pools: [{ chain: "solana" }] }],
     ["a chain slug outside the contract", { pools: [{ chain: "so lana", pairAddress: "A" }] }],
-    ["an extra field the contract does not name", { pools: POOLS, cadenceMs: 1 }],
+    ["an extra field the contract does not name", { pools: POOLS, requestId: CANCEL_REQUEST_ID, cadenceMs: 1 }],
     [
       "a caption smuggled in beside the identity",
       { pools: [{ ...POOLS[0], caption: "buy this" }] },
     ],
     ["not an object at all", "pools"],
+    // The cancellation identity is REQUIRED, not optional. A subscribe without
+    // one would be uncancellable until main chose to answer it, which is the
+    // exact window this contract exists to close.
+    ["no cancellation identity", { pools: POOLS }],
+    ["a cancellation identity that is not an id", { pools: POOLS, requestId: "soon" }],
   ])("refuses %s without reaching the service", async (_label, payload) => {
     const result = await call(CH.boardLive.subscribe, payload);
     expect(result.ok).toBe(false);
@@ -153,7 +170,7 @@ describe("board live IPC", () => {
   it("refuses an untrusted sender and leaks nothing about it", async () => {
     const result = await call(
       CH.boardLive.subscribe,
-      { pools: POOLS },
+      { pools: POOLS, requestId: CANCEL_REQUEST_ID },
       { sender: untrustedSender },
     );
     expect(result.ok).toBe(false);
@@ -169,7 +186,7 @@ describe("board live IPC", () => {
       retryable: true,
       detail: "The market channel could not be reached, so live figures were not started.",
     });
-    const result = await call(CH.boardLive.subscribe, { pools: POOLS });
+    const result = await call(CH.boardLive.subscribe, { pools: POOLS, requestId: CANCEL_REQUEST_ID });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     // Not "unexpected error": the cause and the remedy both survive.
@@ -185,7 +202,7 @@ describe("board live IPC", () => {
     expect(asked.ok).toBe(true);
     if (asked.ok) expect(asked.data["supported"]).toBe(false);
 
-    const result = await call(CH.boardLive.subscribe, { pools: POOLS });
+    const result = await call(CH.boardLive.subscribe, { pools: POOLS, requestId: CANCEL_REQUEST_ID });
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.data["kind"]).toBe("unsupported");
   });
@@ -203,17 +220,50 @@ describe("board live IPC", () => {
     expect(args.leaseId).toBe(LEASE_ID);
     // The owner id came from the trusted sender object, not from anything the
     // renderer wrote: a leaseId is a handle, not a credential.
-    expect(args.ownerId).toBe(
-      (trustedSender as unknown as { sender: { id: number } }).sender.id,
-    );
+    expect(args.ownerId).toBe(TRUSTED_SENDER_ID);
   });
 
-  it("refuses an unsubscribe payload that is not a lease id", async () => {
-    for (const payload of [{}, { leaseId: "" }, { leaseId: "not-a-uuid" }, { leaseId: LEASE_ID, ownerId: 7 }]) {
+  it("refuses an unsubscribe payload that names neither identity, or both", async () => {
+    for (const payload of [
+      {},
+      { leaseId: "" },
+      { leaseId: "not-a-uuid" },
+      { leaseId: LEASE_ID, ownerId: 7 },
+      { requestId: "not-a-uuid" },
+      // BOTH is refused rather than resolved by precedence: a payload that
+      // names two different exchanges is a caller bug, and answering it would
+      // mean picking one by a rule no reader of this file can see.
+      { leaseId: LEASE_ID, requestId: CANCEL_REQUEST_ID },
+    ]) {
       const result = await call(CH.boardLive.unsubscribe, payload);
       expect(result.ok).toBe(false);
     }
     expect(unsubscribe).not.toHaveBeenCalled();
+  });
+
+  it("carries a pre-response cancel to the service under the request id", async () => {
+    unsubscribe.mockReturnValue("closed");
+    const result = await call(CH.boardLive.unsubscribe, {
+      requestId: CANCEL_REQUEST_ID,
+    });
+    expect(result.ok).toBe(true);
+
+    const args = unsubscribe.mock.calls[0]?.[0] as {
+      requestId?: string;
+      leaseId?: string;
+      ownerId: number;
+    };
+    expect(args.requestId).toBe(CANCEL_REQUEST_ID);
+    // No lease id is invented for it, and ownership still comes from the
+    // sender rather than from anything the renderer wrote.
+    expect(args.leaseId).toBeUndefined();
+    expect(args.ownerId).toBe(TRUSTED_SENDER_ID);
+  });
+
+  it("passes the renderer's cancellation identity through to the service", async () => {
+    await call(CH.boardLive.subscribe, { pools: POOLS, requestId: CANCEL_REQUEST_ID });
+    const args = subscribe.mock.calls[0]?.[0] as { requestId: string };
+    expect(args.requestId).toBe(CANCEL_REQUEST_ID);
   });
 
   it("answers honestly when no live service is running in this process", async () => {
@@ -222,7 +272,7 @@ describe("board live IPC", () => {
     expect(asked.ok).toBe(true);
     if (asked.ok) expect(asked.data["supported"]).toBe(false);
 
-    const started = await call(CH.boardLive.subscribe, { pools: POOLS });
+    const started = await call(CH.boardLive.subscribe, { pools: POOLS, requestId: CANCEL_REQUEST_ID });
     expect(started.ok).toBe(true);
     if (started.ok) expect(started.data["kind"]).toBe("unsupported");
 
@@ -248,7 +298,7 @@ describe("board live IPC", () => {
         ],
       },
     });
-    const result = await call(CH.boardLive.subscribe, { pools: POOLS });
+    const result = await call(CH.boardLive.subscribe, { pools: POOLS, requestId: CANCEL_REQUEST_ID });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe("internal.contract_violation");
   });

--- a/vex-app/src/main/ipc/board-live.ts
+++ b/vex-app/src/main/ipc/board-live.ts
@@ -131,6 +131,7 @@ export function registerBoardLiveHandlers(): ReadonlyArray<() => void> {
         const outcome = await service.subscribe({
           target: targetFor(ctx.event.sender),
           pools: input.pools,
+          requestId: input.requestId,
         });
         if (outcome.kind === "failed") {
           // A failed first attempt is a real domain outcome with a remedy, not
@@ -172,9 +173,13 @@ export function registerBoardLiveHandlers(): ReadonlyArray<() => void> {
         const service = getBoardLiveService();
         if (service === null) return Promise.resolve(ok({ outcome: "unknown" }));
         // Ownership is decided by the SENDER's identity, never by anything the
-        // renderer put in the payload: a leaseId is a handle, not a credential.
+        // renderer put in the payload: a leaseId and a requestId are both
+        // handles, not credentials. The schema admits exactly one of the two,
+        // so the branch below is a shape read and not a precedence rule.
         const outcome = service.unsubscribe({
-          leaseId: input.leaseId,
+          ...("leaseId" in input
+            ? { leaseId: input.leaseId }
+            : { requestId: input.requestId }),
           ownerId: ctx.event.sender.id,
         });
         return Promise.resolve(ok({ outcome }));

--- a/vex-app/src/main/market/__tests__/board-live-service.test.ts
+++ b/vex-app/src/main/market/__tests__/board-live-service.test.ts
@@ -30,6 +30,11 @@ const { BoardLiveService } = await import("../board-live-service.js");
 const { DexScreenerSiteErrorCodes } = await import(
   "@tools/dexscreener/site-errors.js"
 );
+const { reconcileBatchRows } = await import(
+  "@tools/dexscreener/endpoints/pairs-batch.js"
+);
+type BatchIdentity =
+  import("@tools/dexscreener/endpoints/pairs-batch.js").BatchIdentity;
 type BoardLiveBatchAnswer =
   import("../board-live-service.js").BoardLiveBatchAnswer;
 type BoardLiveTarget = import("../board-live-service.js").BoardLiveTarget;
@@ -62,21 +67,67 @@ function providerRow(
   };
 }
 
+/**
+ * One batch answer, ASSEMBLED BY THE REAL ADAPTER rather than by hand.
+ *
+ * This is the seam the review found. `reconcileBatchRows` is the shipped
+ * function `fetchPairsBatch` uses to turn raw provider rows into the four
+ * fields the live service consumes, and it REPAIRS two of the divergences on
+ * the way: it removes a row nobody asked for, and it folds a second row for one
+ * identity into the first, recording each in `unrequested` and `collapsed`. A
+ * hand-built answer skipped that repair, so the old R15 cases were injecting
+ * malformed rows on the far side of the very boundary that loses the evidence,
+ * and they passed against a service that had no way to see either divergence.
+ *
+ * Driving the real function means a case here describes what the PROVIDER did,
+ * and the service is judged on the answer production would actually hand it.
+ */
+function answerFrom(
+  requested: readonly { chain: string; pairAddress: string }[],
+  providerRows: readonly unknown[],
+  fetchedAtMs = 1_000,
+): BoardLiveBatchAnswer {
+  const identities: BatchIdentity[] = requested.map((pool) => ({
+    chainId: pool.chain,
+    id: pool.pairAddress,
+    kind: "pair",
+    raw: `${pool.chain}:${pool.pairAddress}`,
+  }));
+  return { ...reconcileBatchRows(identities, providerRows), fetchedAtMs };
+}
+
+/** The ordinary case: the provider answered exactly what was asked, once each. */
 function answerFor(
   pools: readonly { chain: string; pairAddress: string }[],
   fetchedAtMs = 1_000,
   priceUsd?: string,
 ): BoardLiveBatchAnswer {
-  const rows = pools.map((pool) =>
-    providerRow(pool.chain, pool.pairAddress, priceUsd),
-  );
-  return {
-    rows,
-    resolvedKeys: new Set(
-      pools.map((pool) => `${pool.chain}:${pool.pairAddress}`.toLowerCase()),
-    ),
+  return answerFrom(
+    pools,
+    pools.map((pool) => providerRow(pool.chain, pool.pairAddress, priceUsd)),
     fetchedAtMs,
-  };
+  );
+}
+
+/**
+ * Subscribe with a renderer-minted request id, which the contract now requires.
+ *
+ * Sequential rather than random so a test that needs to name a request id it
+ * has not made yet can predict it.
+ */
+let requestCounter = 0;
+function requestId(n: number): string {
+  return `00000000-0000-4000-9000-${String(n).padStart(12, "0")}`;
+}
+function subscribeTo(
+  service: InstanceType<typeof BoardLiveService>,
+  args: {
+    readonly target: BoardLiveTarget;
+    readonly pools: readonly { chain: string; pairAddress: string }[];
+  },
+): ReturnType<InstanceType<typeof BoardLiveService>["subscribe"]> {
+  requestCounter += 1;
+  return service.subscribe({ ...args, requestId: requestId(requestCounter) });
 }
 
 interface FakeTarget {
@@ -184,9 +235,9 @@ describe("board live lease", () => {
     const a = makeTarget(1);
     const b = makeTarget(2);
 
-    const first = service.subscribe({ target: a.target, pools: POOLS });
+    const first = subscribeTo(service, { target: a.target, pools: POOLS });
     // B arrives while A's very first attempt is still in flight.
-    const second = service.subscribe({ target: b.target, pools: POOLS });
+    const second = subscribeTo(service, { target: b.target, pools: POOLS });
 
     // A is closed the moment B claims the slot, not when A's attempt lands.
     expect(kinds(a.events)).toStrictEqual(["closed:superseded"]);
@@ -209,7 +260,7 @@ describe("board live lease", () => {
     const service = makeService(() => Promise.resolve(answerFor(POOLS)));
     live = service;
     const owner = makeTarget(1);
-    const outcome = await service.subscribe({ target: owner.target, pools: POOLS });
+    const outcome = await subscribeTo(service, { target: owner.target, pools: POOLS });
     if (outcome.kind !== "subscribed") throw new Error("expected a lease");
 
     expect(
@@ -241,7 +292,7 @@ describe("board live lease", () => {
     });
     live = service;
     const owner = makeTarget(1);
-    const outcome = await service.subscribe({ target: owner.target, pools: POOLS });
+    const outcome = await subscribeTo(service, { target: owner.target, pools: POOLS });
     if (outcome.kind !== "subscribed") throw new Error("expected a lease");
 
     await vi.advanceTimersByTimeAsync(5_000); // attempt 2: fails
@@ -274,7 +325,7 @@ describe("board live lease", () => {
     });
     live = service;
     const owner = makeTarget(1);
-    await service.subscribe({ target: owner.target, pools: POOLS });
+    await subscribeTo(service, { target: owner.target, pools: POOLS });
 
     await vi.advanceTimersByTimeAsync(5_000);
     expect(kinds(owner.events)).toStrictEqual(["closed:dropped"]);
@@ -298,7 +349,7 @@ describe("board live lease", () => {
     );
     live = service;
     const owner = makeTarget(1);
-    await service.subscribe({ target: owner.target, pools: POOLS });
+    await subscribeTo(service, { target: owner.target, pools: POOLS });
 
     await vi.advanceTimersByTimeAsync(600_000);
     // Two degradations, then the third failure is terminal rather than a
@@ -326,7 +377,7 @@ describe("board live lease", () => {
     });
     live = service;
     const owner = makeTarget(1);
-    const outcome = await service.subscribe({ target: owner.target, pools: POOLS });
+    const outcome = await subscribeTo(service, { target: owner.target, pools: POOLS });
     if (outcome.kind !== "subscribed") throw new Error("expected a lease");
 
     await vi.advanceTimersByTimeAsync(5_000); // attempt 2 is now in flight
@@ -351,7 +402,7 @@ describe("board live lease", () => {
     const service = makeService(() => Promise.resolve(answerFor(POOLS)));
     live = service;
     const owner = makeTarget(1);
-    await service.subscribe({ target: owner.target, pools: POOLS });
+    await subscribeTo(service, { target: owner.target, pools: POOLS });
     expect(owner.listenerCount()).toBe(1);
 
     owner.fireGone();
@@ -377,7 +428,7 @@ describe("board live lease", () => {
       });
     });
     const owner = makeTarget(1);
-    await service.subscribe({ target: owner.target, pools: POOLS });
+    await subscribeTo(service, { target: owner.target, pools: POOLS });
     await vi.advanceTimersByTimeAsync(5_000);
 
     const stopping = service.stop();
@@ -391,7 +442,7 @@ describe("board live lease", () => {
     await service.stop();
     // A subscribe after shutdown is refused honestly rather than starting a
     // poll into a process that is going away.
-    const after = await service.subscribe({ target: owner.target, pools: POOLS });
+    const after = await subscribeTo(service, { target: owner.target, pools: POOLS });
     expect(after.kind).toBe("unsupported");
   });
 
@@ -399,7 +450,7 @@ describe("board live lease", () => {
     const service = makeService(() => Promise.resolve(answerFor(POOLS)));
     live = service;
     const owner = makeTarget(1);
-    const outcome = await service.subscribe({ target: owner.target, pools: POOLS });
+    const outcome = await subscribeTo(service, { target: owner.target, pools: POOLS });
     if (outcome.kind !== "subscribed") throw new Error("expected a lease");
 
     await vi.advanceTimersByTimeAsync(15_000);
@@ -421,29 +472,69 @@ describe("board live lease", () => {
   it.each([
     [
       "a missing identity",
-      (): BoardLiveBatchAnswer => answerFor([POOLS[0]], 9_999),
+      "incomplete",
+      // The provider answered one of the two pools and said nothing about the
+      // other. The adapter has nothing to repair; the counts simply do not
+      // match.
+      (): BoardLiveBatchAnswer =>
+        answerFrom(POOLS, [providerRow("solana", "PairAAA")], 9_999),
     ],
     [
-      "an extra identity nobody asked for",
+      "a live row for a pool this board never named",
+      "incomplete",
+      // MEASURED CLASS. A one-identity batch came back carrying a real, live
+      // row for an entirely different pool. The adapter DROPS that row and
+      // records it in `unrequested`, so the remaining answer covers exactly the
+      // requested keys and reconciles clean unless the accounting is read.
       (): BoardLiveBatchAnswer =>
-        answerFor(
-          [...POOLS, { chain: "base", pairAddress: "PairCCC" }],
+        answerFrom(
+          POOLS,
+          [
+            ...POOLS.map((pool) => providerRow(pool.chain, pool.pairAddress)),
+            providerRow("base", "PairCCC"),
+          ],
           9_999,
         ),
     ],
     [
-      "a duplicated row for one identity",
-      (): BoardLiveBatchAnswer => {
-        const answer = answerFor(POOLS, 9_999);
-        return {
-          ...answer,
-          rows: [...answer.rows, providerRow("solana", "PairAAA", "2.50")],
-        };
-      },
+      "a second row for one identity, folded by the adapter",
+      "incomplete",
+      // The adapter keeps the FIRST row and records the fold in `collapsed`.
+      // The surviving answer is a perfectly well-formed one-row-per-pool set,
+      // which is why this case is invisible without the accounting.
+      (): BoardLiveBatchAnswer =>
+        answerFrom(
+          POOLS,
+          [
+            ...POOLS.map((pool) => providerRow(pool.chain, pool.pairAddress)),
+            providerRow("solana", "PairAAA", "2.50"),
+          ],
+          9_999,
+        ),
+    ],
+    [
+      "a row whose shape the projector cannot read",
+      "provider",
+      // F6. `projectBoardRow` delegates to the surface projector, which THROWS
+      // on shape drift rather than returning nulls. Reconciliation itself is
+      // clean here: both identities resolve, nothing is unrequested and nothing
+      // collapsed. Before the projection was brought inside the classified
+      // path, this throw escaped the state machine and left an active lease
+      // with no next tick ever scheduled.
+      (): BoardLiveBatchAnswer =>
+        answerFrom(
+          POOLS,
+          POOLS.map((pool) => ({
+            ...providerRow(pool.chain, pool.pairAddress),
+            // A scalar where the projector reads a block.
+            baseToken: "not-a-token-block",
+          })),
+          9_999,
+        ),
     ],
   ])(
     "R15: rejects the WHOLE tick on %s, keeping last-good and its timestamp",
-    async (_label, makeBad) => {
+    async (_label, expectedReason, makeBad) => {
       let attempt = 0;
       const service = makeService(() => {
         attempt += 1;
@@ -452,7 +543,7 @@ describe("board live lease", () => {
       });
       live = service;
       const owner = makeTarget(1);
-      const outcome = await service.subscribe({
+      const outcome = await subscribeTo(service, {
         target: owner.target,
         pools: POOLS,
       });
@@ -467,12 +558,196 @@ describe("board live lease", () => {
       expect(kinds(owner.events)).toStrictEqual(["degraded"]);
       const event = owner.events[0];
       if (event?.kind !== "degraded") throw new Error("expected degraded");
-      expect(event.reason).toBe("incomplete");
+      expect(event.reason).toBe(expectedReason);
       expect(event.lastGood?.fetchedAtMs).toBe(1_000);
       expect(event.lastGood?.rows).toHaveLength(POOLS.length);
       expect(event.lastGood?.rows[0]?.row.priceUsd).toBe("1.25");
+
+      // AND THE LEASE IS STILL RUNNING. A degradation that forgot to arm the
+      // next attempt would leave a board frozen with an active lease and no
+      // clock, which is exactly what an escaping projection throw used to do.
+      await vi.advanceTimersByTimeAsync(600_000);
+      expect(kinds(owner.events).length).toBeGreaterThan(1);
     },
   );
+
+  it.each([
+    [
+      "a row the projector cannot read",
+      (): BoardLiveBatchAnswer =>
+        answerFrom(
+          POOLS,
+          POOLS.map((pool) => ({
+            ...providerRow(pool.chain, pool.pairAddress),
+            baseToken: "not-a-token-block",
+          })),
+        ),
+    ],
+    [
+      "an answer that does not cover the board",
+      (): BoardLiveBatchAnswer =>
+        answerFrom(POOLS, [providerRow("solana", "PairAAA")]),
+    ],
+  ])(
+    "F6: a FIRST answer of %s closes the lease instead of leaking it",
+    async (_label, makeBad) => {
+      const service = makeService(() => Promise.resolve(makeBad()));
+      live = service;
+      const owner = makeTarget(1);
+      const outcome = await subscribeTo(service, {
+        target: owner.target,
+        pools: POOLS,
+      });
+
+      // A TYPED REFUSAL, with a sentence the reader can act on. Not a thrown
+      // exception escaping the state machine, which is what an unguarded
+      // projection produced.
+      expect(outcome.kind).toBe("failed");
+      if (outcome.kind !== "failed") throw new Error("expected a failure");
+      expect(outcome.detail.length).toBeGreaterThan(0);
+
+      // AND THE LEASE IS NOT LEAKED. The slot is free, nothing is left
+      // listening on the window, and the terminal event was delivered.
+      expect(kinds(owner.events)).toStrictEqual(["closed:dropped"]);
+      expect(owner.listenerCount()).toBe(0);
+      // The proof the registry is genuinely free: a fresh subscribe claims it
+      // and is granted, which a lease stuck in `subscribing` would have
+      // superseded instead.
+      const next = await subscribeTo(service, {
+        target: makeTarget(2).target,
+        pools: POOLS,
+      });
+      expect(next.kind).toBe("failed");
+      await vi.advanceTimersByTimeAsync(60_000);
+      // No tick was ever scheduled for a lease that never became active.
+      expect(kinds(owner.events)).toStrictEqual(["closed:dropped"]);
+    },
+  );
+
+  it("R6-pre: a cancel by request id aborts the FIRST fetch before it answers", async () => {
+    // The window this test is about: main mints the lease id but does not hand
+    // it back until the first fetch settles, so for up to the attempt deadline
+    // the renderer holds no handle from main at all. The request id is the one
+    // name that exists on both sides from before the call.
+    let seenSignal: AbortSignal | null = null;
+    const release: { fn: ((answer: BoardLiveBatchAnswer) => void) | null } = {
+      fn: null,
+    };
+    const service = makeService((args) => {
+      seenSignal = args.signal;
+      return new Promise<BoardLiveBatchAnswer>((resolve) => {
+        release.fn = resolve;
+      });
+    });
+    live = service;
+    const owner = makeTarget(1);
+    const mine = requestId(9_001);
+
+    const pending = service.subscribe({
+      target: owner.target,
+      pools: POOLS,
+      requestId: mine,
+    });
+    await Promise.resolve();
+    const signal = seenSignal as AbortSignal | null;
+    if (signal === null) throw new Error("expected the first fetch to start");
+    expect(signal.aborted).toBe(false);
+
+    // THE ASSERTION THAT MATTERS is on the underlying signal, not on eventual
+    // cleanup: the exchange must end NOW, not run to its 20 s deadline for a
+    // reader who has already gone.
+    expect(service.unsubscribe({ requestId: mine, ownerId: 1 })).toBe("closed");
+    expect(signal.aborted).toBe(true);
+    expect(kinds(owner.events)).toStrictEqual(["closed:unsubscribed"]);
+
+    // The subscribe still has to settle, and it must publish nothing.
+    release.fn?.(answerFor(POOLS, 9_999));
+    const outcome = await pending;
+    expect(outcome.kind).not.toBe("subscribed");
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(kinds(owner.events)).toStrictEqual(["closed:unsubscribed"]);
+  });
+
+  it("R3-pre: a request id is a handle, not a credential", async () => {
+    // Held open, then released at the end: the point is the state DURING the
+    // first fetch, and `stop()` now genuinely drains that attempt, so a promise
+    // that never settled would hang this file's own teardown.
+    const release: { fn: ((answer: BoardLiveBatchAnswer) => void) | null } = {
+      fn: null,
+    };
+    const service = makeService(
+      () =>
+        new Promise<BoardLiveBatchAnswer>((resolve) => {
+          release.fn = resolve;
+        }),
+    );
+    live = service;
+    const owner = makeTarget(1);
+    const mine = requestId(9_002);
+    void service.subscribe({
+      target: owner.target,
+      pools: POOLS,
+      requestId: mine,
+    });
+    await Promise.resolve();
+
+    // Another window naming this request id gets the same typed refusal it
+    // would get for a lease id, and the lease is left running.
+    expect(service.unsubscribe({ requestId: mine, ownerId: 2 })).toBe(
+      "not-owner",
+    );
+    expect(owner.events).toStrictEqual([]);
+    // An id nobody minted is simply unknown.
+    expect(
+      service.unsubscribe({ requestId: requestId(9_003), ownerId: 1 }),
+    ).toBe("unknown");
+    expect(owner.events).toStrictEqual([]);
+    release.fn?.(answerFor(POOLS, 9_999));
+  });
+
+  it("R9-pre: stop() drains the FIRST fetch, not only a later poll", async () => {
+    // The initial attempt is the one cycle no tick timer schedules, so it was
+    // the one attempt shutdown could abandon in flight rather than drain.
+    let settled = false;
+    const release: { fn: ((answer: BoardLiveBatchAnswer) => void) | null } = {
+      fn: null,
+    };
+    const service = makeService(
+      () =>
+        new Promise<BoardLiveBatchAnswer>((resolve) => {
+          release.fn = (answer): void => {
+            settled = true;
+            resolve(answer);
+          };
+        }),
+    );
+    const owner = makeTarget(1);
+    const pending = service.subscribe({
+      target: owner.target,
+      pools: POOLS,
+      requestId: requestId(9_004),
+    });
+    await Promise.resolve();
+
+    const stopping = service.stop();
+    expect(kinds(owner.events)).toStrictEqual(["closed:shutdown"]);
+    expect(settled).toBe(false);
+
+    let stopResolved = false;
+    void stopping.then(() => {
+      stopResolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    // Ordering, not timing: stop() cannot be finished while the attempt it is
+    // supposed to be draining has not settled.
+    expect(stopResolved).toBe(false);
+
+    release.fn?.(answerFor(POOLS, 9_999));
+    await stopping;
+    expect(settled).toBe(true);
+    await pending;
+    expect(kinds(owner.events)).toStrictEqual(["closed:shutdown"]);
+  });
 
   it("R11: reports live unsupported without a bridge, and refuses subscribe by name", async () => {
     const service = makeService(() => Promise.resolve(answerFor(POOLS)), {
@@ -484,7 +759,7 @@ describe("board live lease", () => {
     expect(capability.detail).not.toBeNull();
 
     const owner = makeTarget(1);
-    const outcome = await service.subscribe({ target: owner.target, pools: POOLS });
+    const outcome = await subscribeTo(service, { target: owner.target, pools: POOLS });
     expect(outcome.kind).toBe("unsupported");
     // Nothing was claimed, so nothing has to be released.
     expect(owner.listenerCount()).toBe(0);
@@ -506,7 +781,7 @@ describe("board live lease", () => {
     });
     live = service;
     const owner = makeTarget(1);
-    await service.subscribe({ target: owner.target, pools: POOLS });
+    await subscribeTo(service, { target: owner.target, pools: POOLS });
 
     await vi.advanceTimersByTimeAsync(5_000);
     elapsed += 5_000;
@@ -535,7 +810,7 @@ describe("board live lease", () => {
     });
     live = service;
     const owner = makeTarget(1);
-    const outcome = await service.subscribe({ target: owner.target, pools: POOLS });
+    const outcome = await subscribeTo(service, { target: owner.target, pools: POOLS });
     if (outcome.kind !== "subscribed") throw new Error("expected a lease");
 
     await vi.advanceTimersByTimeAsync(5_000);

--- a/vex-app/src/main/market/__tests__/board-live-smoke.test.ts
+++ b/vex-app/src/main/market/__tests__/board-live-smoke.test.ts
@@ -97,6 +97,11 @@ function answer(fetchedAtMs: number, priceUsd: string): BoardLiveBatchAnswer {
     resolvedKeys: new Set(
       POOLS.map((pool) => `${pool.chain}:${pool.pairAddress}`.toLowerCase()),
     ),
+    // The recorded run answered exactly what was asked: nothing extra came
+    // back and nothing was folded. The service refuses a tick when either list
+    // carries anything, so the archive's own emptiness is part of the fixture.
+    unrequested: [],
+    collapsed: [],
     fetchedAtMs,
   };
 }
@@ -156,7 +161,11 @@ describe("smoke-live-v1", () => {
       jitterMs: () => 0,
     });
 
-    const first = await service.subscribe({ target: target(eventsA, 1), pools: POOLS });
+    const first = await service.subscribe({
+      target: target(eventsA, 1),
+      pools: POOLS,
+      requestId: "aaaaaaaa-0000-4000-8000-000000000001",
+    });
     if (first.kind !== "subscribed") throw new Error("expected a lease");
     expect(first.snapshot.rows).toHaveLength(3);
     // The projector ran on the recorded bytes: money is TEXT, not a float.
@@ -172,7 +181,11 @@ describe("smoke-live-v1", () => {
     expect(ticksSeen).toBe(4);
 
     // A second board claims the single lease.
-    const second = await service.subscribe({ target: target(eventsB, 2), pools: POOLS });
+    const second = await service.subscribe({
+      target: target(eventsB, 2),
+      pools: POOLS,
+      requestId: "aaaaaaaa-0000-4000-8000-000000000002",
+    });
     if (second.kind !== "subscribed") throw new Error("expected the second lease");
     expect(eventsA[eventsA.length - 1]).toMatchObject({
       kind: "closed",

--- a/vex-app/src/main/market/board-live-service.ts
+++ b/vex-app/src/main/market/board-live-service.ts
@@ -49,6 +49,15 @@
  *     live channel, p50 700 ms, max 941 ms, with no rate limiting
  *     (`board-v2-probes/live-poll.json`).
  *
+ *  5. A LEASE IS CANCELLABLE BEFORE IT HAS A NAME FROM MAIN. `leaseId` is not
+ *     handed back until the first fetch settles, so between the reader's click
+ *     and that response there was no handle either side shared and a toggle-off
+ *     inside that window could not stop the exchange. The renderer therefore
+ *     mints a `requestId` before it calls, the lease binds it in the same
+ *     synchronous critical section that claims the slot, and an unsubscribe
+ *     addressed by it aborts the in-flight first attempt at once. Ownership is
+ *     still the sender's identity: the new handle carries no authority.
+ *
  * VISIBILITY IS NOT THE SIGNAL. The transcript is not virtualized today, so a
  * board that scrolls out of view stays mounted and its lease stays open. That
  * is correct: the lease is a decision the READER made with a toggle, not a
@@ -118,12 +127,39 @@ export interface BoardLiveTarget {
   readonly onGone: (cb: () => void) => () => void;
 }
 
-/** What one batch attempt produced, before reconciliation. */
+/**
+ * What one batch attempt produced, before reconciliation.
+ *
+ * `unrequested` and `collapsed` are the batch channel's OWN accounting of the
+ * two ways a provider answer can diverge from the question, and they are
+ * carried here rather than dropped at the adapter because dropping them made
+ * the reconciliation below unfalsifiable. The channel already removes an
+ * unrequested row from `rows` and folds a duplicate into the first, so an
+ * answer that needed either repair reconciles as if it were clean: the counts
+ * match, every requested key is present, and the tick publishes. Forwarding the
+ * two lists is what lets a tick be rejected for the reason it actually had.
+ */
 export interface BoardLiveBatchAnswer {
   readonly rows: readonly unknown[];
   readonly resolvedKeys: ReadonlySet<string>;
+  /** Row keys the provider returned that this board never named. */
+  readonly unrequested: readonly string[];
+  /** Row keys that arrived more than once and were folded into the first. */
+  readonly collapsed: readonly string[];
   readonly fetchedAtMs: number;
 }
+
+/**
+ * Why one answer could not become a published tick.
+ *
+ * `incomplete` is the answer not covering exactly the subscribed pools.
+ * `provider` is the answer being unreadable: the surface projector threw on a
+ * row whose shape drifted from what it parses. The two are separated because
+ * they are different facts about the provider and the reader is told which.
+ */
+type ReconcileOutcome =
+  | { readonly ok: true; readonly snapshot: BoardLiveSnapshot }
+  | { readonly ok: false; readonly reason: BoardLiveDegradeReason };
 
 export interface BoardLiveServiceDeps {
   /** One batch attempt. Throws a typed site error on any failure. */
@@ -154,6 +190,8 @@ type LeaseState =
 
 interface Lease {
   readonly id: string;
+  /** The renderer's own name for the subscribe that created this lease. */
+  readonly requestId: string;
   readonly target: BoardLiveTarget;
   readonly pools: readonly BoardLivePool[];
   readonly identities: readonly BatchIdentity[];
@@ -246,6 +284,8 @@ async function defaultFetchBatch(args: {
   return {
     rows: batch.rows,
     resolvedKeys: batch.resolvedKeys,
+    unrequested: batch.unrequested,
+    collapsed: batch.collapsed,
     fetchedAtMs: batch.fetchedAtMs,
   };
 }
@@ -303,6 +343,12 @@ export class BoardLiveService {
   async subscribe(args: {
     readonly target: BoardLiveTarget;
     readonly pools: readonly BoardLivePool[];
+    /**
+     * The renderer's own name for this attempt, minted before the call. It is
+     * bound to the lease SYNCHRONOUSLY, before the first fetch is awaited, so a
+     * cancel that arrives while this call is still in flight can find it.
+     */
+    readonly requestId: string;
   }): Promise<BoardLiveSubscribeOutcome> {
     const capability = this.capability();
     if (!capability.supported) {
@@ -328,6 +374,7 @@ export class BoardLiveService {
 
     const lease: Lease = {
       id: this.deps.newLeaseId(),
+      requestId: args.requestId,
       target: args.target,
       pools: args.pools,
       identities,
@@ -351,15 +398,26 @@ export class BoardLiveService {
     });
     // -------------------------------------------------------------------------
 
+    // THE FIRST ATTEMPT IS TRACKED LIKE ANY OTHER CYCLE. `stop()` drains
+    // `inFlight`, and before this was recorded the ONE attempt that is not
+    // scheduled by the tick timer - this one - was the one attempt a shutdown
+    // could abandon mid-flight rather than drain.
+    const attempt = this.deps.fetchBatch({
+      identities,
+      signal: lease.controller.signal,
+      timeoutMs: this.deps.attemptTimeoutMs,
+      coalesceScope: `board-live:${lease.id}`,
+    });
+    lease.inFlight = attempt.then(
+      () => undefined,
+      () => undefined,
+    );
+
     let answer: BoardLiveBatchAnswer;
     try {
-      answer = await this.deps.fetchBatch({
-        identities,
-        signal: lease.controller.signal,
-        timeoutMs: this.deps.attemptTimeoutMs,
-        coalesceScope: `board-live:${lease.id}`,
-      });
+      answer = await attempt;
     } catch (error) {
+      lease.inFlight = null;
       // Superseded or closed while we were waiting: say nothing, publish
       // nothing. The lease that replaced us owns the board now.
       if (this.current !== lease) {
@@ -373,21 +431,27 @@ export class BoardLiveService {
         detail: describeFailure(error, permanent),
       };
     }
+    lease.inFlight = null;
 
     if (this.current !== lease) {
       return { kind: "failed", retryable: false, detail: SUPERSEDED_DETAIL };
     }
 
-    const snapshot = this.reconcile(lease, answer);
-    if (snapshot === null) {
+    const outcome = this.reconcile(lease, answer);
+    if (!outcome.ok) {
+      // A first attempt that cannot be published closes the lease rather than
+      // leaving it registered in `subscribing` forever. That is the leak this
+      // path exists to prevent: a projection that throws used to escape the
+      // whole guarded region, and the lease it belonged to stayed in the
+      // registry with no tick scheduled and no way for anyone to release it.
       this.closeLease(lease, "dropped");
       return {
         kind: "failed",
         retryable: true,
-        detail:
-          "The market channel did not return a row for every pool on this board, so no live figures were shown. The board still shows the figures it was composed with.",
+        detail: describeReconcileFailure(outcome.reason),
       };
     }
+    const snapshot = outcome.snapshot;
 
     lease.lastGood = snapshot;
     lease.state = "active";
@@ -409,11 +473,26 @@ export class BoardLiveService {
    * able to call this twice without seeing an error.
    */
   unsubscribe(args: {
-    readonly leaseId: string;
+    /** Main's handle, once the subscribe has answered. */
+    readonly leaseId?: string;
+    /**
+     * The renderer's own handle, usable BEFORE the subscribe has answered.
+     * Closing on this aborts the lease's controller, which is what cancels the
+     * initial fetch immediately rather than letting it run to its deadline.
+     */
+    readonly requestId?: string;
     readonly ownerId: number;
   }): BoardLiveUnsubscribeOutcome {
     const lease = this.current;
-    if (lease === null || lease.id !== args.leaseId) return "unknown";
+    if (lease === null) return "unknown";
+    const named =
+      args.leaseId !== undefined
+        ? lease.id === args.leaseId
+        : args.requestId !== undefined && lease.requestId === args.requestId;
+    if (!named) return "unknown";
+    // Ownership is checked for BOTH identities. A request id is a handle in
+    // exactly the sense a lease id is, so it buys no authority over another
+    // window's board.
     if (lease.target.ownerId !== args.ownerId) return "not-owner";
     this.closeLease(lease, "unsubscribed");
     return "closed";
@@ -444,32 +523,56 @@ export class BoardLiveService {
   /* ------------------------------------------------------------------ */
 
   /**
-   * Reconcile one answer EXACTLY against what the lease asked for.
+   * Reconcile one answer EXACTLY against what the lease asked for, and project
+   * it.
    *
-   * Returns null on ANY deviation: a missing identity, an identity the board
-   * never named, or a duplicate. Null means the caller must reject the whole
-   * tick, because a board showing seven fresh cards and one from five minutes
-   * ago, labelled "live", is a lie no reader can detect.
+   * Refuses on ANY deviation: a missing identity, an identity the board never
+   * named, a duplicate, or a row the projector cannot read. Refusal means the
+   * caller must reject the whole tick, because a board showing seven fresh
+   * cards and one from five minutes ago, labelled "live", is a lie no reader
+   * can detect.
+   *
+   * THE PROJECTION HAPPENS INSIDE THIS GUARD, and that placement is the point.
+   * `projectBoardRow` delegates to the surface's own row projector, which can
+   * throw when a provider row's shape drifts. Projecting outside the classified
+   * path let that throw escape the state machine entirely: on a first attempt
+   * it left a lease registered in `subscribing` with nobody able to release it,
+   * and on a later tick it left an active lease with no next tick ever
+   * scheduled. Caught here it is an ordinary `provider` failure, which the
+   * backoff, the drop budget and the last-good rule already know how to handle.
    */
   private reconcile(
     lease: Lease,
     answer: BoardLiveBatchAnswer,
-  ): BoardLiveSnapshot | null {
-    if (answer.resolvedKeys.size !== lease.requestedKeys.size) return null;
+  ): ReconcileOutcome {
+    const incomplete: ReconcileOutcome = { ok: false, reason: "incomplete" };
+
+    // THE CHANNEL'S OWN ACCOUNTING FIRST. The batch channel silently REPAIRS
+    // both of these before it returns - it drops a row nobody asked for and
+    // folds a duplicate into the first - so by the time the counts below are
+    // compared, an answer that needed either repair looks exactly like a clean
+    // one. Either list carrying anything means the provider answered a
+    // different question than the one this board asked, and this service does
+    // not publish an answer to a question it did not ask.
+    if (answer.unrequested.length > 0 || answer.collapsed.length > 0) {
+      return incomplete;
+    }
+
+    if (answer.resolvedKeys.size !== lease.requestedKeys.size) return incomplete;
     for (const key of lease.requestedKeys) {
-      if (!answer.resolvedKeys.has(key)) return null;
+      if (!answer.resolvedKeys.has(key)) return incomplete;
     }
 
     const byKey = new Map<string, unknown>();
     for (const row of answer.rows) {
       const key = rowKey(row);
-      if (key === null) return null;
+      if (key === null) return incomplete;
       // A duplicate row for one identity means the answer covers an epoch this
       // service cannot resolve between. Reject rather than pick one.
-      if (byKey.has(key)) return null;
+      if (byKey.has(key)) return incomplete;
       byKey.set(key, row);
     }
-    if (byKey.size !== lease.requestedKeys.size) return null;
+    if (byKey.size !== lease.requestedKeys.size) return incomplete;
 
     const nowMs = this.deps.now();
     const sanitized = new Set<string>();
@@ -477,18 +580,25 @@ export class BoardLiveService {
     for (const [index, pool] of lease.pools.entries()) {
       const key = `${pool.chain}:${pool.pairAddress}`.toLowerCase();
       const source = byKey.get(key);
-      if (source === undefined) return null;
-      rows.push({
-        key,
-        row: projectBoardRow({
+      if (source === undefined) return incomplete;
+      let row;
+      try {
+        row = projectBoardRow({
           source,
           nowMs,
           fieldPathPrefix: `pools[${index}]`,
           sanitizedFieldPaths: sanitized,
-        }),
-      });
+        });
+      } catch (error) {
+        log.warn(
+          `[board-live] lease ${lease.id}: the market channel returned a row this build cannot read`,
+          error instanceof Error ? error.message : String(error),
+        );
+        return { ok: false, reason: "provider" };
+      }
+      rows.push({ key, row });
     }
-    return { fetchedAtMs: answer.fetchedAtMs, rows };
+    return { ok: true, snapshot: { fetchedAtMs: answer.fetchedAtMs, rows } };
   }
 
   /**
@@ -545,14 +655,18 @@ export class BoardLiveService {
 
     if (!this.isCurrent(lease)) return;
 
-    const snapshot = this.reconcile(lease, answer);
-    if (snapshot === null) {
+    const outcome = this.reconcile(lease, answer);
+    if (!outcome.ok) {
       // The whole tick is rejected. Last-good rows AND their timestamp stay
       // exactly as they were: the age on screen is the age of the figures the
-      // reader is looking at, never the age of the last attempt.
-      this.onCycleFailure(lease, "incomplete", false);
+      // reader is looking at, never the age of the last attempt. Degrading
+      // rather than dropping is what keeps the next tick scheduled, which is
+      // the difference between a board that recovers and a board that is
+      // frozen with an active lease and no clock running.
+      this.onCycleFailure(lease, outcome.reason, false);
       return;
     }
+    const snapshot = outcome.snapshot;
 
     lease.lastGood = snapshot;
     lease.consecutiveFailures = 0;
@@ -646,6 +760,14 @@ export class BoardLiveService {
 
 const SUPERSEDED_DETAIL =
   "Another board claimed the live connection while this one was starting, so this board stays on the figures it was composed with.";
+
+/** A reader-facing sentence for a first answer that could not be published. */
+function describeReconcileFailure(reason: BoardLiveDegradeReason): string {
+  if (reason === "provider") {
+    return "The market channel returned figures this build could not read, so no live figures were shown. The board still shows the figures it was composed with.";
+  }
+  return "The market channel did not return a row for every pool on this board, so no live figures were shown. The board still shows the figures it was composed with.";
+}
 
 /** A reader-facing sentence for a failed first attempt. Never a raw provider payload. */
 function describeFailure(error: unknown, permanent: boolean): string {

--- a/vex-app/src/renderer/features/appShell/Board/TokenCard.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/TokenCard.tsx
@@ -40,7 +40,7 @@
  * and can be copied.
  */
 
-import type { JSX, RefObject } from "react";
+import { useState, type JSX, type RefObject } from "react";
 import {
   boardTokenIconDataUrl,
   useBoardTokenIcon,
@@ -265,6 +265,14 @@ function ChartTrigger({
  * non-image outcome (loading, absent, transport trouble) lands on the same
  * monogram, because the card's job is to show the token, not to narrate the
  * state of a decorative fetch.
+ *
+ * AND SO DOES A PICTURE THE BROWSER CANNOT DRAW. Main's validation reads magic
+ * bytes and header dimensions with no decode - no image codec ships with Vex -
+ * so bytes can be a truthful, in-bounds PNG header followed by a corrupt or
+ * truncated body and still reach here. Without `onError` that draws a broken-
+ * image glyph in a slot that has a designed state for exactly this. The failing
+ * URL is remembered rather than a bare boolean, so a LATER answer carrying
+ * different bytes gets its own attempt instead of inheriting this one's verdict.
  */
 function TokenLogo({
   iconId,
@@ -275,8 +283,9 @@ function TokenLogo({
 }): JSX.Element {
   const query = useBoardTokenIcon(iconId);
   const dataUrl = boardTokenIconDataUrl(query);
+  const [undecodableUrl, setUndecodableUrl] = useState<string | null>(null);
 
-  if (dataUrl !== null) {
+  if (dataUrl !== null && dataUrl !== undecodableUrl) {
     return (
       <img
         data-vex-area="board-token-logo"
@@ -284,6 +293,9 @@ function TokenLogo({
         src={dataUrl}
         alt=""
         aria-hidden
+        onError={() => {
+          setUndecodableUrl(dataUrl);
+        }}
         className="h-9 w-9 shrink-0 rounded-full border border-line-2 bg-surface-2 object-cover"
       />
     );

--- a/vex-app/src/renderer/features/appShell/Board/__tests__/BoardLiveToggle.test.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/__tests__/BoardLiveToggle.test.tsx
@@ -34,7 +34,15 @@ const LEASE_B = "22222222-2222-4222-8222-222222222222";
  */
 interface FakeMain {
   readonly listeners: Set<(event: BoardLiveEvent) => void>;
+  /** Releases addressed by main's lease id. */
   readonly unsubscribed: string[];
+  /**
+   * Releases addressed by the RENDERER's own request id, which is the only
+   * name that exists while a subscribe is still in flight.
+   */
+  readonly cancelled: string[];
+  /** Every request id the renderer minted, in call order. */
+  readonly requestIds: string[];
   readonly subscribeCalls: number;
   emit(event: BoardLiveEvent): void;
   /** Resolve a subscribe that was deliberately left in flight. */
@@ -43,17 +51,27 @@ interface FakeMain {
 
 let supported = true;
 let holdSubscribe = false;
+/**
+ * Whether the scripted main GRANTS a lease that was cancelled before it
+ * answered. Real main aborts instead, but the two orders are a genuine race at
+ * the process boundary and the renderer has to be correct under both.
+ */
+let grantDespiteCancel = false;
 
 function installFakeMain(): FakeMain {
   const listeners = new Set<(event: BoardLiveEvent) => void>();
   const unsubscribed: string[] = [];
+  const cancelled: string[] = [];
   const pending: Array<(leaseId: string) => void> = [];
+  const requestIds: string[] = [];
   let issued = 0;
   let currentLease: string | null = null;
 
   const state = {
     listeners,
     unsubscribed,
+    cancelled,
+    requestIds,
     get subscribeCalls(): number {
       return issued;
     },
@@ -123,19 +141,45 @@ function installFakeMain(): FakeMain {
                 : "Live figures need the DexScreener site channel, which this build does not mount.",
             },
           }),
-        subscribe: () => {
+        subscribe: (input: { pools: unknown; requestId: string }) => {
           issued += 1;
           const leaseId = issued === 1 ? LEASE_A : LEASE_B;
+          const requestId = input.requestId;
+          requestIds.push(requestId);
           if (holdSubscribe) {
             return new Promise((resolve) => {
-              pending.push((released: string) => resolve(grant(released)));
+              pending.push((released: string) => {
+                // Main aborted this attempt on the pre-response cancel, so it
+                // answers with the refusal rather than a lease.
+                if (cancelled.includes(requestId) && !grantDespiteCancel) {
+                  resolve({
+                    ok: false,
+                    error: {
+                      code: "provider.unavailable",
+                      domain: "market",
+                      message: "the attempt was cancelled",
+                      retryable: false,
+                      userActionable: false,
+                      redacted: true,
+                      correlationId: "test",
+                    },
+                  });
+                  return;
+                }
+                resolve(grant(released));
+              });
             });
           }
           return Promise.resolve(grant(leaseId));
         },
-        unsubscribe: (input: { leaseId: string }) => {
-          unsubscribed.push(input.leaseId);
-          if (currentLease === input.leaseId) currentLease = null;
+        unsubscribe: (input: { leaseId?: string; requestId?: string }) => {
+          if (input.requestId !== undefined) {
+            cancelled.push(input.requestId);
+            return Promise.resolve({ ok: true, data: { outcome: "closed" } });
+          }
+          const leaseId = input.leaseId ?? "";
+          unsubscribed.push(leaseId);
+          if (currentLease === leaseId) currentLease = null;
           return Promise.resolve({ ok: true, data: { outcome: "closed" } });
         },
         onLeaseEvent: (cb: (event: BoardLiveEvent) => void) => {
@@ -204,6 +248,7 @@ let main: FakeMain;
 beforeEach(() => {
   supported = true;
   holdSubscribe = false;
+  grantDespiteCancel = false;
   main = installFakeMain();
   vi.setSystemTime(FIXTURE_FETCHED_AT + 1_000);
 });
@@ -271,8 +316,102 @@ describe("board LIVE toggle", () => {
     expect(container.textContent).toContain("9.99");
   });
 
+  it("drops a lease event whose generation is not newer than the one already applied", async () => {
+    // K-d. Main's generation is monotonic per lease, so anything at or below
+    // what this mount has already acted on describes a transition it has passed.
+    // Non-blocking by design: everything newer still lands.
+    const { container } = render(withQuery(createElement(BoardBlock, { spec: boardSpec() })));
+    await settle();
+    await clickToggle(container);
+    // The subscribe response carried generation 1 and the figures it granted.
+    expect(container.textContent).toContain("9.99");
+
+    await act(async () => {
+      main.emit({
+        kind: "degraded",
+        leaseId: LEASE_A,
+        // STALE: generation 1 was already applied by the subscribe response.
+        generation: 1,
+        reason: "provider",
+        lastGood: null,
+      });
+    });
+    expect(badgeOf(container)?.getAttribute("data-live-mode")).toBe("live-connected");
+
+    await act(async () => {
+      main.emit({
+        kind: "degraded",
+        leaseId: LEASE_A,
+        generation: 2,
+        reason: "provider",
+        lastGood: null,
+      });
+    });
+    expect(badgeOf(container)?.getAttribute("data-live-mode")).toBe("live-degraded");
+  });
+
+  it("R7-pre: unmounting while connecting cancels the in-flight attempt", async () => {
+    holdSubscribe = true;
+    const { container, unmount } = render(
+      withQuery(createElement(BoardBlock, { spec: boardSpec() })),
+    );
+    await settle();
+    const toggle = await readyToggle(container);
+    await act(async () => {
+      fireEvent.click(toggle);
+      await Promise.resolve();
+    });
+    expect(main.requestIds).toHaveLength(1);
+
+    // A session switch unmounts the row and the effect cleanup is all that
+    // runs. It must still be able to name the exchange it started.
+    unmount();
+    expect(main.cancelled).toStrictEqual([main.requestIds[0]]);
+    expect(main.unsubscribed).toStrictEqual([]);
+  });
+
+  it("R4-pre: toggling off while connecting CANCELS the in-flight attempt by request id", async () => {
+    // THE WINDOW THIS ROW IS ABOUT. Main withholds the lease id until its first
+    // fetch settles, so between the click and that response the renderer holds
+    // no handle from main at all. Without an identity of its own it could only
+    // stop drawing while main kept the exchange open to its deadline.
+    holdSubscribe = true;
+    const { container } = render(withQuery(createElement(BoardBlock, { spec: boardSpec() })));
+    await settle();
+
+    const toggle = await readyToggle(container);
+    await act(async () => {
+      fireEvent.click(toggle);
+      await Promise.resolve();
+    });
+    expect(badgeOf(container)?.getAttribute("data-live-mode")).toBe("live-connecting");
+    expect(main.requestIds).toHaveLength(1);
+
+    await act(async () => {
+      fireEvent.click(toggleOf(container)); // off, still connecting
+      await Promise.resolve();
+    });
+
+    // The cancel went out IMMEDIATELY, addressed by the only name both sides
+    // knew, and it did not wait for the response to arrive first.
+    expect(main.cancelled).toStrictEqual([main.requestIds[0]]);
+    expect(main.unsubscribed).toStrictEqual([]);
+
+    await act(async () => {
+      main.releaseSubscribe(LEASE_A);
+      await Promise.resolve();
+    });
+    await settle();
+    expect(container.textContent).not.toContain("9.99");
+    expect(badgeOf(container)).toBeNull();
+  });
+
   it("R2: discards a subscribe response that lands after the reader turned it off, and releases its lease", async () => {
     holdSubscribe = true;
+    // The race order in which main granted the lease before the cancel reached
+    // it. The generation guard still refuses to paint it, and the orphan is
+    // released by lease id.
+    grantDespiteCancel = true;
     const { container } = render(withQuery(createElement(BoardBlock, { spec: boardSpec() })));
     await settle();
 

--- a/vex-app/src/renderer/features/appShell/Board/__tests__/TokenCard.test.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/__tests__/TokenCard.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * TokenCard - the logo slot's two states, and the third one it used to miss.
+ *
+ * Main validates icon bytes WITHOUT decoding them: it reads magic bytes and
+ * header dimensions, because no image codec ships with Vex. A truthful PNG
+ * header followed by a corrupt or truncated body therefore passes every check
+ * main can make and still fails in the renderer. The card had no `onError`, so
+ * that landed as a broken-image glyph inside a slot that already carries a
+ * designed state for "no picture".
+ *
+ * The composition is real: the actual hook, over a real QueryClient, reading a
+ * stubbed `window.vex.boardIcons.read` exactly as the board does. jsdom never
+ * decodes an image, so the `error` event is dispatched on the real element
+ * rather than waited for - the subject is the card's handling of that event,
+ * not a browser decoder.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+import { TokenCard } from "../TokenCard.js";
+import type { BoardCardModel } from "../boardModel.js";
+import { hydratedRow } from "./boardFixture.js";
+
+const ICON_ID = "abcd1234";
+
+/**
+ * A `data:` URL of the shape the IPC contract admits, whose base64 body is NOT
+ * a decodable PNG. Precisely the case main cannot catch and the renderer must.
+ */
+const UNDECODABLE_DATA_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==";
+
+const readBoardIcon = vi.fn();
+
+beforeEach(() => {
+  readBoardIcon.mockReset();
+  readBoardIcon.mockResolvedValue({
+    ok: true,
+    data: {
+      iconId: ICON_ID,
+      icon: { kind: "image", dataUrl: UNDECODABLE_DATA_URL },
+    },
+  });
+  Object.defineProperty(window, "vex", {
+    configurable: true,
+    writable: true,
+    value: { boardIcons: { read: readBoardIcon } },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  // @ts-expect-error - test cleanup
+  delete window.vex;
+});
+
+function withQuery(ui: ReactNode): ReactNode {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return createElement(QueryClientProvider, { client }, ui);
+}
+
+function card(): BoardCardModel {
+  return {
+    key: "base:0xpool",
+    chain: "base",
+    pairAddress: "0xpool",
+    caption: null,
+    row: hydratedRow({ iconId: ICON_ID }),
+    trendH1: "down",
+    trendH24: "up",
+  };
+}
+
+/** The logo slot, or a named failure rather than a null dereference. */
+function logoSlot(container: HTMLElement): HTMLElement {
+  const el = container.querySelector('[data-vex-area="board-token-logo"]');
+  if (!(el instanceof HTMLElement)) throw new Error("logo slot not found");
+  return el;
+}
+
+function renderCard(): HTMLElement {
+  const { container } = render(
+    withQuery(createElement(TokenCard, { card: card(), stale: false })),
+  );
+  return container;
+}
+
+describe("TokenCard logo slot", () => {
+  it("draws the image main returned", async () => {
+    const container = renderCard();
+    await waitFor(() => {
+      expect(logoSlot(container).getAttribute("data-state")).toBe("image");
+    });
+  });
+
+  it("falls back to the designed monogram when the bytes will not decode", async () => {
+    const container = renderCard();
+    await waitFor(() => {
+      expect(logoSlot(container).getAttribute("data-state")).toBe("image");
+    });
+
+    fireEvent.error(logoSlot(container));
+
+    const fallback = logoSlot(container);
+    expect(fallback.getAttribute("data-state")).toBe("monogram");
+    // The card's OWN placeholder, not a second one invented for this path:
+    // the symbol's monogram, which is what most cards on a board wear.
+    expect(fallback.textContent).toBe("PE");
+  });
+});

--- a/vex-app/src/renderer/lib/api/__tests__/board-icons.test.ts
+++ b/vex-app/src/renderer/lib/api/__tests__/board-icons.test.ts
@@ -1,0 +1,221 @@
+/**
+ * board-icons.ts - the board token icon hook's FRESHNESS policy.
+ *
+ * The defect this file exists to keep fixed: the hook used one
+ * `staleTime: Infinity` for every fulfilled outcome, which froze the three
+ * outcomes that carry NO information about the icon (`busy`, `transport`,
+ * `not_mounted`) for the lifetime of a mounted transcript, and froze a 404
+ * long past the window main itself keeps it for. A board that met one busy
+ * instant stayed logo-less until the user navigated away.
+ *
+ * Two layers, deliberately:
+ *  - a table test on `boardIconFreshnessMs`, the pure decision;
+ *  - three behavioral tests driving the real `useQuery` through fake timers,
+ *    because "the outcome is stale" is not the contract - "the card asks
+ *    again and recovers" is, and only the wired refetch cadence proves it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import type { Result } from "@shared/ipc/result.js";
+import type { BoardIconReadResult } from "@shared/schemas/board-icons.js";
+
+import {
+  BOARD_ICON_NOT_FOUND_STALE_MS,
+  BOARD_ICON_TRANSIENT_STALE_MS,
+  boardIconFreshnessMs,
+  useBoardTokenIcon,
+} from "../board-icons.js";
+
+const ID = "profile_abc123";
+const DATA_URL = "data:image/png;base64,AAAA";
+
+function ok(icon: BoardIconReadResult["icon"]): Result<BoardIconReadResult> {
+  return { ok: true, data: { iconId: ID, icon } };
+}
+
+const IMAGE = ok({ kind: "image", dataUrl: DATA_URL });
+
+const readMock = vi.fn<() => Promise<Result<BoardIconReadResult>>>();
+
+beforeEach(() => {
+  readMock.mockReset();
+  Object.defineProperty(window, "vex", {
+    configurable: true,
+    writable: true,
+    value: { boardIcons: { read: () => readMock() } },
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  // @ts-expect-error - test cleanup
+  delete window.vex;
+});
+
+function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+/** A client that imposes no freshness of its own, so the hook's is the only one. */
+function makeClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+}
+
+describe("boardIconFreshnessMs", () => {
+  it("settles an image forever - the handle names one immutable asset", () => {
+    expect(boardIconFreshnessMs(IMAGE)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("settles a definitive absence forever", () => {
+    expect(
+      boardIconFreshnessMs(ok({ kind: "absent", reason: "unsupported_image" })),
+    ).toBe(Number.POSITIVE_INFINITY);
+    expect(boardIconFreshnessMs(ok({ kind: "absent", reason: "over_cap" }))).toBe(
+      Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it("holds a 404 for exactly main's negative-cache window", () => {
+    expect(boardIconFreshnessMs(ok({ kind: "absent", reason: "not_found" }))).toBe(
+      BOARD_ICON_NOT_FOUND_STALE_MS,
+    );
+    // THE DRIFT GUARD, and the reason it is a literal here rather than an
+    // import: a renderer module may not import a main-process one. Main's
+    // `BOARD_ICON_NOT_FOUND_TTL_MS` is the same ten minutes and is asserted
+    // against the same literal in `src/main/images/__tests__/
+    // board-icon-service.test.ts`, so moving the window on one side alone
+    // turns one of the two red instead of silently desynchronising them.
+    expect(BOARD_ICON_NOT_FOUND_STALE_MS).toBe(600_000);
+  });
+
+  it("holds every transient non-answer only briefly", () => {
+    for (const reason of ["busy", "transport", "not_mounted"] as const) {
+      expect(boardIconFreshnessMs(ok({ kind: "unavailable", reason }))).toBe(
+        BOARD_ICON_TRANSIENT_STALE_MS,
+      );
+    }
+  });
+
+  it("settles a Result error and an unfetched query forever", () => {
+    expect(boardIconFreshnessMs(undefined)).toBe(Number.POSITIVE_INFINITY);
+    expect(
+      boardIconFreshnessMs({
+        ok: false,
+        error: {
+          code: "validation.invalid_input",
+          domain: "data",
+          message: "Not a board token icon id.",
+          retryable: false,
+          userActionable: false,
+          redacted: true,
+          correlationId: "00000000-0000-4000-8000-0000000000ff",
+        },
+      }),
+    ).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe("useBoardTokenIcon - transient outcomes recover", () => {
+  it("re-asks after a transport failure and draws the image that follows", async () => {
+    vi.useFakeTimers();
+    readMock
+      .mockResolvedValueOnce(ok({ kind: "unavailable", reason: "transport" }))
+      .mockResolvedValue(IMAGE);
+
+    const { result } = renderHook(() => useBoardTokenIcon(ID), {
+      wrapper: makeWrapper(makeClient()),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.data).toEqual(
+      ok({ kind: "unavailable", reason: "transport" }),
+    );
+    expect(readMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(BOARD_ICON_TRANSIENT_STALE_MS + 50);
+    });
+
+    expect(readMock).toHaveBeenCalledTimes(2);
+    expect(result.current.data).toEqual(IMAGE);
+  });
+
+  it("re-asks after a queue overflow, so a busy instant is not permanent", async () => {
+    vi.useFakeTimers();
+    readMock
+      .mockResolvedValueOnce(ok({ kind: "unavailable", reason: "busy" }))
+      .mockResolvedValue(IMAGE);
+
+    const { result } = renderHook(() => useBoardTokenIcon(ID), {
+      wrapper: makeWrapper(makeClient()),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(readMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(BOARD_ICON_TRANSIENT_STALE_MS + 50);
+    });
+
+    expect(readMock).toHaveBeenCalledTimes(2);
+    expect(result.current.data).toEqual(IMAGE);
+  });
+
+  it("holds a 404 for main's whole window, then asks again", async () => {
+    vi.useFakeTimers();
+    readMock
+      .mockResolvedValueOnce(ok({ kind: "absent", reason: "not_found" }))
+      .mockResolvedValue(IMAGE);
+
+    const { result } = renderHook(() => useBoardTokenIcon(ID), {
+      wrapper: makeWrapper(makeClient()),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(readMock).toHaveBeenCalledTimes(1);
+
+    // Well past the transient window: a 404 is settled for far longer than a
+    // busy queue, and treating the two alike would hammer the CDN.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(BOARD_ICON_TRANSIENT_STALE_MS * 4);
+    });
+    expect(readMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(BOARD_ICON_NOT_FOUND_STALE_MS);
+    });
+    expect(readMock).toHaveBeenCalledTimes(2);
+    expect(result.current.data).toEqual(IMAGE);
+  });
+
+  it("never re-asks once an image is in hand", async () => {
+    vi.useFakeTimers();
+    readMock.mockResolvedValue(IMAGE);
+
+    renderHook(() => useBoardTokenIcon(ID), {
+      wrapper: makeWrapper(makeClient()),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(BOARD_ICON_NOT_FOUND_STALE_MS * 3);
+    });
+
+    expect(readMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vex-app/src/renderer/lib/api/board-icons.ts
+++ b/vex-app/src/renderer/lib/api/board-icons.ts
@@ -11,17 +11,79 @@
  * pools carry no profile artwork), and a disabled query means the card draws
  * its monogram without ever troubling main.
  *
- * `staleTime: Infinity` is correct rather than lazy: an icon handle names one
- * immutable asset, so a refetch could only return the same `data:` URL. `retry:
- * false` for the same reason a locker thumbnail does not retry - an absent icon
- * is an answer, and a decorative image is never worth a retry storm. Main's own
- * negative cache already keeps a 404 from becoming a per-render fetch.
+ * FRESHNESS IS A PROPERTY OF THE OUTCOME, NOT OF THE QUERY. An icon handle
+ * names one immutable asset, so it is tempting to cache every answer forever -
+ * and that is wrong, because half of what this channel returns is not an answer
+ * ABOUT the asset. `unavailable` means nothing was learned: the fetch queue was
+ * full, the transport failed, or the service was not mounted yet. Freezing that
+ * for the lifetime of a mounted transcript would turn one busy instant into a
+ * permanently logo-less board, and it would silently defeat main's own 404 TTL
+ * as well. So {@link boardIconFreshnessMs} reads the outcome and hands react-
+ * query a per-outcome staleness, with a matching refetch cadence for the two
+ * outcomes that can change on their own.
+ *
+ * `retry: false` stays, and for the original reason a locker thumbnail does not
+ * retry - a decorative image is never worth a retry storm. Recovery here is a
+ * paced re-ask on the cadence below, not an immediate retry loop.
  */
 
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import type { Result } from "@shared/ipc/result.js";
 import type { BoardIconReadResult } from "@shared/schemas/board-icons.js";
 import { boardIconKeys } from "./queryKeys.js";
+
+/**
+ * How long a transient non-answer (`busy` / `transport` / `not_mounted`) is
+ * held before the card asks again.
+ *
+ * Short because all three clear on their own: the queue drains in the time two
+ * icons take, a mount completes during startup, and a transport blip is over
+ * before a reader finishes the card. Not shorter, because the failure mode
+ * being avoided is a board of cards re-asking a struggling CDN in lockstep.
+ */
+export const BOARD_ICON_TRANSIENT_STALE_MS = 15_000;
+
+/**
+ * How long a 404 is held. MUST equal the main service's own negative-cache
+ * window (`BOARD_ICON_NOT_FOUND_TTL_MS` in
+ * `src/main/images/board-icon-service.ts`), which is the shared invariant here:
+ * main will answer `not_found` from memory for exactly that long, so a renderer
+ * asking sooner spends an IPC round trip on a reply it already has, and a
+ * renderer asking later leaves newly added artwork undrawn for no reason.
+ *
+ * It is declared rather than imported because main-process modules may not
+ * cross into the renderer bundle; the two are pinned to one number by a test
+ * that imports both (`src/main/images/__tests__/board-icon-service.test.ts`).
+ */
+export const BOARD_ICON_NOT_FOUND_STALE_MS = 600_000;
+
+/**
+ * How long this outcome may be trusted, in milliseconds.
+ *
+ * `Number.POSITIVE_INFINITY` means settled: asking again cannot produce a
+ * different answer, so the query never refetches.
+ *
+ *   image               the bytes are in hand and the handle is immutable;
+ *   absent/not_found    settled only as long as main says it is;
+ *   absent/other        the bytes the provider serves under this handle are not
+ *                       an image this app can identify, or are past the cap.
+ *                       Settled for those bytes, and re-asking would only
+ *                       re-download them;
+ *   unavailable/*       nothing was learned. Ask again shortly;
+ *   Result error        the input did not validate or the sender was not
+ *                       trusted. Neither changes by asking twice.
+ */
+export function boardIconFreshnessMs(
+  result: Result<BoardIconReadResult> | undefined,
+): number {
+  if (result === undefined || !result.ok) return Number.POSITIVE_INFINITY;
+  const { icon } = result.data;
+  if (icon.kind === "unavailable") return BOARD_ICON_TRANSIENT_STALE_MS;
+  if (icon.kind === "absent" && icon.reason === "not_found") {
+    return BOARD_ICON_NOT_FOUND_STALE_MS;
+  }
+  return Number.POSITIVE_INFINITY;
+}
 
 export function useBoardTokenIcon(
   iconId: string | null,
@@ -30,7 +92,15 @@ export function useBoardTokenIcon(
     queryKey: boardIconKeys.icon(iconId ?? ""),
     queryFn: () => window.vex.boardIcons.read({ iconId: iconId ?? "" }),
     enabled: iconId !== null,
-    staleTime: Infinity,
+    staleTime: (query) => boardIconFreshnessMs(query.state.data),
+    // A card that is already on screen never remounts, so staleness alone
+    // would never recover it. The cadence exists for exactly the two outcomes
+    // that can change without the reader doing anything, and is `false` - no
+    // timer at all - for every settled one.
+    refetchInterval: (query) => {
+      const freshness = boardIconFreshnessMs(query.state.data);
+      return Number.isFinite(freshness) ? freshness : false;
+    },
     retry: false,
   });
 }

--- a/vex-app/src/renderer/lib/api/board-live.ts
+++ b/vex-app/src/renderer/lib/api/board-live.ts
@@ -134,14 +134,47 @@ export function useBoardLive(pools: readonly BoardLivePool[]): BoardLiveState {
   const generation = useRef(0);
   const leaseId = useRef<string | null>(null);
 
+  /**
+   * The id this mount minted for a subscribe that has not answered yet.
+   *
+   * Main withholds the lease id until its FIRST fetch settles, which is up to
+   * the attempt deadline. Without a handle of our own, a reader who toggled off
+   * inside that window could only stop drawing: main kept the exchange open to
+   * the end for a board nobody was watching. This id exists from before the
+   * call, so the cancel is addressable at the instant the decision is made.
+   */
+  const pendingRequestId = useRef<string | null>(null);
+
+  /**
+   * The highest lease generation this mount has acted on, or -1 before any.
+   *
+   * Main's generation is monotonic per lease and rides every event. Anything at
+   * or below what we have already applied describes a transition we have passed,
+   * so it is dropped rather than painted. Cheap, and it is the only defence
+   * against an out-of-order delivery on the event channel.
+   */
+  const appliedGeneration = useRef(-1);
+
   const release = useCallback((): void => {
     const id = leaseId.current;
+    const requestId = pendingRequestId.current;
     leaseId.current = null;
-    if (id === null) return;
+    pendingRequestId.current = null;
+    appliedGeneration.current = -1;
     // Fire and forget by design: nothing on screen depends on the answer, and
     // `unknown` (the lease already ended) is an ordinary outcome. Failures are
     // main's to log; the renderer has already stopped drawing live figures.
-    void window.vex.boardLive.unsubscribe({ leaseId: id });
+    if (id !== null) {
+      void window.vex.boardLive.unsubscribe({ leaseId: id });
+      return;
+    }
+    // PRE-RESPONSE CANCELLATION. No lease id yet means the subscribe is still
+    // in flight, and the request id is the only name both sides know. Main
+    // aborts the lease's controller on it, which ends the exchange now rather
+    // than at its deadline.
+    if (requestId !== null) {
+      void window.vex.boardLive.unsubscribe({ requestId });
+    }
   }, []);
 
   // LEASE EVENTS. Attached for the whole mount, BEFORE any subscribe can be
@@ -150,6 +183,11 @@ export function useBoardLive(pools: readonly BoardLivePool[]): BoardLiveState {
   useEffect(() => {
     const off = window.vex.boardLive.onLeaseEvent((event) => {
       if (leaseId.current !== event.leaseId) return;
+      // The generation guard. Non-blocking by design: it drops what is stale
+      // and applies everything else, so a delivery order that never goes wrong
+      // costs nothing and one that does cannot repaint a transition we left.
+      if (event.generation <= appliedGeneration.current) return;
+      appliedGeneration.current = event.generation;
       if (event.kind === "tick") {
         setRowsByKey(indexRows(event.snapshot));
         setFetchedAtMs(event.snapshot.fetchedAtMs);
@@ -164,6 +202,8 @@ export function useBoardLive(pools: readonly BoardLivePool[]): BoardLiveState {
         return;
       }
       leaseId.current = null;
+      pendingRequestId.current = null;
+      appliedGeneration.current = -1;
       generation.current += 1;
       setMode("live-off");
       setRowsByKey(null);
@@ -191,7 +231,11 @@ export function useBoardLive(pools: readonly BoardLivePool[]): BoardLiveState {
     // not leave, and the generation guard below is exactly what makes leaving
     // it safe: the response that eventually lands is discarded and its lease
     // released.
-    if (leaseId.current !== null || mode === "live-connecting") {
+    if (
+      leaseId.current !== null ||
+      pendingRequestId.current !== null ||
+      mode === "live-connecting"
+    ) {
       // Turning it OFF. The generation moves first, so a subscribe response
       // still in flight can no longer publish anything.
       generation.current += 1;
@@ -217,16 +261,23 @@ export function useBoardLive(pools: readonly BoardLivePool[]): BoardLiveState {
 
     generation.current += 1;
     const requested = generation.current;
+    // Minted BEFORE the call, and published to the ref in the same synchronous
+    // step, so a toggle-off on the very next tick of the event loop already has
+    // a name to cancel with.
+    const requestId = crypto.randomUUID();
+    pendingRequestId.current = requestId;
     setMode("live-connecting");
     setNotice(null);
     setBusy(true);
     void window.vex.boardLive
-      .subscribe({ pools: [...pools] })
+      .subscribe({ pools: [...pools], requestId })
       .then((result) => {
         if (generation.current !== requested) {
-          // R2. The reader moved on while this was in flight. If a lease was
-          // nevertheless granted, RELEASE IT: leaving it would have main
-          // polling a provider for a board that is no longer listening.
+          // R2. The reader moved on while this was in flight. The cancel has
+          // already been sent by `release` under the request id, so main has
+          // normally closed this lease before the response even lands. If it
+          // was nevertheless granted first, RELEASE IT: leaving it would have
+          // main polling a provider for a board that is no longer listening.
           if (result.ok && result.data.kind === "subscribed") {
             void window.vex.boardLive.unsubscribe({
               leaseId: result.data.leaseId,
@@ -234,6 +285,7 @@ export function useBoardLive(pools: readonly BoardLivePool[]): BoardLiveState {
           }
           return;
         }
+        pendingRequestId.current = null;
         if (!result.ok) {
           setMode("live-off");
           setNotice(result.error.message);
@@ -245,6 +297,7 @@ export function useBoardLive(pools: readonly BoardLivePool[]): BoardLiveState {
           return;
         }
         leaseId.current = result.data.leaseId;
+        appliedGeneration.current = result.data.generation;
         setRowsByKey(indexRows(result.data.snapshot));
         setFetchedAtMs(result.data.snapshot.fetchedAtMs);
         setMode("live-connected");

--- a/vex-app/src/shared/schemas/board-live.ts
+++ b/vex-app/src/shared/schemas/board-live.ts
@@ -59,9 +59,29 @@ export type BoardLivePool = z.infer<typeof boardLivePoolSchema>;
 /** Opaque lease handle. Minted by main; the renderer only echoes it back. */
 export const boardLiveLeaseIdSchema = z.string().uuid();
 
+/**
+ * The RENDERER's own name for one subscribe attempt, minted before the call.
+ *
+ * WHY A SECOND IDENTITY EXISTS AT ALL. A lease id is minted by main and is not
+ * handed back until the FIRST fetch has settled, which can be up to the attempt
+ * deadline. Between the click that starts a subscribe and that response there
+ * is a window in which the renderer holds no handle, so a reader who toggles
+ * off, switches session or unmounts inside it had no way to say which exchange
+ * to stop: main kept fetching for a board nobody was watching. This id is
+ * minted by the caller, so it exists from the first instant and a cancel can be
+ * addressed the moment the decision is made.
+ *
+ * It is a HANDLE, never a credential. Ownership is still decided by the sending
+ * webContents, exactly as it is for a lease id, so naming another window's
+ * request id gets the same typed refusal.
+ */
+export const boardLiveRequestIdSchema = z.string().uuid();
+
 export const boardLiveSubscribeInputSchema = z
   .object({
     pools: z.array(boardLivePoolSchema).min(1).max(BOARD_MAX_POOLS),
+    /** Minted by the renderer so this attempt is cancellable before it answers. */
+    requestId: boardLiveRequestIdSchema,
   })
   .strict();
 export type BoardLiveSubscribeInput = z.infer<
@@ -211,9 +231,20 @@ export type BoardLiveSubscribeResult = z.infer<
   typeof boardLiveSubscribeResultSchema
 >;
 
-export const boardLiveUnsubscribeInputSchema = z
-  .object({ leaseId: boardLiveLeaseIdSchema })
-  .strict();
+/**
+ * Release by EITHER identity, and exactly one of them.
+ *
+ * `leaseId` is the ordinary case: the subscribe answered, the renderer holds
+ * main's handle. `requestId` is the pre-response case: the subscribe has not
+ * answered yet, so the only name both sides share is the one the renderer
+ * minted. Two strict members rather than one object with two optional fields,
+ * so "neither" and "both" are rejected at the boundary instead of being
+ * resolved by a precedence rule nobody can see.
+ */
+export const boardLiveUnsubscribeInputSchema = z.union([
+  z.object({ leaseId: boardLiveLeaseIdSchema }).strict(),
+  z.object({ requestId: boardLiveRequestIdSchema }).strict(),
+]);
 export type BoardLiveUnsubscribeInput = z.infer<
   typeof boardLiveUnsubscribeInputSchema
 >;


### PR DESCRIPTION
Ten accepted findings from the external final review of PR #118, each with a red-on-revert regression; details in the commit message. Second commit on this branch after the whole-args hotfix already merged via PR #119.

Verification: tsc clean both trees; root suite 15,825 passed / 0 failed; vex-app 6,679 passed with the single mcp-host-serve-peer-end socket failure reproduced as an environmental flake (passes in isolation, file untouched by this branch); em-dash, unsafe-escapes, process-boundaries, both ratchets green.