### PR TITLE
fix(agentscan): late-fill Uniswap/Pendle/launch amounts instead of a false undecodable

### DIFF
--- a/src/__tests__/vex-agent/sync/executed-amount-fallback.test.ts
+++ b/src/__tests__/vex-agent/sync/executed-amount-fallback.test.ts
@@ -19,8 +19,9 @@
  *    keeps its eligibility rather than burning it on a transport failure.
  * 5. **A conflict is SURFACED, never merged.** Two readings of the same money
  *    disagreeing is a defect to report, not to resolve by last-write-wins.
- * 6. **An unmapped protocol declines BY NAME** rather than falling through to a
- *    "generic" decode — which was disproven on the owner's own swap.
+ * 6. **An unmapped protocol DEFERS** rather than concluding `amounts_undecodable`.
+ *    "No adapter" is not "we proved no amounts are coming"; a generic decode
+ *    is still forbidden. The named decline is only for a decoder that RAN.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -30,6 +31,7 @@ import type { AgentActivityEvent } from "@vex-agent/db/repos/agent-activity.js";
 
 const mockListCandidates = vi.fn();
 const mockFill = vi.fn();
+const mockFillLaunch = vi.fn();
 const mockDeclined = vi.fn();
 const mockNoteVersion = vi.fn();
 
@@ -39,6 +41,7 @@ vi.mock("@vex-agent/db/repos/agent-activity.js", async (importOriginal) => {
     ...actual,
     listAmountCorrectionCandidates: (...a: unknown[]) => mockListCandidates(...a),
     fillExecutedAmountsOnConfirmed: (...a: unknown[]) => mockFill(...a),
+    fillLaunchOutputIdentityOnConfirmed: (...a: unknown[]) => mockFillLaunch(...a),
     noteSettlementDeclined: (...a: unknown[]) => mockDeclined(...a),
     noteSettlementDecodeVersion: (...a: unknown[]) => mockNoteVersion(...a),
   };
@@ -105,6 +108,7 @@ function deps(logs: unknown = KYBER.logs) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockFill.mockResolvedValue({ outcome: "applied", row: legacyRow() });
+  mockFillLaunch.mockResolvedValue(true);
   mockDeclined.mockResolvedValue({ applied: true });
 });
 
