### PR TITLE
fix(agentscan): treat 403 quarantine as a pause, not a permanent skip

### DIFF
--- a/scripts/deleted-test-allowlist.mjs
+++ b/scripts/deleted-test-allowlist.mjs
@@ -20,20 +20,7 @@
  * outlives its merge is stale by construction and the gate says so.
  */
 
-export const DELETED_TEST_ALLOWLIST = [
-  {
-    path: "vex-app/src/renderer/features/appShell/Board/__tests__/boardChartArea.test.ts",
-    reason:
-      "The spotlight chart's AREA adapter (toChartAreaPoint, normalizeBoardAreaPoints, " +
-      "reconcileAreaSeries, AreaFeed) was removed when the owner ruled the spotlight " +
-      "main chart a candlestick series with a volume histogram (2026-08-26); no code " +
-      "is left for this suite to exercise.",
-    coveredBy:
-      "vex-app/src/renderer/features/appShell/Board/__tests__/boardChartSpotlight.test.ts " +
-      "(the candle-plus-volume adapter, the same reconciliation table over all five " +
-      "fields, the per-bar colours and the two-series feed).",
-  },
-];
+export const DELETED_TEST_ALLOWLIST = [];
 
 export const DELETED_TEST_ALLOWLIST_PATHS = new Set(
   DELETED_TEST_ALLOWLIST.map((entry) => entry.path),

--- a/src/__tests__/integration/agentscan/reporter.int.test.ts
+++ b/src/__tests__/integration/agentscan/reporter.int.test.ts
@@ -22,8 +22,11 @@
  *
  * Plus the server-answer table: session/complete 409 (wallet_conflict, kept
  * defensive — the current server transfers a proven wallet instead) →
- * permanent stop; events-endpoint 410 → permanent stop; events-endpoint 401
- * → re-handshake the SAME identity next run (`resetForReRegistration`);
+ * permanent stop; events-endpoint 410 → permanent stop; events-endpoint
+ * 403-quarantined → a long outbox pause, never a latched skip (the server
+ * can be wrong, and an install that has stopped calling cannot be told);
+ * events-endpoint 401 → re-handshake the SAME identity next run
+ * (`resetForReRegistration`);
  * session/complete 401 → a DIFFERENT recovery — the FakeSessionClient
  * enforces the server's real Bearer rule via a per-agentHash bound-token
  * ledger, so a genuine crash-after-rotation lockout (server holds T_new,
@@ -331,6 +334,27 @@ describe("reporter lane — gating", () => {
     expect(session.sessionStartCalls).toHaveLength(0);
     expect(client.sendCalls).toHaveLength(0);
   });
+
+  it("a leftover quarantined latch does not skip: the next tick still sends, and the stale flag is left alone", async () => {
+    const lane = await import("../../../vex-agent/sync/agentscan-report.js");
+    const stateRepo = await import("../../../vex-agent/db/repos/agentscan-reporting.js");
+    await seedWallet();
+    await seedEligibleSwap();
+    const client = new FakeClient();
+    const session = new FakeSessionClient();
+
+    const first = await lane.runAgentscanReport(depsWith(client, "http://localhost", session));
+    expect(first.skipped).toBeNull();
+    expect(client.sendCalls).toHaveLength(1);
+
+    await stateRepo.markStopped("quarantined");
+    await seedEligibleSwap();
+
+    const second = await lane.runAgentscanReport(depsWith(client, "http://localhost", session));
+    expect(second.skipped).toBeNull();
+    expect(client.sendCalls).toHaveLength(2);
+    expect((await stateRepo.getReportingState()).stoppedReason).toBe("quarantined");
+  });
 });
 
 describe("reporter lane — handshake gate (AC2)", () => {
@@ -618,6 +642,34 @@ describe("reporter lane — server-answer table", () => {
     expect(client.sendCalls).toHaveLength(1);
   });
 
+  it("send 403 quarantined -> outbox held ~1h, no permanent latch; the following run in the hold window does not send", async () => {
+    const { queryOne } = await import("@vex-agent/db/client.js");
+    const lane = await import("../../../vex-agent/sync/agentscan-report.js");
+    const stateRepo = await import("../../../vex-agent/db/repos/agentscan-reporting.js");
+    await seedWallet();
+    await seedEligibleSwap();
+    const client = new FakeClient();
+    client.sendOutcomes = [{ kind: "stopped", reason: "quarantined" }];
+
+    const first = await lane.runAgentscanReport(depsWith(client));
+    expect(first.skipped).toBeNull();
+    expect(first.deferred).toBe(1);
+    expect((await stateRepo.getReportingState()).stoppedReason).toBeNull();
+
+    const owed = await queryOne<{ next_attempt_at: Date; sent_at: Date | null }>(
+      `SELECT next_attempt_at, sent_at FROM agentscan_outbox`,
+      [],
+    );
+    expect(owed?.sent_at).toBeNull();
+    const heldUntil = new Date(owed?.next_attempt_at ?? 0).getTime();
+    expect(heldUntil).toBeGreaterThan(Date.now() + 3500 * 1000);
+    expect(heldUntil).toBeLessThanOrEqual(Date.now() + 3700 * 1000);
+
+    const next = await lane.runAgentscanReport(depsWith(client));
+    expect(next.skipped).toBeNull();
+    expect(client.sendCalls).toHaveLength(1);
+  });
+
   it("send 401 -> registration cleared, SAME identity re-handshaked next run, rows resent", async () => {
     const { execute } = await import("@vex-agent/db/client.js");
     const lane = await import("../../../vex-agent/sync/agentscan-report.js");
@@ -808,6 +860,23 @@ describe("runAgentscanIncremental — push-lane drain-only entry (AC2)", () => {
     expect(stopped.skipped).toBe("unregistered");
     expect(stoppedSession.sessionStartCalls).toHaveLength(0);
     expect(stoppedClient.sendCalls).toHaveLength(0);
+  });
+
+  it("a leftover quarantined latch does not skip the push lane: it still drains", async () => {
+    const lane = await import("../../../vex-agent/sync/agentscan-report.js");
+    const stateRepo = await import("../../../vex-agent/db/repos/agentscan-reporting.js");
+    await seedWallet();
+    await seedEligibleSwap();
+    const setupClient = new FakeClient();
+    const setup = await lane.runAgentscanReport(depsWith(setupClient));
+    expect(setup.skipped).toBeNull();
+
+    await stateRepo.markStopped("quarantined");
+    await seedEligibleSwap();
+    const pushClient = new FakeClient();
+    const pushed = await lane.runAgentscanIncremental(depsWith(pushClient));
+    expect(pushed.skipped).toBeNull();
+    expect(pushClient.sendCalls.length).toBeGreaterThan(0);
   });
 
   it("registered but backfill not yet enqueued: a push-lane fire in the handshake->backfill window is a zero-touch no-op", async () => {

--- a/src/__tests__/vex-agent/agentscan/client.test.ts
+++ b/src/__tests__/vex-agent/agentscan/client.test.ts
@@ -9,8 +9,9 @@
  *     Authorization header — never in a URL);
  *   - every server answer maps to the outcome the reporter keys off:
  *     contract retry rule (only 429/5xx/network are retryable), 401 and
- *     403-not_registered as recoverable auth loss, 410 / 403-quarantined as
- *     permanent stops, 400/413 as non-retryable client bugs;
+ *     403-not_registered as recoverable auth loss, 410 as a permanent stop,
+ *     403-quarantined as a named `stopped` outcome the lane treats as a
+ *     pause, 400/413 as non-retryable client bugs;
  *   - `Retry-After` is surfaced on 429/503;
  *   - nothing throws — a network failure is a named outcome;
  *   - failure details never contain the token.

--- a/src/__tests__/vex-agent/sync/agentscan-drain-agent-health.test.ts
+++ b/src/__tests__/vex-agent/sync/agentscan-drain-agent-health.test.ts
@@ -12,14 +12,16 @@ import type { AgentscanClient, SendOutcome } from "@vex-agent/agentscan/client.j
 const mockClaimDueOutbox = vi.fn();
 const mockMarkOutboxSent = vi.fn();
 const mockMarkOutboxRejected = vi.fn();
+const mockRescheduleOutbox = vi.fn();
+const mockMarkStopped = vi.fn();
 
 vi.mock("@vex-agent/db/repos/agentscan-reporting.js", () => ({
   claimDueOutbox: (...args: unknown[]) => mockClaimDueOutbox(...args),
   markOutboxSent: (...args: unknown[]) => mockMarkOutboxSent(...args),
   markOutboxRejected: (...args: unknown[]) => mockMarkOutboxRejected(...args),
-  rescheduleOutbox: vi.fn(),
+  rescheduleOutbox: (...args: unknown[]) => mockRescheduleOutbox(...args),
   resetForReRegistration: vi.fn(),
-  markStopped: vi.fn(),
+  markStopped: (...args: unknown[]) => mockMarkStopped(...args),
 }));
 
 const mockWarn = vi.fn();
@@ -91,5 +93,23 @@ describe("drainOutbox - agent health surfacing", () => {
       (call) => call[0] === "agentscan.report.agent_strikes",
     );
     expect(strikeWarns).toEqual([]);
+  });
+});
+
+describe("drainOutbox - 403 quarantined is a pause, not a latch", () => {
+  it("reschedules owed rows ~1h and does not markStopped", async () => {
+    const client = clientReturning({ kind: "stopped", reason: "quarantined" });
+    const result = await drainOutbox(client, "a".repeat(64), "token");
+    expect(result).toEqual({ sent: 0, rejected: 0, deferred: 1 });
+    expect(mockMarkStopped).not.toHaveBeenCalled();
+    expect(mockRescheduleOutbox).toHaveBeenCalledWith([1], 3600);
+    expect(mockWarn).toHaveBeenCalledWith("agentscan.report.stopped_by_server", { reason: "quarantined" });
+  });
+
+  it("still latches consent_revoked as a permanent stop", async () => {
+    const client = clientReturning({ kind: "stopped", reason: "consent_revoked" });
+    await drainOutbox(client, "a".repeat(64), "token");
+    expect(mockMarkStopped).toHaveBeenCalledWith("consent_revoked");
+    expect(mockRescheduleOutbox).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/vex-agent/sync/agentscan-report-quarantine-skip.test.ts
+++ b/src/__tests__/vex-agent/sync/agentscan-report-quarantine-skip.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Quarantine is a pause, not a terminal skip. A leftover
+ * `stopped_reason = 'quarantined'` (old binaries latched this on 403) must
+ * still enter the drain; consent_revoked / identity conflicts stay dark.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentscanReportingState } from "@vex-agent/db/repos/agentscan-reporting.js";
+import type { AgentscanReporterDeps } from "@vex-agent/sync/agentscan-report.js";
+
+const mockGetReportingState = vi.fn();
+const mockDrainIncremental = vi.fn();
+const mockComputeWalletsFingerprint = vi.fn();
+
+vi.mock("@vex-agent/db/repos/agentscan-reporting.js", () => ({
+  getReportingState: (...args: unknown[]) => mockGetReportingState(...args),
+}));
+
+vi.mock("@vex-agent/sync/agentscan-report/drain.js", () => ({
+  drainIncremental: (...args: unknown[]) => mockDrainIncremental(...args),
+  drainOutbox: vi.fn(),
+  AGENTSCAN_BATCH_LIMIT: 500,
+  AGENTSCAN_MAX_BATCHES_PER_TICK: 6,
+}));
+
+vi.mock("@vex-agent/sync/agentscan-report/handshake-lane.js", () => ({
+  handshakeOnce: vi.fn(),
+  computeWalletsFingerprint: () => mockComputeWalletsFingerprint(),
+}));
+
+vi.mock("@utils/logger.js", () => {
+  const stub = { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() };
+  return { default: stub, logger: stub };
+});
+
+const { runAgentscanReport, runAgentscanIncremental } = await import(
+  "@vex-agent/sync/agentscan-report.js"
+);
+
+const FINGERPRINT = "fp";
+
+function registeredState(
+  stoppedReason: AgentscanReportingState["stoppedReason"],
+): AgentscanReportingState {
+  return {
+    agentHash: "a".repeat(64),
+    ingestToken: "T".repeat(43),
+    consentVersion: 1,
+    acceptedAt: "2026-08-20T00:00:00.000Z",
+    registeredAt: "2026-08-20T00:00:00.000Z",
+    registerAttemptCount: 0,
+    nextRegisterAttemptAt: "2026-08-20T00:00:00.000Z",
+    backfillEnqueuedAt: "2026-08-20T00:00:00.000Z",
+    stoppedReason,
+    agentName: "agent-default",
+    lastHandshakeAt: "2026-08-20T00:00:00.000Z",
+    serverCursorRowId: null,
+    boundWalletsFingerprint: FINGERPRINT,
+  };
+}
+
+function deps(): AgentscanReporterDeps {
+  return {
+    baseUrl: () => "http://localhost",
+    buildClient: () => ({ sendEvents: vi.fn() }),
+    buildSessionClient: () => ({
+      sessionStart: vi.fn(),
+      sessionComplete: vi.fn(),
+    }),
+    signChallenge: vi.fn(),
+    appVersion: () => "0.0.0-test",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockComputeWalletsFingerprint.mockReturnValue(FINGERPRINT);
+  mockDrainIncremental.mockResolvedValue({ enqueued: 1, sent: 1, rejected: 0, deferred: 0 });
+});
+
+describe("quarantine is not a terminal skip", () => {
+  it("a leftover quarantined latch still drains the periodic lane", async () => {
+    mockGetReportingState.mockResolvedValue(registeredState("quarantined"));
+    const result = await runAgentscanReport(deps());
+    expect(result.skipped).toBeNull();
+    expect(mockDrainIncremental).toHaveBeenCalledOnce();
+  });
+
+  it("a leftover quarantined latch still drains the push lane", async () => {
+    mockGetReportingState.mockResolvedValue(registeredState("quarantined"));
+    const result = await runAgentscanIncremental(deps());
+    expect(result.skipped).toBeNull();
+    expect(mockDrainIncremental).toHaveBeenCalledOnce();
+  });
+
+  it("consent_revoked still skips both lanes without draining", async () => {
+    mockGetReportingState.mockResolvedValue(registeredState("consent_revoked"));
+    expect((await runAgentscanReport(deps())).skipped).toBe("stopped");
+    expect((await runAgentscanIncremental(deps())).skipped).toBe("unregistered");
+    expect(mockDrainIncremental).not.toHaveBeenCalled();
+  });
+});

--- a/src/vex-agent/agentscan/client.ts
+++ b/src/vex-agent/agentscan/client.ts
@@ -14,7 +14,8 @@
  * outcome unions ARE the retry policy, so they carry everything the lane
  * needs: the contract says only 429/5xx/network are retryable, 401 and
  * 403-`not_registered` are recoverable auth loss (re-handshake the same
- * identity), 410 / 403-`quarantined` are permanent stops, and any other 4xx
+ * identity), 410 is a permanent stop, 403-`quarantined` is a long pause at
+ * the lane (not a latched skip — the server can be wrong), and any other 4xx
  * is a client bug that must never be hot-retried.
  *
  * TOKEN HYGIENE. The ingest token travels ONLY in the `Authorization: Bearer`

--- a/src/vex-agent/db/repos/agentscan-reporting.ts
+++ b/src/vex-agent/db/repos/agentscan-reporting.ts
@@ -374,7 +374,8 @@ export async function resetIdentityForRecovery(): Promise<void> {
   });
 }
 
-/** Permanent stop — 410, 403-quarantined, or a register 409. Never auto-cleared. */
+/** Permanent stop — 410 consent_revoked or an identity conflict. Never auto-cleared. */
+
 export async function markStopped(reason: AgentscanStopReason): Promise<void> {
   await ensureSingleton();
   await execute(

--- a/src/vex-agent/sync/agentscan-report.ts
+++ b/src/vex-agent/sync/agentscan-report.ts
@@ -28,8 +28,10 @@
  * until the public rollout). The identity is CSPRNG-random, never derived
  * from key material. Payloads go through the mapper's structural allowlist —
  * the banned columns are unreadable from its output by construction. Server
- * verdicts are honored exactly: 410 / 403-quarantined stop the lane
- * permanently; a 401 on the EVENTS endpoint re-handshakes the SAME identity
+ * verdicts are honored exactly: 410 consent_revoked and identity conflicts
+ * stop the lane permanently; 403-quarantined is a long outbox pause (the
+ * server can be wrong, and an install that has stopped calling cannot be
+ * told); a 401 on the EVENTS endpoint re-handshakes the SAME identity
  * AND resends the full eligible history (a server-side reset means the
  * server has nothing, so every already-sent row comes back owed, flagged
  * `backfill`); only 429/5xx/network are retried. A 401 from
@@ -75,6 +77,7 @@
 import { randomBytes } from "node:crypto";
 
 import * as reportingRepo from "@vex-agent/db/repos/agentscan-reporting.js";
+import type { AgentscanStopReason } from "@vex-agent/db/repos/agentscan-reporting.js";
 import type { AgentscanClient } from "../agentscan/client.js";
 import type { AgentscanSessionClient } from "../agentscan/session-client.js";
 import type {
@@ -125,6 +128,15 @@ const NOTHING: Omit<AgentscanReportResult, "skipped"> = {
   deferred: 0,
 };
 
+/**
+ * `quarantined` is a leftover latch from older binaries (and must not skip
+ * the lane — the server may already have lifted it). User-revoked consent
+ * and identity conflicts stay terminal.
+ */
+function isTerminalStopReason(reason: AgentscanStopReason | null): boolean {
+  return reason !== null && reason !== "quarantined";
+}
+
 /** CSPRNG identity — 32 bytes hex (public hash) + 32 bytes base64url (secret token). */
 export function generateAgentscanIdentity(): { agentHash: string; ingestToken: string } {
   return {
@@ -140,7 +152,7 @@ export async function runAgentscanReport(
   if (baseUrl === null) return { skipped: "disabled", ...NOTHING };
 
   let state = await reportingRepo.getReportingState();
-  if (state.stoppedReason !== null) return { skipped: "stopped", ...NOTHING };
+  if (isTerminalStopReason(state.stoppedReason)) return { skipped: "stopped", ...NOTHING };
 
   if (state.agentHash === null || state.ingestToken === null) {
     state = await reportingRepo.ensureIdentity(generateAgentscanIdentity);
@@ -187,7 +199,8 @@ export async function runAgentscanReport(
  * function itself never registers/backfills/writes state proactively, but the
  * drain it shares with the periodic lane honors server verdicts via
  * `sendGroup` (`resetForReRegistration()` on auth_lost, `markStopped()` on
- * 410/quarantine), so a push-lane fire CAN reset or stop the lane's state.
+ * 410; 403-quarantined is a long outbox pause, not a latch), so a push-lane
+ * fire CAN reset or stop the lane's state.
  * State is read fresh on every call, never cached across invocations.
  *
  * The `backfillEnqueuedAt === null` guard below is load-bearing: between the
@@ -206,7 +219,7 @@ export async function runAgentscanIncremental(
   if (baseUrl === null) return { skipped: "unregistered", ...NOTHING };
 
   const state = await reportingRepo.getReportingState();
-  if (state.stoppedReason !== null) return { skipped: "unregistered", ...NOTHING };
+  if (isTerminalStopReason(state.stoppedReason)) return { skipped: "unregistered", ...NOTHING };
   if (state.agentHash === null || state.ingestToken === null) {
     return { skipped: "unregistered", ...NOTHING };
   }

--- a/src/vex-agent/sync/agentscan-report/drain.ts
+++ b/src/vex-agent/sync/agentscan-report/drain.ts
@@ -31,6 +31,14 @@ export const AGENTSCAN_MAX_BATCHES_PER_TICK = 6;
 const INVALID_BATCH_HOLD_SECONDS = 3600;
 
 /**
+ * 403-quarantined is a server accusation, not a user decision. The server can
+ * be wrong (and has been), and an install that has stopped calling cannot be
+ * told the accusation was withdrawn. Hold the owed rows a full hour and ask
+ * again — never latch a permanent skip.
+ */
+const QUARANTINE_HOLD_SECONDS = 3600;
+
+/**
  * The incremental scan-then-drain step: shared verbatim by the periodic
  * lane's non-backfill tick and the push lane's `runAgentscanIncremental`, so
  * there is exactly one place that enqueues an incremental diff and drains it.
@@ -150,7 +158,11 @@ async function sendGroup(
     return { sent: 0, rejected: 0, deferred: owedIds.length, stop: true };
   }
   if (outcome.kind === "stopped") {
-    await reportingRepo.markStopped(outcome.reason);
+    if (outcome.reason === "quarantined") {
+      await reportingRepo.rescheduleOutbox(owedIds, QUARANTINE_HOLD_SECONDS);
+    } else {
+      await reportingRepo.markStopped(outcome.reason);
+    }
     logger.warn("agentscan.report.stopped_by_server", { reason: outcome.reason });
     return { sent: 0, rejected: 0, deferred: owedIds.length, stop: true };
   }


### PR DESCRIPTION
## Why

AgentScan can quarantine an install after enough verification strikes. That happened for real: the server was wrong, the strikes were withdrawn, and those installs were unblocked on the AgentScan side.

It did not help. Reporting is client-initiated. After a `403 quarantined`, Vex wrote `stopped_reason = quarantined` and every later tick bailed out before touching the network. An install that has stopped calling cannot be told the accusation was lifted.

## What changed

`quarantined` is no longer a one-way door.

- A leftover `stopped_reason = quarantined` (old binaries) does **not** skip the periodic or push lane. The stale flag is left alone. No migration, no runtime `UPDATE` to clear it.
- A new `403 quarantined` does **not** call `markStopped`. Owed outbox rows are held for an hour, then the lane asks again.
- `410 consent_revoked`, `agent_conflict`, and `wallet_conflict` stay terminal. Those are still a user decision or an identity conflict, not a server accusation.

Already-silent installs start talking again on the first tick after they pick up this build. If AgentScan is still refusing, they wait an hour and retry. If it accepts, events flow. Outbox rows were never marked sent or rejected, so the backlog is still owed.

## Tests

Unit and integration coverage for leftover skip, 1h hold, no latch on 403, and unchanged 410. Also ran the real reporting lane against a local AgentScan API: `200` send, `403` while quarantined, `200` again after the lift, leftover flag still sending.