@@ -175,14 +179,49 @@ describe("the role contract is imported, never restated", () => {
 });
 
 describe("declines are named, and only then marked", () => {
-  it("declines by name for a protocol with no wired decoder — never a generic decode", async () => {
-    mockListCandidates.mockResolvedValue([legacyRow({ protocol: "jupiter" })]);
+  it("DEFERS a protocol with no wired decoder — never a generic decode, never a false conclusion", async () => {
+    mockListCandidates.mockResolvedValue([legacyRow({ protocol: "unknown-venue" })]);
 
     const result = await repairMissingExecutedAmounts(deps());
 
-    expect(result.declined).toBe(1);
-    expect(mockDeclined).toHaveBeenCalledWith(7, "amounts_undecodable");
-    expect(mockNoteVersion).toHaveBeenCalledWith(7, SETTLEMENT_DECODER_SET_VERSION);
+    expect(result).toMatchObject({ declined: 0, deferred: 1, filled: 0 });
+    expect(mockFill).not.toHaveBeenCalled();
+    expect(mockDeclined).not.toHaveBeenCalled();
+    expect(mockNoteVersion).not.toHaveBeenCalled();
+  });
+
+  it("fills a confirmed Uniswap ERC-20 swap the status sweep left amountless", async () => {
+    const vex = "0xc6911796042b15d7Fa4F6CDe69e245DdCd3d9c31";
+    const virtual = "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984";
+    const wallet = "0xaaaabbbbccccddddeeeeffff0000111122223333";
+    const topic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+    const pad = (a: string) => `0x${"0".repeat(24)}${a.slice(2).toLowerCase()}`;
+    const word = (n: bigint) => `0x${n.toString(16).padStart(64, "0")}`;
+    mockListCandidates.mockResolvedValue([
+      legacyRow({
+        protocol: "uniswap",
+        chainId: 4663,
+        walletAddress: wallet,
+        tokenInAddress: vex,
+        tokenOutAddress: virtual,
+        txHash: "0xuni",
+      }),
+    ]);
+
+    const result = await repairMissingExecutedAmounts({
+      fetchReceiptLogs: vi.fn().mockResolvedValue([
+        { address: vex, topics: [topic, pad(wallet), pad(virtual)], data: word(30480n) },
+        { address: virtual, topics: [topic, pad(virtual), pad(wallet)], data: word(12000n) },
+      ]),
+      fetchTransaction: vi.fn().mockResolvedValue(null),
+      fetchReceiptStatus: vi.fn().mockResolvedValue("success"),
+    });
+
+    expect(result).toMatchObject({ filled: 1, declined: 0 });
+    expect(mockFill).toHaveBeenCalledWith(expect.objectContaining({
+      amounts: { executedAmountInRaw: "30480", executedAmountOutRaw: "12000" },
+    }));
+    expect(mockFillLaunch).not.toHaveBeenCalled();
   });
 
   it("declines when the receipt's evidence does not establish both legs", async () => {

--- a/src/__tests__/vex-agent/sync/venue-dispatch-late-fill.test.ts
+++ b/src/__tests__/vex-agent/sync/venue-dispatch-late-fill.test.ts
@@ -120,6 +120,16 @@ describe("venue dispatch: uniswap", () => {
     expect(result.kind === "decoded" ? result.amounts.executedAmountInRaw : "x").toBeUndefined();
   });
 
+  it("declines an ERC-20/ERC-20 swap whose receipt proves only one Transfer", async () => {
+    const result = await decodeVenueSettlement({
+      row: row(),
+      logs: [transfer(VEX, WALLET, VIRTUAL, 30_480n)],
+      hint: null,
+      deps: deps(),
+    });
+    expect(result).toMatchObject({ kind: "declined", reason: "amounts_undecodable" });
+  });
+
   it("declines when the receipt proves no reportable (non-native-out) leg", async () => {
     const result = await decodeVenueSettlement({
       row: row({ tokenOutAddress: null }),

--- a/src/__tests__/vex-agent/sync/venue-dispatch-late-fill.test.ts
+++ b/src/__tests__/vex-agent/sync/venue-dispatch-late-fill.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Late-fill adapters that were missing from `decodeVenueSettlement`: Uniswap,
+ * Pendle, trench/pools launches, and the catch-all for an unwired protocol.
+ *
+ * Pinned here because copying the Kyber adapter's "both token addresses
+ * required" gate would decline a Uniswap native leg (NULL address, not 0xeee),
+ * and because stamping `amounts_undecodable` for "no decoder wired" released
+ * the AgentScan hold immediately — confirmed, $0 volume.
+ */
+import { describe, expect, it } from "vitest";
+import { encodeAbiParameters, encodeEventTopics, getAddress, type Address, type Hex } from "viem";
+
+import { TRENCH_DIAMOND_ABI } from "@tools/trench-express/abi.js";
+import { TRENCH_DIAMOND_ADDRESS } from "@tools/trench-express/constants.js";
+import type { AgentActivityEvent } from "@vex-agent/db/repos/agent-activity.js";
+import type { DepositEvidenceDeps } from "@vex-agent/sync/executed-amount-fallback/deposit-evidence-resolver.js";
+import { decodeVenueSettlement } from "@vex-agent/sync/executed-amount-fallback/venue-dispatch.js";
+
+const WALLET = "0xaaaabbbbccccddddeeeeffff0000111122223333";
+const VEX = "0xc6911796042b15d7Fa4F6CDe69e245DdCd3d9c31";
+const VIRTUAL = "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984";
+const UNDERLYING = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+const PT = "0x1111111111111111111111111111111111111111";
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const DIAMOND = getAddress(TRENCH_DIAMOND_ADDRESS);
+const TOKEN = getAddress("0x58659Ef9Be57216632BFD341FC57736a429EFB91");
+
+function pad(address: string): string {
+  return `0x${"0".repeat(24)}${address.slice(2).toLowerCase()}`;
+}
+function word(value: bigint): string {
+  return `0x${value.toString(16).padStart(64, "0")}`;
+}
+function transfer(token: string, from: string, to: string, amount: bigint) {
+  return { address: token, topics: [TRANSFER_TOPIC, pad(from), pad(to)], data: word(amount) };
+}
+
+function row(over: Partial<AgentActivityEvent> = {}): AgentActivityEvent {
+  return {
+    id: 7,
+    protocolExecutionId: 1,
+    eventIndex: 0,
+    eventRole: "swap",
+    protocol: "uniswap",
+    chainId: 4663,
+    chainFamily: "eip155",
+    status: "confirmed",
+    txHash: "0xabc",
+    walletAddress: WALLET,
+    tokenInAddress: VEX,
+    tokenOutAddress: VIRTUAL,
+    executedAmountInRaw: null,
+    executedAmountOutRaw: null,
+    tokenIn2Address: null,
+    tokenOut2Address: null,
+    executedAmountIn2Raw: null,
+    executedAmountOut2Raw: null,
+    routeProvenance: null,
+    ...over,
+  } as AgentActivityEvent;
+}
+
+function deps(tx: { from: string; to: string | null; input: string; valueRaw: string } | null = null): DepositEvidenceDeps {
+  return {
+    fetchReceiptStatus: async () => "success",
+    fetchTransaction: async () => tx,
+  };
+}
+
+describe("venue dispatch: unwired protocol is a deferral, not a conclusion", () => {
+  it("does not stamp amounts_undecodable for a protocol with no adapter", async () => {
+    const result = await decodeVenueSettlement({
+      row: row({ protocol: "unknown-venue" }),
+      logs: [transfer(VEX, WALLET, VIRTUAL, 1n)],
+      hint: null,
+      deps: deps(),
+    });
+    expect(result.kind).toBe("deferred");
+  });
+});
+
+describe("venue dispatch: uniswap", () => {
+  it("decodes both ERC-20 legs from wallet Transfer deltas", async () => {
+    const result = await decodeVenueSettlement({
+      row: row(),
+      logs: [transfer(VEX, WALLET, VIRTUAL, 30_480n), transfer(VIRTUAL, VIRTUAL, WALLET, 12_000n)],
+      hint: null,
+      deps: deps(),
+    });
+    expect(result).toEqual({
+      kind: "decoded",
+      amounts: { executedAmountInRaw: "30480", executedAmountOutRaw: "12000" },
+    });
+  });
+
+  it("persists the proven ERC-20 in even when native-out (NULL token address) is omitted", async () => {
+    const result = await decodeVenueSettlement({
+      row: row({ tokenOutAddress: null }),
+      logs: [transfer(VEX, WALLET, VIRTUAL, 30_480n)],
+      hint: null,
+      deps: deps(),
+    });
+    expect(result).toEqual({
+      kind: "decoded",
+      amounts: { executedAmountInRaw: "30480" },
+    });
+  });
+
+  it("does not require a token address the Uniswap handler never stored for a native leg", async () => {
+    const result = await decodeVenueSettlement({
+      row: row({ tokenInAddress: null, tokenOutAddress: VEX }),
+      logs: [transfer(VEX, VIRTUAL, WALLET, 99n)],
+      hint: null,
+      deps: deps(),
+    });
+    expect(result).toMatchObject({
+      kind: "decoded",
+      amounts: { executedAmountOutRaw: "99" },
+    });
+    expect(result.kind === "decoded" ? result.amounts.executedAmountInRaw : "x").toBeUndefined();
+  });
+
+  it("declines when the receipt proves no reportable (non-native-out) leg", async () => {
+    const result = await decodeVenueSettlement({
+      row: row({ tokenOutAddress: null }),
+      logs: [],
+      hint: null,
+      deps: deps(),
+    });
+    expect(result).toMatchObject({ kind: "declined", reason: "amounts_undecodable" });
+  });
+});
+
+describe("venue dispatch: pendle", () => {
+  it("decodes a PT buy through the venue's own decoder, including provenance", async () => {
+    const result = await decodeVenueSettlement({
+      row: row({
+        protocol: "pendle",
+        eventRole: "yield_pt",
+        chainId: 1,
+        tokenInAddress: UNDERLYING,
+        tokenOutAddress: PT,
+      }),
+      logs: [transfer(UNDERLYING, WALLET, PT, 1_000_000n), transfer(PT, PT, WALLET, 990_000n)],
+      hint: null,
+      deps: deps(),
+    });
+    expect(result).toEqual({
+      kind: "decoded",
+      amounts: { executedAmountInRaw: "1000000", executedAmountOutRaw: "990000" },
+    });
+  });
+
+  it("declines a pendle role the decoder does not own rather than guessing", async () => {
+    const result = await decodeVenueSettlement({
+      row: row({ protocol: "pendle", eventRole: "allowance", tokenInAddress: UNDERLYING, tokenOutAddress: PT }),
+      logs: [transfer(UNDERLYING, WALLET, PT, 1n)],
+      hint: null,
+      deps: deps(),
+    });
+    expect(result).toMatchObject({ kind: "declined", reason: "amounts_undecodable" });
+  });
+});
+
+function tokenCreatedLog(token: Address, creator: Address): { address: string; topics: string[]; data: string } {
+  const [topic0] = encodeEventTopics({ abi: TRENCH_DIAMOND_ABI, eventName: "TokenCreated" }) as [Hex];
+  return {
+    address: DIAMOND,
+    topics: [topic0],
+    data: encodeAbiParameters(
+      [
+        { type: "address" }, { type: "address" }, { type: "uint8" },
+        { type: "uint8" }, { type: "bytes" }, { type: "uint256" },
+      ],
+      [token, creator, 0, 0, "0x", 1n],
+    ),
+  };
+}
+
+describe("venue dispatch: trench token_launch is not the curve-trade decoder", () => {
+  it("decodes a no-prebuy launch from TokenCreated + mined value, out proven as 0", async () => {
+    const wallet = getAddress(WALLET);
+    const result = await decodeVenueSettlement({
+      row: row({
+        protocol: "trench",
+        eventRole: "token_launch",
+        tokenInAddress: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        tokenOutAddress: null,
+        walletAddress: wallet,
+        routeProvenance: { prebuyRaw: "0" },
+      }),
+      logs: [tokenCreatedLog(TOKEN, wallet)],
+      hint: null,
+      deps: deps({ from: wallet, to: DIAMOND, input: "0x", valueRaw: "1000000000000000000" }),
+    });
+    expect(result.kind).toBe("decoded");
+    if (result.kind !== "decoded") return;
+    expect(result.amounts).toEqual({
+      executedAmountInRaw: "1000000000000000000",
+      executedAmountOutRaw: "0",
+    });
+    expect(result.launchIdentity).toEqual({ tokenOutAddress: TOKEN });
+  });
+});
+
+describe("venue dispatch: pools token_launch", () => {
+  it("declines rather than guessing when the authorized plan is not on the row", async () => {
+    const result = await decodeVenueSettlement({
+      row: row({ protocol: "pools", eventRole: "token_launch", tokenOutAddress: null }),
+      logs: [],
+      hint: null,
+      deps: deps({ from: WALLET, to: WALLET, input: "0x", valueRaw: "1" }),
+    });
+    expect(result).toMatchObject({ kind: "declined", reason: "amounts_undecodable" });
+  });
+});

--- a/src/__tests__/vex-agent/sync/venue-dispatch-morpho.test.ts
+++ b/src/__tests__/vex-agent/sync/venue-dispatch-morpho.test.ts
@@ -5,7 +5,7 @@
  * THREE THINGS ARE PINNED, and the third is the one that would have gone unnoticed:
  *
  * 1. A confirmed-but-amountless Morpho row DECODES from its own receipt. Before
- *    a branch existed, `morpho` fell through to the unmapped-protocol decline
+ *    a branch existed, `morpho` fell through the unmapped-protocol path
  *    and every repaired row stayed amountless forever, which reads as "the
  *    settlement was unreadable" when the truth is "nobody wired the decoder".
  * 2. A row it cannot prove DECLINES BY NAME (`amounts_undecodable`), rather than
@@ -253,7 +253,7 @@ describe("venue dispatch: morpho", () => {
     expect(result.kind).not.toBe("deferred");
   });
 
-  it("still declines an UNMAPPED protocol by name, which is the fallback morpho used to hit", async () => {
+  it("DEFERS an UNMAPPED protocol rather than concluding amounts_undecodable", async () => {
     const result = await decodeVenueSettlement({
       row: morphoRow({ protocol: "aave" }),
       logs: [],
@@ -261,7 +261,7 @@ describe("venue dispatch: morpho", () => {
       deps,
     });
 
-    expect(result).toMatchObject({ kind: "declined", reason: "amounts_undecodable" });
+    expect(result).toMatchObject({ kind: "deferred" });
     expect((result as { detail: string }).detail).toContain("aave");
   });
 });

--- a/src/__tests__/vex-agent/sync/venue-dispatch-wallet-wrap.test.ts
+++ b/src/__tests__/vex-agent/sync/venue-dispatch-wallet-wrap.test.ts
@@ -269,11 +269,11 @@ describe("venue dispatch: the arm is bound to its two roles", () => {
         deps: NO_CHAIN_READ,
       });
 
-      expect(result.kind).toBe("declined");
-      if (result.kind !== "declined") throw new Error("expected a decline");
-      expect(result.reason).toBe("amounts_undecodable");
+      expect(result.kind).toBe("deferred");
+      if (result.kind !== "deferred") throw new Error("expected a deferral");
       // The UNMAPPED-PROTOCOL sentence, which is the proof it fell past the
-      // wrap branch rather than being judged by it.
+      // wrap branch rather than being judged by it. "No adapter for this
+      // protocol+role" is not a conclusion that no amounts are coming.
       expect(result.detail).toBe(
         'no settlement decoder is wired for protocol "wallet_wrap"',
       );

--- a/src/vex-agent/sync/executed-amount-fallback.ts
+++ b/src/vex-agent/sync/executed-amount-fallback.ts
@@ -42,6 +42,7 @@
 
 import {
   fillExecutedAmountsOnConfirmed,
+  fillLaunchOutputIdentityOnConfirmed,
   listAmountCorrectionCandidates,
   noteSettlementDecodeVersion,
   noteSettlementDeclined,
@@ -63,6 +64,7 @@ import {
 import {
   decodeVenueSettlement,
   type VenueDecodeLog,
+  type VenueDecodeResult,
 } from "./executed-amount-fallback/venue-dispatch.js";
 import { assessRepairedFill } from "./executed-amount-fallback/approved-floor.js";
 import type {
@@ -78,7 +80,7 @@ import type {
  * thing that makes a row eligible again — a timestamp could only re-run the same
  * decode against the same immutable receipt forever.
  */
-export const SETTLEMENT_DECODER_SET_VERSION = "2026-08-28.uniswap-venue-branch";
+export const SETTLEMENT_DECODER_SET_VERSION = "2026-08-29.uniswap-pendle-launch";
 
 /** Bounded per pass — this shares the sync worker with the balance and bridge sweeps. */
 export const AMOUNT_CORRECTION_BATCH_LIMIT = 10;
@@ -373,14 +375,7 @@ async function repairOneRow(
     return "declined";
   }
 
-  const result = await fillExecutedAmountsOnConfirmed({
-    id: row.id,
-    // The decode is bound to the row's OWN hash and chain, so a decode of the
-    // wrong transaction can never land on it.
-    expectedTxHash: txHash,
-    expectedChainId: row.chainId,
-    amounts: decoded.amounts,
-  });
+  const result = await applyDecodedAmounts(row, txHash, decoded);
 
   if (result.outcome === "applied") {
     logger.info("sync.amount_fallback.filled", { id: row.id, protocol: row.protocol });
@@ -416,4 +411,39 @@ async function repairOneRow(
   }
   // `already_complete` / `not_eligible`: someone else finished the row first.
   return "deferred";
+}
+
+async function applyDecodedAmounts(
+  row: AgentActivityEvent,
+  txHash: string,
+  decoded: Extract<VenueDecodeResult, { kind: "decoded" }>,
+): Promise<{ outcome: "applied" | "conflict" | "already_complete" | "not_eligible" }> {
+  const identity = decoded.launchIdentity;
+  if (identity && row.eventRole === "token_launch" && row.tokenOutAddress === null) {
+    const inRaw = decoded.amounts.executedAmountInRaw;
+    const outRaw = decoded.amounts.executedAmountOutRaw;
+    if (inRaw && outRaw) {
+      const filled = await fillLaunchOutputIdentityOnConfirmed(row.id, {
+        executedAmountInRaw: inRaw,
+        executedAmountOutRaw: outRaw,
+        ...(decoded.amounts.executedAmountInHuman !== undefined
+          ? { executedAmountInHuman: decoded.amounts.executedAmountInHuman }
+          : {}),
+        ...(decoded.amounts.executedAmountOutHuman !== undefined
+          ? { executedAmountOutHuman: decoded.amounts.executedAmountOutHuman }
+          : {}),
+        tokenOutAddress: identity.tokenOutAddress,
+        ...(identity.tokenOutSymbol !== undefined ? { tokenOutSymbol: identity.tokenOutSymbol } : {}),
+        ...(identity.tokenOutDecimals !== undefined ? { tokenOutDecimals: identity.tokenOutDecimals } : {}),
+      });
+      if (filled) return { outcome: "applied" };
+    }
+  }
+
+  return fillExecutedAmountsOnConfirmed({
+    id: row.id,
+    expectedTxHash: txHash,
+    expectedChainId: row.chainId,
+    amounts: decoded.amounts,
+  });
 }

--- a/src/vex-agent/sync/executed-amount-fallback/venue-dispatch-launch.ts
+++ b/src/vex-agent/sync/executed-amount-fallback/venue-dispatch-launch.ts
@@ -1,0 +1,164 @@
+/**
+ * Launch late-fill adapters. `protocol = 'trench'` is shared with curve trades,
+ * so these branches MUST be selected by `eventRole === 'token_launch'` before
+ * the trade decoder runs. Activity rows use `protocol = 'pools'`, never
+ * `pools_fun`.
+ *
+ * Native in is the mined transaction's value. No-prebuy trench out is proven
+ * `"0"`. Identity (`token_out_address`) rides `launchIdentity` so the
+ * orchestrator can call `fillLaunchOutputIdentityOnConfirmed`.
+ */
+import { getAddress, type Address, type Hex } from "viem";
+
+import { TRENCH_DIAMOND_ADDRESS } from "@tools/trench-express/constants.js";
+import { decodeLaunchReceipt } from "@vex-agent/tools/protocols/trench/handlers/launch/settlement.js";
+import { decodePoolsLaunchSettlement } from "../pools-settlement-decoder.js";
+
+import type { VenueDecodeInput, VenueDecodeResult } from "./venue-dispatch.js";
+
+export async function decodeTrenchLaunchRow(input: VenueDecodeInput): Promise<VenueDecodeResult> {
+  const { row } = input;
+  const txHash = row.txHash;
+  const wallet = checksum(row.walletAddress);
+  const diamond = checksum(TRENCH_DIAMOND_ADDRESS);
+  if (txHash === null || wallet === null || diamond === null) {
+    return decline("the launch row is missing a wallet, hash, or diamond address");
+  }
+
+  const transaction = await input.deps.fetchTransaction({ chainId: row.chainId, txHash });
+  if (transaction === null) {
+    return { kind: "deferred", detail: "the signed launch transaction could not be read this pass" };
+  }
+  if (!sameAddress(transaction.from, wallet)) {
+    return decline("the mined transaction was not sent by this row's wallet");
+  }
+  if (transaction.to === null || !sameAddress(transaction.to, diamond)) {
+    return decline("the mined transaction did not call this venue's trench diamond");
+  }
+
+  const valueRaw = parseRaw(transaction.valueRaw);
+  if (valueRaw === null || valueRaw <= 0n) {
+    return decline("the mined launch transaction carried no native value");
+  }
+
+  const expectPrebuy = prebuyWei(row.routeProvenance) > 0n;
+  const decoded = decodeLaunchReceipt({
+    logs: input.logs,
+    diamond,
+    wallet,
+    expectPrebuy,
+  });
+  if (decoded === null) {
+    return decline("the receipt does not prove TokenCreated for this wallet on the diamond");
+  }
+  if (expectPrebuy && decoded.prebuyTokensOutRaw === null) {
+    return decline("the receipt does not prove the prebuy token amount");
+  }
+
+  return {
+    kind: "decoded",
+    amounts: {
+      executedAmountInRaw: valueRaw.toString(),
+      executedAmountOutRaw: (decoded.prebuyTokensOutRaw ?? 0n).toString(),
+    },
+    launchIdentity: { tokenOutAddress: decoded.tokenAddress },
+  };
+}
+
+export async function decodePoolsLaunchRow(input: VenueDecodeInput): Promise<VenueDecodeResult> {
+  const { row } = input;
+  const txHash = row.txHash;
+  const wallet = checksum(row.walletAddress);
+  if (txHash === null || wallet === null) {
+    return decline("the launch row is missing a wallet or hash");
+  }
+
+  const expectation = poolsExpectation(row.routeProvenance, wallet);
+  if (expectation === null) {
+    return decline("the authorized pools launch plan is not present on the row");
+  }
+
+  const transaction = await input.deps.fetchTransaction({ chainId: row.chainId, txHash });
+  if (transaction === null) {
+    return { kind: "deferred", detail: "the signed launch transaction could not be read this pass" };
+  }
+  if (!sameAddress(transaction.from, wallet)) {
+    return decline("the mined transaction was not sent by this row's wallet");
+  }
+
+  const valueRaw = parseRaw(transaction.valueRaw);
+  if (valueRaw === null || valueRaw <= 0n) {
+    return decline("the mined launch transaction carried no native value");
+  }
+
+  const decoded = decodePoolsLaunchSettlement(input.logs, expectation);
+  if (!decoded.ok) {
+    return decline(decoded.reason);
+  }
+
+  return {
+    kind: "decoded",
+    amounts: {
+      executedAmountInRaw: valueRaw.toString(),
+      executedAmountOutRaw: decoded.value.devBuyOut.toString(),
+    },
+    launchIdentity: { tokenOutAddress: decoded.value.tokenAddress },
+  };
+}
+
+function poolsExpectation(
+  provenance: Record<string, unknown> | null,
+  launcher: Address,
+): {
+  launcher: Address;
+  feeRecipient: Address;
+  pairedAsset: Address;
+  userSalt: Hex;
+  predictedTokenAddress: Address;
+} | null {
+  if (provenance === null) return null;
+  const feeRecipient = checksum(stringField(provenance.feeRecipient));
+  const pairedAsset = checksum(stringField(provenance.pairedAssetAddress) ?? stringField(provenance.pairedAsset));
+  const predicted = checksum(stringField(provenance.predictedTokenAddress));
+  const salt = stringField(provenance.userSalt);
+  if (feeRecipient === null || pairedAsset === null || predicted === null) return null;
+  if (salt === null || !/^0x[0-9a-fA-F]{64}$/.test(salt)) return null;
+  return {
+    launcher,
+    feeRecipient,
+    pairedAsset,
+    userSalt: salt as Hex,
+    predictedTokenAddress: predicted,
+  };
+}
+
+function prebuyWei(provenance: Record<string, unknown> | null): bigint {
+  const raw = provenance === null ? null : parseRaw(stringField(provenance.prebuyRaw));
+  return raw ?? 0n;
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function decline(detail: string): VenueDecodeResult {
+  return { kind: "declined", reason: "amounts_undecodable", detail };
+}
+
+function checksum(address: string | null): Address | null {
+  if (address === null) return null;
+  try {
+    return getAddress(address.trim());
+  } catch {
+    return null;
+  }
+}
+
+function sameAddress(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+function parseRaw(value: string | null): bigint | null {
+  if (value === null || !/^[0-9]+$/.test(value)) return null;
+  return BigInt(value);
+}

--- a/src/vex-agent/sync/executed-amount-fallback/venue-dispatch-pendle.ts
+++ b/src/vex-agent/sync/executed-amount-fallback/venue-dispatch-pendle.ts
@@ -1,0 +1,49 @@
+/**
+ * Pendle late-fill adapter — the venue decoder owns the per-role rules
+ * (including second legs and router-fallback SY matching). This file only
+ * wraps logs as a receipt and forwards the row's own columns.
+ */
+import { decodePendleSettlement } from "../pendle-settlement-decoder.js";
+
+import type { VenueDecodeInput, VenueDecodeResult } from "./venue-dispatch.js";
+
+export function decodePendleRow(input: VenueDecodeInput): VenueDecodeResult {
+  const { row } = input;
+  if (!row.walletAddress) {
+    return {
+      kind: "declined",
+      reason: "amounts_undecodable",
+      detail: "the row carries no wallet address",
+    };
+  }
+
+  const decoded = decodePendleSettlement({
+    receipt: { logs: input.logs },
+    protocolExecutionId: row.protocolExecutionId,
+    chainId: row.chainId,
+    walletAddress: row.walletAddress,
+    tokenInAddress: row.tokenInAddress,
+    tokenOutAddress: row.tokenOutAddress,
+    eventRole: row.eventRole,
+    tokenIn2Address: row.tokenIn2Address,
+    tokenOut2Address: row.tokenOut2Address,
+    amountInRaw: row.amountInRaw,
+    routeProvenance: row.routeProvenance,
+  });
+
+  if (decoded === null) {
+    return {
+      kind: "declined",
+      reason: "amounts_undecodable",
+      detail: `the pendle decoder could not prove the executed legs for role ${row.eventRole}`,
+    };
+  }
+
+  const amounts = {
+    ...(decoded.executedAmountInRaw !== undefined ? { executedAmountInRaw: decoded.executedAmountInRaw } : {}),
+    ...(decoded.executedAmountOutRaw !== undefined ? { executedAmountOutRaw: decoded.executedAmountOutRaw } : {}),
+    ...(decoded.executedAmountIn2Raw !== undefined ? { executedAmountIn2Raw: decoded.executedAmountIn2Raw } : {}),
+    ...(decoded.executedAmountOut2Raw !== undefined ? { executedAmountOut2Raw: decoded.executedAmountOut2Raw } : {}),
+  };
+  return { kind: "decoded", amounts };
+}

--- a/src/vex-agent/sync/executed-amount-fallback/venue-dispatch-uniswap.ts
+++ b/src/vex-agent/sync/executed-amount-fallback/venue-dispatch-uniswap.ts
@@ -1,0 +1,83 @@
+/**
+ * Uniswap late-fill adapter. The handler's decoder treats a missing token
+ * address as native; Kyber's "both addresses required" gate must not be copied
+ * here or a VEX→ETH row declines as "missing a token".
+ *
+ * Native-out executed amounts are omitted when the row stored no token address:
+ * the AgentScan mapper only withholds native-out for the 0xeee/zero sentinels,
+ * and a NULL address would go out as an unverifiable ERC-20 claim.
+ *
+ * A native sentinel (0xeee / zero) is passed to the decoder as `null` — that is
+ * its contract for "read this leg from the router's WETH Deposit/Withdrawal".
+ * Passing the sentinel through would checksum it as an ERC-20 and miss the wrap
+ * events. A throw from checksum or an unknown chain is a named decline, never a
+ * throw that would kill the sweep.
+ */
+import { decodeUniswapExecutedLegs } from "@tools/uniswap/receipt-decoder.js";
+import type { ConfirmActivityEventInput } from "@vex-agent/db/repos/agent-activity.js";
+
+import type { VenueDecodeInput, VenueDecodeResult } from "./venue-dispatch.js";
+
+const NATIVE_SENTINELS = new Set([
+  "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "0x0000000000000000000000000000000000000000",
+]);
+
+function isNativeStored(address: string | null): boolean {
+  return address === null || address.length === 0 || NATIVE_SENTINELS.has(address.toLowerCase());
+}
+
+/** Decoder input: NULL / empty / sentinel → native leg (`null`). */
+function asDecoderToken(address: string | null): string | null {
+  if (address === null || address.length === 0) return null;
+  if (NATIVE_SENTINELS.has(address.toLowerCase())) return null;
+  return address;
+}
+
+export function decodeUniswapRow(input: VenueDecodeInput): VenueDecodeResult {
+  const { row } = input;
+  const walletAddress = row.walletAddress;
+  if (!walletAddress) {
+    return {
+      kind: "declined",
+      reason: "amounts_undecodable",
+      detail: "the row carries no wallet address",
+    };
+  }
+
+  const tokenInAddress = row.tokenInAddress;
+  const tokenOutAddress = row.tokenOutAddress;
+  let decoded;
+  try {
+    decoded = decodeUniswapExecutedLegs({
+      receipt: { logs: input.logs },
+      chainId: row.chainId,
+      walletAddress,
+      tokenInAddress: asDecoderToken(tokenInAddress),
+      tokenOutAddress: asDecoderToken(tokenOutAddress),
+    });
+  } catch {
+    return {
+      kind: "declined",
+      reason: "amounts_undecodable",
+      detail: "the row's addresses or chain could not be resolved for the uniswap decoder",
+    };
+  }
+
+  const amounts: ConfirmActivityEventInput = {};
+  if (decoded.executedAmountInRaw !== undefined) {
+    amounts.executedAmountInRaw = decoded.executedAmountInRaw.toString();
+  }
+  if (decoded.executedAmountOutRaw !== undefined && !isNativeStored(tokenOutAddress)) {
+    amounts.executedAmountOutRaw = decoded.executedAmountOutRaw.toString();
+  }
+
+  if (amounts.executedAmountInRaw === undefined && amounts.executedAmountOutRaw === undefined) {
+    return {
+      kind: "declined",
+      reason: "amounts_undecodable",
+      detail: "the uniswap decoder proved no reportable executed leg from this receipt",
+    };
+  }
+  return { kind: "decoded", amounts };
+}

--- a/src/vex-agent/sync/executed-amount-fallback/venue-dispatch-uniswap.ts
+++ b/src/vex-agent/sync/executed-amount-fallback/venue-dispatch-uniswap.ts
@@ -72,6 +72,18 @@ export function decodeUniswapRow(input: VenueDecodeInput): VenueDecodeResult {
     amounts.executedAmountOutRaw = decoded.executedAmountOutRaw.toString();
   }
 
+  // Both stored legs are ERC-20: require both, same as the immediate path.
+  // A native/NULL address is a missing identity, not a missing Transfer, so
+  // that case persists the proven ERC-20 side instead of declining.
+  const bothErc20 = !isNativeStored(tokenInAddress) && !isNativeStored(tokenOutAddress);
+  if (bothErc20 && (amounts.executedAmountInRaw === undefined || amounts.executedAmountOutRaw === undefined)) {
+    return {
+      kind: "declined",
+      reason: "amounts_undecodable",
+      detail: "the venue decoder could not establish both legs from this receipt",
+    };
+  }
+
   if (amounts.executedAmountInRaw === undefined && amounts.executedAmountOutRaw === undefined) {
     return {
       kind: "declined",

--- a/src/vex-agent/sync/executed-amount-fallback/venue-dispatch.ts
+++ b/src/vex-agent/sync/executed-amount-fallback/venue-dispatch.ts
@@ -29,23 +29,14 @@
  *
  * ── DECLINES ARE NAMED ─────────────────────────────────────────────────────
  *
- * `amounts_undecodable` — we had the inputs and the evidence did not establish
- * the amounts. `amounts_incomplete` — the decoder produced SOME legs but not
- * every leg this row's role requires. The `detail` string is for OUR logs and
- * never for a user surface; the stored fact is the named reason.
+ * `amounts_undecodable` — a wired decoder RAN and the evidence did not
+ * establish the amounts. An unmapped protocol DEFERS instead: "no adapter" is
+ * not a conclusion that no amounts are coming. `amounts_incomplete` — the
+ * decoder produced SOME legs but not every leg this row's role requires.
  */
 
 import { decodeKyberSwapSettlement } from "@tools/kyberswap/evm-utils.js";
-import {
-  decodeUniswapExecutedLegs,
-  type DecodedUniswapLegs,
-} from "@tools/uniswap/receipt-decoder.js";
 import { decodeCurveBuy, decodeCurveSell } from "@tools/trench-express/evm/settlement.js";
-import {
-  decodeMorphoBorrowSettlement,
-  decodeMorphoSettlement,
-  readMorphoBorrowRouteProvenance,
-} from "../morpho-settlement-decoder.js";
 import { TRENCH_DIAMOND_ADDRESS } from "@tools/trench-express/constants.js";
 import { getAddress, type Address } from "viem";
 import {
@@ -60,6 +51,9 @@ import type { SettlementDecodeHint } from "@vex-agent/db/repos/agent-activity.js
 import type { AgentActivityEvent } from "@vex-agent/db/repos/agent-activity.js";
 import type { ConfirmActivityEventInput } from "@vex-agent/db/repos/agent-activity.js";
 import type { SettlementDeclineReason } from "@vex-agent/db/repos/agent-activity.js";
+import { decodeUniswapRow } from "./venue-dispatch-uniswap.js";
+import { decodePendleRow } from "./venue-dispatch-pendle.js";
+import { decodePoolsLaunchRow, decodeTrenchLaunchRow } from "./venue-dispatch-launch.js";
 
 /** One mined log, in the shape every venue decoder already accepts. */
 export interface VenueDecodeLog {
@@ -80,8 +74,19 @@ export interface VenueDecodeInput {
   readonly deps: DepositEvidenceDeps;
 }
 
+export type LaunchIdentity = {
+  readonly tokenOutAddress: string;
+  readonly tokenOutSymbol?: string;
+  readonly tokenOutDecimals?: number | null;
+};
+
 export type VenueDecodeResult =
-  | { readonly kind: "decoded"; readonly amounts: ConfirmActivityEventInput }
+  | {
+    readonly kind: "decoded";
+    readonly amounts: ConfirmActivityEventInput;
+    /** Present when a launch decoder proved the created token. */
+    readonly launchIdentity?: LaunchIdentity;
+  }
   | {
     readonly kind: "declined";
     readonly reason: SettlementDeclineReason;
@@ -109,19 +114,24 @@ export type VenueDecodeResult =
 /**
  * Route the row to its venue's decoder.
  *
- * An unmapped protocol declines by NAME rather than falling through to a
- * "generic" decode. A generic wallet-relative decode was tried on paper and
- * DISPROVEN on the owner's own swap: the native output arrives as a WETH-clone
- * burn with no Withdrawal, and the router's `spentAmount` would have been wrong
- * for the input because the Vex fee sits inside it.
+ * An unmapped protocol DEFERS rather than concluding `amounts_undecodable`.
+ * "No adapter" is not proof that no amounts are coming; a generic wallet-
+ * relative decode is still forbidden (disproven on the owner's Kyber native-out
+ * swap). A named decline is only for a decoder that actually ran.
  */
 export async function decodeVenueSettlement(input: VenueDecodeInput): Promise<VenueDecodeResult> {
   const protocol = input.row.protocol?.toLowerCase() ?? "";
+  const role = input.row.eventRole;
   if (protocol === "kyberswap") return decodeKyberRow(input);
   if (protocol === "uniswap") return decodeUniswapRow(input);
-  if (protocol === "trench") return decodeTrenchRow(input);
+  if (protocol === "pendle") return decodePendleRow(input);
+  if (protocol === "trench") {
+    if (role === "token_launch") return decodeTrenchLaunchRow(input);
+    return decodeTrenchRow(input);
+  }
+  if (protocol === "pools" && role === "token_launch") return decodePoolsLaunchRow(input);
   if (protocol === "morpho") return decodeMorphoRow(input);
-  if ((protocol === "relay" || protocol === "khalani") && input.row.eventRole === "bridge_deposit") {
+  if ((protocol === "relay" || protocol === "khalani") && role === "bridge_deposit") {
     return decodeBridgeDepositRow(input);
   }
   if (
@@ -131,8 +141,7 @@ export async function decodeVenueSettlement(input: VenueDecodeInput): Promise<Ve
     return decodeWrapRow(input, input.row.eventRole);
   }
   return {
-    kind: "declined",
-    reason: "amounts_undecodable",
+    kind: "deferred",
     detail: `no settlement decoder is wired for protocol "${protocol}"`,
   };
 }
@@ -203,71 +212,6 @@ function decodeKyberRow(input: VenueDecodeInput): VenueDecodeResult {
     amounts: {
       executedAmountInRaw: decoded.amountInRaw,
       executedAmountOutRaw: decoded.amountOutRaw,
-    },
-  };
-}
-
-/**
- * A Uniswap swap confirmed without amounts. The rule for what the receipt
- * proves is `@tools/uniswap/receipt-decoder.ts` - the SAME function the
- * immediate path runs in `finalize-confirmed.ts`; this branch only resolves its
- * inputs from the row's validated columns.
- *
- * A NATIVE LEG IS PASSED AS `null`, not as a sentinel address. That is the
- * decoder's own contract for "read this leg from the WETH Deposit/Withdrawal
- * event the router emitted", and it is why this branch needs neither the
- * declared value nor a wrapped-native lookup: the decoder resolves both from
- * the chain's own verified deployment registry, bound to a registered router.
- *
- * Takes no chain read, so it never DEFERS. A deployment this build does not
- * know, or a receipt that proves only one leg, declines by name.
- */
-function decodeUniswapRow(input: VenueDecodeInput): VenueDecodeResult {
-  const { row } = input;
-  const tokenInAddress = row.tokenInAddress;
-  const tokenOutAddress = row.tokenOutAddress;
-  const walletAddress = row.walletAddress;
-  if (!tokenInAddress || !tokenOutAddress || !walletAddress) {
-    return {
-      kind: "declined",
-      reason: "amounts_undecodable",
-      detail: "the row is missing a token or wallet address the decoder requires",
-    };
-  }
-
-  let decoded: DecodedUniswapLegs;
-  try {
-    decoded = decodeUniswapExecutedLegs({
-      receipt: { logs: input.logs },
-      chainId: row.chainId,
-      walletAddress,
-      tokenInAddress: isNativeAddress(tokenInAddress) ? null : tokenInAddress,
-      tokenOutAddress: isNativeAddress(tokenOutAddress) ? null : tokenOutAddress,
-    });
-  } catch {
-    // The decoder checksums addresses and reads the deployment registry; a
-    // malformed column or an unknown chain is a NAMED decline, never a throw
-    // that would kill the whole sweep pass.
-    return {
-      kind: "declined",
-      reason: "amounts_undecodable",
-      detail: "the row's addresses or chain could not be resolved for the uniswap decoder",
-    };
-  }
-
-  if (decoded.executedAmountInRaw === undefined || decoded.executedAmountOutRaw === undefined) {
-    return {
-      kind: "declined",
-      reason: "amounts_undecodable",
-      detail: "the venue decoder could not establish both legs from this receipt",
-    };
-  }
-
-  return {
-    kind: "decoded",
-    amounts: {
-      executedAmountInRaw: decoded.executedAmountInRaw.toString(),
-      executedAmountOutRaw: decoded.executedAmountOutRaw.toString(),
     },
   };
 }
@@ -519,7 +463,10 @@ async function decodeTrenchRow(input: VenueDecodeInput): Promise<VenueDecodeResu
  * reach here too, and the decoder declines them by role: an approval moves
  * nothing, so no net delta could confirm one.
  */
-function decodeMorphoRow(input: VenueDecodeInput): VenueDecodeResult {
+async function decodeMorphoRow(input: VenueDecodeInput): Promise<VenueDecodeResult> {
+  const { decodeMorphoSettlement, readMorphoBorrowRouteProvenance } = await import(
+    "../morpho-settlement-decoder.js"
+  );
   const { row } = input;
   if (!row.walletAddress) {
     return { kind: "declined", reason: "amounts_undecodable", detail: "the row carries no wallet address" };
@@ -582,7 +529,10 @@ function decodeMorphoRow(input: VenueDecodeInput): VenueDecodeResult {
  *
  * Takes no chain read, so it never DEFERS - same reason as the vault branch.
  */
-function decodeMorphoBorrowRow(input: VenueDecodeInput, walletAddress: string): VenueDecodeResult {
+async function decodeMorphoBorrowRow(input: VenueDecodeInput, walletAddress: string): Promise<VenueDecodeResult> {
+  const { decodeMorphoBorrowSettlement, readMorphoBorrowRouteProvenance } = await import(
+    "../morpho-settlement-decoder.js"
+  );
   const { row } = input;
   const decoded = decodeMorphoBorrowSettlement({
     logs: input.logs,


### PR DESCRIPTION
## Why

A confirmed Uniswap swap on Robinhood showed up verified on AgentScan with a requested 30,480 VEX in, and **no executed amount**. Daily volume prices only `executed_*_raw`. Requested size and Vex dollar estimates do not count. Result: a real swap, $0 volume.

Vex can confirm a mined tx **status-only** (no amounts). Amounts have to ride the one terminal ingest event; a second terminal is dropped. The late-fill lane is supposed to decode the receipt before that window closes.

For Uniswap it did not. `decodeVenueSettlement` had no Uniswap adapter, so it stamped `amounts_undecodable` — as if we had proven no amounts were coming. That released reporting **immediately**. Pendle and launches had the same hole. The Uniswap decoder already existed in the handler.

## What changed

Late-fill now calls the venue's own decoder:

- **Uniswap** — missing token address means native (do not copy Kyber's both-addresses gate). Persist a proven ERC-20 leg even if the other is missing. Do not write native-out executed amounts when `token_out_address` is NULL (the mapper would send an unverifiable ERC-20 claim).
- **Pendle** — per-role rules, second legs, `routeProvenance`.
- **Trench launch** — split on `eventRole` before the curve-trade decoder. Same `protocol` string as trades.
- **Pools launch** — `protocol === "pools"` (not `pools_fun`). Plan from `route_provenance`, or decline. Identity on an already-confirmed launch goes through `fillLaunchOutputIdentityOnConfirmed`.

Unknown protocol **defers**. That is honesty, not a volume fix: without a decoder the 15-minute grace can still ship a blank confirmed event. A decoder that actually ran and failed still declines by name.

`SETTLEMENT_DECODER_SET_VERSION` bumped so rows already stamped "no decoder wired" are retried.

Does not change the money path (no signing, no status rewrite). Does not recover volume for events AgentScan already accepted without executed amounts.

## Tests

Unit coverage for Uniswap both-legs and native-out omission, Pendle, trench no-prebuy launch identity, pools missing-plan decline, unknown protocol defer, and an orchestrated Uniswap fill.
