### PR TITLE
feat(engine): mission autonomy - stable runs until the goal

### DIFF
--- a/src/__tests__/integration/engine/restart-orphan-reclaim.int.test.ts
+++ b/src/__tests__/integration/engine/restart-orphan-reclaim.int.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Integration: the restart-orphan reclaim, against REAL Postgres.
+ *
+ * The defect this covers is a crash: the app dies mid-slice and the run row
+ * stays `running` forever while the lease that proved someone owned it quietly
+ * expires. Every guarantee the reclaim makes is a statement about concurrent
+ * rows and locks - a live lease beats the sweep, an exact CAS refuses a run
+ * that moved, a queued operator Stop wins - and none of them can be shown with
+ * a mocked client: there is no second transaction, no lock queue and no CAS.
+ * So every proof below drives the real repo functions over real rows.
+ *
+ * What is proven:
+ *   1. a crashed run (running, EXPIRED lease) is reclaimed once the lease has
+ *      lapsed, with cause `restart_orphan` and a truthful summary;
+ *   2. a crashed run with NO lease row at all is reclaimed too;
+ *   3. a LIVE lease is never reclaimed, at either stage (candidate query and
+ *      the locked re-read), and the run is left untouched for the next pass;
+ *   4. two concurrent reclaims of the same run produce exactly ONE write;
+ *   5. the pass is idempotent - a second sweep reclaims nothing;
+ *   6. non-`running` rows (paused and terminal) are never written, which is
+ *      what the exact CAS buys over `updateStatusIfNotTerminal`;
+ *   7. a queued operator Stop is applied INSTEAD of the park, and the run ends
+ *      terminal rather than recoverable;
+ *   8. a freshly-started run is not a candidate (staleness floor).
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { query, queryOne } from "@vex-agent/db/client.js";
+import { enqueueOperatorStopRequest } from "@vex-agent/engine/runtime/lease-and-status.js";
+import {
+  RESTART_ORPHAN_STOP_REASON,
+  RESTART_ORPHAN_SUMMARY,
+  findOrphanCandidates,
+  reclaimOrphanedRun,
+  runRestartOrphanReclaimPass,
+} from "@vex-agent/engine/runtime/restart-orphan-reclaim.js";
+import { makeSession, resetDb } from "../setup/fixtures.js";
+
+/** Both defaults are irrelevant to these rows; keep the sweep deterministic. */
+const PASS = { limit: 50, minStaleMs: 0 } as const;
+
+interface Seeded {
+  readonly sessionId: string;
+  readonly missionId: string;
+  readonly runId: string;
+}
+
+async function seedRun(
+  status: string,
+  options: { readonly startedMinutesAgo?: number } = {},
+): Promise<Seeded> {
+  const sessionId = await makeSession();
+  const missionId = `mission-${sessionId}`;
+  const runId = `run-${sessionId}`;
+  await query(
+    `INSERT INTO missions (id, root_session_id, status, goal)
+     VALUES ($1, $2, 'running', 'restart-orphan integration')`,
+    [missionId, sessionId],
+  );
+  await query(
+    `INSERT INTO mission_runs (id, mission_id, session_id, status, started_at)
+     VALUES ($1, $2, $3, $4, NOW() - ($5::int * interval '1 minute'))`,
+    [runId, missionId, sessionId, status, options.startedMinutesAgo ?? 10],
+  );
+  return { sessionId, missionId, runId };
+}
+
+/** `expiresInMs` negative = an expired lease, exactly what a crash leaves. */
+async function seedLease(
+  seeded: Seeded,
+  expiresInMs: number,
+  ownerId = "owner-crashed",
+): Promise<void> {
+  await query(
+    `INSERT INTO runner_leases
+       (session_id, mission_run_id, owner_id, process_kind,
+        acquired_at, heartbeat_at, expires_at)
+     VALUES ($1, $2, $3, 'electron_main', NOW(), NOW(),
+             NOW() + ($4::int * interval '1 millisecond'))`,
+    [seeded.sessionId, seeded.runId, ownerId, expiresInMs],
+  );
+}
+
+async function readRun(runId: string): Promise<{
+  status: string;
+  stop_reason: string | null;
+  stop_summary: string | null;
+  stop_evidence_json: Record<string, unknown> | null;
+} | null> {
+  return queryOne(
+    `SELECT status, stop_reason, stop_summary, stop_evidence_json
+       FROM mission_runs WHERE id = $1`,
+    [runId],
+  );
+}
+
+async function candidateFor(seeded: Seeded) {
+  const candidates = await findOrphanCandidates(PASS);
+  const found = candidates.find((c) => c.runId === seeded.runId);
+  if (!found) throw new Error(`no candidate for ${seeded.runId}`);
+  return found;
+}
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("restart-orphan reclaim", () => {
+  it("reclaims a crashed run once its lease has expired", async () => {
+    const seeded = await seedRun("running");
+    await seedLease(seeded, -1_000);
+
+    const summary = await runRestartOrphanReclaimPass(PASS);
+
+    expect(summary.reclaimed).toBe(1);
+    const row = await readRun(seeded.runId);
+    expect(row?.status).toBe("paused_error");
+    expect(row?.stop_reason).toBe(RESTART_ORPHAN_STOP_REASON);
+    expect(row?.stop_summary).toBe(RESTART_ORPHAN_SUMMARY);
+    // Truthful evidence: the lease we observed, not a guess.
+    expect(row?.stop_evidence_json).toMatchObject({
+      restartOrphan: { leaseObserved: true },
+    });
+  });
+
+  it("reclaims a crashed run whose lease row is gone entirely", async () => {
+    const seeded = await seedRun("running");
+
+    const summary = await runRestartOrphanReclaimPass(PASS);
+
+    expect(summary.reclaimed).toBe(1);
+    const row = await readRun(seeded.runId);
+    expect(row?.status).toBe("paused_error");
+    expect(row?.stop_evidence_json).toMatchObject({
+      restartOrphan: { leaseObserved: false, leaseExpiresAt: null },
+    });
+  });
+
+  it("NEVER reclaims a run whose session holds a live lease", async () => {
+    const seeded = await seedRun("running");
+    await seedLease(seeded, 5 * 60_000);
+
+    // Stage 1: not even a candidate.
+    const candidates = await findOrphanCandidates(PASS);
+    expect(candidates.map((c) => c.runId)).not.toContain(seeded.runId);
+
+    const summary = await runRestartOrphanReclaimPass(PASS);
+    expect(summary.reclaimed).toBe(0);
+    expect((await readRun(seeded.runId))?.status).toBe("running");
+  });
+
+  it("refuses under the lock when the lease is re-acquired after the candidate read", async () => {
+    // The candidate read is a read of the PAST: a runner can come back between
+    // the sweep's SELECT and its transaction. The locked re-read is what makes
+    // the guarantee hold, and this is the only way to exercise it.
+    const seeded = await seedRun("running");
+    await seedLease(seeded, -1_000);
+    const candidate = await candidateFor(seeded);
+
+    await query("DELETE FROM runner_leases WHERE session_id = $1", [
+      seeded.sessionId,
+    ]);
+    await seedLease(seeded, 5 * 60_000, "owner-returned");
+
+    expect(await reclaimOrphanedRun(candidate)).toBe("lease_live");
+    expect((await readRun(seeded.runId))?.status).toBe("running");
+  });
+
+  it("writes exactly once when two reclaims race the same run", async () => {
+    const seeded = await seedRun("running");
+    await seedLease(seeded, -1_000);
+    const candidate = await candidateFor(seeded);
+
+    const [a, b] = await Promise.all([
+      reclaimOrphanedRun(candidate),
+      reclaimOrphanedRun(candidate),
+    ]);
+
+    expect([a, b].filter((o) => o === "reclaimed")).toHaveLength(1);
+    expect([a, b].filter((o) => o === "not_running")).toHaveLength(1);
+    expect((await readRun(seeded.runId))?.status).toBe("paused_error");
+  });
+
+  it("is idempotent across passes", async () => {
+    const seeded = await seedRun("running");
+    await seedLease(seeded, -1_000);
+
+    expect((await runRestartOrphanReclaimPass(PASS)).reclaimed).toBe(1);
+    const second = await runRestartOrphanReclaimPass(PASS);
+
+    expect(second.candidates).toBe(0);
+    expect(second.reclaimed).toBe(0);
+    expect((await readRun(seeded.runId))?.status).toBe("paused_error");
+  });
+
+  it.each([
+    "paused_approval",
+    "paused_user_form",
+    "paused_wake",
+    "completed",
+    "stopped",
+  ])("never touches a %s run", async (status) => {
+    const seeded = await seedRun(status);
+    await seedLease(seeded, -1_000);
+
+    const summary = await runRestartOrphanReclaimPass(PASS);
+    expect(summary.candidates).toBe(0);
+    expect(summary.reclaimed).toBe(0);
+    expect((await readRun(seeded.runId))?.status).toBe(status);
+  });
+
+  it("refuses the exact CAS when the run left `running` after the candidate read", async () => {
+    const seeded = await seedRun("running");
+    await seedLease(seeded, -1_000);
+    const candidate = await candidateFor(seeded);
+
+    await query(
+      "UPDATE mission_runs SET status = 'paused_approval' WHERE id = $1",
+      [seeded.runId],
+    );
+
+    expect(await reclaimOrphanedRun(candidate)).toBe("not_running");
+    // The whole point of the exact CAS: a live pause is not overwritten with
+    // `paused_error`, which would strand whatever the pause was waiting for.
+    const row = await readRun(seeded.runId);
+    expect(row?.status).toBe("paused_approval");
+    expect(row?.stop_reason).toBeNull();
+  });
+
+  it("applies a queued operator Stop instead of parking the run", async () => {
+    const seeded = await seedRun("running");
+    await seedLease(seeded, -1_000);
+    await enqueueOperatorStopRequest({
+      sessionId: seeded.sessionId,
+      missionRunId: seeded.runId,
+      correlationId: "reclaim-stop-test",
+    });
+
+    const summary = await runRestartOrphanReclaimPass(PASS);
+
+    expect(summary.reclaimed).toBe(0);
+    const row = await readRun(seeded.runId);
+    expect(row?.status).toBe("stopped");
+    expect(row?.stop_reason).toBe("user_stopped");
+  });
+
+  it("leaves a freshly started run alone (staleness floor)", async () => {
+    const seeded = await seedRun("running", { startedMinutesAgo: 0 });
+
+    const candidates = await findOrphanCandidates({
+      limit: 50,
+      minStaleMs: 60_000,
+    });
+
+    expect(candidates.map((c) => c.runId)).not.toContain(seeded.runId);
+  });
+});

--- a/src/__tests__/integration/repos/recovery-money-gate-race.int.test.ts
+++ b/src/__tests__/integration/repos/recovery-money-gate-race.int.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Integration: the recovery money gate is a BOUNDARY, not a snapshot - proven
+ * with two real Postgres clients racing each other.
+ *
+ * THE DEFECT THIS PINS. The gate used to read the unresolved money state under
+ * the session control lock, RELEASE the lock, and then claim the run in a
+ * separate transaction. `claimRunLeaseAndFlipToRunning` takes row locks on
+ * `mission_runs` and `runner_leases` but never the session control lock, so a
+ * money writer blocked behind the gate's read would commit the instant that
+ * read released - and Recover would resume the run over exactly the unproven
+ * outcome the gate exists to refuse. The loss is a double spend.
+ *
+ * WHY THIS CANNOT BE A UNIT TEST. The existing retry tests mock the lock, and a
+ * mocked lock excludes nothing: there is no second transaction, no lock queue
+ * and no commit ordering to observe. The property under test is that two
+ * concurrent transactions cannot interleave, which only real clients can show.
+ *
+ * BOTH ORDERINGS ARE ASSERTED, because "the gate blocked" is only half the
+ * claim - a gate that blocked because it never ran would pass that half too:
+ *
+ *   A. the money writer commits FIRST -> the gate sees it and refuses, and the
+ *      run is left untouched, its scheduled auto-retry still pending;
+ *   B. the gate takes the lock FIRST -> the money writer is made to WAIT on the
+ *      lock until the claim is durable, and the claim succeeds.
+ *
+ * Ordering B is the one that regressed: before the fix the writer did not wait,
+ * because by the time it mattered the gate had already let go.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { Client } from "pg";
+
+import { execute, query } from "@vex-agent/db/client.js";
+// The real key builder, never a hand-spelled namespace: a test that guessed the
+// lock key would take a DIFFERENT lock and prove exclusion that does not exist.
+import { sessionControlLockKey } from "@vex-agent/engine/runtime/lease-and-status.js";
+import { makeSession, resetDb } from "../setup/fixtures.js";
+
+/** The same advisory-lock statement every holder of this lock issues. */
+const TAKE_SESSION_LOCK =
+  "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))";
+
+function containerUrl(): string {
+  const raw = process.env.VEX_DB_URL;
+  if (raw === undefined) {
+    throw new Error("VEX_DB_URL is unset - the postgres global setup did not run");
+  }
+  return raw;
+}
+
+// The dispatcher module reaches the desktop compose credentials and the
+// electron logger on the way in. Neither is the subject; the gate itself,
+// the lock, the money reader and the claim are all real below.
+vi.mock("../../../../vex-app/src/main/database/db-config.js", () => ({
+  buildPoolConfig: async () => {
+    const url = new URL(containerUrl());
+    return {
+      host: url.hostname,
+      port: Number(url.port),
+      database: url.pathname.replace(/^\//, ""),
+      user: decodeURIComponent(url.username),
+      password: decodeURIComponent(url.password),
+    };
+  },
+}));
+vi.mock("../../../../vex-app/src/main/logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { gatedClaimUnderSessionLock } = await import(
+  "../../../../vex-app/src/main/ipc/_shared/runtime-retry-dispatch.js"
+);
+
+interface Seeded {
+  readonly sessionId: string;
+  readonly runId: string;
+}
+
+async function seedPausedErrorRun(): Promise<Seeded> {
+  const sessionId = await makeSession();
+  const missionId = `mission-${sessionId}`;
+  const runId = `run-${sessionId}`;
+  await execute(
+    `INSERT INTO missions (id, root_session_id, status, goal)
+     VALUES ($1, $2, 'running', 'money gate race')`,
+    [missionId, sessionId],
+  );
+  await execute(
+    `INSERT INTO mission_runs (id, mission_id, session_id, status, started_at)
+     VALUES ($1, $2, $3, 'paused_error', NOW())`,
+    [runId, missionId, sessionId],
+  );
+  return { sessionId, runId };
+}
+
+/** A pending auto-retry wake, so the cancellation's transactionality is visible. */
+async function seedRetryWake(seeded: Seeded): Promise<void> {
+  await execute(
+    `INSERT INTO loop_wake_requests
+       (session_id, mission_run_id, due_at, status, reason)
+     VALUES ($1, $2, NOW() + interval '30 seconds', 'pending', 'error_retry')`,
+    [seeded.sessionId, seeded.runId],
+  );
+}
+
+/** The realistic unresolved money state: an approval the operator still owes. */
+const INSERT_PENDING_APPROVAL = `
+  INSERT INTO approval_queue (id, tool_call, reasoning, status, session_id)
+  VALUES ($1, '{}'::jsonb, 'money gate race', 'pending', $2)`;
+
+async function runStatus(runId: string): Promise<string> {
+  const rows = await query<{ status: string }>(
+    `SELECT status FROM mission_runs WHERE id = $1`,
+    [runId],
+  );
+  return rows[0]?.status ?? "missing";
+}
+
+async function pendingWakeCount(sessionId: string): Promise<number> {
+  const rows = await query<{ n: string }>(
+    `SELECT COUNT(*)::text AS n FROM loop_wake_requests
+      WHERE session_id = $1 AND status = 'pending'`,
+    [sessionId],
+  );
+  return Number(rows[0]?.n ?? "0");
+}
+
+/** A second, independent connection - the money writer's own client. */
+async function openWriter(): Promise<Client> {
+  const client = new Client({ connectionString: containerUrl() });
+  await client.connect();
+  return client;
+}
+
+function gateFor(seeded: Seeded) {
+  return gatedClaimUnderSessionLock({
+    sessionId: seeded.sessionId,
+    runId: seeded.runId,
+    status: "paused_error",
+    ownerId: `race-owner-${randomUUID()}`,
+  });
+}
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("the recovery money gate under a real concurrent money writer", () => {
+  it("A. a money writer that commits FIRST is seen, and Recover is refused", async () => {
+    const seeded = await seedPausedErrorRun();
+    await seedRetryWake(seeded);
+
+    const writer = await openWriter();
+    try {
+      await writer.query("BEGIN");
+      await writer.query(TAKE_SESSION_LOCK, [
+        sessionControlLockKey(seeded.sessionId),
+      ]);
+      await writer.query(INSERT_PENDING_APPROVAL, [
+        randomUUID(),
+        seeded.sessionId,
+      ]);
+      await writer.query("COMMIT");
+    } finally {
+      await writer.end();
+    }
+
+    const gated = await gateFor(seeded);
+
+    expect(gated.kind).toBe("blocked_money_state");
+    if (gated.kind !== "blocked_money_state") return;
+    expect(gated.reasonKinds).toContain("approval_queue_pending");
+    // Refused means UNTOUCHED. The run is still parked and its scheduled
+    // auto-retry is still pending: a refused Recover that had already
+    // cancelled the retry would leave the run with neither.
+    expect(await runStatus(seeded.runId)).toBe("paused_error");
+    expect(await pendingWakeCount(seeded.sessionId)).toBe(1);
+  });
+
+  /**
+   * THE discriminating case, and the only one that fails against the pre-fix
+   * code. It is worth explaining why the obvious version of this test is
+   * worthless.
+   *
+   * The obvious version has the writer take the lock first and commit, then
+   * runs the gate. That passes either way: a writer that commits BEFORE the
+   * money read is seen by the old code too. The defect is not "a writer that
+   * commits first is missed" - it is "a writer that commits between the READ
+   * and the CLAIM is missed", and reaching that window means stalling the gate
+   * strictly inside its decision.
+   *
+   * A third client does the stalling by holding the `mission_runs` row the
+   * claim must lock. That splits the two implementations cleanly:
+   *
+   *   PRE-FIX: read money (clear), COMMIT, release the session lock, then block
+   *     on the run row. The writer - queued on the session lock - wakes while
+   *     the run is STILL `paused_error`, commits its unresolved approval, and
+   *     the claim then resumes the run over it.
+   *   FIXED: the session lock is held across the read AND the claim, so the
+   *     writer cannot wake until the claim has committed. It observes the run
+   *     already `running`.
+   *
+   * So the writer's OWN observation of the run status, taken the instant it
+   * finally gets the lock, is the assertion. It is a fact about lock
+   * ownership, not a timing coincidence.
+   */
+  it("B. a money writer cannot commit between the money read and the claim", async () => {
+    const seeded = await seedPausedErrorRun();
+    await seedRetryWake(seeded);
+
+    const blocker = await openWriter();
+    const writer = await openWriter();
+    try {
+      // 1. Stall the claim: hold the run row the claim must lock FOR UPDATE.
+      await blocker.query("BEGIN");
+      await blocker.query(
+        `SELECT id FROM mission_runs WHERE id = $1 FOR UPDATE`,
+        [seeded.runId],
+      );
+
+      // 2. The gate starts. It reads a CLEAR money state, then reaches the
+      //    claim and blocks on the row the blocker holds.
+      const gatePromise = gateFor(seeded);
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      // 3. A money writer arrives and does what every real money-path writer
+      //    does: take the session control lock, then write. The status it sees
+      //    the moment it holds the lock is the evidence.
+      const writerObserved = (async () => {
+        await writer.query("BEGIN");
+        await writer.query(TAKE_SESSION_LOCK, [
+          sessionControlLockKey(seeded.sessionId),
+        ]);
+        const seen = await writer.query<{ status: string }>(
+          `SELECT status FROM mission_runs WHERE id = $1`,
+          [seeded.runId],
+        );
+        await writer.query(INSERT_PENDING_APPROVAL, [
+          randomUUID(),
+          seeded.sessionId,
+        ]);
+        await writer.query("COMMIT");
+        return seen.rows[0]?.status ?? "missing";
+      })();
+
+      // 4. Let the claim through.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      await blocker.query("COMMIT");
+
+      const gated = await gatePromise;
+      const observed = await writerObserved;
+
+      expect(gated.kind).toBe("claimed");
+      // The whole property. `paused_error` here means the writer held the
+      // session control lock while the run was still parked - i.e. the gate
+      // had released it after the read and the claim had not happened yet,
+      // which is precisely the window in which an unresolved money row can be
+      // committed under a Recover that already decided to proceed.
+      expect(observed).toBe("running");
+    } finally {
+      await blocker.end();
+      await writer.end();
+    }
+  });
+
+  it("C. with the money state clear the gate claims, and the claim is durable", async () => {
+    const seeded = await seedPausedErrorRun();
+    await seedRetryWake(seeded);
+
+    const gated = await gateFor(seeded);
+
+    expect(gated.kind).toBe("claimed");
+    if (gated.kind !== "claimed") return;
+    expect(gated.claim.outcome).toBe("claimed");
+    // All three effects committed together: status flipped, the superseded
+    // auto-retry cancelled, the lease held.
+    expect(await runStatus(seeded.runId)).toBe("running");
+    expect(await pendingWakeCount(seeded.sessionId)).toBe(0);
+    const leases = await query<{ owner_id: string }>(
+      `SELECT owner_id FROM runner_leases WHERE session_id = $1`,
+      [seeded.sessionId],
+    );
+    expect(leases).toHaveLength(1);
+  });
+
+  it("D. a money writer AFTER a successful claim does not undo it", async () => {
+    const seeded = await seedPausedErrorRun();
+
+    const gated = await gateFor(seeded);
+    expect(gated.kind).toBe("claimed");
+
+    // The writer was blocked behind the gate and commits once it is through.
+    // The run is already running and owned; the late row is the next gate's
+    // problem, not this claim's.
+    const writer = await openWriter();
+    try {
+      await writer.query(INSERT_PENDING_APPROVAL, [
+        randomUUID(),
+        seeded.sessionId,
+      ]);
+    } finally {
+      await writer.end();
+    }
+
+    expect(await runStatus(seeded.runId)).toBe("running");
+    // And a SECOND Recover now refuses, which is the correct next answer.
+    const second = await gateFor(seeded);
+    expect(second.kind).toBe("blocked_money_state");
+  });
+
+  it("two concurrent gated claims produce exactly ONE winner", async () => {
+    const seeded = await seedPausedErrorRun();
+
+    const [first, second] = await Promise.all([
+      gateFor(seeded),
+      gateFor(seeded),
+    ]);
+
+    const claimed = [first, second].filter(
+      (r) => r.kind === "claimed" && r.claim.outcome === "claimed",
+    );
+    expect(claimed).toHaveLength(1);
+    expect(await runStatus(seeded.runId)).toBe("running");
+  });
+});

--- a/src/__tests__/integration/repos/recovery-reverse-lock-order.int.test.ts
+++ b/src/__tests__/integration/repos/recovery-reverse-lock-order.int.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Integration: the recovery gate takes its row locks in the SAME order as every
+ * other claimant, proven against real Postgres with a real lock cycle staged.
+ *
+ * THE DEFECT THIS PINS. Making the money gate atomic put the auto-retry wake
+ * cancellation inside the transaction - and, at first, BEFORE the claim. That
+ * inverted the system's lock order. `claimRunLeaseAndFlipToRunningWith` locks
+ * `mission_runs`, then `runner_leases`, then pending `loop_wake_requests`;
+ * cancelling first took the wake rows before the run row. A lock-order
+ * inversion is only a latent bug until two parties actually interleave, and
+ * this one had a reachable interleaving:
+ *
+ *   1. `runRetryDispatch` reads the run status OUTSIDE the transaction and
+ *      sees `paused_error`;
+ *   2. the run advances to `paused_wake` before the gate's transaction opens
+ *      (an auto-retry was scheduled, a wake was enqueued);
+ *   3. a wake or Continue claimant locks the `mission_runs` row and heads for
+ *      the wake rows;
+ *   4. the stale Recover locks the pending wake row - its captured status
+ *      still says `paused_error`, so it believes it should - then waits on the
+ *      run row the claimant holds;
+ *   5. the claimant waits on the wake row Recover holds.
+ *
+ * A cycle. Postgres detects it and aborts one side with SQLSTATE 40P01, which
+ * turns "you lost a race" into "a control action failed". The correct outcome
+ * for a stale Recover is a clean `status_mismatch`.
+ *
+ * WHY THE EXISTING RACE SUITE CANNOT SEE THIS. Every case in
+ * `recovery-money-gate-race.int.test.ts` keeps the run at `paused_error` for
+ * the whole test, so step 2 never happens and the two parties never contend
+ * for the same pair of rows. The status CHANGE is the entire precondition, so
+ * it has to be staged explicitly.
+ *
+ * WHAT IS ASSERTED. Not "no deadlock happened" - that would pass by luck on a
+ * fast machine. The claimant is made to HOLD the run row across the whole
+ * attempt, so under the reverse order the cycle is forced rather than raced.
+ * Under the correct order there is no cycle to force: Recover blocks on the
+ * run row like any other waiter, and once released reads `paused_wake`, fails
+ * its `fromStatuses` check and returns `status_mismatch` having touched
+ * nothing.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { Client } from "pg";
+
+import { execute, query } from "@vex-agent/db/client.js";
+import { makeSession, resetDb } from "../setup/fixtures.js";
+
+function containerUrl(): string {
+  const raw = process.env.VEX_DB_URL;
+  if (raw === undefined) {
+    throw new Error("VEX_DB_URL is unset - the postgres global setup did not run");
+  }
+  return raw;
+}
+
+vi.mock("../../../../vex-app/src/main/database/db-config.js", () => ({
+  buildPoolConfig: async () => {
+    const url = new URL(containerUrl());
+    return {
+      host: url.hostname,
+      port: Number(url.port),
+      database: url.pathname.replace(/^\//, ""),
+      user: decodeURIComponent(url.username),
+      password: decodeURIComponent(url.password),
+    };
+  },
+}));
+vi.mock("../../../../vex-app/src/main/logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { gatedClaimUnderSessionLock } = await import(
+  "../../../../vex-app/src/main/ipc/_shared/runtime-retry-dispatch.js"
+);
+
+interface Seeded {
+  readonly sessionId: string;
+  readonly runId: string;
+}
+
+async function seedRun(status: string): Promise<Seeded> {
+  const sessionId = await makeSession();
+  const missionId = `mission-${sessionId}`;
+  const runId = `run-${sessionId}`;
+  await execute(
+    `INSERT INTO missions (id, root_session_id, status, goal)
+     VALUES ($1, $2, 'running', 'reverse lock order')`,
+    [missionId, sessionId],
+  );
+  await execute(
+    `INSERT INTO mission_runs (id, mission_id, session_id, status, started_at)
+     VALUES ($1, $2, $3, $4, NOW())`,
+    [runId, missionId, sessionId, status],
+  );
+  return { sessionId, runId };
+}
+
+/** The scheduled auto-retry both parties would contend for. */
+async function seedPendingWake(seeded: Seeded): Promise<string> {
+  const rows = await query<{ id: string }>(
+    `INSERT INTO loop_wake_requests
+       (session_id, mission_run_id, due_at, status, reason)
+     VALUES ($1, $2, NOW() + interval '30 seconds', 'pending', 'error_retry')
+     RETURNING id`,
+    [seeded.sessionId, seeded.runId],
+  );
+  const id = rows[0]?.id;
+  if (id === undefined) throw new Error("wake insert returned no id");
+  return id;
+}
+
+async function readWake(
+  id: string,
+): Promise<{ status: string; cancelled_reason: string | null }> {
+  const rows = await query<{ status: string; cancelled_reason: string | null }>(
+    `SELECT status, cancelled_reason FROM loop_wake_requests WHERE id = $1`,
+    [id],
+  );
+  const row = rows[0];
+  if (row === undefined) throw new Error("wake row vanished");
+  return row;
+}
+
+async function runStatus(runId: string): Promise<string> {
+  const rows = await query<{ status: string }>(
+    `SELECT status FROM mission_runs WHERE id = $1`,
+    [runId],
+  );
+  return rows[0]?.status ?? "missing";
+}
+
+async function openClient(): Promise<Client> {
+  const client = new Client({ connectionString: containerUrl() });
+  await client.connect();
+  return client;
+}
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("the recovery gate's row-lock order", () => {
+  /**
+   * The staged inversion, end to end.
+   *
+   * `status: "paused_error"` passed to the gate is deliberately STALE - it is
+   * what the dispatcher read outside the transaction. The row underneath has
+   * already moved to `paused_wake`, which is precisely the situation in which
+   * the old ordering cancelled a wake it had no business touching and then
+   * queued behind a claimant that was coming the other way.
+   */
+  it("a STALE Recover loses cleanly instead of deadlocking with a wake claimant", async () => {
+    const seeded = await seedRun("paused_error");
+    const wakeId = await seedPendingWake(seeded);
+
+    // The run advances after the dispatcher's outside read: an auto-retry was
+    // scheduled and the run parked on it.
+    await execute(`UPDATE mission_runs SET status = 'paused_wake' WHERE id = $1`, [
+      seeded.runId,
+    ]);
+
+    const claimant = await openClient();
+    try {
+      // The competing claimant takes the run row FIRST, the correct order, and
+      // holds it. Under the reverse order this is one half of the cycle; under
+      // the correct order it is just a lock Recover has to wait for.
+      await claimant.query("BEGIN");
+      await claimant.query(
+        `SELECT id FROM mission_runs WHERE id = $1 FOR UPDATE`,
+        [seeded.runId],
+      );
+
+      // Recover runs with its stale status. Under the OLD order it grabs the
+      // pending wake row here and then blocks on the run row, completing the
+      // cycle the moment the claimant reaches for the wake.
+      const gatePromise = gatedClaimUnderSessionLock({
+        sessionId: seeded.sessionId,
+        runId: seeded.runId,
+        status: "paused_error",
+        ownerId: `reverse-order-${randomUUID()}`,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      // The claimant now reaches for the wake rows, exactly as
+      // `claimRunLeaseAndFlipToRunningWith` does for a `paused_wake` run. With
+      // the wake row held by Recover this statement is the closing edge of the
+      // cycle; with the correct order it returns immediately.
+      await claimant.query(
+        `UPDATE loop_wake_requests
+            SET status = 'cancelled',
+                cancelled_at = NOW(),
+                cancelled_reason = 'consumed_by_resume'
+          WHERE session_id = $1 AND status = 'pending'`,
+        [seeded.sessionId],
+      );
+      await claimant.query("COMMIT");
+
+      const gated = await gatePromise;
+
+      // The stale Recover revalidated under the run-row lock, saw a status it
+      // was not claiming from, and gave up. No deadlock, no exception.
+      expect(gated.kind).toBe("claimed");
+      if (gated.kind !== "claimed") return;
+      expect(gated.claim.outcome).toBe("status_mismatch");
+    } finally {
+      await claimant.end();
+    }
+
+    // The run is whatever the CLAIMANT left it, untouched by the loser.
+    expect(await runStatus(seeded.runId)).toBe("paused_wake");
+    // And the wake carries the claimant's reason, never Recover's: the stale
+    // path must not have written to this row at all.
+    const wake = await readWake(wakeId);
+    expect(wake.cancelled_reason).toBe("consumed_by_resume");
+    expect(wake.cancelled_reason).not.toBe("superseded_by_manual_recover");
+  });
+
+  /**
+   * The same staleness with no competitor at all. Isolates the ordering rule
+   * from the contention: a claim that does not win must leave every wake row
+   * exactly as it found it, because the cancellation is now conditional on
+   * what the claim OBSERVED under the row lock rather than on the status read
+   * outside the transaction.
+   */
+  it("a stale Recover touches no wake row when it loses the status check", async () => {
+    const seeded = await seedRun("paused_wake");
+    const wakeId = await seedPendingWake(seeded);
+
+    const gated = await gatedClaimUnderSessionLock({
+      sessionId: seeded.sessionId,
+      runId: seeded.runId,
+      status: "paused_error",
+      ownerId: `stale-${randomUUID()}`,
+    });
+
+    expect(gated.kind).toBe("claimed");
+    if (gated.kind !== "claimed") return;
+    expect(gated.claim.outcome).toBe("status_mismatch");
+    // Still pending: the loser cancelled nothing.
+    expect((await readWake(wakeId)).status).toBe("pending");
+    expect(await runStatus(seeded.runId)).toBe("paused_wake");
+  });
+
+  /**
+   * The winning path still supersedes the auto-retry - the cancellation was
+   * reordered, not dropped. `previousStatus` is the claim's own observation,
+   * so this is the only shape in which Recover writes to a wake row.
+   */
+  it("a WINNING Recover still cancels the scheduled auto-retry", async () => {
+    const seeded = await seedRun("paused_error");
+    const wakeId = await seedPendingWake(seeded);
+
+    const gated = await gatedClaimUnderSessionLock({
+      sessionId: seeded.sessionId,
+      runId: seeded.runId,
+      status: "paused_error",
+      ownerId: `winner-${randomUUID()}`,
+    });
+
+    expect(gated.kind).toBe("claimed");
+    if (gated.kind !== "claimed") return;
+    expect(gated.claim.outcome).toBe("claimed");
+    const wake = await readWake(wakeId);
+    expect(wake.status).toBe("cancelled");
+    expect(wake.cancelled_reason).toBe("superseded_by_manual_recover");
+    expect(await runStatus(seeded.runId)).toBe("running");
+  });
+
+  /**
+   * The dead-lease reclaim path claims from `running`, so `previousStatus` is
+   * `running` and no auto-retry supersession applies - a `running` row never
+   * has an error-retry wake pending. Pinned so the condition is not loosened
+   * back to "whatever the dispatcher read".
+   */
+  it("the dead-lease reclaim path cancels nothing", async () => {
+    const seeded = await seedRun("running");
+    const wakeId = await seedPendingWake(seeded);
+
+    const gated = await gatedClaimUnderSessionLock({
+      sessionId: seeded.sessionId,
+      runId: seeded.runId,
+      status: "running",
+      ownerId: `reclaim-${randomUUID()}`,
+    });
+
+    expect(gated.kind).toBe("claimed");
+    if (gated.kind !== "claimed") return;
+    expect(gated.claim.outcome).toBe("claimed");
+    expect((await readWake(wakeId)).status).toBe("pending");
+  });
+});

--- a/src/__tests__/integration/repos/session-control-state-wake.int.test.ts
+++ b/src/__tests__/integration/repos/session-control-state-wake.int.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Integration: the control-state aggregate's session-wake projection, against
+ * REAL Postgres.
+ *
+ * WHY THIS EXISTS. `CONTROL_FACTS_SQL` is one hand-written statement, and the
+ * M5 wave added a correlated subquery to it that names three things the unit
+ * tests cannot check: the table `loop_wake_requests`, the column
+ * `mission_run_id` that migration 057 made nullable, and the `due_at` ordering
+ * the "next wake" claim rests on. A mocked `pg.Client` returns whatever row the
+ * test hands it, so every one of those names could be wrong and the whole unit
+ * suite would still be green. It nearly was: the same wave shipped the
+ * statement with a backtick inside its own template literal, which truncated
+ * the SQL and went unnoticed because nothing ever executed it.
+ *
+ * So this drives the REAL reader (`readSessionControlFacts`) over a real client
+ * against a migrated schema, and asserts the projection through
+ * `readSessionActivity` - the same two functions `runtime.getState` calls, in
+ * the same order, with no SQL restated here. A test that re-wrote the query
+ * would prove only that the copy runs.
+ *
+ * WHAT IS SUBSTITUTED, AND WHY THAT IS STILL THE REAL PATH. Only
+ * `buildPoolConfig` (the desktop compose-credential lookup) and the main
+ * process's electron logger. Both are environment plumbing, not the subject:
+ * the statement text, the parameter binding, `withRuntimeDbClient`'s own client
+ * lifecycle, the row shape and `toFacts` are all untouched. What is being
+ * proven is that the SQL survives contact with the real schema.
+ *
+ * The four cases are the projection's whole contract:
+ *   (a) a pending SESSION-scoped wake (mission_run_id IS NULL) is carried, and
+ *       reads as sleeping with that instant;
+ *   (b) a MISSION-scoped wake alone leaves it NULL - the projection must not
+ *       leak a mission run's park into session activity;
+ *   (c) a live lease plus a pending session wake reads running - the executor
+ *       holds the lease before it consumes the row, and "running" is the only
+ *       honest word for that interval;
+ *   (d) a consumed or cancelled wake is not a park at all.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { query } from "@vex-agent/db/client.js";
+import { makeSession, resetDb } from "../setup/fixtures.js";
+
+/**
+ * The container's coordinates, published by the global setup as `VEX_DB_URL`.
+ * Parsed rather than hardcoded: the port is assigned by Docker per run.
+ */
+function containerPoolConfig(): {
+  host: string;
+  port: number;
+  database: string;
+  user: string;
+  password: string;
+} {
+  const raw = process.env.VEX_DB_URL;
+  if (raw === undefined) {
+    throw new Error("VEX_DB_URL is unset - the postgres global setup did not run");
+  }
+  const url = new URL(raw);
+  return {
+    host: url.hostname,
+    port: Number(url.port),
+    database: url.pathname.replace(/^\//, ""),
+    user: decodeURIComponent(url.username),
+    password: decodeURIComponent(url.password),
+  };
+}
+
+// The desktop credential lookup reads the compose stack's mounted secret file
+// and hardcodes the production database name. Neither exists here, and neither
+// is what this test is about.
+vi.mock("../../../../vex-app/src/main/database/db-config.js", () => ({
+  buildPoolConfig: async () => containerPoolConfig(),
+}));
+
+// The main-process logger imports `electron`, which has no app instance in a
+// node test runner. The reader only ever calls `log.warn` on a failure path.
+vi.mock("../../../../vex-app/src/main/logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { readSessionControlFacts, readSessionActivity } = await import(
+  "../../../../vex-app/src/main/database/session-control-state.js"
+);
+
+const CORRELATION = "session-wake-int";
+
+/** The reader returns a Result; a failure here is a defect, not a case. */
+async function factsFor(sessionId: string) {
+  const outcome = await readSessionControlFacts(sessionId, CORRELATION);
+  if (!outcome.ok) {
+    throw new Error(
+      `readSessionControlFacts failed: ${outcome.error.code} ${outcome.error.message}`,
+    );
+  }
+  return outcome.data;
+}
+
+/**
+ * A session-scoped wake: `mission_run_id` NULL, which is exactly what
+ * migration 057 made possible and what the projection selects on.
+ */
+async function seedSessionWake(
+  sessionId: string,
+  dueAt: string,
+  status: "pending" | "consumed" | "cancelled" = "pending",
+): Promise<void> {
+  await query(
+    `INSERT INTO loop_wake_requests
+       (session_id, mission_run_id, due_at, status, reason)
+     VALUES ($1, NULL, $2, $3, 'session-wake integration')`,
+    [sessionId, dueAt, status],
+  );
+}
+
+/** A mission-scoped wake needs the mission + run rows it references. */
+async function seedMissionWake(
+  sessionId: string,
+  dueAt: string,
+): Promise<string> {
+  const missionId = `mission-${sessionId}`;
+  const runId = `run-${sessionId}`;
+  await query(
+    `INSERT INTO missions (id, root_session_id, status, goal)
+     VALUES ($1, $2, 'running', 'session-wake integration')`,
+    [missionId, sessionId],
+  );
+  await query(
+    `INSERT INTO mission_runs (id, mission_id, session_id, status, started_at)
+     VALUES ($1, $2, $3, 'paused_wake', NOW())`,
+    [runId, missionId, sessionId],
+  );
+  await query(
+    `INSERT INTO loop_wake_requests
+       (session_id, mission_run_id, due_at, status, reason)
+     VALUES ($1, $2, $3, 'pending', 'mission wake')`,
+    [sessionId, runId, dueAt],
+  );
+  return runId;
+}
+
+/** `expiresInMs` positive = a lease a runner still holds. */
+async function seedLease(
+  sessionId: string,
+  expiresInMs: number,
+  missionRunId: string | null = null,
+): Promise<void> {
+  await query(
+    `INSERT INTO runner_leases
+       (session_id, mission_run_id, owner_id, process_kind,
+        acquired_at, heartbeat_at, expires_at)
+     VALUES ($1, $2, 'owner-int', 'electron_main', NOW(), NOW(),
+             NOW() + ($3::int * interval '1 millisecond'))`,
+    [sessionId, missionRunId, expiresInMs],
+  );
+}
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+/**
+ * The schema facts the projection is written against. Asserted directly, so a
+ * migration that renames or re-tightens one fails HERE with the reason, rather
+ * than as a confusing null in the cases below.
+ */
+describe("the live schema the projection names", () => {
+  it("loop_wake_requests.mission_run_id exists and is NULLABLE (migration 057)", async () => {
+    const rows = await query<{ column_name: string; is_nullable: string }>(
+      `SELECT column_name, is_nullable
+         FROM information_schema.columns
+        WHERE table_name = 'loop_wake_requests'
+          AND column_name IN ('mission_run_id', 'session_id', 'due_at', 'status')
+        ORDER BY column_name`,
+    );
+    const byName = new Map(rows.map((r) => [r.column_name, r.is_nullable]));
+    expect([...byName.keys()].sort()).toEqual([
+      "due_at",
+      "mission_run_id",
+      "session_id",
+      "status",
+    ]);
+    // The whole session-scoped branch depends on this being nullable. Before
+    // 057 it was NOT NULL, and the subquery could never have matched a row.
+    expect(byName.get("mission_run_id")).toBe("YES");
+    expect(byName.get("session_id")).toBe("NO");
+    expect(byName.get("due_at")).toBe("NO");
+  });
+
+  it("accepts a session-scoped wake row - the constraint really is dropped", async () => {
+    const sessionId = await makeSession();
+    await seedSessionWake(sessionId, "2026-08-29T12:04:00.000Z");
+    const rows = await query<{ n: string }>(
+      `SELECT COUNT(*)::text AS n FROM loop_wake_requests
+        WHERE session_id = $1 AND mission_run_id IS NULL`,
+      [sessionId],
+    );
+    expect(rows[0]?.n).toBe("1");
+  });
+});
+
+describe("session_wake_due_at over the real schema", () => {
+  it("(a) carries a pending session-scoped wake and reads as sleeping", async () => {
+    const sessionId = await makeSession();
+    const dueAt = "2026-08-29T12:04:00.000Z";
+    await seedSessionWake(sessionId, dueAt);
+
+    const facts = await factsFor(sessionId);
+
+    expect(facts.sessionWakeDueAt).toBe(dueAt);
+    // The broad fact sees it too; only the narrow one is session-scoped.
+    expect(facts.hasPendingWake).toBe(true);
+    expect(facts.leaseActive).toBe(false);
+    expect(readSessionActivity(facts)).toEqual({
+      kind: "sleeping",
+      nextWakeAt: dueAt,
+    });
+  });
+
+  it("(b) leaves a MISSION-scoped wake out of the session projection", async () => {
+    const sessionId = await makeSession();
+    await seedMissionWake(sessionId, "2026-08-29T12:04:00.000Z");
+
+    const facts = await factsFor(sessionId);
+
+    // The mission park is real and the broad fact reports it - that is what
+    // keeps the Stop key alive. The SESSION projection must stay silent, or a
+    // sleeping mission would drive the agent-session status word too and the
+    // two surfaces would contradict each other.
+    expect(facts.hasPendingWake).toBe(true);
+    expect(facts.sessionWakeDueAt).toBeNull();
+    expect(readSessionActivity(facts)).toEqual({ kind: "none" });
+  });
+
+  it("(c) reports running when a lease is held over a pending session wake", async () => {
+    const sessionId = await makeSession();
+    await seedSessionWake(sessionId, "2026-08-29T12:04:00.000Z");
+    await seedLease(sessionId, 60_000);
+
+    const facts = await factsFor(sessionId);
+
+    // Both facts are true at once, which is the executor's real interval: it
+    // claims the row and takes the lease before it marks the row consumed.
+    expect(facts.leaseActive).toBe(true);
+    expect(facts.sessionWakeDueAt).toBe("2026-08-29T12:04:00.000Z");
+    expect(readSessionActivity(facts)).toEqual({ kind: "running" });
+  });
+
+  it.each(["consumed", "cancelled"] as const)(
+    "(d) ignores a %s wake - a settled park is not sleep",
+    async (status) => {
+      const sessionId = await makeSession();
+      await seedSessionWake(sessionId, "2026-08-29T12:04:00.000Z", status);
+
+      const facts = await factsFor(sessionId);
+
+      expect(facts.sessionWakeDueAt).toBeNull();
+      expect(facts.hasPendingWake).toBe(false);
+      expect(readSessionActivity(facts)).toEqual({ kind: "none" });
+    },
+  );
+
+  /**
+   * The subquery orders by `due_at` and takes one row. The partial unique index
+   * `uniq_loop_wake_pending_per_session` means production can only hold one
+   * PENDING row per session, so the ordering is belt and braces - but it is the
+   * claim the copy makes ("the next wake"), and a settled row sorting earlier
+   * must not win it.
+   */
+  it("takes the earliest PENDING row, never an earlier settled one", async () => {
+    const sessionId = await makeSession();
+    await seedSessionWake(sessionId, "2026-08-29T11:00:00.000Z", "cancelled");
+    await seedSessionWake(sessionId, "2026-08-29T12:04:00.000Z", "pending");
+
+    const facts = await factsFor(sessionId);
+
+    expect(facts.sessionWakeDueAt).toBe("2026-08-29T12:04:00.000Z");
+  });
+
+  it("reports no park for a session with no wake rows at all", async () => {
+    const sessionId = await makeSession();
+
+    const facts = await factsFor(sessionId);
+
+    expect(facts.sessionWakeDueAt).toBeNull();
+    expect(readSessionActivity(facts)).toEqual({ kind: "none" });
+  });
+});
+
+/**
+ * The `recoveryReady` mirror's READY branch, proven at the reader that decides
+ * it. `runtime.getState` maps `clear === true` to `{ kind: "ready" }` and
+ * everything else to `blocked`, so this is the fact the mapping turns on.
+ *
+ * GAP, named rather than faked: `readRecoveryReadiness` itself is private to
+ * `ipc/runtime/get-state.ts` and reachable only through a registered IPC
+ * handler, which needs the electron `ipcMain` surface this harness does not
+ * boot. What is unproven here is that wiring, not the money fact.
+ */
+describe("the recoveryReady mirror's underlying money fact", () => {
+  it("a session with no money-path rows reads clear", async () => {
+    const sessionId = await makeSession();
+    const { withTransaction } = await import("@vex-agent/db/client.js");
+    const { getUnresolvedMoneyStateForSession } = await import(
+      "@vex-agent/db/repos/approval-intents/money-state.js"
+    );
+
+    const money = await withTransaction(async (client) =>
+      getUnresolvedMoneyStateForSession(client, sessionId),
+    );
+
+    expect(money.clear).toBe(true);
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/operator-instruction-disposition.test.ts
+++ b/src/__tests__/vex-agent/engine/core/operator-instruction-disposition.test.ts
@@ -186,3 +186,65 @@ describe("both rows, one transaction, events after the commit", () => {
     expect(emitTranscriptAppend).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * The classifier, as a truth table. It is the ONE place `steered` may be
+ * decided, and both ingress routes now defer to it - they used to disagree
+ * with each other in opposite directions on the same session.
+ */
+describe("classifyOperatorInterruptDisposition", () => {
+  it("says steered ONLY for executing work with a live matching lease", async () => {
+    const { classifyOperatorInterruptDisposition } = await import(
+      "@vex-agent/engine/core/operator-instructions.js"
+    );
+    const cases: ReadonlyArray<
+      [string | null, boolean, "steered" | "queued_interrupt"]
+    > = [
+      // A live mission run whose runner holds the lease: the loop merges it.
+      ["running", true, "steered"],
+      // `running` is a ROW STATUS. With a dead lease it is the crashed-runner
+      // state the restart-orphan sweep reclaims, and nothing is alive to merge.
+      ["running", false, "queued_interrupt"],
+      // An agent session has no run row; the lease is the whole question.
+      [null, true, "steered"],
+      [null, false, "queued_interrupt"],
+      // Parked states. A live lease does not make a parked run executing - it
+      // is held for work that is waiting on a human or a clock.
+      ["paused_approval", true, "queued_interrupt"],
+      ["paused_approval", false, "queued_interrupt"],
+      ["paused_error", true, "queued_interrupt"],
+      ["paused_error", false, "queued_interrupt"],
+      ["paused_wake", true, "queued_interrupt"],
+      ["paused_user", true, "queued_interrupt"],
+      ["paused_user_form", true, "queued_interrupt"],
+      ["paused_plan_acceptance", true, "queued_interrupt"],
+    ];
+    for (const [runStatus, hasLiveMatchingLease, expected] of cases) {
+      expect(
+        classifyOperatorInterruptDisposition({ runStatus, hasLiveMatchingLease }),
+      ).toBe(expected);
+    }
+  });
+
+  /**
+   * `preempted_wake` is a fact about an ACTION that won its race, not a
+   * derivation from state. Only the code that performed the claim and saw it
+   * succeed may assert it - deriving it from `paused_wake` would claim a
+   * preempt that may have lost.
+   */
+  it("never produces preempted_wake from state alone", async () => {
+    const { classifyOperatorInterruptDisposition } = await import(
+      "@vex-agent/engine/core/operator-instructions.js"
+    );
+    for (const runStatus of [null, "running", "paused_wake", "paused_error"]) {
+      for (const hasLiveMatchingLease of [true, false]) {
+        expect(
+          classifyOperatorInterruptDisposition({
+            runStatus,
+            hasLiveMatchingLease,
+          }),
+        ).not.toBe("preempted_wake");
+      }
+    }
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/operator-instruction-disposition.test.ts
+++ b/src/__tests__/vex-agent/engine/core/operator-instruction-disposition.test.ts
@@ -1,0 +1,188 @@
+/**
+ * M6 - the durable, typed acknowledgement of an operator instruction.
+ *
+ * What this replaced: `QUEUED_INTERRUPT_TEXT`, one paragraph returned as
+ * `TurnResult.text` from three ingress branches with three different meanings.
+ * It was not durable (a reload lost it), not distinguishable (the branch that
+ * had actually preempted a scheduled wake and resumed the run said the same
+ * words as the branch that had merely saved a row onto an errored run), and
+ * anything downstream that wanted to know what happened could only have
+ * compared prose.
+ *
+ * What is pinned here:
+ *   - the disposition is a TYPED value on the instruction row's own payload -
+ *     an existing JSONB column, no schema change anywhere;
+ *   - the engine's acknowledgement is a durable, USER-visible engine notice
+ *     row, not assistant text, one per instruction row;
+ *   - both rows commit in ONE transaction, and BOTH events are emitted only
+ *     after that commit returns - an acknowledgement without its instruction
+ *     would tell the operator the agent has a message that nothing has;
+ *   - each disposition says something DIFFERENT about when the agent reads it,
+ *     which is the fact the single paragraph could not tell the truth about.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const appendMessage = vi.fn();
+const appendEngineMessage = vi.fn();
+const emitTranscriptAppend = vi.fn();
+const withTransaction = vi.fn();
+
+vi.mock("@vex-agent/engine/events/index.js", () => ({
+  TRANSCRIPT_APPEND_EVENT_TYPE: "engine.transcript.append",
+  appendMessage: (...a: unknown[]) => appendMessage(...a),
+  appendEngineMessage: (...a: unknown[]) => appendEngineMessage(...a),
+  emitTranscriptAppend: (...a: unknown[]) => emitTranscriptAppend(...a),
+}));
+vi.mock("@vex-agent/db/client.js", () => ({
+  withTransaction: (...a: unknown[]) => withTransaction(...a),
+}));
+vi.mock("@vex-agent/db/repos/messages.js", () => ({
+  getOperatorInstructionsAfter: vi.fn(),
+}));
+
+const {
+  OPERATOR_INSTRUCTION_ACK_MESSAGE_TYPE,
+  OPERATOR_INTERRUPT_MESSAGE_TYPE,
+  addOperatorInstruction,
+} = await import("../../../../vex-agent/engine/core/operator-instructions.js");
+
+const CLIENT = { fake: "client" };
+
+interface AppendCall {
+  readonly sessionId: string;
+  readonly content: string;
+  readonly metadata: {
+    source?: string;
+    messageType?: string;
+    visibility?: string;
+    payload?: Record<string, unknown>;
+  };
+  readonly opts?: { client?: unknown };
+}
+
+function instructionCall(): AppendCall {
+  const [sessionId, msg, metadata, opts] = appendMessage.mock.calls[0] as [
+    string, { content: string }, AppendCall["metadata"], AppendCall["opts"],
+  ];
+  return { sessionId, content: msg.content, metadata, opts };
+}
+
+function ackCall(): AppendCall {
+  const [sessionId, content, metadata, opts] = appendEngineMessage.mock.calls[0] as [
+    string, string, AppendCall["metadata"], AppendCall["opts"],
+  ];
+  return { sessionId, content, metadata, opts };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  appendMessage.mockResolvedValue({ id: 11, role: "user", timestamp: "2026-08-28T00:00:00.000Z" });
+  appendEngineMessage.mockResolvedValue({ id: 12, role: "system", timestamp: "2026-08-28T00:00:01.000Z" });
+  withTransaction.mockImplementation(async (fn: (c: unknown) => Promise<unknown>) => fn(CLIENT));
+});
+
+describe("addOperatorInstruction - the instruction row", () => {
+  it("carries the typed disposition on its payload", async () => {
+    await addOperatorInstruction("s1", "steer this", "steered", { target: "agent_turn" });
+
+    const call = instructionCall();
+    expect(call.metadata.messageType).toBe(OPERATOR_INTERRUPT_MESSAGE_TYPE);
+    expect(call.metadata.payload).toMatchObject({
+      operatorInstruction: true,
+      target: "agent_turn",
+      disposition: "steered",
+    });
+  });
+
+  it("a caller-supplied `disposition` in the free-form payload cannot override the typed one", async () => {
+    // The whole point of the typed argument is that it is the single answer.
+    // A loose fourth value arriving through the context bag is exactly the
+    // drift this field exists to end.
+    await addOperatorInstruction("s1", "x", "queued_interrupt", {
+      disposition: "definitely_delivered",
+    });
+
+    expect(instructionCall().metadata.payload?.["disposition"]).toBe("queued_interrupt");
+  });
+});
+
+describe("addOperatorInstruction - the acknowledgement row", () => {
+  it("is a USER-visible engine notice, never assistant prose", async () => {
+    await addOperatorInstruction("s1", "x", "steered");
+
+    const ack = ackCall();
+    expect(ack.metadata.source).toBe("engine");
+    expect(ack.metadata.messageType).toBe(OPERATOR_INSTRUCTION_ACK_MESSAGE_TYPE);
+    // The agent did not say this; the runtime did. A user-visible engine row
+    // renders as a runtime notice, not as a turn from the model.
+    expect(ack.metadata.visibility).toBe("user");
+    expect(ack.metadata.messageType).not.toBe(OPERATOR_INTERRUPT_MESSAGE_TYPE);
+  });
+
+  it("is emitted exactly once per instruction row", async () => {
+    await addOperatorInstruction("s1", "x", "steered");
+    expect(appendMessage).toHaveBeenCalledTimes(1);
+    expect(appendEngineMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("says something DIFFERENT for each disposition, and names the typed value", async () => {
+    const texts = new Map<string, string>();
+    for (const disposition of ["steered", "queued_interrupt", "preempted_wake"] as const) {
+      vi.clearAllMocks();
+      appendMessage.mockResolvedValue({ id: 11, role: "user", timestamp: "t" });
+      appendEngineMessage.mockResolvedValue({ id: 12, role: "system", timestamp: "t" });
+      withTransaction.mockImplementation(async (fn: (c: unknown) => Promise<unknown>) => fn(CLIENT));
+
+      await addOperatorInstruction("s1", "x", disposition);
+      const ack = ackCall();
+      texts.set(disposition, ack.content);
+      // Every channel derives from the typed value, never from prose.
+      expect(ack.metadata.payload).toMatchObject({ disposition });
+    }
+
+    expect(new Set(texts.values()).size).toBe(3);
+    // The two claims that must not be confused: one promises the agent is
+    // mid-turn, the other admits it is not running.
+    expect(texts.get("steered")).toContain("mid-turn");
+    expect(texts.get("queued_interrupt")).toContain("not running a turn");
+    expect(texts.get("preempted_wake")).toContain("resuming now");
+  });
+});
+
+describe("both rows, one transaction, events after the commit", () => {
+  it("writes both rows on the SAME client inside one withTransaction", async () => {
+    await addOperatorInstruction("s1", "x", "queued_interrupt");
+
+    expect(withTransaction).toHaveBeenCalledTimes(1);
+    expect(instructionCall().opts?.client).toBe(CLIENT);
+    expect(ackCall().opts?.client).toBe(CLIENT);
+  });
+
+  it("emits one event per row, and only after the transaction resolves", async () => {
+    let committed = false;
+    withTransaction.mockImplementation(async (fn: (c: unknown) => Promise<unknown>) => {
+      const value = await fn(CLIENT);
+      expect(emitTranscriptAppend).not.toHaveBeenCalled();
+      committed = true;
+      return value;
+    });
+
+    await addOperatorInstruction("s1", "x", "steered");
+
+    expect(committed).toBe(true);
+    expect(emitTranscriptAppend).toHaveBeenCalledTimes(2);
+    expect(emitTranscriptAppend.mock.calls.map(([e]) => (e as { messageId: number }).messageId))
+      .toEqual([11, 12]);
+  });
+
+  it("emits NOTHING when the transaction fails - no phantom acknowledgement", async () => {
+    // An event implies a row a reader can fetch. Telling the operator their
+    // message was delivered when the write rolled back is the worst available
+    // failure, so the throw reaches the caller instead.
+    withTransaction.mockRejectedValue(new Error("db down"));
+
+    await expect(addOperatorInstruction("s1", "x", "steered")).rejects.toThrow("db down");
+    expect(emitTranscriptAppend).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/runner/agent-turn-runtime-bounds.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/agent-turn-runtime-bounds.test.ts
@@ -121,6 +121,7 @@ const {
   ITERATION_LIMIT_REPLY,
   TIMEOUT_REPLY,
   NO_PROGRESS_REPLY,
+  TOOL_CALL_LOOP_REPLY,
 } = await import("../../../../../vex-agent/engine/core/runner/shared.js");
 const { MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS } = await import(
   "../../../../../vex-agent/engine/core/runner/unproductive-rounds.js"
@@ -244,7 +245,15 @@ describe("Full-Autonomous agent session continuation", () => {
         expect.objectContaining({ sessionId: "session-1", missionRunId: null }),
         expect.anything(),
       );
-      expect(result.stopReason).toBe(trigger);
+      // M2 contract change: a SUCCESSFULLY continued full-autonomy turn
+      // reports `waiting_for_wake`, not the raw slice guard. The guard names
+      // what fired inside the turn; the stop reason is read downstream as an
+      // account of how the turn ENDED, and this one ended parked on a live
+      // wake the executor resumes in seconds. Reporting `timeout` here is what
+      // made the composer render a terminal failure banner over work that was
+      // still running. The raw guard is still reported everywhere else - see
+      // the restricted-session and scheduling-failure cases below.
+      expect(result.stopReason).toBe("waiting_for_wake");
       // The session continues — no user-visible "I gave up" paragraph.
       expect(mockAddMessage).not.toHaveBeenCalledWith(
         "session-1",
@@ -579,5 +588,108 @@ describe("foreground stop — committed-wake cleanup", () => {
     const result = await processAgentTurn("session-1", "go", abortedSignal());
 
     expect(result.text).toBe("partial");
+  });
+});
+
+// ── 5. M2: the reported stop reason is an account of the TURN ──
+
+/**
+ * `stopReason` is read downstream as "how did this turn end". For a
+ * successfully continued full-autonomy turn the honest answer is
+ * `waiting_for_wake`, not the slice guard that fired inside it - the composer
+ * renders a terminal failure banner for `timeout`, exports record it as the
+ * ending, bug reports classify on it, and none of those are true of a turn the
+ * executor is about to resume.
+ *
+ * The remap is NARROW, and the tests below are what keeps it narrow. Every
+ * path that does NOT actually leave a live wake behind must keep the raw
+ * guard, because promising a resume nothing will perform is the same
+ * dishonesty pointed the other way.
+ */
+describe("M2 - only a CONTINUED full-autonomy turn reports waiting_for_wake", () => {
+  for (const trigger of ["iteration_limit", "timeout"] as const) {
+    it(`a RESTRICTED session keeps the raw ${trigger} - it was never continued`, async () => {
+      mockHydrate.mockResolvedValue(makeHydratedSession("restricted"));
+      mockRunTurnLoop.mockResolvedValue({
+        text: null, toolCallsMade: 4, pendingApprovals: [], stopReason: trigger,
+      });
+
+      const result = await processAgentTurn("session-1", "go");
+
+      expect(mockEnqueueWake).not.toHaveBeenCalled();
+      expect(result.stopReason).toBe(trigger);
+      expect(result.text).toBe(
+        trigger === "timeout" ? TIMEOUT_REPLY : ITERATION_LIMIT_REPLY,
+      );
+    });
+  }
+
+  it("a full-autonomy turn whose SCHEDULING FAILED keeps the raw guard", async () => {
+    // The operator stopped the session while the slice was unwinding, so the
+    // gate refuses and no wake row exists. Nothing is going to resume this.
+    mockHydrate.mockResolvedValue(makeHydratedSession("full"));
+    mockGateOnOperatorStop.mockResolvedValue({ kind: "stopped", runStatus: "stopped" });
+    mockRunTurnLoop.mockResolvedValue({
+      text: null, toolCallsMade: 12, pendingApprovals: [], stopReason: "timeout",
+    });
+
+    const result = await processAgentTurn("session-1", "go");
+
+    expect(mockEnqueueWake).not.toHaveBeenCalled();
+    expect(result.stopReason).toBe("timeout");
+    expect(result.text).toBe(TIMEOUT_REPLY);
+  });
+
+  it("a stall is never remapped - no_progress is not continued under any permission", async () => {
+    mockHydrate.mockResolvedValue(makeHydratedSession("full"));
+    mockRunTurnLoop.mockResolvedValue({
+      text: null, toolCallsMade: 0, pendingApprovals: [], stopReason: "no_progress",
+    });
+
+    const result = await processAgentTurn("session-1", "go");
+
+    expect(mockEnqueueWake).not.toHaveBeenCalled();
+    expect(result.stopReason).toBe("no_progress");
+    expect(result.text).toBe(NO_PROGRESS_REPLY);
+  });
+});
+
+// ── 6. M4: the tool-call repetition arm, beside the stall arm ──
+
+describe("tool_call_loop - the agent-session synthesis arm", () => {
+  it("synthesises the repetition reply and schedules NOTHING, even under full autonomy", async () => {
+    // The decisive property. Waking a session that just proved it repeats
+    // itself schedules the repetition; the reply must also be the repetition
+    // one, not the stall one - they describe opposite things about what ran.
+    mockHydrate.mockResolvedValue(makeHydratedSession("full"));
+    mockRunTurnLoop.mockResolvedValue({
+      text: null, toolCallsMade: 6, pendingApprovals: [], stopReason: "tool_call_loop",
+    });
+
+    const result = await processAgentTurn("session-1", "go");
+
+    expect(mockEnqueueWake).not.toHaveBeenCalled();
+    expect(result.stopReason).toBe("tool_call_loop");
+    expect(result.text).toBe(TOOL_CALL_LOOP_REPLY);
+    expect(result.text).not.toBe(NO_PROGRESS_REPLY);
+  });
+
+  it("preserves partial model text instead of overwriting it with the canned reply", async () => {
+    mockHydrate.mockResolvedValue(makeHydratedSession("full"));
+    mockRunTurnLoop.mockResolvedValue({
+      text: "Here is what I found before I got stuck.",
+      toolCallsMade: 6,
+      pendingApprovals: [],
+      stopReason: "tool_call_loop",
+    });
+
+    const result = await processAgentTurn("session-1", "go");
+
+    expect(result.text).toBe("Here is what I found before I got stuck.");
+    expect(mockAddMessage).not.toHaveBeenCalledWith(
+      "session-1",
+      expect.objectContaining({ content: TOOL_CALL_LOOP_REPLY }),
+      expect.anything(),
+    );
   });
 });

--- a/src/__tests__/vex-agent/engine/core/runner/mission-finalize-error-message-bound.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/mission-finalize-error-message-bound.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The persisted mission error text is BOUNDED, and the bound is REPORTED.
+ *
+ * A bare `slice` here would hand the operator and the support record a
+ * partial provider message that looks like the whole one. The contract is:
+ * under the limit the message is verbatim with no marker; over it, the
+ * stored text names the cut and the ORIGINAL length so the reader can tell
+ * exactly how much is missing.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  ERROR_MESSAGE_LIMIT,
+  boundErrorMessage,
+} from "../../../../../vex-agent/engine/core/runner/mission-finalize/error-pause.js";
+
+describe("boundErrorMessage", () => {
+  it("stores a short message verbatim and adds no truncation marker", () => {
+    const message = "upstream provider returned 502";
+    expect(boundErrorMessage(message)).toBe(message);
+    expect(boundErrorMessage(message)).not.toContain("truncated");
+  });
+
+  it("stores a message exactly at the limit verbatim", () => {
+    const message = "x".repeat(ERROR_MESSAGE_LIMIT);
+    expect(boundErrorMessage(message)).toBe(message);
+    expect(boundErrorMessage(message)).not.toContain("truncated");
+  });
+
+  it("keeps the first ERROR_MESSAGE_LIMIT characters when the message is longer", () => {
+    const original = "y".repeat(ERROR_MESSAGE_LIMIT + 1234);
+    const bounded = boundErrorMessage(original);
+    expect(bounded.startsWith(original.slice(0, ERROR_MESSAGE_LIMIT))).toBe(true);
+  });
+
+  it("names the cut and the original length instead of hiding the rest", () => {
+    const originalLength = ERROR_MESSAGE_LIMIT + 1234;
+    const bounded = boundErrorMessage("y".repeat(originalLength));
+    // The marker must state BOTH how much is shown and how much existed;
+    // a bare "..." would tell the reader nothing about what is missing.
+    expect(bounded).toContain(
+      `[truncated: first ${ERROR_MESSAGE_LIMIT} of ${originalLength} characters shown]`,
+    );
+    expect(bounded).not.toMatch(/\.\.\.$/);
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/runner/mission-finalize-tool-call-loop.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/mission-finalize-tool-call-loop.test.ts
@@ -18,6 +18,8 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { definedValue } from "../../../../_test-value-guards.js";
+
 const mockMissionRunsUpdateStatus = vi.fn();
 const mockMissionRunsUpdateStatusIfNotTerminal = vi.fn().mockResolvedValue(true);
 const mockMissionsSetStatus = vi.fn();
@@ -85,8 +87,10 @@ describe("finalizeMissionRunStatus - tool_call_loop", () => {
 
     expect(mockMissionRunsUpdateStatus).not.toHaveBeenCalled();
     expect(mockMissionRunsUpdateStatusIfNotTerminal).toHaveBeenCalledTimes(1);
-    const [runId, status, reason, payload] =
-      mockMissionRunsUpdateStatusIfNotTerminal.mock.calls[0]!;
+    const [runId, status, reason, payload] = definedValue(
+      mockMissionRunsUpdateStatusIfNotTerminal.mock.calls[0],
+      "updateStatusIfNotTerminal first call",
+    );
     expect(runId).toBe("run-1");
     expect(status).toBe("paused_error");
     expect(reason).toBe("tool_call_loop");
@@ -102,8 +106,10 @@ describe("finalizeMissionRunStatus - tool_call_loop", () => {
     // every pass, and it is why this cause is not one-click retryable.
     await finalizeMissionRunStatus("mission-1", "run-1", "session-1", "tool_call_loop");
 
-    const payload = mockMissionRunsUpdateStatusIfNotTerminal.mock
-      .calls[0]![3] as { summary: string };
+    const payload = definedValue(
+      mockMissionRunsUpdateStatusIfNotTerminal.mock.calls[0],
+      "updateStatusIfNotTerminal first call",
+    )[3] as { summary: string };
     expect(payload.summary).toContain("did execute");
     expect(payload.summary).toContain("review the transcript");
   });

--- a/src/__tests__/vex-agent/engine/core/runner/mission-finalize-tool-call-loop.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/mission-finalize-tool-call-loop.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Mission-finalize - the `tool_call_loop` park arm.
+ *
+ * Sibling of `mission-finalize-compact-unable.test.ts`, and it exists for the
+ * same failure: without a guarded arm, a new stop reason falls through
+ * `finalizeMissionRunStatus` to `return "running"` and the run row is left
+ * `running` with no wake and no lease - an orphan the operator can neither
+ * resume nor see a reason for. A stop reason and a finalize arm land together
+ * or the stop reason strands runs.
+ *
+ * The second thing pinned here is that the park write goes through the
+ * terminal-safe CAS with the operator-stop gate in the same transaction. This
+ * park reaches `paused_error` with NO wake, so it is the last iteration
+ * boundary the run will ever have: an unguarded write would move a run back out
+ * of a terminal state, and a `stop_terminal` still queued at this point would
+ * be stranded until the operator pressed Stop a second time.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockMissionRunsUpdateStatus = vi.fn();
+const mockMissionRunsUpdateStatusIfNotTerminal = vi.fn().mockResolvedValue(true);
+const mockMissionsSetStatus = vi.fn();
+const mockMissionsClearApprovedAt = vi.fn();
+const mockConsumeAbortIntent = vi.fn().mockReturnValue(null);
+const mockIsContinuableRuntimeStop = vi.fn().mockReturnValue(false);
+const mockGateOnOperatorStop = vi.fn().mockResolvedValue({ kind: "clear" });
+
+vi.mock("@vex-agent/engine/runtime/lease-and-status.js", () => ({
+  applyStopForEditTransaction: vi.fn(),
+  gateOnOperatorStopWithClient: (...a: unknown[]) => mockGateOnOperatorStop(...a),
+  withSessionControlLock: async <T>(
+    _sessionId: string,
+    fn: (client: unknown) => Promise<T>,
+  ): Promise<T> => fn({ client: true }),
+}));
+
+vi.mock("@vex-agent/db/repos/missions.js", () => ({
+  setStatus: (...a: unknown[]) => mockMissionsSetStatus(...a),
+  clearApprovedAt: (...a: unknown[]) => mockMissionsClearApprovedAt(...a),
+}));
+
+vi.mock("@vex-agent/db/repos/mission-runs.js", () => ({
+  updateStatus: (...a: unknown[]) => mockMissionRunsUpdateStatus(...a),
+  updateStatusIfNotTerminal: (...a: unknown[]) =>
+    mockMissionRunsUpdateStatusIfNotTerminal(...a),
+}));
+
+vi.mock("../../../../../vex-agent/engine/core/runner/abort.js", () => ({
+  consumeMissionRunAbortIntent: (...a: unknown[]) => mockConsumeAbortIntent(...a),
+}));
+
+vi.mock("../../../../../vex-agent/engine/core/runner/runtime-continuation.js", () => ({
+  isContinuableRuntimeStop: (...a: unknown[]) => mockIsContinuableRuntimeStop(...a),
+  scheduleRuntimeContinuation: vi.fn(),
+}));
+
+import { finalizeMissionRunStatus } from "../../../../../vex-agent/engine/core/runner/mission-finalize.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsContinuableRuntimeStop.mockReturnValue(false);
+  mockConsumeAbortIntent.mockReturnValue(null);
+  mockMissionRunsUpdateStatusIfNotTerminal.mockResolvedValue(true);
+  mockGateOnOperatorStop.mockResolvedValue({ kind: "clear" });
+});
+
+describe("finalizeMissionRunStatus - tool_call_loop", () => {
+  it("parks the run as paused_error with the cause, and never strands it as running", async () => {
+    const result = await finalizeMissionRunStatus(
+      "mission-1",
+      "run-1",
+      "session-1",
+      "tool_call_loop",
+      {
+        summary: "repeated swap_quote",
+        evidence: { toolName: "swap_quote", cycleLength: 1, repeatCount: 5 },
+      },
+    );
+
+    // The parent mission row stays `running` so the active-run lookup still
+    // surfaces it for /retry, exactly like every other error pause.
+    expect(result).toBe("running");
+    expect(mockMissionsSetStatus).not.toHaveBeenCalled();
+
+    expect(mockMissionRunsUpdateStatus).not.toHaveBeenCalled();
+    expect(mockMissionRunsUpdateStatusIfNotTerminal).toHaveBeenCalledTimes(1);
+    const [runId, status, reason, payload] =
+      mockMissionRunsUpdateStatusIfNotTerminal.mock.calls[0]!;
+    expect(runId).toBe("run-1");
+    expect(status).toBe("paused_error");
+    expect(reason).toBe("tool_call_loop");
+    expect(payload).toMatchObject({
+      summary: "repeated swap_quote",
+      evidence: { toolName: "swap_quote", cycleLength: 1, repeatCount: 5 },
+    });
+  });
+
+  it("falls back to copy that does NOT claim the run was inert", async () => {
+    // The repeated calls DID execute, up to the correction. Copy implying an
+    // untouched run would be false about a run that may have moved funds on
+    // every pass, and it is why this cause is not one-click retryable.
+    await finalizeMissionRunStatus("mission-1", "run-1", "session-1", "tool_call_loop");
+
+    const payload = mockMissionRunsUpdateStatusIfNotTerminal.mock
+      .calls[0]![3] as { summary: string };
+    expect(payload.summary).toContain("did execute");
+    expect(payload.summary).toContain("review the transcript");
+  });
+
+  it("consumes the operator-stop gate in the same transaction as the park", async () => {
+    await finalizeMissionRunStatus("mission-1", "run-1", "session-1", "tool_call_loop");
+
+    expect(mockGateOnOperatorStop).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ sessionId: "session-1", missionRunId: "run-1" }),
+    );
+  });
+
+  it("writes NOTHING when an operator Stop won the race", async () => {
+    mockGateOnOperatorStop.mockResolvedValue({ kind: "stopped", runStatus: "stopped" });
+
+    const result = await finalizeMissionRunStatus(
+      "mission-1", "run-1", "session-1", "tool_call_loop",
+    );
+
+    expect(mockMissionRunsUpdateStatusIfNotTerminal).not.toHaveBeenCalled();
+    expect(result).toBe("running");
+  });
+
+  it("does not re-open a run that reached a terminal status first", async () => {
+    // A terminal run row is immutable audit history; the CAS refuses and the
+    // arm reports what it did to the mission row, which is nothing.
+    mockMissionRunsUpdateStatusIfNotTerminal.mockResolvedValue(false);
+
+    const result = await finalizeMissionRunStatus(
+      "mission-1", "run-1", "session-1", "tool_call_loop",
+    );
+
+    expect(result).toBe("running");
+    expect(mockMissionsSetStatus).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/runner/tool-call-loop-detector.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/tool-call-loop-detector.test.ts
@@ -109,16 +109,37 @@ describe("the signature", () => {
   });
 
   /**
-   * What the NUL separator buys. Without a separator that cannot occur in the
-   * canonical form, a tool named "ab" whose output is "c" and one named "a"
-   * whose output is "bc" would hash identically, and the detector would count
-   * two unrelated calls as a repeat - which, five times over, stops a run.
+   * What the NUL separator actually buys, with a pair that genuinely collides
+   * without it.
+   *
+   * The fields are name, canonical args, the success flag, then output. A
+   * NUMERIC argument canonicalises to bare digits, so a character can be moved
+   * across the name/args boundary with nothing else changing:
+   *
+   *     "a"  + "12" + "ok" + "x"   ->  a12okx
+   *     "a1" + "2"  + "ok" + "x"   ->  a12okx
+   *
+   * Concatenated with no delimiter these are byte-identical, so an unseparated
+   * signature would treat two unrelated calls as the same call - and five of
+   * those STOP A RUN. The NUL cannot occur in either the JSON-encoded canonical
+   * form or a bare number, so it is the thing that keeps them apart.
+   *
+   * (An earlier version of this test used "ab"+"c" against "a"+"bc", which
+   * proved nothing: the args and the flag sit between name and output, so
+   * those two differ with or without a separator.)
    */
-  it("cannot be made to collide by shifting a field boundary", () => {
-    expect(
-      toolCallSignature(call({ toolName: "ab", args: {}, output: "c" })),
-    ).not.toBe(
-      toolCallSignature(call({ toolName: "a", args: {}, output: "bc" })),
+  it("would collide across a field boundary if the separator were removed", () => {
+    const shiftedLeft = call({ toolName: "a", args: 12, success: true, output: "x" });
+    const shiftedRight = call({ toolName: "a1", args: 2, success: true, output: "x" });
+
+    // The precondition this test rests on: identical once concatenated.
+    const concatenated = (o: CompletedToolCallObservation) =>
+      `${o.toolName}${canonicalize(o.args)}${o.success ? "ok" : "err"}${o.output}`;
+    expect(concatenated(shiftedLeft)).toBe(concatenated(shiftedRight));
+
+    // And distinct once the separator is in place.
+    expect(toolCallSignature(shiftedLeft)).not.toBe(
+      toolCallSignature(shiftedRight),
     );
   });
 });

--- a/src/__tests__/vex-agent/engine/core/runner/tool-call-loop-detector.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/tool-call-loop-detector.test.ts
@@ -1,0 +1,225 @@
+/**
+ * The tool-call repetition detector, as a pure decision.
+ *
+ * The module imports nothing, so these are table tests over the real thing -
+ * no mocks, no harness, and every assertion is about the contract the batch
+ * orchestrator relies on: WHEN it fires, WHEN it must not, and WHAT it is
+ * allowed to say about what it saw.
+ *
+ * The negative cases carry as much weight as the positive ones. A detector
+ * that fires on correct polling would end honest autonomous work mid-flight,
+ * which is a strictly worse failure than the loop it exists to catch.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_TOOL_CALL_CYCLE_LENGTH,
+  TOOL_CALL_LOOP_THRESHOLD,
+  TOOL_CALL_SIGNATURE_HISTORY_LIMIT,
+  canonicalize,
+  createToolCallLoopDetector,
+  toolCallSignature,
+  type CompletedToolCallObservation,
+  type ToolCallLoopVerdict,
+} from "@vex-agent/engine/core/runner/tool-call-loop-detector.js";
+
+let nextId = 0;
+
+function call(
+  overrides: Partial<CompletedToolCallObservation> = {},
+): CompletedToolCallObservation {
+  nextId += 1;
+  return {
+    toolCallId: `call-${nextId}`,
+    toolName: "wallet_balance",
+    args: { address: "So1111" },
+    output: "balance: 0",
+    success: true,
+    ...overrides,
+  };
+}
+
+/** Verdict kinds produced by feeding `observations` to one fresh detector. */
+function verdicts(
+  observations: readonly CompletedToolCallObservation[],
+): ToolCallLoopVerdict["kind"][] {
+  const detector = createToolCallLoopDetector();
+  return observations.map((o) => detector.observe(o).kind);
+}
+
+describe("the bound is what the module documents", () => {
+  it("threshold 5, cycles up to 5, history exactly what the longest needs", () => {
+    expect(TOOL_CALL_LOOP_THRESHOLD).toBe(5);
+    expect(MAX_TOOL_CALL_CYCLE_LENGTH).toBe(5);
+    expect(TOOL_CALL_SIGNATURE_HISTORY_LIMIT).toBe(25);
+  });
+});
+
+describe("the signature", () => {
+  it("ignores argument key ORDER - the same call written two ways is one call", () => {
+    expect(canonicalize({ a: 1, b: 2 })).toBe(canonicalize({ b: 2, a: 1 }));
+  });
+
+  it("keeps array order - a reordered list is a different request", () => {
+    expect(canonicalize([1, 2])).not.toBe(canonicalize([2, 1]));
+  });
+
+  it("terminates on a cyclic argument object instead of throwing into the batch", () => {
+    const cyclic: Record<string, unknown> = { name: "x" };
+    cyclic["self"] = cyclic;
+    expect(() => canonicalize(cyclic)).not.toThrow();
+  });
+
+  it("excludes the call id and the duration, which differ on every call", () => {
+    // Two observations that differ ONLY in their call id must collide, or the
+    // detector could never see a repeat at all.
+    expect(toolCallSignature(call({ toolCallId: "a" })))
+      .toBe(toolCallSignature(call({ toolCallId: "b" })));
+  });
+
+  it("separates a success from a failure carrying the same output", () => {
+    expect(toolCallSignature(call({ success: true, output: "no route" })))
+      .not.toBe(toolCallSignature(call({ success: false, output: "no route" })));
+  });
+});
+
+describe("what triggers", () => {
+  it("corrects on the FIFTH identical call, and not before", () => {
+    expect(verdicts(Array.from({ length: 5 }, () => call()))).toEqual([
+      "clear", "clear", "clear", "clear", "correct",
+    ]);
+  });
+
+  it("stops on the SIXTH - the repeat that survived the correction", () => {
+    expect(verdicts(Array.from({ length: 6 }, () => call()))).toEqual([
+      "clear", "clear", "clear", "clear", "correct", "stop",
+    ]);
+  });
+
+  it("detects an A-B-A-B cycle at its fifth full pass, k = 2", () => {
+    const observations = Array.from({ length: 10 }, (_, i) =>
+      i % 2 === 0
+        ? call({ toolName: "quote", output: "no route" })
+        : call({ toolName: "retry_quote", output: "unchanged" }));
+    const detector = createToolCallLoopDetector();
+    const results = observations.map((o) => detector.observe(o));
+
+    expect(results.slice(0, 9).map((r) => r.kind)).toEqual(Array(9).fill("clear"));
+    const last = results[9];
+    expect(last?.kind).toBe("correct");
+    if (last?.kind !== "correct") throw new Error("expected a correction");
+    expect(last.facts.cycleLength).toBe(2);
+    // The cycle's HEAD, so an operator reading the log can find it in the tape.
+    expect(last.facts.toolName).toBe("quote");
+    expect(last.facts.toolCallIds).toHaveLength(10);
+  });
+});
+
+describe("what must NOT trigger", () => {
+  /**
+   * The single most important negative case. A model polling a pending
+   * transaction emits byte-identical name and arguments every time and is
+   * behaving CORRECTLY. Only the answer moving distinguishes it from the
+   * incident, which is exactly why the result is in the signature.
+   */
+  it("identical polling with a CHANGING result never triggers, at any length", () => {
+    const polls = Array.from({ length: 40 }, (_, i) =>
+      call({ toolName: "tx_status", args: { sig: "abc" }, output: `confirmations: ${i}` }));
+    expect(verdicts(polls).every((k) => k === "clear")).toBe(true);
+  });
+
+  it("five DISTINCT calls never trigger", () => {
+    const distinct = Array.from({ length: 5 }, (_, i) =>
+      call({ toolName: `tool_${i}`, args: { i }, output: `out_${i}` }));
+    expect(verdicts(distinct)).toEqual(Array(5).fill("clear"));
+  });
+
+  it("a single different call breaks a run of four and resets the window", () => {
+    const detector = createToolCallLoopDetector();
+    for (let i = 0; i < 4; i++) expect(detector.observe(call()).kind).toBe("clear");
+    expect(detector.observe(call({ toolName: "other", output: "different" })).kind)
+      .toBe("clear");
+    // Four more identical calls: the tail is now [same, same, same, same]
+    // preceded by the interloper, so no window of five matches.
+    for (let i = 0; i < 4; i++) expect(detector.observe(call()).kind).toBe("clear");
+  });
+
+  it("a cycle longer than the maximum is not treated as a loop", () => {
+    // Six distinct calls repeated five times: 30 observations, no k in [1,5].
+    const detector = createToolCallLoopDetector();
+    const kinds: string[] = [];
+    for (let pass = 0; pass < 5; pass++) {
+      for (let i = 0; i < 6; i++) {
+        kinds.push(detector.observe(
+          call({ toolName: `t${i}`, args: { i }, output: `o${i}` }),
+        ).kind);
+      }
+    }
+    expect(kinds.every((k) => k === "clear")).toBe(true);
+  });
+});
+
+describe("what it reports", () => {
+  it("names the shape of the repetition and NEVER the arguments", () => {
+    const detector = createToolCallLoopDetector();
+    const secret = { destination: "attacker-wallet", amountLamports: "999999" };
+    let facts: Record<string, unknown> | null = null;
+    for (let i = 0; i < 5; i++) {
+      const verdict = detector.observe(call({
+        toolName: "wallet_send",
+        args: secret,
+        output: "insufficient funds for attacker-wallet",
+      }));
+      if (verdict.kind === "correct") facts = { ...verdict.facts };
+    }
+    expect(facts).not.toBeNull();
+    expect(facts).toMatchObject({
+      toolName: "wallet_send",
+      cycleLength: 1,
+      repeatCount: 5,
+      strike: 1,
+    });
+    // The privacy property, asserted on the serialized facts so a future field
+    // cannot smuggle arguments back in.
+    const serialized = JSON.stringify(facts);
+    expect(serialized).not.toContain("attacker-wallet");
+    expect(serialized).not.toContain("999999");
+    expect(serialized).not.toContain("insufficient funds");
+  });
+
+  it("numbers the strikes, so the consumer can tell correct from stop", () => {
+    const detector = createToolCallLoopDetector();
+    const seen: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const verdict = detector.observe(call());
+      if (verdict.kind !== "clear") seen.push(verdict.facts.strike);
+    }
+    expect(seen).toEqual([1, 2]);
+  });
+});
+
+describe("boundedness", () => {
+  /**
+   * The history is a ring, and the three parallel arrays are shifted together.
+   * If they ever drifted, the reported call ids would name calls that are not
+   * the repeated ones - a fact that reads as evidence and would be wrong.
+   */
+  it("keeps a bounded history and still reports call ids from the real cycle", () => {
+    const detector = createToolCallLoopDetector();
+    // 60 distinct calls, far past the 25-entry bound, then five identical ones.
+    for (let i = 0; i < 60; i++) {
+      detector.observe(call({ toolName: `pad_${i}`, args: { i }, output: `p${i}` }));
+    }
+    const ids: string[] = [];
+    let verdict: ToolCallLoopVerdict = { kind: "clear" };
+    for (let i = 0; i < 5; i++) {
+      const observation = call({ toolName: "looped", output: "same" });
+      ids.push(observation.toolCallId);
+      verdict = detector.observe(observation);
+    }
+    expect(verdict.kind).toBe("correct");
+    if (verdict.kind === "clear") throw new Error("expected a correction");
+    expect(verdict.facts.toolCallIds).toEqual(ids);
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/runner/tool-call-loop-detector.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/tool-call-loop-detector.test.ts
@@ -82,6 +82,45 @@ describe("the signature", () => {
     expect(toolCallSignature(call({ success: true, output: "no route" })))
       .not.toBe(toolCallSignature(call({ success: false, output: "no route" })));
   });
+
+  /**
+   * The signature is a DIGEST, and the reason is retention: arguments and
+   * model-visible output are where addresses, amounts and user content live,
+   * and the history holds a turn's worth of them in memory for the life of the
+   * turn. A signature that still contained them would be a copy of that
+   * content under another name.
+   */
+  it("is a sha256 digest that retains none of what it hashes", () => {
+    const signature = toolCallSignature(
+      call({
+        args: { to: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", amount: "125" },
+        output: "sent to 0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      }),
+    );
+    expect(signature).toMatch(/^[0-9a-f]{64}$/);
+    expect(signature).not.toContain("0xdeadbeef");
+    expect(signature).not.toContain("125");
+  });
+
+  it("is stable for the same call and different for a changed argument", () => {
+    const a = toolCallSignature(call({ args: { page: 1 } }));
+    expect(toolCallSignature(call({ args: { page: 1 } }))).toBe(a);
+    expect(toolCallSignature(call({ args: { page: 2 } }))).not.toBe(a);
+  });
+
+  /**
+   * What the NUL separator buys. Without a separator that cannot occur in the
+   * canonical form, a tool named "ab" whose output is "c" and one named "a"
+   * whose output is "bc" would hash identically, and the detector would count
+   * two unrelated calls as a repeat - which, five times over, stops a run.
+   */
+  it("cannot be made to collide by shifting a field boundary", () => {
+    expect(
+      toolCallSignature(call({ toolName: "ab", args: {}, output: "c" })),
+    ).not.toBe(
+      toolCallSignature(call({ toolName: "a", args: {}, output: "bc" })),
+    );
+  });
 });
 
 describe("what triggers", () => {

--- a/src/__tests__/vex-agent/engine/core/runner/turn-wall-clock-invariant.test.ts
+++ b/src/__tests__/vex-agent/engine/core/runner/turn-wall-clock-invariant.test.ts
@@ -1,0 +1,41 @@
+/**
+ * M1 - the turn wall clock is never below 30 minutes (owner decision
+ * 2026-08-28).
+ *
+ * A floor, not an equality, because the owner's instruction is a floor: raising
+ * it later is allowed, lowering it is the regression. Ten minutes was ending
+ * productive autonomous turns mid-flight, and every recovery from that costs a
+ * fresh full-context continuation.
+ *
+ * `TIMEOUT_REPLY` derives its duration from the same constant on purpose, so
+ * the sentence the user reads cannot drift away from the bound that produced
+ * it. That derivation is asserted here rather than trusted.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_LOOP_CONFIG,
+  TIMEOUT_REPLY,
+} from "@vex-agent/engine/core/runner/shared.js";
+
+const THIRTY_MINUTES_MS = 1_800_000;
+
+describe("turn wall clock", () => {
+  it("is at least 30 minutes", () => {
+    expect(DEFAULT_LOOP_CONFIG.timeoutMs).toBeGreaterThanOrEqual(THIRTY_MINUTES_MS);
+  });
+
+  it("the timeout reply states the real bound, derived not written", () => {
+    const minutes = Math.round(DEFAULT_LOOP_CONFIG.timeoutMs / 60_000);
+    expect(TIMEOUT_REPLY).toContain(`${minutes}-minute`);
+    expect(minutes).toBeGreaterThanOrEqual(30);
+  });
+
+  it("mission setup inherits it through the spread, and is not capped lower", () => {
+    // Setup overrides `maxIterations` only. If it ever grows a `timeoutMs` of
+    // its own, this test is where that decision has to be made explicitly.
+    const setupConfig = { ...DEFAULT_LOOP_CONFIG, maxIterations: 25 };
+    expect(setupConfig.timeoutMs).toBeGreaterThanOrEqual(THIRTY_MINUTES_MS);
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/turn-loop-tool-batch-loop-detection.test.ts
+++ b/src/__tests__/vex-agent/engine/core/turn-loop-tool-batch-loop-detection.test.ts
@@ -23,8 +23,22 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { definedValue } from "../../../_test-value-guards.js";
+
+/**
+ * The single argument `persistBatchTranscript` receives, narrowed to the two
+ * fields these tests read. Declaring it on the MOCK is what lets `mock.calls`
+ * carry a real type, so the accessor below needs no cast to reach them.
+ */
+interface PersistedBatchArg {
+  readonly executedCalls: ReadonlyArray<{ readonly id: string }>;
+  readonly executedResults: ReadonlyArray<{ readonly output: string }>;
+}
+
 const dispatchTool = vi.fn();
-const persistBatchTranscript = vi.fn().mockResolvedValue(undefined);
+const persistBatchTranscript = vi
+  .fn<(batch: PersistedBatchArg, ...rest: unknown[]) => Promise<void>>()
+  .mockResolvedValue(undefined);
 const appendEngineMessage = vi.fn().mockResolvedValue({ id: 1, role: "system" });
 const enqueueApprovalIntent = vi.fn();
 const parkTurnOnUserForm = vi.fn();
@@ -54,7 +68,9 @@ vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/results.js", async (
   importOriginal,
 ) => ({
   ...(await importOriginal<Record<string, unknown>>()),
-  persistBatchTranscript: (...args: unknown[]) => persistBatchTranscript(...args),
+  persistBatchTranscript: (
+    ...args: Parameters<typeof persistBatchTranscript>
+  ) => persistBatchTranscript(...args),
 }));
 
 const { processTurnToolBatch } = await import(
@@ -76,18 +92,25 @@ const { TOOL_CALL_LOOP_CORRECTION_MESSAGE_TYPE } = await import(
 
 import type { Message } from "@vex-agent/db/repos/messages.js";
 import type { ToolCallLoopDetector } from "@vex-agent/engine/core/runner/tool-call-loop-detector.js";
+import type { EngineContext } from "@vex-agent/engine/types/engine-context.js";
 
-function context() {
+/**
+ * A REAL `EngineContext`, not a cast bag. The cast hid which fields the batch
+ * orchestrator actually requires, so a context that drifted out of shape would
+ * have kept type-checking here and failed only at runtime.
+ */
+function context(): EngineContext {
   return {
     sessionId: "session-1",
     sessionKind: "mission",
     sessionPermission: "full",
     missionId: "mission-1",
     missionRunId: "run-1",
-    loadedDocuments: new Map(),
+    selectedEvmWallet: null,
+    selectedSolanaWallet: null,
+    loadedDocuments: new Map<string, string>(),
     walletPolicy: { kind: "none" },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any;
+  };
 }
 
 /** N copies of the SAME call - same name, same arguments, distinct ids. */
@@ -117,13 +140,12 @@ async function runBatch(args: {
   });
 }
 
-function persisted(callIndex = 0): {
-  executedCalls: Array<{ id: string }>;
-  executedResults: Array<{ output: string }>;
-} {
-  const call = persistBatchTranscript.mock.calls[callIndex];
-  if (call === undefined) throw new Error("persistBatchTranscript not called");
-  return call[0] as never;
+/** The batch argument of the `callIndex`-th persist call, typed by the mock. */
+function persisted(callIndex = 0): PersistedBatchArg {
+  return definedValue(
+    persistBatchTranscript.mock.calls[callIndex],
+    `persistBatchTranscript call ${callIndex}`,
+  )[0];
 }
 
 beforeEach(() => {
@@ -191,8 +213,12 @@ describe("strike one - seven identical calls in ONE batch", () => {
     expect(live?.content).toBe(cue);
 
     // Ordering: the cue is written after the batch transcript, never before.
-    expect(persistBatchTranscript.mock.invocationCallOrder[0])
-      .toBeLessThan(appendEngineMessage.mock.invocationCallOrder[0]!);
+    expect(persistBatchTranscript.mock.invocationCallOrder[0]).toBeLessThan(
+      definedValue(
+        appendEngineMessage.mock.invocationCallOrder[0],
+        "appendEngineMessage first invocation order",
+      ),
+    );
   });
 });
 

--- a/src/__tests__/vex-agent/engine/core/turn-loop-tool-batch-loop-detection.test.ts
+++ b/src/__tests__/vex-agent/engine/core/turn-loop-tool-batch-loop-detection.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tool-call repetition detection INSIDE a tool batch - the six-step ordering.
+ *
+ * The detector itself is proved as a pure decision in
+ * `runner/tool-call-loop-detector.test.ts`. What is pinned HERE is everything
+ * the batch orchestrator owns and the detector cannot know:
+ *
+ *   1. the result exists only post-dispatch, so the observation happens after
+ *      `dispatchTool` returns and after `resolvePreparedActionFollowUp`;
+ *   2. operator Stop still outranks detection;
+ *   3. approval, user-form, prepared-action and engine-signal outcomes keep
+ *      their stronger semantics and are NOT detector inputs;
+ *   4. the completed result feeds the history;
+ *   5. STRIKE 1 drains the rest of the emitted batch through the EXISTING
+ *      drain mechanism, keeps the pairing balanced, and makes the corrective
+ *      cue visible to the model before any further real call executes;
+ *   6. STRIKE 2 drains the remainder and returns `tool_call_loop`.
+ *
+ * Only the DB writes are stubbed. The real drain constants, the real
+ * `mapBatchOutcome`, the real detector and the real cue text stay in play, so
+ * these assert production behaviour rather than a re-implementation of it.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dispatchTool = vi.fn();
+const persistBatchTranscript = vi.fn().mockResolvedValue(undefined);
+const appendEngineMessage = vi.fn().mockResolvedValue({ id: 1, role: "system" });
+const enqueueApprovalIntent = vi.fn();
+const parkTurnOnUserForm = vi.fn();
+
+vi.mock("@vex-agent/tools/dispatcher.js", () => ({
+  dispatchTool: (...args: unknown[]) => dispatchTool(...args),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/execute.js", () => ({
+  buildToolContext: (context: Record<string, unknown>) => ({
+    ...context,
+    approved: false,
+    contextUsageBand: "normal",
+  }),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/approval-stop.js", () => ({
+  assertApprovalActionKind: () => "read",
+  enqueueApprovalIntent: (...args: unknown[]) => enqueueApprovalIntent(...args),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/user-form-stop.js", () => ({
+  parkTurnOnUserForm: (...args: unknown[]) => parkTurnOnUserForm(...args),
+}));
+vi.mock("@vex-agent/engine/events/index.js", () => ({
+  appendEngineMessage: (...args: unknown[]) => appendEngineMessage(...args),
+  appendMessage: vi.fn().mockResolvedValue({ id: 1, role: "system" }),
+}));
+vi.mock("@vex-agent/engine/core/turn-loop-tool-batch/results.js", async (
+  importOriginal,
+) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  persistBatchTranscript: (...args: unknown[]) => persistBatchTranscript(...args),
+}));
+
+const { processTurnToolBatch } = await import(
+  "../../../../vex-agent/engine/core/turn-loop-tool-batch.js"
+);
+const {
+  BATCH_ABORTED_BY_LOOP_CORRECTION_OUTPUT,
+  BATCH_ABORTED_BY_TOOL_CALL_LOOP_OUTPUT,
+  BATCH_ABORTED_BY_USER_STOP_OUTPUT,
+} = await import(
+  "../../../../vex-agent/engine/core/turn-loop-tool-batch/results.js"
+);
+const { createToolCallLoopDetector } = await import(
+  "../../../../vex-agent/engine/core/runner/tool-call-loop-detector.js"
+);
+const { TOOL_CALL_LOOP_CORRECTION_MESSAGE_TYPE } = await import(
+  "../../../../vex-agent/engine/core/turn-loop-tool-batch/loop-correction-emit.js"
+);
+
+import type { Message } from "@vex-agent/db/repos/messages.js";
+import type { ToolCallLoopDetector } from "@vex-agent/engine/core/runner/tool-call-loop-detector.js";
+
+function context() {
+  return {
+    sessionId: "session-1",
+    sessionKind: "mission",
+    sessionPermission: "full",
+    missionId: "mission-1",
+    missionRunId: "run-1",
+    loadedDocuments: new Map(),
+    walletPolicy: { kind: "none" },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+/** N copies of the SAME call - same name, same arguments, distinct ids. */
+function identicalCalls(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `call-${i}`,
+    name: "swap_quote",
+    arguments: { inputMint: "SOL", outputMint: "USDC" },
+  }));
+}
+
+async function runBatch(args: {
+  readonly calls: ReturnType<typeof identicalCalls>;
+  readonly detector: ToolCallLoopDetector;
+  readonly liveMessages?: Message[];
+  readonly abortSignal?: AbortSignal;
+}) {
+  return processTurnToolBatch({
+    context: context(),
+    turnResult: { content: null, reasoning: null, toolCalls: args.calls },
+    liveMessages: args.liveMessages ?? [],
+    currentTokenCount: 0,
+    contextLimit: 100_000,
+    lastTextSoFar: null,
+    loopDetector: args.detector,
+    ...(args.abortSignal !== undefined ? { abortSignal: args.abortSignal } : {}),
+  });
+}
+
+function persisted(callIndex = 0): {
+  executedCalls: Array<{ id: string }>;
+  executedResults: Array<{ output: string }>;
+} {
+  const call = persistBatchTranscript.mock.calls[callIndex];
+  if (call === undefined) throw new Error("persistBatchTranscript not called");
+  return call[0] as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  persistBatchTranscript.mockResolvedValue(undefined);
+  appendEngineMessage.mockResolvedValue({ id: 1, role: "system" });
+  // The incident's shape: the call succeeds and returns the SAME thing forever.
+  dispatchTool.mockResolvedValue({ success: true, output: "no route found" });
+});
+
+describe("strike one - seven identical calls in ONE batch", () => {
+  it("dispatches exactly five, drains the remainder, keeps the pairing balanced", async () => {
+    const outcome = await runBatch({
+      calls: identicalCalls(7),
+      detector: createToolCallLoopDetector(),
+    });
+
+    // Five real dispatches: the fifth is the one that trips the detector, and
+    // it had to RUN for its result to exist.
+    expect(dispatchTool).toHaveBeenCalledTimes(5);
+    expect(outcome.toolCallsExecuted).toBe(5);
+
+    const { executedCalls, executedResults } = persisted();
+    // The persisted assistant message still carries the FULL emitted batch.
+    expect(executedCalls).toHaveLength(7);
+    expect(executedResults).toHaveLength(7);
+    expect(executedResults.slice(5).map((r) => r.output)).toEqual([
+      BATCH_ABORTED_BY_LOOP_CORRECTION_OUTPUT,
+      BATCH_ABORTED_BY_LOOP_CORRECTION_OUTPUT,
+    ]);
+  });
+
+  it("does NOT end the turn - the slice continues so the model can act on the cue", async () => {
+    const outcome = await runBatch({
+      calls: identicalCalls(7),
+      detector: createToolCallLoopDetector(),
+    });
+    expect(outcome.kind).toBe("normal_complete");
+  });
+
+  it("makes the correction visible to the model, AFTER the tool results", async () => {
+    const liveMessages: Message[] = [];
+    await runBatch({
+      calls: identicalCalls(7),
+      detector: createToolCallLoopDetector(),
+      liveMessages,
+    });
+
+    // Durable: the model-visible cue is reconstructable from history (rule 09).
+    expect(appendEngineMessage).toHaveBeenCalledTimes(1);
+    const [, cue, metadata] = appendEngineMessage.mock.calls[0] as [
+      string, string, { messageType: string; visibility: string; payload: Record<string, unknown> },
+    ];
+    expect(metadata.messageType).toBe(TOOL_CALL_LOOP_CORRECTION_MESSAGE_TYPE);
+    expect(cue).toContain("tool_call_loop_correction");
+    expect(cue).toContain("swap_quote");
+    // The structured facts ride the row and carry no arguments.
+    expect(metadata.payload).toMatchObject({ cycleLength: 1, repeatCount: 5, strike: 1 });
+    expect(JSON.stringify(metadata.payload)).not.toContain("USDC");
+
+    // Live: the CURRENT turn's next round must read it, or the correction
+    // exists only for a turn that already ended.
+    const live = liveMessages.at(-1);
+    expect(live?.role).toBe("system");
+    expect(live?.content).toBe(cue);
+
+    // Ordering: the cue is written after the batch transcript, never before.
+    expect(persistBatchTranscript.mock.invocationCallOrder[0])
+      .toBeLessThan(appendEngineMessage.mock.invocationCallOrder[0]!);
+  });
+});
+
+describe("strike two - the sixth identical call, on the next turn", () => {
+  it("executes, then ends the turn with tool_call_loop and evidence", async () => {
+    const detector = createToolCallLoopDetector();
+    // Turn 1: five identical calls trip the correction.
+    await runBatch({ calls: identicalCalls(5), detector });
+    expect(dispatchTool).toHaveBeenCalledTimes(5);
+
+    // Turn 2: the model repeats itself anyway. A fresh batch, the SAME
+    // turn-scoped detector - which is the whole reason it is threaded from
+    // `runTurnLoop` rather than created per batch.
+    vi.clearAllMocks();
+    dispatchTool.mockResolvedValue({ success: true, output: "no route found" });
+    const outcome = await runBatch({
+      calls: [
+        { id: "call-6", name: "swap_quote", arguments: { inputMint: "SOL", outputMint: "USDC" } },
+        { id: "call-7", name: "other_tool", arguments: {} },
+      ],
+      detector,
+    });
+
+    // The repeat still RAN: it had to, for its result to be observable.
+    expect(dispatchTool).toHaveBeenCalledTimes(1);
+    expect(outcome.kind).toBe("engine_stop");
+    if (outcome.kind !== "engine_stop") throw new Error("expected engine_stop");
+    expect(outcome.stopReason).toBe("tool_call_loop");
+    expect(outcome.stopPayload?.evidence).toMatchObject({
+      toolName: "swap_quote",
+      cycleLength: 1,
+      repeatCount: 5,
+    });
+    // Durable evidence never carries arguments (inference-sensitive).
+    expect(JSON.stringify(outcome.stopPayload)).not.toContain("USDC");
+
+    const { executedResults } = persisted();
+    expect(executedResults).toHaveLength(2);
+    expect(executedResults[1]?.output).toBe(BATCH_ABORTED_BY_TOOL_CALL_LOOP_OUTPUT);
+    // No second correction: the cue is spent.
+    expect(appendEngineMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("precedence - what outranks detection and what is never observed", () => {
+  it("an operator Stop mid-batch wins: no detection, no correction", async () => {
+    const controller = new AbortController();
+    const detector = createToolCallLoopDetector();
+    // Four identical calls land first, so the fifth would trip the detector -
+    // except the Stop is checked at the top of its iteration.
+    dispatchTool.mockImplementation(async () => {
+      if (dispatchTool.mock.calls.length >= 4) controller.abort();
+      return { success: true, output: "no route found" };
+    });
+
+    const outcome = await runBatch({
+      calls: identicalCalls(7),
+      detector,
+      abortSignal: controller.signal,
+    });
+
+    expect(outcome.kind).toBe("engine_stop");
+    if (outcome.kind !== "engine_stop") throw new Error("expected engine_stop");
+    expect(outcome.stopReason).toBe("user_stopped");
+    expect(appendEngineMessage).not.toHaveBeenCalled();
+    expect(persisted().executedResults.at(-1)?.output)
+      .toBe(BATCH_ABORTED_BY_USER_STOP_OUTPUT);
+  });
+
+  it("approval breaks are never detector inputs - five identical approvals do not loop", async () => {
+    enqueueApprovalIntent.mockResolvedValue({ kind: "enqueued", approvalId: "appr-1" });
+    dispatchTool.mockResolvedValue({
+      success: false,
+      output: "approval required",
+      pendingApproval: { actionKind: "read" },
+    });
+
+    const detector = createToolCallLoopDetector();
+    for (let turn = 0; turn < 5; turn++) {
+      const outcome = await runBatch({ calls: identicalCalls(1), detector });
+      expect(outcome.kind).toBe("approval_break");
+    }
+    expect(appendEngineMessage).not.toHaveBeenCalled();
+  });
+
+  it("user-form parks are never detector inputs", async () => {
+    parkTurnOnUserForm.mockResolvedValue({ kind: "parked" });
+    dispatchTool.mockResolvedValue({
+      success: true,
+      output: "form drafted",
+      pendingUserForm: { intentId: "intent-1" },
+    });
+
+    const detector = createToolCallLoopDetector();
+    for (let turn = 0; turn < 5; turn++) {
+      const outcome = await runBatch({ calls: identicalCalls(1), detector });
+      expect(outcome.kind).toBe("user_form_pause");
+    }
+    expect(appendEngineMessage).not.toHaveBeenCalled();
+  });
+
+  it("engine signals are never detector inputs - five identical defers do not loop", async () => {
+    dispatchTool.mockResolvedValue({
+      success: true,
+      output: "deferred",
+      engineSignal: { type: "defer_until", summary: "later", reason: "waiting", dueAt: null },
+    });
+
+    const detector = createToolCallLoopDetector();
+    for (let turn = 0; turn < 5; turn++) {
+      const outcome = await runBatch({ calls: identicalCalls(1), detector });
+      expect(outcome.kind).toBe("waiting_for_wake");
+    }
+    expect(appendEngineMessage).not.toHaveBeenCalled();
+  });
+
+  it("a batch run WITHOUT a detector behaves exactly as before", async () => {
+    // The parameter is optional, so every pre-existing call site and test is
+    // unaffected: no observation, no correction, no stop.
+    const outcome = await processTurnToolBatch({
+      context: context(),
+      turnResult: { content: null, reasoning: null, toolCalls: identicalCalls(7) },
+      liveMessages: [],
+      currentTokenCount: 0,
+      contextLimit: 100_000,
+      lastTextSoFar: null,
+    });
+    expect(outcome.kind).toBe("normal_complete");
+    expect(dispatchTool).toHaveBeenCalledTimes(7);
+    expect(appendEngineMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("polling is not a loop, inside the batch too", () => {
+  it("seven identical calls with CHANGING results all dispatch and nothing fires", async () => {
+    let n = 0;
+    dispatchTool.mockImplementation(async () => {
+      n += 1;
+      return { success: true, output: `confirmations: ${n}` };
+    });
+
+    const outcome = await runBatch({
+      calls: identicalCalls(7),
+      detector: createToolCallLoopDetector(),
+    });
+
+    expect(dispatchTool).toHaveBeenCalledTimes(7);
+    expect(outcome.kind).toBe("normal_complete");
+    expect(appendEngineMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/vex-agent/engine/ingress-steering.test.ts
+++ b/src/__tests__/vex-agent/engine/ingress-steering.test.ts
@@ -71,7 +71,10 @@ describe("submitSteeringMessage", () => {
     const result = await submitSteeringMessage(SESSION, "steer this");
     expect(result).toEqual({ outcome: "queued_live" });
     expect(mockAddOperatorInstruction).toHaveBeenCalledTimes(1);
-    expect(mockAddOperatorInstruction).toHaveBeenCalledWith(SESSION, "steer this", {
+    // M6 contract change: the disposition is a TYPED argument on the persist
+    // call, not prose derived downstream. Steering into a live run is
+    // `steered` - the loop merges it at its next batch boundary.
+    expect(mockAddOperatorInstruction).toHaveBeenCalledWith(SESSION, "steer this", "steered", {
       target: "mission_run",
       runId: "run-1",
       runStatus: "running",
@@ -101,7 +104,7 @@ describe("submitSteeringMessage", () => {
     mockGetLease.mockResolvedValue(liveLease());
     const result = await submitSteeringMessage(SESSION, "steer this");
     expect(result).toEqual({ outcome: "queued_live" });
-    expect(mockAddOperatorInstruction).toHaveBeenCalledWith(SESSION, "steer this", {
+    expect(mockAddOperatorInstruction).toHaveBeenCalledWith(SESSION, "steer this", "steered", {
       target: "agent_turn",
     });
   });

--- a/src/__tests__/vex-agent/engine/ingress-steering.test.ts
+++ b/src/__tests__/vex-agent/engine/ingress-steering.test.ts
@@ -38,7 +38,11 @@ vi.mock("../../../vex-agent/engine/core/runner.js", () => ({
   resumeMissionRun: (...a: unknown[]) => mockResumeMissionRun(...a),
 }));
 
-vi.mock("../../../vex-agent/engine/core/operator-instructions.js", () => ({
+// The two WRITERS are mocked; `classifyOperatorInterruptDisposition` is kept
+// REAL via importActual. It is the decision these tests exist to check, and a
+// stubbed classifier would let the routes assert their own answer back.
+vi.mock("../../../vex-agent/engine/core/operator-instructions.js", async (importActual) => ({
+  ...(await importActual<Record<string, unknown>>()),
   addOperatorInstruction: (...a: unknown[]) => mockAddOperatorInstruction(...a),
   addOperatorCue: (...a: unknown[]) => mockAddOperatorCue(...a),
 }));
@@ -51,12 +55,23 @@ const { submitSteeringMessage } = await import("../../../vex-agent/engine/ingres
 
 const SESSION = "session-1";
 
-function liveLease(): { expiresAt: Date } {
-  return { expiresAt: new Date(Date.now() + 60_000) };
+/**
+ * `missionRunId` is part of the fixture because the route MATCHES on it: a
+ * lease held for a different run is another turn's and cannot merge this
+ * message. `null` is the agent-session shape (no run row exists).
+ */
+function liveLease(missionRunId: string | null = null): {
+  expiresAt: Date;
+  missionRunId: string | null;
+} {
+  return { expiresAt: new Date(Date.now() + 60_000), missionRunId };
 }
 
-function expiredLease(): { expiresAt: Date } {
-  return { expiresAt: new Date(Date.now() - 1_000) };
+function expiredLease(missionRunId: string | null = null): {
+  expiresAt: Date;
+  missionRunId: string | null;
+} {
+  return { expiresAt: new Date(Date.now() - 1_000), missionRunId };
 }
 
 beforeEach(() => {
@@ -68,6 +83,8 @@ beforeEach(() => {
 describe("submitSteeringMessage", () => {
   it("a running mission run gets exactly one persisted interrupt and queued_live - no turn fires", async () => {
     mockGetActiveRunBySession.mockResolvedValue({ id: "run-1", status: "running" });
+    // A live lease for THIS run is what makes the claim `steered` provable.
+    mockGetLease.mockResolvedValue(liveLease("run-1"));
     const result = await submitSteeringMessage(SESSION, "steer this");
     expect(result).toEqual({ outcome: "queued_live" });
     expect(mockAddOperatorInstruction).toHaveBeenCalledTimes(1);
@@ -83,11 +100,55 @@ describe("submitSteeringMessage", () => {
     expect(mockResumeMissionRun).not.toHaveBeenCalled();
   });
 
-  it("a paused_approval run steers too - the loop resumes through the approval flow, not this entry", async () => {
+  /**
+   * M6 correction. This route used to persist `steered` for `paused_approval`,
+   * which told the operator a run parked on a human decision would pick their
+   * message up mid-turn. The row still persists - it is on the tape and will be
+   * read - but the DISPOSITION is now the honest weaker one.
+   */
+  it("a paused_approval run persists as QUEUED, not steered - nothing is executing", async () => {
     mockGetActiveRunBySession.mockResolvedValue({ id: "run-1", status: "paused_approval" });
+    mockGetLease.mockResolvedValue(liveLease("run-1"));
     const result = await submitSteeringMessage(SESSION, "steer this");
     expect(result).toEqual({ outcome: "queued_live" });
     expect(mockAddOperatorInstruction).toHaveBeenCalledTimes(1);
+    expect(mockAddOperatorInstruction).toHaveBeenCalledWith(
+      SESSION,
+      "steer this",
+      "queued_interrupt",
+      { target: "mission_run", runId: "run-1", runStatus: "paused_approval" },
+    );
+  });
+
+  /**
+   * The other half of the same correction: `running` is a ROW STATUS, and a
+   * row status with a dead lease is the crashed-runner state the restart-orphan
+   * sweep reclaims. Claiming a message was steered into it would describe a
+   * merge that nothing is alive to perform.
+   */
+  it("a running run with a DEAD lease persists as queued, not steered", async () => {
+    mockGetActiveRunBySession.mockResolvedValue({ id: "run-1", status: "running" });
+    mockGetLease.mockResolvedValue(expiredLease("run-1"));
+    const result = await submitSteeringMessage(SESSION, "steer this");
+    expect(result).toEqual({ outcome: "queued_live" });
+    expect(mockAddOperatorInstruction).toHaveBeenCalledWith(
+      SESSION,
+      "steer this",
+      "queued_interrupt",
+      { target: "mission_run", runId: "run-1", runStatus: "running" },
+    );
+  });
+
+  it("a running run whose live lease belongs to ANOTHER run is not this turn", async () => {
+    mockGetActiveRunBySession.mockResolvedValue({ id: "run-1", status: "running" });
+    mockGetLease.mockResolvedValue(liveLease("run-2"));
+    await submitSteeringMessage(SESSION, "steer this");
+    expect(mockAddOperatorInstruction).toHaveBeenCalledWith(
+      SESSION,
+      "steer this",
+      "queued_interrupt",
+      { target: "mission_run", runId: "run-1", runStatus: "running" },
+    );
   });
 
   it.each(["paused_wake", "paused_error", "paused_user", "paused_plan_acceptance", "paused_user_form"])(

--- a/src/__tests__/vex-agent/engine/ingress.test.ts
+++ b/src/__tests__/vex-agent/engine/ingress.test.ts
@@ -24,6 +24,7 @@ const mockAddEngineMessage = vi.fn();
 const mockProcessAgentTurn = vi.fn();
 const mockProcessMissionSetupTurn = vi.fn();
 const mockResumeMissionRun = vi.fn();
+const mockGetLease = vi.fn();
 const mockAddOperatorInstruction = vi.fn();
 const mockAddOperatorCue = vi.fn();
 
@@ -119,13 +120,23 @@ vi.mock("@vex-agent/engine/runtime/release-and-emit.js", () => ({
   releaseLeaseAndEmitControlState: vi.fn().mockResolvedValue(undefined),
 }));
 
+// The lease is the route's evidence that a runner is actually executing, which
+// is what separates a `steered` instruction from a merely `queued` one.
+vi.mock("@vex-agent/db/repos/runner-leases.js", () => ({
+  getLease: (...a: unknown[]) => mockGetLease(...a),
+}));
+
 vi.mock("../../../vex-agent/engine/core/runner.js", () => ({
   processAgentTurn: (...a: unknown[]) => mockProcessAgentTurn(...a),
   processMissionSetupTurn: (...a: unknown[]) => mockProcessMissionSetupTurn(...a),
   resumeMissionRun: (...a: unknown[]) => mockResumeMissionRun(...a),
 }));
 
-vi.mock("../../../vex-agent/engine/core/operator-instructions.js", () => ({
+// The two WRITERS are mocked; `classifyOperatorInterruptDisposition` stays
+// REAL. It is the shared decision this route now defers to, and stubbing it
+// would let the route assert its own answer back at itself.
+vi.mock("../../../vex-agent/engine/core/operator-instructions.js", async (importActual) => ({
+  ...(await importActual<Record<string, unknown>>()),
   addOperatorInstruction: (...a: unknown[]) => mockAddOperatorInstruction(...a),
   addOperatorCue: (...a: unknown[]) => mockAddOperatorCue(...a),
 }));
@@ -138,6 +149,9 @@ const resumeResult = { text: null, toolCallsMade: 2, pendingApprovals: [], stopR
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // No lease by default: every route that does not stage one is, correctly,
+  // unable to prove anything is executing.
+  mockGetLease.mockResolvedValue(null);
   mockCancelForSession.mockResolvedValue(0);
   mockProcessAgentTurn.mockResolvedValue(agentResult);
   mockProcessMissionSetupTurn.mockResolvedValue(setupResult);
@@ -216,13 +230,45 @@ describe("ingress.routeUserMessage", () => {
     expect(mockProcessAgentTurn).not.toHaveBeenCalled();
   });
 
-  it("persists an interrupt when the run is still running", async () => {
+  /**
+   * M6: this route used to hardcode `queued_interrupt` for `running`, so a
+   * message a live loop was about to merge told the operator it would be read
+   * "the next time it runs". It now asks the same classifier the steering
+   * entry point asks, and a live MATCHING lease is the proof it requires.
+   */
+  it("persists a STEERED interrupt when the run is running with a live lease", async () => {
     mockGetActiveRunBySession.mockResolvedValue({ id: "run-3", status: "running" });
+    mockGetLease.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      missionRunId: "run-3",
+    });
 
     await routeUserMessage("s1", "FYI");
 
-    expect(mockAddOperatorInstruction).toHaveBeenCalled();
+    expect(mockAddOperatorInstruction).toHaveBeenCalledWith(
+      "s1",
+      "FYI",
+      "steered",
+      expect.objectContaining({ runId: "run-3", runStatus: "running" }),
+    );
     expect(mockProcessAgentTurn).not.toHaveBeenCalled();
+  });
+
+  it("persists a QUEUED interrupt when the running run's lease is dead", async () => {
+    mockGetActiveRunBySession.mockResolvedValue({ id: "run-3", status: "running" });
+    mockGetLease.mockResolvedValue({
+      expiresAt: new Date(Date.now() - 1_000),
+      missionRunId: "run-3",
+    });
+
+    await routeUserMessage("s1", "FYI");
+
+    expect(mockAddOperatorInstruction).toHaveBeenCalledWith(
+      "s1",
+      "FYI",
+      "queued_interrupt",
+      expect.objectContaining({ runId: "run-3", runStatus: "running" }),
+    );
   });
 
   it("returns a recovery hint instead of empty fallback for paused_error", async () => {

--- a/src/__tests__/vex-agent/engine/ingress.test.ts
+++ b/src/__tests__/vex-agent/engine/ingress.test.ts
@@ -174,9 +174,13 @@ describe("ingress.routeUserMessage", () => {
         fromStatuses: ["paused_wake"],
       }),
     );
+    // M6: the wake-preempt route is the ONE disposition with an immediate
+    // consequence for the run, and it is now recorded as such rather than
+    // sharing a paragraph with every other queued write.
     expect(mockAddOperatorInstruction).toHaveBeenCalledWith(
       "s1",
       "can you pause?",
+      "preempted_wake",
       expect.objectContaining({
         target: "mission_run",
         runId: "run-1",
@@ -196,9 +200,18 @@ describe("ingress.routeUserMessage", () => {
 
     const result = await routeUserMessage("s1", "wait!");
 
-    expect(result.text).toContain("queued");
+    // M6: `QUEUED_INTERRUPT_TEXT` as `TurnResult.text` is retired. The
+    // acknowledgement is a durable, user-visible engine notice row written in
+    // the same transaction as the instruction, so it survives a reload; the
+    // response object carries no ephemeral copy of it.
+    expect(result.text).toBeNull();
     expect(result.toolCallsMade).toBe(0);
-    expect(mockAddOperatorInstruction).toHaveBeenCalled();
+    expect(mockAddOperatorInstruction).toHaveBeenCalledWith(
+      "s1",
+      "wait!",
+      "queued_interrupt",
+      expect.objectContaining({ runStatus: "paused_approval" }),
+    );
     expect(mockResumeMissionRun).not.toHaveBeenCalled();
     expect(mockProcessAgentTurn).not.toHaveBeenCalled();
   });
@@ -220,6 +233,7 @@ describe("ingress.routeUserMessage", () => {
     expect(mockAddOperatorInstruction).toHaveBeenCalledWith(
       "s1",
       "anything",
+      "queued_interrupt",
       expect.objectContaining({ target: "mission_run", runId: "run-4", runStatus: "paused_error" }),
     );
     expect(result.text).toContain("Recover button");

--- a/src/__tests__/vex-agent/engine/ingress.test.ts
+++ b/src/__tests__/vex-agent/engine/ingress.test.ts
@@ -242,6 +242,42 @@ describe("ingress.routeUserMessage", () => {
     expect(mockProcessAgentTurn).not.toHaveBeenCalled();
   });
 
+  // M3/M4: the hint must not CLAIM a provider/runtime error for a pause that
+  // had neither. `restart_orphan` was parked by the reclaim sweep after Vex
+  // died mid-slice; `tool_call_loop` was stopped by the detector. The shared
+  // tail (what happened to the message, what clears the pause) stays on all
+  // three.
+  it.each([
+    ["restart_orphan", "Vex restarted while it was executing"],
+    ["tool_call_loop", "repeated the same tool call without making progress"],
+  ])("names %s as the cause of the pause", async (stopReason, cause) => {
+    mockGetActiveRunBySession.mockResolvedValue({
+      id: "run-5",
+      status: "paused_error",
+      stopReason,
+    });
+
+    const result = await routeUserMessage("s1", "anything");
+
+    expect(result.text).toContain(cause);
+    expect(result.text).not.toContain("provider/runtime error");
+    expect(result.text).toContain("Recover button");
+  });
+
+  // An unnamed reason keeps today's generic wording rather than a wrong one.
+  it("falls back to the generic pause wording for an unnamed stop reason", async () => {
+    mockGetActiveRunBySession.mockResolvedValue({
+      id: "run-6",
+      status: "paused_error",
+      stopReason: "some_future_reason",
+    });
+
+    const result = await routeUserMessage("s1", "anything");
+
+    expect(result.text).toContain("provider/runtime error");
+    expect(result.text).toContain("Recover button");
+  });
+
   it("routes to mission-setup when a draft mission exists and there is no run", async () => {
     mockGetActiveRunBySession.mockResolvedValue(null);
     mockGetSession.mockResolvedValue({ id: "s1", mode: "mission", permission: "restricted" });

--- a/src/__tests__/vex-agent/engine/mission-run-status-vocabulary-drift.test.ts
+++ b/src/__tests__/vex-agent/engine/mission-run-status-vocabulary-drift.test.ts
@@ -107,17 +107,23 @@ describe("mission run status vocabulary — cross-package drift guard", () => {
     ).toEqual(expected);
   });
 
-  it("the composer's free-text gate covers every non-terminal status", () => {
+  it("the composer's free-text gate covers every non-terminal status except running", () => {
     // A status missing here silently lets the user type free text into a run
-    // that cannot answer it.
-    const nonTerminal = MISSION_RUN_STATUSES.filter((s) => !TERMINAL_RUN_STATUSES.has(s)).sort();
+    // that cannot answer it. `running` is the ONE deliberate exception
+    // (mission-autonomy wave 2): a message sent while a run executes STEERS
+    // it through the engine's operator_interrupt path, which is the designed
+    // behavior, so the composer must not gate it. Any OTHER status leaving
+    // this set is drift and must fail here.
+    const expected = MISSION_RUN_STATUSES.filter(
+      (s) => !TERMINAL_RUN_STATUSES.has(s) && s !== "running",
+    ).sort();
     expect(
       literalsBetween(
         read("vex-app/src/renderer/features/appShell/composer-helpers.ts"),
         "export const FREE_TEXT_DISALLOWED",
         "]);",
       ),
-    ).toEqual(nonTerminal);
+    ).toEqual(expected);
   });
 
   it("every paused status has its own gatedReason case — no silent default", () => {

--- a/src/__tests__/vex-agent/engine/mission/restart-with-instruction.test.ts
+++ b/src/__tests__/vex-agent/engine/mission/restart-with-instruction.test.ts
@@ -95,6 +95,9 @@ describe("restartMissionWithInstruction", () => {
     expect(mockAddOperatorInstruction).toHaveBeenCalledWith(
       "session-1",
       "Rebalance into USDC",
+      // M6: the restart's instruction waits for the new run's FIRST turn, so
+      // the honest disposition is `queued_interrupt`, not `steered`.
+      "queued_interrupt",
       { missionRestart: true, missionId: "mission-1" },
     );
   });

--- a/src/__tests__/vex-agent/engine/prompts/tool-call-loop-correction-cue.test.ts
+++ b/src/__tests__/vex-agent/engine/prompts/tool-call-loop-correction-cue.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The tool-call repetition CORRECTION cue, as a versioned prompt artifact
+ * (rule 09).
+ *
+ * ## Why the bytes are pinned HERE and not in `__promptsnaps__`
+ *
+ * The promptsnaps freeze the assembled STATIC PREFIX of each mode. This cue is
+ * not a prompt-stack layer and never enters that prefix: it is a TRANSCRIPT
+ * cue, written into the tape at the moment a repetition is detected and read
+ * by the model on its next round - the same class of artifact as
+ * `OPERATOR_INTERRUPT_CUE`, which is likewise absent from the snapshots.
+ * Regenerating the promptsnaps for this change produces an empty diff, which
+ * would be evidence of nothing.
+ *
+ * So this test IS the reviewed diff surface for it: the cue's exact bytes, in
+ * both of its shapes, so a change to text the model reads is a change to this
+ * file and shows up as a contract diff in review.
+ *
+ * The semantic assertions below are the eval half. They are deterministic
+ * because the artifact is: it is a pure function of three structured facts,
+ * with no model in the loop.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildToolCallLoopCorrectionCue } from "@vex-agent/engine/prompts/tool-call-loop-correction.js";
+
+const SINGLE = buildToolCallLoopCorrectionCue({
+  toolName: "swap_quote",
+  cycleLength: 1,
+  repeatCount: 5,
+});
+
+const CYCLE = buildToolCallLoopCorrectionCue({
+  toolName: "swap_quote",
+  cycleLength: 2,
+  repeatCount: 5,
+});
+
+describe("the cue's exact bytes", () => {
+  it("k = 1: the same call repeating", () => {
+    expect(SINGLE).toBe(
+      "[Engine: tool_call_loop_correction - you have now called swap_quote 5 times in a row"
+      + " with identical arguments and received an identical result every time."
+      + " Repeating it again will not change the answer. Do not re-issue that call."
+      + " Do exactly one of these instead: try a genuinely different approach to the same goal,"
+      + " tell the user what is blocking you and ask for the missing decision or input,"
+      + " or stop and summarise what you established so far."
+      + " The remaining tool calls from your last message were not executed."
+      + " If this repetition continues, the turn will be ended for you.]",
+    );
+  });
+
+  it("k > 1: a cycle of calls repeating", () => {
+    expect(CYCLE).toBe(
+      "[Engine: tool_call_loop_correction - your last 10 tool calls are the same cycle of 2 calls"
+      + " repeated 5 times, starting with swap_quote, each returning an identical result."
+      + " Repeating it again will not change the answer. Do not re-issue that call."
+      + " Do exactly one of these instead: try a genuinely different approach to the same goal,"
+      + " tell the user what is blocking you and ask for the missing decision or input,"
+      + " or stop and summarise what you established so far."
+      + " The remaining tool calls from your last message were not executed."
+      + " If this repetition continues, the turn will be ended for you.]",
+    );
+  });
+});
+
+describe("what the cue must do", () => {
+  it("is an engine marker, so the model cannot mistake it for a user instruction", () => {
+    for (const cue of [SINGLE, CYCLE]) {
+      expect(cue.startsWith("[Engine: ")).toBe(true);
+      expect(cue.endsWith("]")).toBe(true);
+    }
+  });
+
+  it("describes what the model ACTUALLY did - the two shapes are not interchangeable", () => {
+    // A cue that calls an A-B-A-B ping-pong "the same tool call" is factually
+    // wrong about the transcript the model is reading, and a model that can
+    // see it is wrong has a reason to dismiss it.
+    expect(SINGLE).toContain("5 times in a row with identical arguments");
+    expect(CYCLE).toContain("the same cycle of 2 calls");
+    expect(CYCLE).not.toContain("in a row with identical arguments");
+  });
+
+  it("names three concrete exits, not a yes/no question", () => {
+    expect(SINGLE).toContain("a genuinely different approach");
+    expect(SINGLE).toContain("ask for the missing decision or input");
+    expect(SINGLE).toContain("stop and summarise");
+  });
+
+  it("states the consequence, so the next round has a reason to be different", () => {
+    expect(SINGLE).toContain("the turn will be ended for you");
+  });
+
+  it("tells the model its remaining calls did not run - the drain is not silent", () => {
+    expect(SINGLE).toContain("were not executed");
+  });
+
+  it("interpolates ONLY the tool name and the counts, never arguments or results", () => {
+    const cue = buildToolCallLoopCorrectionCue({
+      toolName: "wallet_send",
+      cycleLength: 1,
+      repeatCount: 5,
+    });
+    // Nothing but `{toolName}` and the numbers may vary between two cues built
+    // from calls that differ only in their (sensitive) arguments.
+    expect(cue).toBe(SINGLE.replace("swap_quote", "wallet_send"));
+  });
+});

--- a/src/__tests__/vex-agent/engine/runtime/restart-orphan-reclaim-scheduler.test.ts
+++ b/src/__tests__/vex-agent/engine/runtime/restart-orphan-reclaim-scheduler.test.ts
@@ -1,0 +1,166 @@
+/**
+ * The restart-orphan reclaim's RECURRING handle: lifecycle only.
+ *
+ * What the reclaim WRITES is proven against real Postgres
+ * (`integration/engine/restart-orphan-reclaim.int.test.ts`); a mocked client
+ * cannot show a CAS or a lock. What is proven HERE is the handle contract that
+ * makes it safe to own a repeating sweep at all, and those are scheduler
+ * properties with no DB in them: single-flight (a slow pass is never lapped),
+ * a drained shutdown, and no pass started after `stop()`.
+ *
+ * The pass is injected, so this file never touches `db/client.js`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  startRestartOrphanReclaim,
+  type ReclaimPassSummary,
+} from "../../../../vex-agent/engine/runtime/restart-orphan-reclaim.js";
+
+const EMPTY: ReclaimPassSummary = {
+  candidates: 0,
+  reclaimed: 0,
+  skipped: 0,
+  failed: 0,
+};
+
+/** A pass whose completion the test controls. */
+function deferredPass() {
+  let release: (() => void) | null = null;
+  const calls: number[] = [];
+  const runPass = vi.fn(async (): Promise<ReclaimPassSummary> => {
+    calls.push(Date.now());
+    await new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return EMPTY;
+  });
+  return {
+    runPass,
+    calls,
+    finish: () => {
+      if (!release) throw new Error("pass not started");
+      const r = release;
+      release = null;
+      r();
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("startRestartOrphanReclaim", () => {
+  it("runs a pass every interval", async () => {
+    const runPass = vi.fn().mockResolvedValue(EMPTY);
+    const handle = startRestartOrphanReclaim({ intervalMs: 1000, runPass });
+
+    expect(runPass).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(runPass).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(runPass).toHaveBeenCalledTimes(2);
+
+    await handle.stop();
+  });
+
+  it("is single-flight: a slow pass is never lapped by the interval", async () => {
+    const pass = deferredPass();
+    const handle = startRestartOrphanReclaim({
+      intervalMs: 1000,
+      runPass: pass.runPass,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(pass.runPass).toHaveBeenCalledTimes(1);
+
+    // Five intervals pass while the first sweep is still working.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(pass.runPass).toHaveBeenCalledTimes(1);
+
+    pass.finish();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(pass.runPass).toHaveBeenCalledTimes(2);
+    pass.finish();
+
+    await handle.stop();
+  });
+
+  it("stop() resolves only after the in-flight pass settles", async () => {
+    const pass = deferredPass();
+    const handle = startRestartOrphanReclaim({
+      intervalMs: 1000,
+      runPass: pass.runPass,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    let stopped = false;
+    const stopping = handle.stop().then(() => {
+      stopped = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    // The reclaim writes inside a transaction; quit sequences this stop before
+    // Postgres teardown, so resolving early would tear the DB out from under it.
+    expect(stopped).toBe(false);
+
+    pass.finish();
+    await stopping;
+    expect(stopped).toBe(true);
+  });
+
+  it("starts no further pass after stop(), and stop() is idempotent", async () => {
+    const pass = deferredPass();
+    const handle = startRestartOrphanReclaim({
+      intervalMs: 1000,
+      runPass: pass.runPass,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const stopping = handle.stop();
+    pass.finish();
+    await stopping;
+    await handle.stop();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(pass.runPass).toHaveBeenCalledTimes(1);
+  });
+
+  it("tells the pass to stop between candidates once stopping", async () => {
+    // `shouldContinue` is how a shutdown drains promptly instead of working
+    // through a whole backlog: the pass checks it between candidates.
+    let shouldContinue: (() => boolean) | undefined;
+    const pass = vi.fn(async (options: { shouldContinue?: () => boolean }) => {
+      shouldContinue = options.shouldContinue;
+      return EMPTY;
+    });
+    const handle = startRestartOrphanReclaim({
+      intervalMs: 1000,
+      runPass: pass,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(shouldContinue?.()).toBe(true);
+    await handle.stop();
+    expect(shouldContinue?.()).toBe(false);
+  });
+
+  it("keeps sweeping after a pass throws", async () => {
+    const runPass = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient db failure"))
+      .mockResolvedValue(EMPTY);
+    const handle = startRestartOrphanReclaim({ intervalMs: 1000, runPass });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(runPass).toHaveBeenCalledTimes(2);
+    await handle.stop();
+  });
+});

--- a/src/__tests__/vex-agent/engine/stop-reason-vocabulary-drift.test.ts
+++ b/src/__tests__/vex-agent/engine/stop-reason-vocabulary-drift.test.ts
@@ -1,0 +1,177 @@
+/**
+ * STOP REASON - CROSS-PACKAGE VOCABULARY DRIFT GUARD.
+ *
+ * Sibling of `mission-run-status-vocabulary-drift.test.ts`, for the second
+ * closed vocabulary that spans the process boundary. `STOP_REASONS` in
+ * `engine/types/stop-reasons.ts` is the single source of truth, but
+ * `check:boundaries` forbids `vex-app` from importing `src/vex-agent`, so the
+ * app's strict chat schema is a hand-typed literal list and is therefore free
+ * to rot.
+ *
+ * The cost of that rot is not cosmetic. `chatStopReasonSchema` is a STRICT
+ * boundary validator: a stop reason the engine really produced and the schema
+ * has never heard of does not degrade to "unknown", it fails validation, and
+ * the honest account of how a turn ended is replaced by a validation error at
+ * the IPC edge. Every stop reason added to the engine must arrive here in the
+ * same change.
+ *
+ * A normal import cannot cross the boundary, so this test reads the mirror as
+ * TEXT. Deliberately crude, deliberately unskippable.
+ *
+ * It also pins the two contracts the mission-autonomy work must NOT touch: the
+ * model-facing `MissionStop` tool enum and the business stop list it mirrors.
+ * A new RUNTIME cause is an engine fact about a turn; putting it in the tool
+ * schema would offer the model a way to CLAIM it, which is a different and
+ * much worse thing.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { describe, it, expect } from "vitest";
+
+import {
+  BUSINESS_STOP_REASONS,
+  RUNTIME_STOP_REASONS,
+  STOP_REASONS,
+} from "@vex-agent/engine/types.js";
+import {
+  isBusinessStop,
+  isResumablePause,
+  isRuntimePause,
+  shouldTerminateRun,
+} from "@vex-agent/engine/core/stop-conditions.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
+}
+
+function literalsBetween(source: string, startAnchor: string, endAnchor: string): string[] {
+  const start = source.indexOf(startAnchor);
+  expect(start, `anchor not found: ${startAnchor}`).toBeGreaterThan(-1);
+  const end = source.indexOf(endAnchor, start + startAnchor.length);
+  expect(end, `end anchor not found: ${endAnchor}`).toBeGreaterThan(-1);
+  const block = source.slice(start + startAnchor.length, end);
+  return [...block.matchAll(/"([a-z_]+)"/g)]
+    .map((m) => m[1])
+    .filter((literal): literal is string => literal !== undefined);
+}
+
+describe("stop reason vocabulary - cross-package drift guard", () => {
+  it("the app's strict chat schema mirrors the canonical list, in order", () => {
+    // SEQUENCE, not set: a reordering is a reviewed diff rather than a silent
+    // one, and the engine tuple documents the business-then-runtime grouping
+    // the schema is supposed to keep.
+    expect(
+      literalsBetween(
+        read("vex-app/src/shared/schemas/chat.ts"),
+        "export const chatStopReasonSchema = z.enum([",
+        "]);",
+      ),
+    ).toEqual([...STOP_REASONS]);
+  });
+
+  it("the canonical list has no duplicates and no overlap between its halves", () => {
+    expect(new Set(STOP_REASONS).size).toBe(STOP_REASONS.length);
+    const business = new Set<string>(BUSINESS_STOP_REASONS);
+    for (const runtime of RUNTIME_STOP_REASONS) {
+      expect(business.has(runtime), `${runtime} is in both halves`).toBe(false);
+    }
+  });
+});
+
+describe("classification is exhaustive by construction", () => {
+  /**
+   * The gap this closes. `isRuntimePause` declares `reason is
+   * RuntimeStopReason`, which is a PROMISE that it answers true for every
+   * member of that union - and the hand-maintained set behind it answered
+   * false for `user_paused` and `user_form_required`, so the predicate
+   * narrowed to a type it had just denied. The previous test enumerated eight
+   * of the members and could not see it. Enumerating the tuple itself is what
+   * makes the promise structural.
+   */
+  it.each([...RUNTIME_STOP_REASONS])("%s is a runtime pause and not a business stop", (reason) => {
+    expect(isRuntimePause(reason)).toBe(true);
+    expect(isBusinessStop(reason)).toBe(false);
+    expect(shouldTerminateRun(reason)).toBe(false);
+  });
+
+  it.each([...BUSINESS_STOP_REASONS])("%s is a business stop and not a runtime pause", (reason) => {
+    expect(isBusinessStop(reason)).toBe(true);
+    expect(isRuntimePause(reason)).toBe(false);
+    expect(shouldTerminateRun(reason)).toBe(true);
+  });
+
+  it("only the three directly-resumable pauses are resumable", () => {
+    // Every OTHER stop reason, including both new causes, must be non-resumable
+    // by default. A resumable stop reason is a claim that some component will
+    // pick the run back up on its own.
+    const resumable = STOP_REASONS.filter((reason) => isResumablePause(reason));
+    expect([...resumable].sort()).toEqual([
+      "approval_required",
+      "checkpoint_pause",
+      "waiting_for_wake",
+    ]);
+  });
+});
+
+describe("the new causes - restart_orphan and tool_call_loop", () => {
+  it.each(["restart_orphan", "tool_call_loop"] as const)(
+    "%s is a runtime pause, never terminal, never auto-resumable",
+    (reason) => {
+      expect(RUNTIME_STOP_REASONS).toContain(reason);
+      expect(isRuntimePause(reason)).toBe(true);
+      expect(isBusinessStop(reason)).toBe(false);
+      // `restart_orphan` needs a fresh run (the process that owned the old one
+      // is gone); `tool_call_loop` needs a human to change something, because
+      // resuming is precisely what the model just proved it would repeat.
+      expect(isResumablePause(reason)).toBe(false);
+      expect(shouldTerminateRun(reason)).toBe(false);
+    },
+  );
+
+  it("`no_progress` keeps its mirror - the arm it shares must not silently move", () => {
+    // The previous suite had no `no_progress` case at all, so the day it was
+    // added to the union nothing here would have failed.
+    expect(RUNTIME_STOP_REASONS).toContain("no_progress");
+    expect(isRuntimePause("no_progress")).toBe(true);
+    expect(isResumablePause("no_progress")).toBe(false);
+    expect(
+      read("src/vex-agent/engine/core/runner/mission-finalize.ts"),
+    ).toContain('stopReason === "no_progress"');
+  });
+
+  it("each new cause has a guarded mission-finalize arm, so neither strands a run", () => {
+    // Falling through to `return "running"` would leave the run row `running`
+    // with no wake and no lease - an orphan the operator can neither resume nor
+    // see a reason for.
+    const finalize = read("src/vex-agent/engine/core/runner/mission-finalize.ts");
+    expect(finalize).toContain('stopReason === "tool_call_loop"');
+  });
+});
+
+describe("contracts that must NOT gain the new causes", () => {
+  /**
+   * The model-facing `MissionStop` tool enum. A runtime cause is the ENGINE's
+   * account of a turn; exposing it here would let the model claim it, which
+   * would let a looping model report itself as having been stopped for looping
+   * and a crashed-process cause be asserted by inference output.
+   */
+  it("the MissionStop tool schema exposes only business stops", () => {
+    // The enum literal lives on the registered tool's JSON schema - the shape
+    // the MODEL is actually shown - not on the handler.
+    const source = literalsBetween(
+      read("src/vex-agent/tools/registry/mission.ts"),
+      "reason: { type: \"string\", enum: [",
+      "]",
+    );
+    // Exact sequence: business stops minus `user_stopped`, which is the
+    // OPERATOR's stop and never the model's to declare.
+    expect(source).toEqual(
+      BUSINESS_STOP_REASONS.filter((reason) => reason !== "user_stopped"),
+    );
+  });
+});

--- a/src/__tests__/vex-agent/engine/wake/executor-surface.test.ts
+++ b/src/__tests__/vex-agent/engine/wake/executor-surface.test.ts
@@ -136,4 +136,26 @@ describe("startWakeExecutor — self-scheduling lifecycle (fake timers)", () => 
     await vi.advanceTimersByTimeAsync(10_000);
     expect(claimDue).toHaveBeenCalledTimes(1);
   });
+
+  it("owns the restart-orphan reclaim handle and drains it on stop()", async () => {
+    // The reclaim has no other lifecycle owner: the host's supervisor timer is
+    // cleared the moment this executor starts, so if stop() did not stop the
+    // sweep, a quit would leave a reclaim transaction running against a
+    // Postgres pool being torn down.
+    vi.useFakeTimers();
+    const stopReclaim = vi.fn().mockResolvedValue(undefined);
+    const startReclaim = vi.fn(() => ({ stop: stopReclaim }));
+
+    const handle = startWakeExecutor({
+      intervalMs: 2000,
+      deps: makeDeps(),
+      startRestartOrphanReclaim: startReclaim,
+    });
+
+    expect(startReclaim).toHaveBeenCalledTimes(1);
+    expect(stopReclaim).not.toHaveBeenCalled();
+
+    await handle.stop();
+    expect(stopReclaim).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/vex-agent/db/repos/loop-wake.ts
+++ b/src/vex-agent/db/repos/loop-wake.ts
@@ -113,15 +113,36 @@ export async function cancelForSession(
   sessionId: string,
   reason: string,
 ): Promise<number> {
-  return execute(
-    `UPDATE loop_wake_requests
-     SET status = 'cancelled',
-         cancelled_at = NOW(),
-         cancelled_reason = $2
-     WHERE session_id = $1 AND status = 'pending'`,
-    [sessionId, reason],
-  );
+  return execute(CANCEL_PENDING_FOR_SESSION_SQL, [sessionId, reason]);
 }
+
+/**
+ * The same cancellation on a transaction the CALLER owns.
+ *
+ * The recovery money gate needs the cancellation, the money read and the run
+ * claim to be ONE commit: cancelling a scheduled auto-retry is an effect, and
+ * an effect that survives a refused or lost Recover would leave the run with no
+ * retry scheduled and no recovery performed. Sharing the caller's transaction
+ * makes it roll back with the decision that caused it.
+ */
+export async function cancelForSessionWith(
+  client: PoolClient,
+  sessionId: string,
+  reason: string,
+): Promise<number> {
+  return executeWith(client, CANCEL_PENDING_FOR_SESSION_SQL, [
+    sessionId,
+    reason,
+  ]);
+}
+
+/** One statement, two entry points - never two spellings of the same effect. */
+const CANCEL_PENDING_FOR_SESSION_SQL = `
+    UPDATE loop_wake_requests
+       SET status = 'cancelled',
+           cancelled_at = NOW(),
+           cancelled_reason = $2
+     WHERE session_id = $1 AND status = 'pending'`;
 
 // ── Claim due (exactly-once) ────────────────────────────────────────
 

--- a/src/vex-agent/db/repos/mission-runs.ts
+++ b/src/vex-agent/db/repos/mission-runs.ts
@@ -275,6 +275,58 @@ export async function updateStatusIfNotTerminal(
 }
 
 /**
+ * EXACT-status CAS: park a run that is STILL `running`, and only then.
+ *
+ * `updateStatusIfNotTerminal` is deliberately broad (`status NOT IN terminal`)
+ * because its callers are the run's OWN runner, parking work it was executing.
+ * The restart-orphan reclaim is the opposite case: it is a THIRD PARTY writing
+ * about a run no process is holding, and the only state that licences that
+ * write is `running`. A broad CAS would let a reclaim pass land on a run that
+ * had meanwhile been legitimately parked (`paused_approval`, `paused_wake`,
+ * `paused_user_form`, …) by a runner that came back or by an operator control,
+ * overwriting a live, meaningful pause with `paused_error` and stranding the
+ * pending approval or form behind it. The narrow CAS makes that impossible
+ * without the caller having to enumerate every pause status it must not touch.
+ *
+ * `client` is REQUIRED, unlike the sibling helpers. The exact-status CAS is a
+ * decision about a row the caller must already have re-read under
+ * `SELECT … FOR UPDATE` inside the session control lock; run outside such a
+ * transaction it is a check-then-act on a row anyone may be moving. Making the
+ * transaction client a required parameter is what stops that misuse at compile
+ * time (the same argument the money-state reader makes for its own client).
+ *
+ * `running` is excluded as a TARGET at the type level for the same reason as in
+ * `updateStatusIfNotTerminal`: this helper COALESCE-merges prior stop evidence,
+ * whereas a flip to `running` must clear it.
+ *
+ * Returns `true` when the row was parked, `false` when the run had already
+ * moved off `running` (or no longer exists).
+ */
+export async function updateStatusIfRunning(
+  id: string,
+  status: Exclude<MissionRunStatus, "running">,
+  stopReason: string,
+  stopPayload: { summary?: string; evidence?: Record<string, unknown> },
+  client: PoolClient,
+): Promise<boolean> {
+  const ended = TERMINAL_RUN_STATUSES.has(status) ? "NOW()" : "ended_at";
+  const sql = `UPDATE mission_runs SET status = $1,
+     stop_reason = $2,
+     stop_summary = COALESCE($3, stop_summary),
+     stop_evidence_json = COALESCE($4::jsonb, stop_evidence_json),
+     ended_at = ${ended}
+     WHERE id = $5 AND status = 'running'`;
+  const result = await client.query(sql, [
+    status,
+    stopReason,
+    stopPayload.summary ?? null,
+    nullableJsonb(stopPayload.evidence ?? null),
+    id,
+  ]);
+  return (result.rowCount ?? 0) > 0;
+}
+
+/**
  * Guarded `running` flip — the counterpart of `updateStatusIfNotTerminal` for
  * the one status that helper excludes at the type level.
  *

--- a/src/vex-agent/engine/core/operator-instructions.ts
+++ b/src/vex-agent/engine/core/operator-instructions.ts
@@ -192,6 +192,19 @@ export async function addOperatorInstruction(
     // acknowledgement the operator reads. It is an engine notice row, never
     // assistant prose - the agent did not say this, the runtime did.
     visibility: "user",
+    // The disposition IS persisted here, deliberately: this row and the
+    // instruction row are two records of one event, and an audit forced to
+    // infer the ack's disposition from its prose would be reading rendered
+    // text back as data.
+    //
+    // It is equally deliberately NOT PROJECTED onto the ack DTO. The mapper
+    // reads `payload -> 'disposition'` only for the `operator_interrupt` row
+    // (`extractInterruptDisposition` in the app's messages mapper). This row's
+    // own TEXT already states what happened, so projecting the field as well
+    // would give the renderer two sources for one fact and a chance to render
+    // them differently - which is the exact class of contradiction the typed
+    // disposition was introduced to end. The instruction row is where the
+    // renderer's delivery words come from.
     payload: { operatorInstructionAck: true, disposition },
   } as const;
 

--- a/src/vex-agent/engine/core/operator-instructions.ts
+++ b/src/vex-agent/engine/core/operator-instructions.ts
@@ -6,12 +6,74 @@
 
 import type { Message, MessageWithId } from "@vex-agent/db/repos/messages.js";
 import * as messagesRepo from "@vex-agent/db/repos/messages.js";
+import { withTransaction } from "@vex-agent/db/client.js";
 import {
+  TRANSCRIPT_APPEND_EVENT_TYPE,
   appendEngineMessage,
   appendMessage,
+  emitTranscriptAppend,
 } from "@vex-agent/engine/events/index.js";
 
 export const OPERATOR_INTERRUPT_MESSAGE_TYPE = "operator_interrupt";
+
+/**
+ * The engine's own acknowledgement of an operator instruction, as a distinct
+ * `message_type` from the instruction row and from the model-facing cue.
+ * Distinctness is the point: all three describe the same event and only this
+ * one is the engine telling the USER what it did with their message.
+ */
+export const OPERATOR_INSTRUCTION_ACK_MESSAGE_TYPE = "operator_interrupt_ack";
+
+/**
+ * What the engine actually DID with an operator instruction, decided by the
+ * ingress route that persisted it and recorded on the instruction row itself.
+ *
+ * ## Why this is a typed field and not prose
+ *
+ * The acknowledgement used to be `QUEUED_INTERRUPT_TEXT` returned as
+ * `TurnResult.text`: a sentence, produced by one branch, that vanished the
+ * moment the response was consumed. It was not durable (a reload lost it), it
+ * was not distinguishable (every route that queued anything returned the same
+ * paragraph, including the one that had actually PREEMPTED a scheduled wake
+ * and resumed the run), and anything downstream that wanted to know what
+ * happened could only have compared strings. Every channel now derives from
+ * this value.
+ *
+ * - `steered`: persisted into a LIVE turn (a running mission run, or an agent
+ *   session whose runner lease is held). The loop merges it at its next tool
+ *   batch boundary; nothing was interrupted and nothing was started.
+ * - `queued_interrupt`: persisted for a run that is NOT currently executing a
+ *   turn - parked on an approval, parked on an error, or claimed by someone
+ *   else. It is read whenever the run next runs, which may be after a human
+ *   acts. This is the honest, weaker claim, and it is the default for a route
+ *   that cannot prove the stronger one.
+ * - `preempted_wake`: the instruction cancelled a scheduled wake and the run
+ *   was resumed immediately to read it. The only disposition whose write has
+ *   an immediate consequence for the run's status.
+ */
+export type OperatorInterruptDisposition =
+  | "steered"
+  | "queued_interrupt"
+  | "preempted_wake";
+
+/**
+ * The user-visible acknowledgement per disposition.
+ *
+ * One sentence each, saying what happened and when the agent will read it -
+ * that second half is the part the old single paragraph could not tell the
+ * truth about, because it was shared by routes with different answers. Written
+ * for the operator, so no engine vocabulary and no run ids.
+ */
+const DISPOSITION_ACKNOWLEDGEMENT: Readonly<
+  Record<OperatorInterruptDisposition, string>
+> = {
+  steered:
+    "Sent to the agent. It is mid-turn, so it will pick this up at its next step and keep going.",
+  queued_interrupt:
+    "Saved. The agent is not running a turn right now, so it will read this the next time it runs.",
+  preempted_wake:
+    "Sent to the agent. Its scheduled wake was cancelled and it is resuming now to read this.",
+};
 
 const OPERATOR_INTERRUPT_CUE = [
   "[Engine: operator_interrupt — The operator sent new guidance while this autonomous run was active.",
@@ -34,21 +96,85 @@ export function maxOperatorInstructionId(messages: readonly Message[]): number {
   return max;
 }
 
+/**
+ * Persist one operator instruction together with the engine's durable
+ * acknowledgement of what it did with it.
+ *
+ * ## One transaction, on purpose
+ *
+ * The instruction row and its acknowledgement are two statements about one
+ * event, and either one alone is a lie. An instruction with no acknowledgement
+ * is the failure this replaced - the operator has no record that the system
+ * received it and no idea when it will be read. An acknowledgement with no
+ * instruction is worse: it tells the operator the agent has their message when
+ * nothing does. So both rows commit together or neither does, and the
+ * disposition rides the instruction row's own payload, which is an existing
+ * JSONB column - no schema change is involved anywhere in this.
+ *
+ * Events are emitted only after the COMMIT returns (the rule
+ * `append-transcript.ts` documents): an event implies a row a reader can
+ * fetch, so a rollback must take both events with it. `withTransaction`
+ * rethrows, so a failed write reaches the caller instead of silently
+ * degrading to "queued" for a message nobody has.
+ *
+ * `payload` is the route's own free-form context (target, run id, run status).
+ * It cannot override `disposition`: the spread is ordered so the typed value
+ * wins, because a caller passing a fourth disposition as a loose string is
+ * exactly the drift this field exists to end.
+ */
 export async function addOperatorInstruction(
   sessionId: string,
   content: string,
+  disposition: OperatorInterruptDisposition,
   payload: Record<string, unknown> = {},
 ): Promise<void> {
-  await appendMessage(
-    sessionId,
-    { role: "user", content, timestamp: new Date().toISOString() },
-    {
-      source: "user",
-      messageType: OPERATOR_INTERRUPT_MESSAGE_TYPE,
-      visibility: "user",
-      payload: { operatorInstruction: true, ...payload },
-    },
-  );
+  const instructionMetadata = {
+    source: "user",
+    messageType: OPERATOR_INTERRUPT_MESSAGE_TYPE,
+    visibility: "user",
+    payload: { operatorInstruction: true, ...payload, disposition },
+  } as const;
+
+  const ackMetadata = {
+    source: "engine",
+    messageType: OPERATOR_INSTRUCTION_ACK_MESSAGE_TYPE,
+    // USER-visible, unlike the model-facing cue below: this row IS the
+    // acknowledgement the operator reads. It is an engine notice row, never
+    // assistant prose - the agent did not say this, the runtime did.
+    visibility: "user",
+    payload: { operatorInstructionAck: true, disposition },
+  } as const;
+
+  const { instruction, ack } = await withTransaction(async (client) => {
+    const instructionRow = await appendMessage(
+      sessionId,
+      { role: "user", content, timestamp: new Date().toISOString() },
+      instructionMetadata,
+      { client },
+    );
+    const ackRow = await appendEngineMessage(
+      sessionId,
+      DISPOSITION_ACKNOWLEDGEMENT[disposition],
+      ackMetadata,
+      { client },
+    );
+    return { instruction: instructionRow, ack: ackRow };
+  });
+
+  for (const [row, metadata] of [
+    [instruction, instructionMetadata],
+    [ack, ackMetadata],
+  ] as const) {
+    emitTranscriptAppend({
+      type: TRANSCRIPT_APPEND_EVENT_TYPE,
+      sessionId,
+      messageId: row.id,
+      role: row.role,
+      createdAt: row.timestamp,
+      messageType: metadata.messageType,
+      correlationId: null,
+    });
+  }
 }
 
 export async function addOperatorCue(sessionId: string): Promise<void> {

--- a/src/vex-agent/engine/core/operator-instructions.ts
+++ b/src/vex-agent/engine/core/operator-instructions.ts
@@ -57,6 +57,56 @@ export type OperatorInterruptDisposition =
   | "preempted_wake";
 
 /**
+ * THE classifier for the two dispositions that are DERIVED from state, in one
+ * place, used by every route that persists an operator instruction.
+ *
+ * ## Why it had to be one function
+ *
+ * The routes disagreed, and each disagreement was visible to the operator.
+ * `routeUserMessage` labelled every `running` run `queued_interrupt` even when
+ * a runner was demonstrably executing it, so a genuinely steered message told
+ * the user it would be read "the next time it runs". `submitSteeringMessage`
+ * made the opposite error and labelled `paused_approval` as `steered`, telling
+ * the user a parked run would pick their message up mid-turn when nothing was
+ * running at all. Two routes, two answers, wrong in opposite directions, and no
+ * single place to correct either.
+ *
+ * ## The rule
+ *
+ * `steered` requires PROOF that something is executing: a live lease belonging
+ * to this session's current work. A row status alone is not proof - `running`
+ * with a dead lease is exactly the crashed-runner state the restart-orphan
+ * sweep exists to clean up, and telling the operator their message was steered
+ * into it would be a lie about a run nobody is driving.
+ *
+ * Everything else is `queued_interrupt`: the honest, weaker claim, and the
+ * default on purpose, because a route that cannot prove the stronger claim
+ * should make the weaker one.
+ *
+ * ## `preempted_wake` is deliberately NOT produced here
+ *
+ * It is not derivable from status and lease. It is a fact about an ACTION that
+ * succeeded - a wake cancelled and the run claimed - so only the code that
+ * performed that claim and saw it WIN may assert it. Deriving it from a
+ * `paused_wake` status would claim a preempt that may have lost its race.
+ */
+export function classifyOperatorInterruptDisposition(input: {
+  /** The mission run's status, or `null` for an agent session with no run. */
+  readonly runStatus: string | null;
+  /**
+   * A lease that is unexpired AND belongs to this work: the same run for a
+   * mission run, the session itself for an agent session. A lease held for a
+   * DIFFERENT run is someone else's turn and cannot merge this message.
+   */
+  readonly hasLiveMatchingLease: boolean;
+}): OperatorInterruptDisposition {
+  const executing = input.runStatus === "running" || input.runStatus === null;
+  return executing && input.hasLiveMatchingLease
+    ? "steered"
+    : "queued_interrupt";
+}
+
+/**
  * The user-visible acknowledgement per disposition.
  *
  * One sentence each, saying what happened and when the agent will read it -

--- a/src/vex-agent/engine/core/runner/agent.ts
+++ b/src/vex-agent/engine/core/runner/agent.ts
@@ -448,8 +448,31 @@ export async function runAgentTurnUnderLease(
   // means a woken slice would re-send the identical request and stall again -
   // a wake loop that spends input tokens forever. Both permissions get the
   // honest reply and the turn ends.
-  if (result.stopReason === "no_progress") {
-    if (!text) await persistSynthesisedReply(runtimeBoundExhaustedReply("no_progress"));
+  //
+  // ── Tool-call repetition ───────────────────────────────────────
+  //
+  // A SECOND arm on the same principle, and deliberately its own branch rather
+  // than a second literal in the stall test: the two stops mean opposite
+  // things about what happened. A stall produced nothing; a repetition
+  // produced real, executed tool calls over and over. They owe the user
+  // different sentences (`runtimeBoundExhaustedReply` picks), and they must
+  // never be conflated in a log or a copy change. What they share is the one
+  // decision that matters here - never continued, not even under full
+  // autonomy. Waking a session that just proved it repeats itself schedules
+  // the repetition.
+  //
+  // The stop reason returned below is the RAW `tool_call_loop`: this turn was
+  // not continued, so claiming `waiting_for_wake` would be a lie about a
+  // session nothing is going to wake.
+  /**
+   * The reason reported to the caller. It is the loop's own reason EXCEPT on
+   * the one path that changes what actually happens to the session - see the
+   * continuation branch below.
+   */
+  let reportedStopReason = result.stopReason;
+
+  if (result.stopReason === "no_progress" || result.stopReason === "tool_call_loop") {
+    if (!text) await persistSynthesisedReply(runtimeBoundExhaustedReply(result.stopReason));
   } else if (isContinuableRuntimeStop(result.stopReason)) {
     // The slice's own cancellation signal (a wake-driven slice carries it in
     // both positions). Handed to the scheduler, which re-reads it INSIDE the
@@ -463,7 +486,26 @@ export async function runAgentTurnUnderLease(
       })
       : { scheduled: false };
 
-    if (!continuation.scheduled && !text) {
+    if (continuation.scheduled) {
+      // ── M2: report what actually happened, not what the guard was called ──
+      //
+      // A continued full-autonomy turn is NOT over. `iteration_limit` and
+      // `timeout` describe the slice guard that fired INSIDE it, and every
+      // consumer downstream reads a stop reason as an account of the turn's
+      // outcome: the composer renders a terminal failure banner for `timeout`,
+      // exports record it as how the work ended, bug reports classify on it.
+      // The turn is parked with a live wake and the executor will resume it in
+      // seconds, so `waiting_for_wake` is the only honest answer, and it is
+      // the same reason a mission run reports for the same situation.
+      //
+      // Narrow ON PURPOSE. Only this arm remaps: a restricted session was
+      // never continued, and a full-autonomy session whose scheduling FAILED
+      // (`scheduled === false`, gated by an operator stop or a lost race) is
+      // genuinely over on the raw guard. Reporting `waiting_for_wake` there
+      // would promise a resume that nothing is going to perform - the exact
+      // dishonesty this change exists to remove, pointed the other way.
+      reportedStopReason = "waiting_for_wake";
+    } else if (!text) {
       await persistSynthesisedReply(runtimeBoundExhaustedReply(result.stopReason));
     }
   }
@@ -472,7 +514,7 @@ export async function runAgentTurnUnderLease(
     text,
     toolCallsMade: result.toolCallsMade,
     pendingApprovals: result.pendingApprovals,
-    stopReason: result.stopReason,
+    stopReason: reportedStopReason,
     missionStatus: null,
   };
 }

--- a/src/vex-agent/engine/core/runner/mission-finalize.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize.ts
@@ -30,6 +30,7 @@ import { finalizeBusinessOutcome } from "./mission-finalize/business-outcome.js"
 import { finalizeRuntimeContinuationPark } from "./mission-finalize/runtime-continuation-park.js";
 import { finalizeSystemError } from "./mission-finalize/system-error-escalation.js";
 import { finalizeOperatorReviewPark } from "./mission-finalize/operator-review-park.js";
+import { finalizeToolCallLoopPark } from "./mission-finalize/tool-call-loop-park.js";
 
 export { finalizeMissionRunError } from "./mission-finalize/error-pause.js";
 
@@ -73,6 +74,10 @@ export async function finalizeMissionRunStatus(
 
   if (stopReason === "system_error") {
     return finalizeSystemError(missionId, runId, sessionId, stopPayload);
+  }
+
+  if (stopReason === "tool_call_loop") {
+    return finalizeToolCallLoopPark(missionId, runId, sessionId, stopPayload);
   }
 
   if (stopReason === "compact_unable_at_critical" || stopReason === "no_progress") {

--- a/src/vex-agent/engine/core/runner/mission-finalize.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize.ts
@@ -13,66 +13,25 @@
  *     Persists `paused_error` with structured evidence; the caller is
  *     expected to re-throw `MissionRunPausedError` so shell wrappers map
  *     the failure to `{ ok: false }` instead of a fake "started" line.
+ *
+ * THIS FILE IS THE ROUTING TABLE. Each terminal / park policy owns its own
+ * module under `mission-finalize/`; the ORDER of the arms below is itself
+ * part of the contract (an operator stop outranks every business outcome),
+ * which is why the dispatch stays readable in one place. Both public entry
+ * points keep this module path, so existing importers are unaffected.
  */
 
 import type { MissionStatus, StopReason } from "../../types.js";
-import * as missionsRepo from "@vex-agent/db/repos/missions.js";
-import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
-import logger from "@utils/logger.js";
 import { consumeMissionRunAbortIntent } from "./abort.js";
-import { reconcileDraftReadiness } from "../../mission/draft-readiness.js";
-import {
-  isContinuableRuntimeStop,
-  scheduleRuntimeContinuation,
-} from "./runtime-continuation.js";
-import {
-  enqueueAutoRetryWake,
-  persistErrorPauseWithMaybeAutoRetry,
-} from "./mission-auto-retry.js";
-import { readMissionErrorSignal } from "./mission-error-signal.js";
+import { isContinuableRuntimeStop } from "./runtime-continuation.js";
+import { finalizeStopForEdit } from "./mission-finalize/stop-for-edit-outcome.js";
+import { finalizeUserStop } from "./mission-finalize/user-stop-outcome.js";
+import { finalizeBusinessOutcome } from "./mission-finalize/business-outcome.js";
+import { finalizeRuntimeContinuationPark } from "./mission-finalize/runtime-continuation-park.js";
+import { finalizeSystemError } from "./mission-finalize/system-error-escalation.js";
+import { finalizeOperatorReviewPark } from "./mission-finalize/operator-review-park.js";
 
-const ERROR_MESSAGE_LIMIT = 4096;
-
-/**
- * Helper — broadcast the post-finalize control-state event (puzzle 03).
- * Codex review acceptance: turn-loop emits at observe time with the
- * still-active lease; this helper fires AFTER finalize so the renderer
- * sees the canonical terminal status (an operator stop lands on
- * `stopped` / `user_stopped`) and the lease cleared. Wraps a DB re-read
- * for canonical state.
- */
-async function emitFinalizeControlState(
-  sessionId: string,
-  runId: string,
-): Promise<void> {
-  try {
-    const { controlStateBus, CONTROL_STATE_EVENT_TYPE } = await import(
-      "../../runtime/control-bus.js"
-    );
-    const { getLease } = await import(
-      "../../../db/repos/runner-leases.js"
-    );
-    const run = await missionRunsRepo.getRun(runId);
-    const lease = await getLease(sessionId);
-    if (run === null) return;
-    controlStateBus.emit({
-      type: CONTROL_STATE_EVENT_TYPE,
-      sessionId,
-      missionRunId: runId,
-      runStatus: run.status,
-      stopReason: run.stopReason ?? null,
-      pendingControlKind: null,
-      leaseActive: lease !== null && lease.expiresAt >= new Date(),
-      leaseExpiresAt:
-        lease !== null && lease.expiresAt >= new Date()
-          ? lease.expiresAt.toISOString()
-          : null,
-      correlationId: null,
-    });
-  } catch {
-    // intentionally swallowed — finalize must not break on bus errors
-  }
-}
+export { finalizeMissionRunError } from "./mission-finalize/error-pause.js";
 
 export async function finalizeMissionRunStatus(
   missionId: string,
@@ -87,476 +46,44 @@ export async function finalizeMissionRunStatus(
 
   if (shouldTerminateRun(stopReason)) {
     if (stopReason === "user_stopped" && consumeMissionRunAbortIntent(runId) === "edit") {
-      // ONE atomic, lock-aware transition, shared with `abort.ts`. The mission
-      // demotion is gated on WINNING the run transition, so an ordinary Stop
-      // that committed while this loop was unwinding is never overwritten and
-      // its `cancelled` mission is never resurrected into `draft`.
-      const { applyStopForEditTransaction } = await import(
-        "../../runtime/lease-and-status.js"
-      );
-      const applied = await applyStopForEditTransaction({
-        sessionId,
-        missionRunId: runId,
-        ...(stopPayload !== undefined ? { stopPayload } : {}),
-      });
-      await emitFinalizeControlState(sessionId, runId);
-      if (applied.outcome === "stopped_for_edit") {
-        // The async finalizer runs AFTER `stopMissionRunForEdit` already
-        // reconciled once (abort.ts) — this demote-then-finalize sequence is
-        // exactly the timing window issue #41 needs closed at every write
-        // site, not just the first one.
-        const reconciled = await reconcileDraftReadiness(applied.missionId);
-        return reconciled.promoted ? "ready" : "draft";
-      }
-      if (applied.outcome === "run_not_found") return "cancelled";
-      if (applied.outcome === "lost_to_terminal") {
-        logger.warn("engine.mission.edit_superseded_by_terminal_stop", {
-          runId,
-          missionId,
-          sessionId,
-          runStatus: applied.currentRunStatus,
-          missionStatus: applied.missionStatus,
-        });
-      }
-      // Either the sibling `abort.ts` transaction already landed this edit, or
-      // an ordinary Stop won. Report the mission row's REAL status either way.
-      return applied.missionStatus;
+      return finalizeStopForEdit(missionId, runId, sessionId, stopPayload);
     }
 
     if (stopReason === "user_stopped") {
-      // Finalize-after-local-abort: the operator's Stop fired the in-process
-      // AbortController, so the loop unwound before the iteration-boundary
-      // observer could apply the queued request. Run the SAME idempotent
-      // stop transaction the observer runs — whichever path wins the race,
-      // the DB ends up identical (run `stopped`/`user_stopped`, mission
-      // `cancelled`, approvals rejected, wakes cancelled, request cleared).
-      // Idempotent: a no-op when the observer already applied it.
-      const { applyUserStopTransaction } = await import(
-        "../../runtime/lease-and-status.js"
-      );
-      await applyUserStopTransaction({
-        sessionId,
-        missionRunId: runId,
-        stopPayload,
-      });
-      await emitFinalizeControlState(sessionId, runId);
-      // Mission-level terminal for an operator stop. `MissionStatus` has no
-      // `stopped` arm; only the RUN row carries the canonical
-      // `stopped` + `user_stopped` pair.
-      return "cancelled";
+      return finalizeUserStop(runId, sessionId, stopPayload);
     }
 
-    const status: MissionStatus = stopReason === "goal_reached"
-      ? "completed"
-      : "failed";
-    // TERMINAL-STOP PRECEDENCE for a real BUSINESS OUTCOME. `completed` and
-    // `failed` do move a run TO terminal, which is the one case the
-    // unconditional write exists for — but the outcome was decided by a
-    // turn-loop result that is arbitrarily stale by the time it lands here, and
-    // an operator Stop can have committed `stopped`/`user_stopped` in between.
-    // A user who pressed Stop asked for the run to end THERE; overwriting that
-    // with `completed` erases what they asked for and re-labels the audit row.
-    // The Stop wins.
-    //
-    // The RUN transition goes first and the PARENT MISSION row is written ONLY
-    // if it wins. The previous order (mission, then run) could mark the mission
-    // `completed` even when the run write lost the race — the mission row and
-    // its run row then disagreed about what happened.
-    const landed = await missionRunsRepo.updateStatusIfNotTerminal(
+    return finalizeBusinessOutcome(
+      missionId,
       runId,
-      status,
+      sessionId,
       stopReason,
       stopPayload,
     );
-    if (!landed) {
-      // The outcome is NOT silently dropped: it is recorded here as the one
-      // durable statement this path may make. Writing it onto the run row
-      // instead would mutate terminal audit history — the very thing this guard
-      // exists to prevent — and the row already carries the truthful pair.
-      logger.warn("engine.mission.outcome_superseded_by_terminal_stop", {
-        runId,
-        missionId,
-        sessionId,
-        supersededRunStatus: status,
-        stopReason,
-      });
-      await emitFinalizeControlState(sessionId, runId);
-      // `cancelled` is the mission-level terminal an operator stop writes (the
-      // stop transaction already set it). Returning the superseded outcome
-      // would report a mission as completed when the DB says it was stopped.
-      return "cancelled";
-    }
-    await missionsRepo.setStatus(missionId, status);
-    await emitFinalizeControlState(sessionId, runId);
-    return status;
   }
 
-  // Same TERMINAL-STOP PRECEDENCE rule as the `compact_unable_at_critical` arm
-  // below: parking a run for a later wake is a RECOVERY write, decided from a
-  // turn-loop outcome that is arbitrarily stale by the time it lands here, and
-  // it must never re-open a run an operator Stop already took terminal.
-  //
-  // The wake is enqueued BEFORE the CAS and cancelled when the CAS refuses,
-  // rather than enqueued after a successful CAS. That ordering is deliberate:
-  // a Stop landing between a successful CAS and a later enqueue would leave a
-  // continuation scheduled on a stopped run (the stop transaction's own wake
-  // cancellation would already have run), which is worse than the status write
-  // — the executor would wake the run back up. Enqueue-then-CAS-then-cancel
-  // closes that window instead of moving it.
   if (isContinuableRuntimeStop(stopReason)) {
-    const continuation = await scheduleRuntimeContinuation({
+    return finalizeRuntimeContinuationPark(
+      missionId,
+      runId,
       sessionId,
-      missionRunId: runId,
-      trigger: stopReason,
-    });
-    // DURABLE STOP CONSUMER (full rationale in `mission-auto-retry.ts`). The
-    // enqueue → park → cancel-if-lost ordering above is unchanged; only the park
-    // itself moves under the session control lock, and a gate that reports
-    // `stopped` is handled EXACTLY like a refused CAS below — including
-    // cancelling the wake this arm just enqueued.
-    const { gateOnOperatorStopWithClient, withSessionControlLock } = await import(
-      "../../runtime/lease-and-status.js"
+      stopReason,
     );
-    const parked = await withSessionControlLock(sessionId, async (client) => {
-      const gate = await gateOnOperatorStopWithClient(client, {
-        sessionId,
-        missionRunId: runId,
-      });
-      // Fail-closed: a stopped run gets no park write at all.
-      if (gate.kind === "stopped") return false;
-      return missionRunsRepo.updateStatusIfNotTerminal(
-        runId,
-        "paused_wake",
-        "waiting_for_wake",
-        {
-          summary: `${stopReason}: runtime slice exhausted; automatic continuation scheduled`,
-          evidence: {
-            trigger: stopReason,
-            dueAt: continuation.dueAt,
-            enqueued: continuation.enqueued,
-          },
-        },
-        client,
-      );
-    });
-    if (!parked) {
-      // The run went terminal while the slice was unwinding (or the gate just
-      // landed the operator's queued Stop). The row is
-      // immutable audit history and was left untouched — but the wake this arm
-      // just enqueued must not survive, or the executor resumes a stopped run.
-      // Only cancel a wake WE enqueued: `enqueued === false` means a pending
-      // wake already existed (partial unique index on session), and adopting
-      // someone else's row is not this arm's call to make.
-      if (continuation.enqueued) {
-        const { cancelForSession } = await import(
-          "@vex-agent/db/repos/loop-wake.js"
-        );
-        await cancelForSession(
-          sessionId,
-          `run ${runId} reached a terminal status before the ${stopReason} continuation could be parked`,
-        );
-      }
-      logger.warn("engine.mission.runtime_continuation_after_terminal", {
-        runId,
-        missionId,
-        sessionId,
-        trigger: stopReason,
-        wakeCancelled: continuation.enqueued,
-      });
-    }
-    return "running";
   }
 
   if (stopReason === "system_error") {
-    // Same TERMINAL-STOP PRECEDENCE and same run-before-mission ordering as the
-    // business-outcome arm above: `system_error` is a genuine terminal outcome,
-    // but a Stop that already committed outranks it.
-    const landed = await missionRunsRepo.updateStatusIfNotTerminal(
-      runId,
-      "failed",
-      stopReason,
-    );
-    if (!landed) {
-      logger.warn("engine.mission.outcome_superseded_by_terminal_stop", {
-        runId,
-        missionId,
-        sessionId,
-        supersededRunStatus: "failed",
-        stopReason,
-      });
-      await emitFinalizeControlState(sessionId, runId);
-      // The bug report is deliberately skipped: its `runtimeStatus: "failed"`
-      // would be a false statement about a run that is actually `stopped` —
-      // the same rule `finalizeMissionRunError` applies on its terminal branch.
-      // The warn above is the record that the escalation was superseded.
-      return "cancelled";
-    }
-    await missionsRepo.setStatus(missionId, "failed");
-    await emitFinalizeControlState(sessionId, runId);
-    // Phase 2 BUG-REPORTING emit (puzzle 03): terminal `system_error`
-    // is a hard failure surface — record the mission state. Fail-
-    // closed so a sink outage cannot mask the terminal flip.
-    const { getBugReportSink } = await import(
-      "../../support/bug-report-registry.js"
-    );
-    const { emitBugReportSafe } = await import(
-      "../../../../lib/diagnostics/bug-report-sink.js"
-    );
-    await emitBugReportSafe(
-      getBugReportSink(),
-      {
-        source: "agent",
-        category: "mission_system_error",
-        severity: "critical",
-        title: "mission.system_error",
-        description: stopPayload?.summary ?? "system_error terminal",
-        refs: {
-          sessionId,
-          missionId,
-          missionRunId: runId,
-        },
-        agentContext: {
-          stopReason: "system_error",
-          runtimeStatus: "failed",
-        },
-      },
-      logger,
-    );
-    return "failed";
+    return finalizeSystemError(missionId, runId, sessionId, stopPayload);
   }
 
-  // PR2 cutover: the runtime escalates to `compact_unable_at_critical` when
-  // the forced-fallback compact returns `noop` twice in a row at critical
-  // band — the agent cannot make forward progress without compaction it
-  // refuses to perform. Treat as a paused error (operator intervention
-  // surface) rather than a hard "failed" finalisation: the run row stays
-  // visible for /retry just like provider-error pauses, and the parent
-  // mission row stays `running` so the active-run lookup still surfaces it.
-  //
-  // TERMINAL-STOP PRECEDENCE. This is the LAST write in the escalation chain,
-  // so it — not the turn-loop helper that decided to escalate — is what the run
-  // row ends up carrying. The decision itself is arbitrarily stale by the time
-  // it lands here: `maybeRunForcedCompactFallback` is an await that can span a
-  // whole forced compaction, and an operator Stop can land terminally at any
-  // point inside it, INCLUDING after the helper's own CAS already succeeded.
-  // Guarding only the earlier write is therefore not enough — whichever write
-  // is last decides, so every write in the chain goes through the one repo CAS
-  // that owns this invariant (`updateStatusIfNotTerminal`). The unconditional
-  // `updateStatus` is reserved for writes that legitimately move a run TO a
-  // terminal state; a park/recovery write must never move one back out. A
-  // terminal user stop outranks every other terminal state.
-  // `no_progress` shares this arm's shape exactly: a run that cannot make
-  // forward progress on its own, parked for operator review with NO wake.
-  // It must NOT fall through to the `return "running"` at the bottom - that
-  // would leave the run row `running` with no wake and no lease, an orphan the
-  // operator can neither resume nor see the reason for. It is equally not a
-  // continuable stop: an unproductive round persists nothing, so a scheduled
-  // continuation would re-ask the identical question (see `stop-conditions.ts`).
   if (stopReason === "compact_unable_at_critical" || stopReason === "no_progress") {
-    // DURABLE STOP CONSUMER (see `mission-auto-retry.ts` for the full
-    // rationale). Parking here reaches `paused_error` with NO wake, so this is
-    // the last iteration boundary the run will ever have: a `stop_terminal`
-    // request still queued at this point would be stranded until the operator
-    // clicked Stop a second time. Gate + park commit together under the
-    // session control lock so a Stop cannot slip between them.
-    const defaultSummary = stopReason === "no_progress"
-      ? "The model returned only empty responses - no answer and no tool call - for several consecutive rounds; operator review required."
-      : "Two consecutive forced-fallback noops at critical pressure - operator review required.";
-    const { gateOnOperatorStopWithClient, withSessionControlLock } = await import(
-      "../../runtime/lease-and-status.js"
+    return finalizeOperatorReviewPark(
+      missionId,
+      runId,
+      sessionId,
+      stopReason,
+      stopPayload,
     );
-    const parked = await withSessionControlLock(sessionId, async (client) => {
-      const gate = await gateOnOperatorStopWithClient(client, {
-        sessionId,
-        missionRunId: runId,
-      });
-      // Fail-closed: the gate only COMPLETES the stop; it never resumes or
-      // dispatches anything. A stopped run gets no park write at all.
-      if (gate.kind === "stopped") return false;
-      return missionRunsRepo.updateStatusIfNotTerminal(
-        runId,
-        "paused_error",
-        stopReason,
-        {
-          summary: stopPayload?.summary ?? defaultSummary,
-          evidence: stopPayload?.evidence,
-        },
-        client,
-      );
-    });
-    if (!parked) {
-      // The run reached a terminal status while the compaction was awaited —
-      // in practice an operator Stop, whose own transaction already set the
-      // mission row. Nothing was written here and nothing may be: a terminal
-      // run row is immutable audit history. The return value describes what
-      // THIS arm did to the mission row (nothing, on both branches), which is
-      // why it is unchanged; the warn log is the record that the escalation
-      // was superseded.
-      logger.warn("engine.mission.operator_review_park_after_terminal", {
-        runId,
-        missionId,
-        sessionId,
-        stopReason,
-      });
-    }
-    return "running";
   }
 
   return "running";
-}
-
-/**
- * Persist a recoverable provider / runtime failure as `paused_error`.
- *
- * The mission row is intentionally left at `running` so `getActiveRunBySession`
- * still surfaces the run for `/retry` and the ingress-router paused_error
- * branch. The caller MUST re-throw `MissionRunPausedError` (defined in
- * engine/types.ts) so shell action wrappers turn the failure into a real
- * `{ ok: false, error, hint }` instead of a fake success.
- */
-export async function finalizeMissionRunError(
-  missionId: string,
-  runId: string,
-  sessionId: string,
-  err: unknown,
-): Promise<void> {
-  const errorMessage = formatErrorMessage(err);
-  const errorClass = err instanceof Error ? err.constructor.name : typeof err;
-  // Bounded transport signals (own-properties, never message text) — fed into
-  // the persisted evidence below AND the bug-report `context`.
-  //
-  // `errorClass` above is `err.constructor.name`, which is very nearly always
-  // the useless literal "Error"; the signal's own `errorClass` comes from the
-  // CLOSED SDK dictionary and its `errorType` is OpenRouter's canonical enum.
-  // Persisting THOSE is what lets the runtime DTO expose a `lastError` the
-  // renderer can classify — one vocabulary, the same one the engine error
-  // push channel uses. The free-text `errorMessage` stays server-side.
-  const signal = readMissionErrorSignal(err);
-  const causeCode = signal.causeCode;
-  // Log first — even if the DB write below fails, the failure stays visible.
-  logger.error("engine.mission.runtime_throw", {
-    runId,
-    missionId,
-    sessionId,
-    errorClass,
-    errorMessage,
-  });
-
-  try {
-    // Phase 4d: decide auto-retry eligibility on a FRESH locked read and persist
-    // paused_error (incrementing the retry count in the same tx when eligible).
-    const decision = await persistErrorPauseWithMaybeAutoRetry(
-      {
-        runId,
-        sessionId,
-        err,
-        summary: errorMessage,
-        evidenceBase: {
-          errorMessage,
-          errorClass,
-          causeCode,
-          // Bounded classification vocabulary — read by the runtime DTO's
-          // `lastError`. Keys are omitted when null so evidence written by
-          // older code and evidence with nothing to say look identical to the
-          // reader (absent ⇒ no lastError).
-          ...(signal.errorType !== null ? { errorType: signal.errorType } : {}),
-          ...(signal.errorClass !== null ? { sdkErrorClass: signal.errorClass } : {}),
-          ...(signal.status !== null ? { statusCode: signal.status } : {}),
-          occurredAt: new Date().toISOString(),
-          missionId,
-          runId,
-        },
-      },
-      Date.now(),
-    );
-    await emitFinalizeControlState(sessionId, runId);
-    if (!decision.persisted) {
-      // The run was already TERMINAL under the row lock — almost always an
-      // operator Stop that landed while the loop was unwinding. Nothing was
-      // written and nothing may be: a terminal run row is immutable audit
-      // history. The failure itself stays visible through the `error` log
-      // above; the bug report below is deliberately skipped because its
-      // `runtimeStatus: "paused_error"` would be a false statement about a
-      // run that is actually stopped.
-      logger.warn("engine.mission.runtime_throw_after_terminal", {
-        runId,
-        missionId,
-        sessionId,
-        errorClass,
-      });
-      return;
-    }
-    // Enqueue the retry wake AFTER the persist commits. A failed/duplicate
-    // enqueue leaves the run recoverable (no auto-resume) — never throws.
-    if (decision.scheduled !== null) {
-      await enqueueAutoRetryWake({
-        sessionId,
-        runId,
-        attempt: decision.scheduled.attempt,
-        dueAt: decision.scheduled.dueAt,
-      });
-      logger.info("engine.mission.auto_retry_scheduled", {
-        runId,
-        missionId,
-        sessionId,
-        attempt: decision.scheduled.attempt,
-        nextRetryAt: decision.scheduled.dueAt,
-      });
-    }
-    // Phase 2 BUG-REPORTING emit (puzzle 03): persisting `paused_error`
-    // is the canonical recoverable-failure surface — emit so support
-    // records carry the error class + agent context. Fail-closed
-    // through `emitBugReportSafe` so a support outage cannot mask the
-    // original runtime failure.
-    const { getBugReportSink } = await import(
-      "../../support/bug-report-registry.js"
-    );
-    const { emitBugReportSafe } = await import(
-      "../../../../lib/diagnostics/bug-report-sink.js"
-    );
-    await emitBugReportSafe(
-      getBugReportSink(),
-      {
-        source: "agent",
-        category: "mission_paused_error",
-        severity: "error",
-        title: `mission.${errorClass}`,
-        description: errorMessage,
-        refs: {
-          sessionId,
-          missionId,
-          missionRunId: runId,
-        },
-        // `context` itself is `z.record(z.string(), z.unknown())` (unbounded;
-        // `bug-report-schema.ts`) — redaction happens later in the bug-report
-        // service. The VALUE stored under `causeCode` here is shape-validated
-        // (errno-shaped, own-property-read — see `mission-error-signal.ts`),
-        // never raw message text beyond what already flows through
-        // `description`.
-        context: { causeCode },
-        agentContext: {
-          stopReason: "provider_error",
-          runtimeStatus: "paused_error",
-        },
-      },
-      logger,
-    );
-  } catch (dbErr: unknown) {
-    logger.error("engine.mission.paused_error_persist_failed", {
-      runId,
-      missionId,
-      sessionId,
-      dbError: dbErr instanceof Error ? dbErr.message : String(dbErr),
-    });
-    // Re-throw so the caller's catch path still trips the recoverable
-    // throw — masking the persist failure would silently leave the run
-    // in `running` while the user sees the error, recreating the very
-    // orphan-state bug this module exists to fix.
-    throw dbErr;
-  }
-}
-
-function formatErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message.slice(0, ERROR_MESSAGE_LIMIT);
-  return String(err).slice(0, ERROR_MESSAGE_LIMIT);
 }

--- a/src/vex-agent/engine/core/runner/mission-finalize/bug-report-emit.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize/bug-report-emit.ts
@@ -1,0 +1,106 @@
+/**
+ * Mission bug-report emission (phase 2 BUG-REPORTING, puzzle 03).
+ *
+ * The two mission failure surfaces that record a support entry both live
+ * in the finalize family: terminal `system_error` and the recoverable
+ * `paused_error` pause. Both emit through `emitBugReportSafe`, which is
+ * fail-closed so a support-sink outage can never mask the real failure.
+ *
+ * Neither emitter runs when the run turned out to be terminal under an
+ * operator Stop: the `runtimeStatus` it would report would be a false
+ * statement about the row. That precedence decision belongs to the
+ * calling arm; this module owns only the emission.
+ */
+
+import logger from "@utils/logger.js";
+
+interface MissionBugReportRefs {
+  readonly sessionId: string;
+  readonly missionId: string;
+  readonly runId: string;
+}
+
+/**
+ * Terminal `system_error` escalation record. `severity: "critical"` -
+ * terminal `system_error` is a hard failure surface, so the mission state
+ * is recorded.
+ */
+export async function emitMissionSystemErrorReport(
+  refs: MissionBugReportRefs,
+  description: string,
+): Promise<void> {
+  const { getBugReportSink } = await import(
+    "../../../support/bug-report-registry.js"
+  );
+  const { emitBugReportSafe } = await import(
+    "../../../../../lib/diagnostics/bug-report-sink.js"
+  );
+  await emitBugReportSafe(
+    getBugReportSink(),
+    {
+      source: "agent",
+      category: "mission_system_error",
+      severity: "critical",
+      title: "mission.system_error",
+      description,
+      refs: {
+        sessionId: refs.sessionId,
+        missionId: refs.missionId,
+        missionRunId: refs.runId,
+      },
+      agentContext: {
+        stopReason: "system_error",
+        runtimeStatus: "failed",
+      },
+    },
+    logger,
+  );
+}
+
+/**
+ * Recoverable `paused_error` record - the canonical recoverable-failure
+ * surface, so support records carry the error class plus agent context.
+ *
+ * `context` itself is `z.record(z.string(), z.unknown())` (unbounded;
+ * `bug-report-schema.ts`) - redaction happens later in the bug-report
+ * service. The VALUE stored under `causeCode` here is shape-validated
+ * (errno-shaped, own-property-read - see `mission-error-signal.ts`),
+ * never raw message text beyond what already flows through
+ * `description`.
+ */
+export async function emitMissionPausedErrorReport(
+  refs: MissionBugReportRefs,
+  input: {
+    readonly errorClass: string;
+    readonly errorMessage: string;
+    readonly causeCode: string | null;
+  },
+): Promise<void> {
+  const { getBugReportSink } = await import(
+    "../../../support/bug-report-registry.js"
+  );
+  const { emitBugReportSafe } = await import(
+    "../../../../../lib/diagnostics/bug-report-sink.js"
+  );
+  await emitBugReportSafe(
+    getBugReportSink(),
+    {
+      source: "agent",
+      category: "mission_paused_error",
+      severity: "error",
+      title: `mission.${input.errorClass}`,
+      description: input.errorMessage,
+      refs: {
+        sessionId: refs.sessionId,
+        missionId: refs.missionId,
+        missionRunId: refs.runId,
+      },
+      context: { causeCode: input.causeCode },
+      agentContext: {
+        stopReason: "provider_error",
+        runtimeStatus: "paused_error",
+      },
+    },
+    logger,
+  );
+}

--- a/src/vex-agent/engine/core/runner/mission-finalize/business-outcome.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize/business-outcome.ts
@@ -1,0 +1,63 @@
+/**
+ * Real BUSINESS OUTCOME finalisation: `goal_reached` -> `completed`,
+ * every other terminating stop -> `failed`, written across the run row
+ * and its parent mission row.
+ */
+
+import type { MissionStatus, StopReason } from "../../../types.js";
+import * as missionsRepo from "@vex-agent/db/repos/missions.js";
+import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
+import logger from "@utils/logger.js";
+import { emitFinalizeControlState } from "./control-state-emit.js";
+
+export async function finalizeBusinessOutcome(
+  missionId: string,
+  runId: string,
+  sessionId: string,
+  stopReason: StopReason,
+  stopPayload?: { summary?: string; evidence?: Record<string, unknown> },
+): Promise<MissionStatus> {
+  const status: MissionStatus = stopReason === "goal_reached"
+    ? "completed"
+    : "failed";
+  // TERMINAL-STOP PRECEDENCE for a real BUSINESS OUTCOME. `completed` and
+  // `failed` do move a run TO terminal, which is the one case the
+  // unconditional write exists for - but the outcome was decided by a
+  // turn-loop result that is arbitrarily stale by the time it lands here, and
+  // an operator Stop can have committed `stopped`/`user_stopped` in between.
+  // A user who pressed Stop asked for the run to end THERE; overwriting that
+  // with `completed` erases what they asked for and re-labels the audit row.
+  // The Stop wins.
+  //
+  // The RUN transition goes first and the PARENT MISSION row is written ONLY
+  // if it wins. The previous order (mission, then run) could mark the mission
+  // `completed` even when the run write lost the race - the mission row and
+  // its run row then disagreed about what happened.
+  const landed = await missionRunsRepo.updateStatusIfNotTerminal(
+    runId,
+    status,
+    stopReason,
+    stopPayload,
+  );
+  if (!landed) {
+    // The outcome is NOT silently dropped: it is recorded here as the one
+    // durable statement this path may make. Writing it onto the run row
+    // instead would mutate terminal audit history - the very thing this guard
+    // exists to prevent - and the row already carries the truthful pair.
+    logger.warn("engine.mission.outcome_superseded_by_terminal_stop", {
+      runId,
+      missionId,
+      sessionId,
+      supersededRunStatus: status,
+      stopReason,
+    });
+    await emitFinalizeControlState(sessionId, runId);
+    // `cancelled` is the mission-level terminal an operator stop writes (the
+    // stop transaction already set it). Returning the superseded outcome
+    // would report a mission as completed when the DB says it was stopped.
+    return "cancelled";
+  }
+  await missionsRepo.setStatus(missionId, status);
+  await emitFinalizeControlState(sessionId, runId);
+  return status;
+}

--- a/src/vex-agent/engine/core/runner/mission-finalize/control-state-emit.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize/control-state-emit.ts
@@ -1,0 +1,47 @@
+/**
+ * Post-finalize control-state broadcast (puzzle 03).
+ *
+ * Codex review acceptance: turn-loop emits at observe time with the
+ * still-active lease; this helper fires AFTER finalize so the renderer
+ * sees the canonical terminal status (an operator stop lands on
+ * `stopped` / `user_stopped`) and the lease cleared. Wraps a DB re-read
+ * for canonical state.
+ *
+ * Owned by the finalize family and consumed by every arm that writes a
+ * run row. Never throws: finalize must not break on bus errors.
+ */
+
+import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
+
+export async function emitFinalizeControlState(
+  sessionId: string,
+  runId: string,
+): Promise<void> {
+  try {
+    const { controlStateBus, CONTROL_STATE_EVENT_TYPE } = await import(
+      "../../../runtime/control-bus.js"
+    );
+    const { getLease } = await import(
+      "../../../../db/repos/runner-leases.js"
+    );
+    const run = await missionRunsRepo.getRun(runId);
+    const lease = await getLease(sessionId);
+    if (run === null) return;
+    controlStateBus.emit({
+      type: CONTROL_STATE_EVENT_TYPE,
+      sessionId,
+      missionRunId: runId,
+      runStatus: run.status,
+      stopReason: run.stopReason ?? null,
+      pendingControlKind: null,
+      leaseActive: lease !== null && lease.expiresAt >= new Date(),
+      leaseExpiresAt:
+        lease !== null && lease.expiresAt >= new Date()
+          ? lease.expiresAt.toISOString()
+          : null,
+      correlationId: null,
+    });
+  } catch {
+    // intentionally swallowed - finalize must not break on bus errors
+  }
+}

--- a/src/vex-agent/engine/core/runner/mission-finalize/error-pause.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize/error-pause.ts
@@ -1,0 +1,142 @@
+/**
+ * Thrown-failure pause path: persist a recoverable provider / runtime
+ * failure as `paused_error`.
+ *
+ * Covers anything thrown from the post-`createRun` block in `startMission`
+ * or the post-`updateStatus("running")` block in `resumeMissionRun`.
+ *
+ * The mission row is intentionally left at `running` so `getActiveRunBySession`
+ * still surfaces the run for `/retry` and the ingress-router paused_error
+ * branch. The caller MUST re-throw `MissionRunPausedError` (defined in
+ * engine/types.ts) so shell action wrappers turn the failure into a real
+ * `{ ok: false, error, hint }` instead of a fake success.
+ */
+
+import logger from "@utils/logger.js";
+import {
+  enqueueAutoRetryWake,
+  persistErrorPauseWithMaybeAutoRetry,
+} from "../mission-auto-retry.js";
+import { readMissionErrorSignal } from "../mission-error-signal.js";
+import { emitFinalizeControlState } from "./control-state-emit.js";
+import { emitMissionPausedErrorReport } from "./bug-report-emit.js";
+
+/**
+ * Character bound on the persisted error text. The bound exists because the
+ * message is free text from a provider or an SDK and lands in a durable row,
+ * a bug-report description and a log line.
+ */
+const ERROR_MESSAGE_LIMIT = 4096;
+
+export async function finalizeMissionRunError(
+  missionId: string,
+  runId: string,
+  sessionId: string,
+  err: unknown,
+): Promise<void> {
+  const errorMessage = formatErrorMessage(err);
+  const errorClass = err instanceof Error ? err.constructor.name : typeof err;
+  // Bounded transport signals (own-properties, never message text) - fed into
+  // the persisted evidence below AND the bug-report `context`.
+  //
+  // `errorClass` above is `err.constructor.name`, which is very nearly always
+  // the useless literal "Error"; the signal's own `errorClass` comes from the
+  // CLOSED SDK dictionary and its `errorType` is OpenRouter's canonical enum.
+  // Persisting THOSE is what lets the runtime DTO expose a `lastError` the
+  // renderer can classify - one vocabulary, the same one the engine error
+  // push channel uses. The free-text `errorMessage` stays server-side.
+  const signal = readMissionErrorSignal(err);
+  const causeCode = signal.causeCode;
+  // Log first - even if the DB write below fails, the failure stays visible.
+  logger.error("engine.mission.runtime_throw", {
+    runId,
+    missionId,
+    sessionId,
+    errorClass,
+    errorMessage,
+  });
+
+  try {
+    // Phase 4d: decide auto-retry eligibility on a FRESH locked read and persist
+    // paused_error (incrementing the retry count in the same tx when eligible).
+    const decision = await persistErrorPauseWithMaybeAutoRetry(
+      {
+        runId,
+        sessionId,
+        err,
+        summary: errorMessage,
+        evidenceBase: {
+          errorMessage,
+          errorClass,
+          causeCode,
+          // Bounded classification vocabulary - read by the runtime DTO's
+          // `lastError`. Keys are omitted when null so evidence written by
+          // older code and evidence with nothing to say look identical to the
+          // reader (absent ⇒ no lastError).
+          ...(signal.errorType !== null ? { errorType: signal.errorType } : {}),
+          ...(signal.errorClass !== null ? { sdkErrorClass: signal.errorClass } : {}),
+          ...(signal.status !== null ? { statusCode: signal.status } : {}),
+          occurredAt: new Date().toISOString(),
+          missionId,
+          runId,
+        },
+      },
+      Date.now(),
+    );
+    await emitFinalizeControlState(sessionId, runId);
+    if (!decision.persisted) {
+      // The run was already TERMINAL under the row lock - almost always an
+      // operator Stop that landed while the loop was unwinding. Nothing was
+      // written and nothing may be: a terminal run row is immutable audit
+      // history. The failure itself stays visible through the `error` log
+      // above; the bug report below is deliberately skipped because its
+      // `runtimeStatus: "paused_error"` would be a false statement about a
+      // run that is actually stopped.
+      logger.warn("engine.mission.runtime_throw_after_terminal", {
+        runId,
+        missionId,
+        sessionId,
+        errorClass,
+      });
+      return;
+    }
+    // Enqueue the retry wake AFTER the persist commits. A failed/duplicate
+    // enqueue leaves the run recoverable (no auto-resume) - never throws.
+    if (decision.scheduled !== null) {
+      await enqueueAutoRetryWake({
+        sessionId,
+        runId,
+        attempt: decision.scheduled.attempt,
+        dueAt: decision.scheduled.dueAt,
+      });
+      logger.info("engine.mission.auto_retry_scheduled", {
+        runId,
+        missionId,
+        sessionId,
+        attempt: decision.scheduled.attempt,
+        nextRetryAt: decision.scheduled.dueAt,
+      });
+    }
+    await emitMissionPausedErrorReport(
+      { sessionId, missionId, runId },
+      { errorClass, errorMessage, causeCode },
+    );
+  } catch (dbErr: unknown) {
+    logger.error("engine.mission.paused_error_persist_failed", {
+      runId,
+      missionId,
+      sessionId,
+      dbError: dbErr instanceof Error ? dbErr.message : String(dbErr),
+    });
+    // Re-throw so the caller's catch path still trips the recoverable
+    // throw - masking the persist failure would silently leave the run
+    // in `running` while the user sees the error, recreating the very
+    // orphan-state bug this module exists to fix.
+    throw dbErr;
+  }
+}
+
+function formatErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message.slice(0, ERROR_MESSAGE_LIMIT);
+  return String(err).slice(0, ERROR_MESSAGE_LIMIT);
+}

--- a/src/vex-agent/engine/core/runner/mission-finalize/error-pause.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize/error-pause.ts
@@ -26,7 +26,7 @@ import { emitMissionPausedErrorReport } from "./bug-report-emit.js";
  * message is free text from a provider or an SDK and lands in a durable row,
  * a bug-report description and a log line.
  */
-const ERROR_MESSAGE_LIMIT = 4096;
+export const ERROR_MESSAGE_LIMIT = 4096;
 
 export async function finalizeMissionRunError(
   missionId: string,
@@ -136,7 +136,21 @@ export async function finalizeMissionRunError(
   }
 }
 
+/**
+ * Bound the error text WITHOUT hiding that it was bounded.
+ *
+ * A bare slice is forbidden here: an error message is content the operator
+ * and the support record must be able to read honestly, so a cut that leaves
+ * no trace would make a partial provider message look like the whole one.
+ * When the message is cut, the stored text NAMES the cut and the original
+ * length, so the reader can tell exactly how much is missing. Under the
+ * limit the message is stored verbatim and carries no marker.
+ */
+export function boundErrorMessage(raw: string): string {
+  if (raw.length <= ERROR_MESSAGE_LIMIT) return raw;
+  return `${raw.slice(0, ERROR_MESSAGE_LIMIT)}\n[truncated: first ${ERROR_MESSAGE_LIMIT} of ${raw.length} characters shown]`;
+}
+
 function formatErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message.slice(0, ERROR_MESSAGE_LIMIT);
-  return String(err).slice(0, ERROR_MESSAGE_LIMIT);
+  return boundErrorMessage(err instanceof Error ? err.message : String(err));
 }

--- a/src/vex-agent/engine/core/runner/mission-finalize/operator-review-park.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize/operator-review-park.ts
@@ -1,0 +1,97 @@
+/**
+ * No-wake operator-review park for `compact_unable_at_critical` and
+ * `no_progress`.
+ *
+ * PR2 cutover: the runtime escalates to `compact_unable_at_critical` when
+ * the forced-fallback compact returns `noop` twice in a row at critical
+ * band - the agent cannot make forward progress without compaction it
+ * refuses to perform. Treat as a paused error (operator intervention
+ * surface) rather than a hard "failed" finalisation: the run row stays
+ * visible for /retry just like provider-error pauses, and the parent
+ * mission row stays `running` so the active-run lookup still surfaces it.
+ *
+ * TERMINAL-STOP PRECEDENCE. This is the LAST write in the escalation chain,
+ * so it - not the turn-loop helper that decided to escalate - is what the run
+ * row ends up carrying. The decision itself is arbitrarily stale by the time
+ * it lands here: `maybeRunForcedCompactFallback` is an await that can span a
+ * whole forced compaction, and an operator Stop can land terminally at any
+ * point inside it, INCLUDING after the helper's own CAS already succeeded.
+ * Guarding only the earlier write is therefore not enough - whichever write
+ * is last decides, so every write in the chain goes through the one repo CAS
+ * that owns this invariant (`updateStatusIfNotTerminal`). The unconditional
+ * `updateStatus` is reserved for writes that legitimately move a run TO a
+ * terminal state; a park/recovery write must never move one back out. A
+ * terminal user stop outranks every other terminal state.
+ *
+ * `no_progress` shares this arm's shape exactly: a run that cannot make
+ * forward progress on its own, parked for operator review with NO wake.
+ * It must NOT fall through to the caller's `return "running"` default - that
+ * would leave the run row `running` with no wake and no lease, an orphan the
+ * operator can neither resume nor see the reason for. It is equally not a
+ * continuable stop: an unproductive round persists nothing, so a scheduled
+ * continuation would re-ask the identical question (see `stop-conditions.ts`).
+ */
+
+import type { MissionStatus } from "../../../types.js";
+import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
+import logger from "@utils/logger.js";
+
+export type OperatorReviewParkStop =
+  | "compact_unable_at_critical"
+  | "no_progress";
+
+export async function finalizeOperatorReviewPark(
+  missionId: string,
+  runId: string,
+  sessionId: string,
+  stopReason: OperatorReviewParkStop,
+  stopPayload?: { summary?: string; evidence?: Record<string, unknown> },
+): Promise<MissionStatus> {
+  // DURABLE STOP CONSUMER (see `mission-auto-retry.ts` for the full
+  // rationale). Parking here reaches `paused_error` with NO wake, so this is
+  // the last iteration boundary the run will ever have: a `stop_terminal`
+  // request still queued at this point would be stranded until the operator
+  // clicked Stop a second time. Gate + park commit together under the
+  // session control lock so a Stop cannot slip between them.
+  const defaultSummary = stopReason === "no_progress"
+    ? "The model returned only empty responses - no answer and no tool call - for several consecutive rounds; operator review required."
+    : "Two consecutive forced-fallback noops at critical pressure - operator review required.";
+  const { gateOnOperatorStopWithClient, withSessionControlLock } = await import(
+    "../../../runtime/lease-and-status.js"
+  );
+  const parked = await withSessionControlLock(sessionId, async (client) => {
+    const gate = await gateOnOperatorStopWithClient(client, {
+      sessionId,
+      missionRunId: runId,
+    });
+    // Fail-closed: the gate only COMPLETES the stop; it never resumes or
+    // dispatches anything. A stopped run gets no park write at all.
+    if (gate.kind === "stopped") return false;
+    return missionRunsRepo.updateStatusIfNotTerminal(
+      runId,
+      "paused_error",
+      stopReason,
+      {
+        summary: stopPayload?.summary ?? defaultSummary,
+        evidence: stopPayload?.evidence,
+      },
+      client,
+    );
+  });
+  if (!parked) {
+    // The run reached a terminal status while the compaction was awaited -
+    // in practice an operator Stop, whose own transaction already set the
+    // mission row. Nothing was written here and nothing may be: a terminal
+    // run row is immutable audit history. The return value describes what
+    // THIS arm did to the mission row (nothing, on both branches), which is
+    // why it is unchanged; the warn log is the record that the escalation
+    // was superseded.
+    logger.warn("engine.mission.operator_review_park_after_terminal", {
+      runId,
+      missionId,
+      sessionId,
+      stopReason,
+    });
+  }
+  return "running";
+}

--- a/src/vex-agent/engine/core/runner/mission-finalize/runtime-continuation-park.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize/runtime-continuation-park.ts
@@ -1,0 +1,95 @@
+/**
+ * Continuable-runtime-stop park: the slice ran out of iterations or wall
+ * clock, so the run is parked `paused_wake` / `waiting_for_wake` and an
+ * automatic continuation is scheduled.
+ *
+ * Same TERMINAL-STOP PRECEDENCE rule as the operator-review park: parking
+ * a run for a later wake is a RECOVERY write, decided from a turn-loop
+ * outcome that is arbitrarily stale by the time it lands here, and it must
+ * never re-open a run an operator Stop already took terminal.
+ *
+ * The wake is enqueued BEFORE the CAS and cancelled when the CAS refuses,
+ * rather than enqueued after a successful CAS. That ordering is deliberate:
+ * a Stop landing between a successful CAS and a later enqueue would leave a
+ * continuation scheduled on a stopped run (the stop transaction's own wake
+ * cancellation would already have run), which is worse than the status write
+ * - the executor would wake the run back up. Enqueue-then-CAS-then-cancel
+ * closes that window instead of moving it.
+ */
+
+import type { MissionStatus } from "../../../types.js";
+import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
+import logger from "@utils/logger.js";
+import {
+  scheduleRuntimeContinuation,
+  type ContinuableRuntimeStop,
+} from "../runtime-continuation.js";
+
+export async function finalizeRuntimeContinuationPark(
+  missionId: string,
+  runId: string,
+  sessionId: string,
+  stopReason: ContinuableRuntimeStop,
+): Promise<MissionStatus> {
+  const continuation = await scheduleRuntimeContinuation({
+    sessionId,
+    missionRunId: runId,
+    trigger: stopReason,
+  });
+  // DURABLE STOP CONSUMER (full rationale in `mission-auto-retry.ts`). The
+  // enqueue → park → cancel-if-lost ordering above is unchanged; only the park
+  // itself moves under the session control lock, and a gate that reports
+  // `stopped` is handled EXACTLY like a refused CAS below - including
+  // cancelling the wake this arm just enqueued.
+  const { gateOnOperatorStopWithClient, withSessionControlLock } = await import(
+    "../../../runtime/lease-and-status.js"
+  );
+  const parked = await withSessionControlLock(sessionId, async (client) => {
+    const gate = await gateOnOperatorStopWithClient(client, {
+      sessionId,
+      missionRunId: runId,
+    });
+    // Fail-closed: a stopped run gets no park write at all.
+    if (gate.kind === "stopped") return false;
+    return missionRunsRepo.updateStatusIfNotTerminal(
+      runId,
+      "paused_wake",
+      "waiting_for_wake",
+      {
+        summary: `${stopReason}: runtime slice exhausted; automatic continuation scheduled`,
+        evidence: {
+          trigger: stopReason,
+          dueAt: continuation.dueAt,
+          enqueued: continuation.enqueued,
+        },
+      },
+      client,
+    );
+  });
+  if (!parked) {
+    // The run went terminal while the slice was unwinding (or the gate just
+    // landed the operator's queued Stop). The row is
+    // immutable audit history and was left untouched - but the wake this arm
+    // just enqueued must not survive, or the executor resumes a stopped run.
+    // Only cancel a wake WE enqueued: `enqueued === false` means a pending
+    // wake already existed (partial unique index on session), and adopting
+    // someone else's row is not this arm's call to make.
+    if (continuation.enqueued) {
+      const { cancelForSession } = await import(
+        "@vex-agent/db/repos/loop-wake.js"
+      );
+      await cancelForSession(
+        sessionId,
+        `run ${runId} reached a terminal status before the ${stopReason} continuation could be parked`,
+      );
+    }
+    logger.warn("engine.mission.runtime_continuation_after_terminal", {
+      runId,
+      missionId,
+      sessionId,
+      trigger: stopReason,
+      wakeCancelled: continuation.enqueued,
+    });
+  }
+  return "running";
+}

--- a/src/vex-agent/engine/core/runner/mission-finalize/stop-for-edit-outcome.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize/stop-for-edit-outcome.ts
@@ -1,0 +1,55 @@
+/**
+ * Stop-for-edit terminal policy.
+ *
+ * The operator stopped the run in order to EDIT the mission, so the parent
+ * mission row is demoted back to `draft` / `ready` instead of `cancelled`.
+ * Reached only when the run's abort intent was `edit` (consumed by the
+ * caller before this arm runs).
+ */
+
+import type { MissionStatus } from "../../../types.js";
+import logger from "@utils/logger.js";
+import { reconcileDraftReadiness } from "../../../mission/draft-readiness.js";
+import { emitFinalizeControlState } from "./control-state-emit.js";
+
+export async function finalizeStopForEdit(
+  missionId: string,
+  runId: string,
+  sessionId: string,
+  stopPayload?: { summary?: string; evidence?: Record<string, unknown> },
+): Promise<MissionStatus> {
+  // ONE atomic, lock-aware transition, shared with `abort.ts`. The mission
+  // demotion is gated on WINNING the run transition, so an ordinary Stop
+  // that committed while this loop was unwinding is never overwritten and
+  // its `cancelled` mission is never resurrected into `draft`.
+  const { applyStopForEditTransaction } = await import(
+    "../../../runtime/lease-and-status.js"
+  );
+  const applied = await applyStopForEditTransaction({
+    sessionId,
+    missionRunId: runId,
+    ...(stopPayload !== undefined ? { stopPayload } : {}),
+  });
+  await emitFinalizeControlState(sessionId, runId);
+  if (applied.outcome === "stopped_for_edit") {
+    // The async finalizer runs AFTER `stopMissionRunForEdit` already
+    // reconciled once (abort.ts) - this demote-then-finalize sequence is
+    // exactly the timing window issue #41 needs closed at every write
+    // site, not just the first one.
+    const reconciled = await reconcileDraftReadiness(applied.missionId);
+    return reconciled.promoted ? "ready" : "draft";
+  }
+  if (applied.outcome === "run_not_found") return "cancelled";
+  if (applied.outcome === "lost_to_terminal") {
+    logger.warn("engine.mission.edit_superseded_by_terminal_stop", {
+      runId,
+      missionId,
+      sessionId,
+      runStatus: applied.currentRunStatus,
+      missionStatus: applied.missionStatus,
+    });
+  }
+  // Either the sibling `abort.ts` transaction already landed this edit, or
+  // an ordinary Stop won. Report the mission row's REAL status either way.
+  return applied.missionStatus;
+}

--- a/src/vex-agent/engine/core/runner/mission-finalize/system-error-escalation.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize/system-error-escalation.ts
@@ -1,0 +1,49 @@
+/**
+ * Terminal `system_error` escalation.
+ *
+ * Same TERMINAL-STOP PRECEDENCE and same run-before-mission ordering as the
+ * business-outcome arm: `system_error` is a genuine terminal outcome, but a
+ * Stop that already committed outranks it.
+ */
+
+import type { MissionStatus } from "../../../types.js";
+import * as missionsRepo from "@vex-agent/db/repos/missions.js";
+import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
+import logger from "@utils/logger.js";
+import { emitFinalizeControlState } from "./control-state-emit.js";
+import { emitMissionSystemErrorReport } from "./bug-report-emit.js";
+
+export async function finalizeSystemError(
+  missionId: string,
+  runId: string,
+  sessionId: string,
+  stopPayload?: { summary?: string; evidence?: Record<string, unknown> },
+): Promise<MissionStatus> {
+  const landed = await missionRunsRepo.updateStatusIfNotTerminal(
+    runId,
+    "failed",
+    "system_error",
+  );
+  if (!landed) {
+    logger.warn("engine.mission.outcome_superseded_by_terminal_stop", {
+      runId,
+      missionId,
+      sessionId,
+      supersededRunStatus: "failed",
+      stopReason: "system_error",
+    });
+    await emitFinalizeControlState(sessionId, runId);
+    // The bug report is deliberately skipped: its `runtimeStatus: "failed"`
+    // would be a false statement about a run that is actually `stopped` -
+    // the same rule `finalizeMissionRunError` applies on its terminal branch.
+    // The warn above is the record that the escalation was superseded.
+    return "cancelled";
+  }
+  await missionsRepo.setStatus(missionId, "failed");
+  await emitFinalizeControlState(sessionId, runId);
+  await emitMissionSystemErrorReport(
+    { sessionId, missionId, runId },
+    stopPayload?.summary ?? "system_error terminal",
+  );
+  return "failed";
+}

--- a/src/vex-agent/engine/core/runner/mission-finalize/tool-call-loop-park.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize/tool-call-loop-park.ts
@@ -1,0 +1,91 @@
+/**
+ * No-wake park for `tool_call_loop`: the model repeated the same completed
+ * tool call after already being corrected once, so the run stops for a human.
+ *
+ * ## Why this is its own arm and not a branch of the operator-review park
+ *
+ * `operator-review-park.ts` covers two stops that share one story: the run
+ * cannot make forward progress ON ITS OWN and nothing about it ran. This one
+ * has a different story and a different piece of user-facing truth in it -
+ * the repeated calls DID execute, up to the correction. Any copy that implies
+ * an inert run would be false about a run that may have signed, broadcast or
+ * spent something on each pass of the cycle. That difference is exactly why
+ * the renderer refuses one-click retry for this cause, and a shared arm with a
+ * ternary on the summary would have buried the reason for it.
+ *
+ * ## Why it must exist at all
+ *
+ * Without a guarded arm here, `tool_call_loop` falls through
+ * `finalizeMissionRunStatus` to its `return "running"` default: the run row
+ * stays `running` with no wake and no lease, an orphan the operator can
+ * neither resume nor see a reason for. It is equally not a CONTINUABLE stop -
+ * a scheduled continuation would wake the model into the identical state that
+ * just produced the repetition, which is the loop with extra steps.
+ *
+ * TERMINAL-STOP PRECEDENCE. Like every other park in this family, the write
+ * goes through `updateStatusIfNotTerminal` under the session control lock,
+ * with the operator-stop gate consumed in the same transaction. A park write
+ * must never move a run back out of a terminal state, and a `stop_terminal`
+ * queued at this point would otherwise be stranded: parking here reaches
+ * `paused_error` with NO wake, so this is the last iteration boundary the run
+ * will ever have.
+ */
+
+import type { MissionStatus } from "../../../types.js";
+import * as missionRunsRepo from "@vex-agent/db/repos/mission-runs.js";
+import logger from "@utils/logger.js";
+
+/**
+ * Truthful default when the batch did not supply its own summary. It names the
+ * repetition and the correction (so "just retry it" is visibly not the answer)
+ * and it does NOT claim the run did nothing.
+ */
+const TOOL_CALL_LOOP_SUMMARY =
+  "The agent repeated the same tool call with the same result, was corrected once, and "
+  + "repeated it again - so the run was stopped instead of continuing to spend on it. The "
+  + "calls before the stop did execute; review the transcript before re-running.";
+
+export async function finalizeToolCallLoopPark(
+  missionId: string,
+  runId: string,
+  sessionId: string,
+  stopPayload?: { summary?: string; evidence?: Record<string, unknown> },
+): Promise<MissionStatus> {
+  const { gateOnOperatorStopWithClient, withSessionControlLock } = await import(
+    "../../../runtime/lease-and-status.js"
+  );
+  const parked = await withSessionControlLock(sessionId, async (client) => {
+    const gate = await gateOnOperatorStopWithClient(client, {
+      sessionId,
+      missionRunId: runId,
+    });
+    // Fail-closed: the gate only COMPLETES the stop; it never resumes or
+    // dispatches anything. A stopped run gets no park write at all.
+    if (gate.kind === "stopped") return false;
+    return missionRunsRepo.updateStatusIfNotTerminal(
+      runId,
+      "paused_error",
+      "tool_call_loop",
+      {
+        summary: stopPayload?.summary ?? TOOL_CALL_LOOP_SUMMARY,
+        // The batch's evidence carries the SHAPE of the repetition (tool name,
+        // cycle length, repeat count, call ids) and never the arguments - see
+        // `runner/tool-call-loop-detector.ts`.
+        evidence: stopPayload?.evidence,
+      },
+      client,
+    );
+  });
+  if (!parked) {
+    // The run reached a terminal status while the batch was unwinding - in
+    // practice an operator Stop, whose own transaction already set the mission
+    // row. Nothing was written here and nothing may be: a terminal run row is
+    // immutable audit history.
+    logger.warn("engine.mission.tool_call_loop_park_after_terminal", {
+      runId,
+      missionId,
+      sessionId,
+    });
+  }
+  return "running";
+}

--- a/src/vex-agent/engine/core/runner/mission-finalize/user-stop-outcome.ts
+++ b/src/vex-agent/engine/core/runner/mission-finalize/user-stop-outcome.ts
@@ -1,0 +1,34 @@
+/**
+ * Ordinary operator-stop terminal policy (`user_stopped`, no edit intent).
+ *
+ * Finalize-after-local-abort: the operator's Stop fired the in-process
+ * AbortController, so the loop unwound before the iteration-boundary
+ * observer could apply the queued request. Runs the SAME idempotent stop
+ * transaction the observer runs - whichever path wins the race, the DB
+ * ends up identical (run `stopped`/`user_stopped`, mission `cancelled`,
+ * approvals rejected, wakes cancelled, request cleared). Idempotent: a
+ * no-op when the observer already applied it.
+ */
+
+import type { MissionStatus } from "../../../types.js";
+import { emitFinalizeControlState } from "./control-state-emit.js";
+
+export async function finalizeUserStop(
+  runId: string,
+  sessionId: string,
+  stopPayload?: { summary?: string; evidence?: Record<string, unknown> },
+): Promise<MissionStatus> {
+  const { applyUserStopTransaction } = await import(
+    "../../../runtime/lease-and-status.js"
+  );
+  await applyUserStopTransaction({
+    sessionId,
+    missionRunId: runId,
+    stopPayload,
+  });
+  await emitFinalizeControlState(sessionId, runId);
+  // Mission-level terminal for an operator stop. `MissionStatus` has no
+  // `stopped` arm; only the RUN row carries the canonical
+  // `stopped` + `user_stopped` pair.
+  return "cancelled";
+}

--- a/src/vex-agent/engine/core/runner/shared.ts
+++ b/src/vex-agent/engine/core/runner/shared.ts
@@ -30,10 +30,20 @@ export const DEFAULT_LOOP_CONFIG: TurnLoopConfig = {
   // Mission runs use this cap (50). Agent (one-shot) and mission setup
   // override it locally — see processAgentTurn (50) and
   // processMissionSetupTurn (25). All three are finite, deliberate
-  // backstops against runaway tool-call loops; the 10-minute timeoutMs and
+  // backstops against runaway tool-call loops; the 30-minute timeoutMs and
   // context-pressure compaction are the independent wall-clock backstops.
   maxIterations: 50,
-  timeoutMs: 600_000, // 10 minutes
+  // 30 minutes, and never below it (owner decision 2026-08-28, pinned by
+  // `DEFAULT_LOOP_CONFIG.timeoutMs >= 1_800_000`). Ten minutes was cutting
+  // real autonomous work in half: a slice that does genuine research and
+  // several on-chain reads spends most of it waiting on providers, so the
+  // clock was ending productive turns and charging a fresh full-context
+  // continuation to resume them. The bound still exists - it is the backstop
+  // against a turn that never ends - it is just no longer the thing that
+  // normally ends a turn. Setup inherits it through the spread below, which
+  // is accepted fleet-wide: a setup turn that runs long is a conversation
+  // the operator is still in.
+  timeoutMs: 1_800_000,
   contextLimit: 256_000,
 };
 
@@ -100,6 +110,34 @@ export const NO_PROGRESS_REPLY =
   "different model if it keeps happening.";
 
 /**
+ * The `tool_call_loop` sibling of `ITERATION_LIMIT_REPLY`.
+ *
+ * Says the one thing the user needs to decide what to do next: the model was
+ * repeating an identical call that kept returning an identical result, it was
+ * told so once, and it did it again. Naming the repetition is what separates
+ * this from a budget message - "continue" is precisely the wrong next step
+ * here, because continuing is what the model already proved it would do.
+ *
+ * Like `NO_PROGRESS_REPLY` it does NOT claim that nothing ran: the repeated
+ * calls DID execute up to the correction, and earlier rounds in the turn can
+ * have done real work, including work that moved funds. It points at the
+ * transcript instead, which is both honest and the same policy the renderer's
+ * notice uses to withhold one-click retry.
+ *
+ * It deliberately names no tool and no arguments. The arguments are the
+ * sensitive part (a repeated call can carry an address, an amount, a key
+ * fragment in an error string), and a reply the user reads is not the place to
+ * re-print them; the structured facts on the stop payload carry the tool name
+ * and the counts for operators.
+ */
+export const TOOL_CALL_LOOP_REPLY =
+  "I stopped this turn early: I kept repeating the same tool call and getting the "
+  + "same result back, and I did it again after being asked to change approach, so "
+  + "continuing would just repeat it. Check the transcript above for what did run, "
+  + "then tell me what to try differently - a different approach, a narrower step, "
+  + "or a different tool.";
+
+/**
  * A runtime bound that ends a turn and therefore owes the user a deterministic
  * reply when the model produced no text.
  *
@@ -112,7 +150,7 @@ export const NO_PROGRESS_REPLY =
  */
 export type RuntimeBoundStop = Extract<
   RuntimeStopReason,
-  "iteration_limit" | "timeout" | "no_progress"
+  "iteration_limit" | "timeout" | "no_progress" | "tool_call_loop"
 >;
 
 export function isRuntimeBoundStop(
@@ -122,6 +160,10 @@ export function isRuntimeBoundStop(
     stopReason === "iteration_limit"
     || stopReason === "timeout"
     || stopReason === "no_progress"
+    // Same reason `no_progress` is here and not in `isContinuableRuntimeStop`:
+    // a turn that ended on a repetition must never be silent, and must never
+    // be auto-continued into repeating it again.
+    || stopReason === "tool_call_loop"
   );
 }
 
@@ -133,5 +175,6 @@ export function isRuntimeBoundStop(
 export function runtimeBoundExhaustedReply(trigger: RuntimeBoundStop): string {
   if (trigger === "timeout") return TIMEOUT_REPLY;
   if (trigger === "no_progress") return NO_PROGRESS_REPLY;
+  if (trigger === "tool_call_loop") return TOOL_CALL_LOOP_REPLY;
   return ITERATION_LIMIT_REPLY;
 }

--- a/src/vex-agent/engine/core/runner/tool-call-loop-detector.ts
+++ b/src/vex-agent/engine/core/runner/tool-call-loop-detector.ts
@@ -55,16 +55,25 @@
  * Cost of a false positive at strike two: a turn ends with an honest message
  * and a transcript the user can read. Cost of not having it: the incident.
  *
- * ## Zero imports, on purpose
+ * ## No project imports, on purpose
  *
- * This module imports NOTHING - the `unproductive-rounds.ts` precedent. Its
- * only consumer is `turn-loop-tool-batch.ts`, which it must never import back
- * (the batch orchestrator would then depend on a module that depends on it),
- * and a detector with no dependencies is a pure function of what it was told,
- * which is what makes the table tests over it worth anything.
+ * This module imports NO PROJECT CODE - the `unproductive-rounds.ts`
+ * precedent. Its only consumer is `turn-loop-tool-batch.ts`, which it must
+ * never import back (the batch orchestrator would then depend on a module that
+ * depends on it), and a detector with no project dependencies is a pure
+ * function of what it was told, which is what makes the table tests over it
+ * worth anything.
+ *
+ * The one exception is `node:crypto`, a runtime builtin used for the signature
+ * digest. It is not an engine edge, cannot join an import cycle, and cannot
+ * change underneath this module - so the property this rule protects is
+ * untouched. `toolCallSignature` states why a real digest rather than a
+ * hand-rolled hash.
  *
  * Derived in pattern, not in code, from gemini-cli's `loopDetectionService`.
  */
+
+import { createHash } from "node:crypto";
 
 /** Identical repeats of a cycle before the detector reacts. */
 export const TOOL_CALL_LOOP_THRESHOLD = 5;
@@ -185,22 +194,43 @@ export function canonicalize(value: unknown): string {
 }
 
 /**
- * The signature of a completed call: name, canonical arguments, success flag,
- * and model-visible output.
+ * The signature of a completed call: a sha256 over the tool name, its canonical
+ * arguments, the success flag and the model-visible output.
  *
- * Deliberately a readable joined string and not a cryptographic digest. It is
- * compared for equality and never persisted, logged, or shown to anyone - the
- * facts above are what leaves this module - so hashing would buy nothing and
- * cost the ability to see, in a debugger, exactly which two calls the detector
- * thought were the same.
+ * ## Why it is HASHED and not the joined string
+ *
+ * The joined string RETAINS what it joins. Tool arguments and model-visible
+ * output are exactly where wallet addresses, amounts, provider responses and
+ * user content live, and the history array holds `THRESHOLD * MAX_CYCLE_LENGTH`
+ * of them for the life of the turn. A digest keeps the only property the
+ * detector uses - equality - and keeps that content out of a structure whose
+ * whole job is to sit in memory beside the runner. It is also the shape the
+ * approved design specified and the shape this module's header already
+ * describes; the joined string was the drift.
+ *
+ * ## sha256, not a local FNV-1a
+ *
+ * The alternative was a hand-rolled 32-bit hash to preserve this module's
+ * zero-import property. Rejected on consequence: a collision here means two
+ * DIFFERENT calls count as a repeat, and five of those STOP A RUN. A 32-bit
+ * hash over a turn's worth of entries has a real collision probability;
+ * sha256's is not a number anyone needs to reason about. `node:crypto` is a
+ * runtime builtin, so it adds no engine edge and cannot join an import cycle -
+ * the property the zero-import habit protected is intact.
+ *
+ * The separator is an escaped NUL, which cannot occur in the JSON-encoded
+ * canonical form, so no shifting of a field boundary can forge a collision. It
+ * is written `\u0000` rather than typed literally: a raw NUL byte makes this
+ * file classify as binary data, which breaks diffs, greps and review tooling.
  */
 export function toolCallSignature(observation: CompletedToolCallObservation): string {
-  return [
+  const canonical = [
     observation.toolName,
     canonicalize(observation.args),
     observation.success ? "ok" : "err",
     observation.output,
-  ].join(" ");
+  ].join("\u0000");
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
 }
 
 /**

--- a/src/vex-agent/engine/core/runner/tool-call-loop-detector.ts
+++ b/src/vex-agent/engine/core/runner/tool-call-loop-detector.ts
@@ -1,0 +1,279 @@
+/**
+ * The tool-call REPETITION detector - a cycle detector over completed tool
+ * calls, deliberately kept separate from both the iteration budget and the
+ * unproductive-round stall counter.
+ *
+ * ## Why this is a third bound and not one of the two we already had
+ *
+ * `iteration-budget.ts` bounds how much WORK a turn may do. A round that
+ * batches six tool calls costs one unit, so it is a backstop against a model
+ * that works forever, not against a model that works in a circle.
+ *
+ * `unproductive-rounds.ts` bounds how many times in a row the model may answer
+ * with NOTHING. Its whole premise is that the round persisted nothing.
+ *
+ * This one catches the opposite failure and the one the production incident
+ * actually showed: the model emits a real tool call, the call really executes,
+ * it really returns a result, and that result is byte-identical to the last
+ * five - the same refusal, the same "not found", the same balance. Every round
+ * is productive by both other measures. The budget drains, the wall clock
+ * drains, real money is spent on input tokens, and nothing changes. Neither
+ * existing bound can see it, because both of them are counting the wrong
+ * thing.
+ *
+ * ## The signature, and why the RESULT is in it
+ *
+ * A signature is the hash of the tool NAME, its CANONICAL arguments, and its
+ * canonical RESULT (the success flag plus the model-visible output). Duration
+ * and tool-call id are excluded: they differ on every call by construction,
+ * so including them would make every signature unique and the detector inert.
+ *
+ * Including the result is the decision that makes this safe to ship. A model
+ * polling an endpoint until it changes - a pending transaction, a filling
+ * order, a block confirmation - is CORRECT behaviour, and it emits the
+ * identical name and arguments every time. What distinguishes correct polling
+ * from a loop is that the answer moves. So a poll whose result changes never
+ * accumulates a repeat, and a poll whose result is frozen is, after five
+ * identical answers, indistinguishable from the incident.
+ *
+ * ## The bound, and why the first strike only corrects
+ *
+ * Five identical repeats of a cycle of length k, k in [1,5]. The history is
+ * bounded to `THRESHOLD * MAX_CYCLE_LENGTH` entries, which is exactly what the
+ * longest detectable cycle needs and nothing more.
+ *
+ * Detection is GRADUATED (owner decision 2026-08-28). The first strike does
+ * not end the turn: it drains the rest of the emitted batch and hands the model
+ * a corrective cue, so it SEES that it is repeating itself before another real
+ * call executes. Models recover from this far more often than they recover from
+ * being killed, and the cost of a false positive drops to one wasted round plus
+ * a sentence of context. Only the SECOND strike - the model repeating the same
+ * signature again AFTER being told - ends the turn, because at that point the
+ * repetition survived the cheapest possible intervention and the next thing to
+ * try is a human.
+ *
+ * Cost of a false positive at strike two: a turn ends with an honest message
+ * and a transcript the user can read. Cost of not having it: the incident.
+ *
+ * ## Zero imports, on purpose
+ *
+ * This module imports NOTHING - the `unproductive-rounds.ts` precedent. Its
+ * only consumer is `turn-loop-tool-batch.ts`, which it must never import back
+ * (the batch orchestrator would then depend on a module that depends on it),
+ * and a detector with no dependencies is a pure function of what it was told,
+ * which is what makes the table tests over it worth anything.
+ *
+ * Derived in pattern, not in code, from gemini-cli's `loopDetectionService`.
+ */
+
+/** Identical repeats of a cycle before the detector reacts. */
+export const TOOL_CALL_LOOP_THRESHOLD = 5;
+
+/**
+ * Longest repeating cycle the detector looks for. `k = 1` is the plain
+ * "same call five times"; `k = 2` catches the A-B-A-B ping-pong between two
+ * calls that keep undoing each other. Beyond five the pattern is long enough
+ * that the model is plausibly working through a list.
+ */
+export const MAX_TOOL_CALL_CYCLE_LENGTH = 5;
+
+/** Bounded history: exactly what the longest detectable cycle needs. */
+export const TOOL_CALL_SIGNATURE_HISTORY_LIMIT =
+  TOOL_CALL_LOOP_THRESHOLD * MAX_TOOL_CALL_CYCLE_LENGTH;
+
+/**
+ * One completed, ORDINARY tool call. The caller filters: approval breaks,
+ * user-form parks, prepared-action follow-ups and engine signals carry
+ * stronger semantics of their own and are never observed here.
+ */
+export interface CompletedToolCallObservation {
+  readonly toolCallId: string;
+  readonly toolName: string;
+  /** The arguments the model emitted, as dispatched. */
+  readonly args: unknown;
+  /** The result's model-visible output, verbatim. */
+  readonly output: string;
+  /** The result's success flag, as the model saw it. */
+  readonly success: boolean;
+}
+
+/**
+ * What the detector observed, with NO raw arguments in it.
+ *
+ * Arguments are the sensitive part of a repeated call by inference: a repeated
+ * transfer carries a destination, a repeated quote carries an amount, a
+ * repeated failure carries whatever the provider echoed back. These facts go
+ * into a durable stop payload, a log line and an operator-visible surface, so
+ * they carry the shape of the repetition and never its contents.
+ */
+export interface ToolCallLoopFacts {
+  /** The tool at the head of the repeating cycle. */
+  readonly toolName: string;
+  /** Cycle length k: 1 for a single call repeating, 2 for A-B-A-B. */
+  readonly cycleLength: number;
+  /** Identical repeats observed, always at least `TOOL_CALL_LOOP_THRESHOLD`. */
+  readonly repeatCount: number;
+  /** Call ids of the repeated calls, oldest first - the transcript pointer. */
+  readonly toolCallIds: readonly string[];
+  /** 1 = corrected, 2 = stopped. */
+  readonly strike: number;
+}
+
+export type ToolCallLoopVerdict =
+  /** Nothing to do; the batch continues normally. */
+  | { readonly kind: "clear" }
+  /** Strike 1: drain the batch remainder and show the model the cue. */
+  | { readonly kind: "correct"; readonly facts: ToolCallLoopFacts }
+  /** Strike 2: drain the remainder and end the turn with `tool_call_loop`. */
+  | { readonly kind: "stop"; readonly facts: ToolCallLoopFacts };
+
+/**
+ * A detector instance. Owned by ONE `runTurnLoop` invocation and threaded into
+ * every tool batch that turn runs.
+ *
+ * The lifetime matters and is the whole reason this is an object rather than a
+ * pure function over a batch: strike one lands mid-batch, and strike two
+ * normally lands on the NEXT model turn, after the model read the cue and
+ * chose to repeat itself anyway. A detector scoped to a single batch could
+ * never observe the second strike, and one scoped to the process would carry a
+ * dead turn's history into a live one.
+ */
+export interface ToolCallLoopDetector {
+  observe(observation: CompletedToolCallObservation): ToolCallLoopVerdict;
+}
+
+/**
+ * Canonical JSON: object keys sorted at every depth, so two argument objects
+ * that differ only in key order produce one signature. Arrays keep their order
+ * (order is meaning in an argument list). Anything not JSON-representable
+ * degrades to its `String()` form rather than throwing - a signature that is
+ * merely coarse is far better than a detector that can crash a tool batch.
+ */
+export function canonicalize(value: unknown): string {
+  const seen = new Set<object>();
+
+  const walk = (node: unknown): string => {
+    if (node === null) return "null";
+    if (node === undefined) return "undefined";
+    const nodeType = typeof node;
+    if (nodeType === "string") return JSON.stringify(node);
+    if (nodeType === "number" || nodeType === "boolean") return String(node);
+    if (nodeType === "bigint") return `${String(node)}n`;
+    if (nodeType !== "object") return JSON.stringify(String(node));
+
+    const asObject = node as object;
+    // A cycle in tool arguments is pathological, not expected. Naming it in
+    // the signature keeps two different cyclic shapes from colliding while
+    // still terminating.
+    if (seen.has(asObject)) return '"[circular]"';
+    seen.add(asObject);
+    try {
+      if (Array.isArray(node)) {
+        return `[${node.map(walk).join(",")}]`;
+      }
+      const entries = Object.entries(node as Record<string, unknown>)
+        .filter(([, entryValue]) => entryValue !== undefined)
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        .map(([key, entryValue]) => `${JSON.stringify(key)}:${walk(entryValue)}`);
+      return `{${entries.join(",")}}`;
+    } finally {
+      seen.delete(asObject);
+    }
+  };
+
+  return walk(value);
+}
+
+/**
+ * The signature of a completed call: name, canonical arguments, success flag,
+ * and model-visible output.
+ *
+ * Deliberately a readable joined string and not a cryptographic digest. It is
+ * compared for equality and never persisted, logged, or shown to anyone - the
+ * facts above are what leaves this module - so hashing would buy nothing and
+ * cost the ability to see, in a debugger, exactly which two calls the detector
+ * thought were the same.
+ */
+export function toolCallSignature(observation: CompletedToolCallObservation): string {
+  return [
+    observation.toolName,
+    canonicalize(observation.args),
+    observation.success ? "ok" : "err",
+    observation.output,
+  ].join(" ");
+}
+
+/**
+ * Whether the tail of `history` is `threshold` back-to-back repeats of its last
+ * `cycleLength` entries.
+ *
+ * Read from the end: the last window is compared against each earlier window,
+ * so a cycle that has just completed its fifth pass is detected on the call
+ * that completed it, not one call later.
+ */
+function tailRepeatsCycle(
+  history: readonly string[],
+  cycleLength: number,
+  threshold: number,
+): boolean {
+  const needed = cycleLength * threshold;
+  if (history.length < needed) return false;
+  const start = history.length - needed;
+  for (let offset = cycleLength; offset < needed; offset++) {
+    if (history[start + offset] !== history[start + (offset % cycleLength)]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function createToolCallLoopDetector(): ToolCallLoopDetector {
+  const signatures: string[] = [];
+  const callIds: string[] = [];
+  const names: string[] = [];
+  let strikes = 0;
+
+  return {
+    observe(observation: CompletedToolCallObservation): ToolCallLoopVerdict {
+      signatures.push(toolCallSignature(observation));
+      callIds.push(observation.toolCallId);
+      names.push(observation.toolName);
+      // Ring bound, applied to all three parallel arrays together so an index
+      // always names the same call in each of them.
+      if (signatures.length > TOOL_CALL_SIGNATURE_HISTORY_LIMIT) {
+        signatures.shift();
+        callIds.shift();
+        names.shift();
+      }
+
+      // Shortest cycle first: five copies of one call is a k=1 loop, and
+      // reporting it as a k=5 one (which it also technically is) would name a
+      // pattern the operator cannot recognise in the transcript.
+      for (
+        let cycleLength = 1;
+        cycleLength <= MAX_TOOL_CALL_CYCLE_LENGTH;
+        cycleLength++
+      ) {
+        if (!tailRepeatsCycle(signatures, cycleLength, TOOL_CALL_LOOP_THRESHOLD)) {
+          continue;
+        }
+        const needed = cycleLength * TOOL_CALL_LOOP_THRESHOLD;
+        const start = signatures.length - needed;
+        strikes += 1;
+        const facts: ToolCallLoopFacts = {
+          // The head of the cycle, which for k=1 is simply the repeated tool.
+          toolName: names[start] ?? observation.toolName,
+          cycleLength,
+          repeatCount: TOOL_CALL_LOOP_THRESHOLD,
+          toolCallIds: callIds.slice(start),
+          strike: strikes,
+        };
+        return strikes >= 2
+          ? { kind: "stop", facts }
+          : { kind: "correct", facts };
+      }
+
+      return { kind: "clear" };
+    },
+  };
+}

--- a/src/vex-agent/engine/core/stop-conditions.ts
+++ b/src/vex-agent/engine/core/stop-conditions.ts
@@ -7,45 +7,36 @@
  * mission/full-autonomous runners convert into a wake continuation.
  */
 
-import type {
-  StopReason,
-  BusinessStopReason,
-  RuntimeStopReason,
+import {
+  BUSINESS_STOP_REASONS,
+  RUNTIME_STOP_REASONS,
+  type StopReason,
+  type BusinessStopReason,
+  type RuntimeStopReason,
 } from "../types.js";
 
 // ── Classification ──────────────────────────────────────────────
 
-const BUSINESS_STOPS = new Set<string>([
-  "goal_reached",
-  "deadline_reached",
-  "capital_depleted",
-  "max_loss_hit",
-  "no_viable_opportunity",
-  "emergency_stop",
-  "user_stopped",
-]);
+/**
+ * Both sets are DERIVED from the canonical tuples in `types/stop-reasons.ts`,
+ * never re-typed here.
+ *
+ * `isRuntimePause` declares `reason is RuntimeStopReason`, which is a promise
+ * that it answers `true` for every member of that union. A hand-maintained
+ * list could not keep that promise and did not: `user_paused`,
+ * `user_form_required` and (before this) every newly added runtime stop were
+ * missing, so the predicate narrowed to a type it had just denied. Building
+ * the set from the union's own tuple makes the promise structural - a new
+ * member is classified the moment it is declared, not the moment someone
+ * remembers this file.
+ *
+ * `RESUMABLE_STOPS` below is deliberately NOT derived: it is a genuine policy
+ * subset, so every member is a decision and the default for a new stop reason
+ * must be "not directly resumable".
+ */
+const BUSINESS_STOPS: ReadonlySet<string> = new Set<string>(BUSINESS_STOP_REASONS);
 
-const RUNTIME_PAUSES = new Set<string>([
-  "approval_required",
-  "checkpoint_pause",
-  "iteration_limit",
-  "timeout",
-  "waiting_for_wake",
-  "waiting_for_compact_commit",
-  "compact_unable_at_critical",
-  "system_error",
-  // Plan-mode acceptance pause: a runtime pause, but deliberately NOT a
-  // RESUMABLE_STOP — once the plan is accepted it resumes via `plan.accept` or
-  // any control resume path, never via a plain user chat message, so ingress
-  // must not treat an incoming message as a resume.
-  "plan_acceptance_required",
-  // Model stall: a run of rounds that emitted nothing at all. A runtime pause,
-  // and deliberately NOT a RESUMABLE_STOP and NOT a continuable runtime stop -
-  // an unproductive round persists nothing, so an automatic continuation would
-  // re-ask the identical question and stall identically. Only a human deciding
-  // what to do differently (retry, narrow, switch model) breaks it.
-  "no_progress",
-]);
+const RUNTIME_PAUSES: ReadonlySet<string> = new Set<string>(RUNTIME_STOP_REASONS);
 
 /**
  * The subset of runtime pauses that allow a direct resume path:
@@ -53,7 +44,10 @@ const RUNTIME_PAUSES = new Set<string>([
  * the wake executor, and `checkpoint_pause` by checkpoint auto-resume.
  * `iteration_limit` and `timeout` are converted by autonomous runners into
  * `waiting_for_wake`; they are not direct ingress-resume statuses.
- * `system_error` remains non-resumable here.
+ * `system_error` remains non-resumable here, and so are `restart_orphan` and
+ * `tool_call_loop`: the first needs a fresh run (the process that owned the
+ * old one is gone), the second needs a human to change something, because
+ * resuming is precisely what the model just proved it would repeat.
  */
 const RESUMABLE_STOPS = new Set<string>([
   "approval_required",

--- a/src/vex-agent/engine/core/stop-conditions.ts
+++ b/src/vex-agent/engine/core/stop-conditions.ts
@@ -45,9 +45,15 @@ const RUNTIME_PAUSES: ReadonlySet<string> = new Set<string>(RUNTIME_STOP_REASONS
  * `iteration_limit` and `timeout` are converted by autonomous runners into
  * `waiting_for_wake`; they are not direct ingress-resume statuses.
  * `system_error` remains non-resumable here, and so are `restart_orphan` and
- * `tool_call_loop`: the first needs a fresh run (the process that owned the
- * old one is gone), the second needs a human to change something, because
- * resuming is precisely what the model just proved it would repeat.
+ * `tool_call_loop`.
+ *
+ * Non-resumable means NOT RESUMABLE BY INGRESS - a user message must not
+ * silently restart either one. Both remain recoverable by the operator through
+ * Recover (`mission.retry`), which claims and resumes the SAME run row, and
+ * neither requires a fresh run: `restart_orphan` parked a run whose process
+ * died, and the claim simply takes a new lease on that row; `tool_call_loop`
+ * needs a human to read the transcript first, which is a reason to withhold
+ * the automatic path, not to discard the run.
  */
 const RESUMABLE_STOPS = new Set<string>([
   "approval_required",

--- a/src/vex-agent/engine/core/turn-loop-tool-batch.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch.ts
@@ -62,6 +62,8 @@ import {
   USER_FORM_ABANDONED_RUN_TERMINAL_OUTPUT,
   APPROVAL_SKIPPED_BY_USER_STOP_OUTPUT,
   BATCH_ABORTED_BY_COMPACT_OUTPUT,
+  BATCH_ABORTED_BY_LOOP_CORRECTION_OUTPUT,
+  BATCH_ABORTED_BY_TOOL_CALL_LOOP_OUTPUT,
   BATCH_ABORTED_BY_DEADLINE_OUTPUT,
   BATCH_ABORTED_BY_TIMEOUT_OUTPUT,
   BATCH_ABORTED_BY_USER_STOP_OUTPUT,
@@ -80,6 +82,11 @@ import {
   dispatchPreparedActionFollowUp,
   resolvePreparedActionFollowUp,
 } from "./turn-loop-tool-batch/prepared-follow-up.js";
+import { emitToolCallLoopCorrection } from "./turn-loop-tool-batch/loop-correction-emit.js";
+import type {
+  ToolCallLoopDetector,
+  ToolCallLoopFacts,
+} from "./runner/tool-call-loop-detector.js";
 
 export type { StopPayload, ToolBatchOutcome } from "./turn-loop-tool-batch/outcome.js";
 
@@ -112,6 +119,15 @@ export async function processTurnToolBatch(args: {
    * by an unbounded margin. See `./turn-loop-tool-batch/deadline.ts`.
    */
   readonly deadlines?: BatchDeadlines;
+  /**
+   * The TURN's tool-call repetition detector (`runner/tool-call-loop-detector.ts`),
+   * owned by `runTurnLoop` and threaded through every batch that turn runs.
+   *
+   * Optional so the many existing call sites and tests that do not care about
+   * repetition compile unchanged; absent means the detector is simply not
+   * consulted, which is the pre-existing behaviour and never a stop.
+   */
+  readonly loopDetector?: ToolCallLoopDetector;
 }): Promise<ToolBatchOutcome> {
   const { context, turnResult, liveMessages } = args;
   const executedCalls: ParsedToolCall[] = [];
@@ -132,6 +148,8 @@ export async function processTurnToolBatch(args: {
   let compactCommittedThisBatch = false;
   let approvalId: string | null = null;
   let userFormIntentId: string | null = null;
+  /** Set by a first-strike detection; emitted after the transcript persists. */
+  let loopCorrectionFacts: ToolCallLoopFacts | null = null;
 
   const dispatchBand = computeBand(args.currentTokenCount, args.contextLimit);
 
@@ -451,6 +469,83 @@ export async function processTurnToolBatch(args: {
         drainUndispatchedCalls(i + 1, BATCH_ABORTED_BY_COMPACT_OUTPUT);
         break;
       }
+      // Any OTHER engine signal falls through to the next iteration. It is
+      // still an engine-signal outcome, so it is not a detector input either:
+      // the `continue` below skips the observation deliberately.
+      continue;
+    }
+
+    // ── Tool-call repetition detection, LAST in the per-call ordering ──
+    //
+    // Placed here, after everything above, because every branch above carries
+    // stronger semantics that must win outright and must never be fed to the
+    // detector:
+    //   - operator Stop (checked twice) outranks a bound that merely fired;
+    //   - an approval break and a user-form park are parked HUMAN decisions,
+    //     and their call has no ordinary result at all;
+    //   - a prepared-action follow-up already returned above;
+    //   - an engine signal is the model asking the engine to do something,
+    //     not the model repeating itself.
+    // What reaches this line is exactly the plan's "ordinary completed
+    // result": dispatched, answered, persisted, with nothing else claiming it.
+    //
+    // The result is only available HERE, post-dispatch, which is the whole
+    // reason the detector cannot sit before the call: its signature includes
+    // what the call returned, and that is the field that separates a model
+    // polling a changing value from a model in a circle.
+    const verdict = args.loopDetector?.observe({
+      toolCallId: toolCall.id,
+      toolName: toolCall.name,
+      args: toolCall.arguments,
+      output: resultForTranscript.output,
+      success: resultForTranscript.success,
+    }) ?? { kind: "clear" as const };
+
+    if (verdict.kind === "correct") {
+      // STRIKE 1. The turn does NOT end. Drain what the model emitted after
+      // this call so no further real call runs on a repeating trajectory,
+      // then let the batch fall through to persistence; the cue is written
+      // immediately after it, so the model's very next round reads the
+      // correction before it chooses anything.
+      loopCorrectionFacts = verdict.facts;
+      logger.warn("engine.turn.tool_call_loop_corrected", {
+        sessionId: context.sessionId,
+        missionRunId: context.missionRunId ?? null,
+        toolName: verdict.facts.toolName,
+        cycleLength: verdict.facts.cycleLength,
+        repeatCount: verdict.facts.repeatCount,
+        callsDrained: turnResult.toolCalls.length - (i + 1),
+      });
+      drainUndispatchedCalls(i + 1, BATCH_ABORTED_BY_LOOP_CORRECTION_OUTPUT);
+      break;
+    }
+
+    if (verdict.kind === "stop") {
+      // STRIKE 2. The correction was already delivered and the model repeated
+      // itself anyway, so the cheapest intervention is spent and the turn ends.
+      logger.warn("engine.turn.tool_call_loop_stop", {
+        sessionId: context.sessionId,
+        missionRunId: context.missionRunId ?? null,
+        toolName: verdict.facts.toolName,
+        cycleLength: verdict.facts.cycleLength,
+        repeatCount: verdict.facts.repeatCount,
+        callsDrained: turnResult.toolCalls.length - (i + 1),
+      });
+      drainUndispatchedCalls(i + 1, BATCH_ABORTED_BY_TOOL_CALL_LOOP_OUTPUT);
+      batchStopReason = "tool_call_loop";
+      batchStopPayload = {
+        summary:
+          "The model repeated the same completed tool call after being corrected once.",
+        // Shape of the repetition only - `ToolCallLoopFacts` carries no raw
+        // arguments by construction, and this evidence is durable.
+        evidence: {
+          toolName: verdict.facts.toolName,
+          cycleLength: verdict.facts.cycleLength,
+          repeatCount: verdict.facts.repeatCount,
+          toolCallIds: verdict.facts.toolCallIds,
+        },
+      };
+      break;
     }
   }
 
@@ -462,6 +557,20 @@ export async function processTurnToolBatch(args: {
     liveMessages,
     reasoning: turnResult.reasoning,
   });
+
+  // ── First-strike correction, strictly AFTER the transcript ──
+  // The tape must read assistant message → every tool result (including the
+  // drained remainder) → correction. Emitting before persistence would put an
+  // instruction about those calls ahead of their own results and break the
+  // tool_call/tool_result adjacency the provider expects on reload.
+  if (loopCorrectionFacts !== null) {
+    await emitToolCallLoopCorrection({
+      sessionId: context.sessionId,
+      missionRunId: context.missionRunId ?? null,
+      facts: loopCorrectionFacts,
+      liveMessages,
+    });
+  }
 
   // Update lastText from current turn (assistant may have content alongside toolCalls)
   const lastText = turnResult.content ?? args.lastTextSoFar;

--- a/src/vex-agent/engine/core/turn-loop-tool-batch/loop-correction-emit.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch/loop-correction-emit.ts
@@ -1,0 +1,74 @@
+/**
+ * Emission of the tool-call-loop correction cue into a live turn.
+ *
+ * Split from the batch orchestrator for the same reason every other policy in
+ * this folder is: the orchestrator owns the dispatch ordering, and this owns
+ * one durable write plus one live-tape mutation. The TEXT is a versioned
+ * prompt artifact and lives in `prompts/tool-call-loop-correction.ts`; this
+ * module only decides where it lands and when.
+ *
+ * ORDERING is the contract. The cue is written AFTER `persistBatchTranscript`,
+ * so the tape reads: assistant message with the full emitted batch, then every
+ * tool result including the drained remainder, then the correction. A cue
+ * placed before the results would have the model reading an instruction about
+ * calls it has not yet seen the outcome of, and would break the
+ * tool_call/tool_result adjacency the provider expects.
+ *
+ * Both halves of the write matter and neither is optional:
+ *   - the durable row, so the cue survives a reload and is reconstructable
+ *     from history (rule 09's model-visible-iff-logged);
+ *   - the `liveMessages` push, so the CURRENT turn's next inference actually
+ *     carries it. Persisting only would leave the very round the correction
+ *     exists for reading a tape without it.
+ *
+ * `visibility: "internal"` mirrors the operator cue: this is engine-to-model
+ * text, not an announcement to the user. The user's account of the same event
+ * is the run's own stop payload and, at strike two, the honest reply.
+ */
+
+import type { Message } from "@vex-agent/db/repos/messages.js";
+import { appendEngineMessage } from "@vex-agent/engine/events/index.js";
+import { buildToolCallLoopCorrectionCue } from "../../prompts/tool-call-loop-correction.js";
+import type { ToolCallLoopFacts } from "../runner/tool-call-loop-detector.js";
+
+export const TOOL_CALL_LOOP_CORRECTION_MESSAGE_TYPE = "tool_call_loop_correction";
+
+export async function emitToolCallLoopCorrection(input: {
+  readonly sessionId: string;
+  readonly missionRunId: string | null;
+  readonly facts: ToolCallLoopFacts;
+  /** MUTATED: pushed with the cue so THIS turn's next round reads it. */
+  readonly liveMessages: Message[];
+}): Promise<string> {
+  const cue = buildToolCallLoopCorrectionCue({
+    toolName: input.facts.toolName,
+    cycleLength: input.facts.cycleLength,
+    repeatCount: input.facts.repeatCount,
+  });
+
+  const metadata = {
+    source: "engine" as const,
+    messageType: TOOL_CALL_LOOP_CORRECTION_MESSAGE_TYPE,
+    visibility: "internal" as const,
+    payload: {
+      // Structured facts, never raw arguments - see `ToolCallLoopFacts`.
+      toolName: input.facts.toolName,
+      cycleLength: input.facts.cycleLength,
+      repeatCount: input.facts.repeatCount,
+      toolCallIds: input.facts.toolCallIds,
+      strike: input.facts.strike,
+      missionRunId: input.missionRunId,
+    },
+  };
+
+  await appendEngineMessage(input.sessionId, cue, metadata);
+
+  input.liveMessages.push({
+    role: "system",
+    content: cue,
+    timestamp: new Date().toISOString(),
+    metadata,
+  });
+
+  return cue;
+}

--- a/src/vex-agent/engine/core/turn-loop-tool-batch/results.ts
+++ b/src/vex-agent/engine/core/turn-loop-tool-batch/results.ts
@@ -53,6 +53,29 @@ export const BATCH_ABORTED_BY_DEADLINE_OUTPUT =
   + "It did NOT execute and had no effect.";
 
 /**
+ * Synthetic tool-result emitted for batch tool calls that were never dispatched
+ * because the loop detector's FIRST strike landed earlier in the same batch.
+ *
+ * Same pairing contract as every other drain. It says "not dispatched" rather
+ * than "cancelled" because the turn is not ending: the very next thing the
+ * model reads is the correction cue, and a drain message implying the turn died
+ * would contradict it.
+ */
+export const BATCH_ABORTED_BY_LOOP_CORRECTION_OUTPUT =
+  "batch_aborted_by_loop_correction: a repeated tool call was detected earlier in this batch, "
+  + "so this tool call was not dispatched. It did NOT execute and had no effect. Read the engine "
+  + "correction that follows before deciding what to call next.";
+
+/**
+ * Synthetic tool-result for batch tool calls never dispatched because the loop
+ * detector's SECOND strike ended the turn. Distinct from the correction drain
+ * above because the consequence differs: nothing follows this one.
+ */
+export const BATCH_ABORTED_BY_TOOL_CALL_LOOP_OUTPUT =
+  "batch_aborted_by_tool_call_loop: the turn was ended because the same tool call kept repeating, "
+  + "so this tool call was not dispatched. It did NOT execute and had no effect.";
+
+/**
  * Synthetic tool-result for a call that returned "approval required" onto a
  * run that had already gone terminal. The approval is auto-rejected in the
  * enqueue transaction; this keeps the call/result pairing intact.

--- a/src/vex-agent/engine/core/turn-loop.ts
+++ b/src/vex-agent/engine/core/turn-loop.ts
@@ -90,6 +90,7 @@ import {
   MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS,
   isProductiveRound,
 } from "./runner/unproductive-rounds.js";
+import { createToolCallLoopDetector } from "./runner/tool-call-loop-detector.js";
 
 /**
  * Run the turn loop.
@@ -125,6 +126,14 @@ export async function runTurnLoop(
   // tool call; reset by every productive round. See `runner/unproductive-rounds.ts`
   // for why it must stay separate from `maxIterations` and why the bound is small.
   let consecutiveUnproductiveRounds = 0;
+  // REPETITION detector, and a third bound distinct from both of the above:
+  // `maxIterations` counts work, `consecutiveUnproductiveRounds` counts
+  // silence, this counts a model doing the same productive thing forever. Its
+  // lifetime is exactly this turn loop, which is what lets the graduated second
+  // strike land on a LATER round than the correction that preceded it, while
+  // never carrying one turn's history into the next. See
+  // `runner/tool-call-loop-detector.ts`.
+  const loopDetector = createToolCallLoopDetector();
   // Rounds actually entered, so the exhaustion events can report what the turn
   // consumed rather than only which bound fired (rule 05).
   let iterationsUsed = 0;
@@ -448,6 +457,9 @@ export async function runTurnLoop(
           turnTimeoutAtMs: startTime + loopConfig.timeoutMs,
           missionDeadlineAtMs: loopConfig.missionDeadlineMs ?? null,
         },
+        // Turn-scoped, so a repetition that starts in one batch is still
+        // remembered when the model repeats it in the next one.
+        loopDetector,
       });
       totalToolCalls += batchOutcome.toolCallsExecuted;
       lastText = batchOutcome.lastText;

--- a/src/vex-agent/engine/ingress.ts
+++ b/src/vex-agent/engine/ingress.ts
@@ -27,9 +27,35 @@ import * as missionsRepo from "@vex-agent/db/repos/missions.js";
 import {
   addOperatorCue,
   addOperatorInstruction,
+  classifyOperatorInterruptDisposition,
 } from "./core/operator-instructions.js";
+import { getLease } from "@vex-agent/db/repos/runner-leases.js";
 import logger from "@utils/logger.js";
 import { releaseLeaseAndEmitControlState } from "./runtime/release-and-emit.js";
+
+/**
+ * Whether a runner is demonstrably executing THIS work right now.
+ *
+ * Two conditions, and both matter. The lease must be UNEXPIRED - an expired row
+ * is the fingerprint of a crashed runner, not a live one, and it is exactly
+ * what the restart-orphan sweep reclaims. And it must MATCH: a lease held for a
+ * different mission run belongs to another turn, and nothing in that turn will
+ * merge a message written for this one. `missionRunId` is `null` on both sides
+ * for an agent session, which matches by the same rule.
+ *
+ * This is the only input to `classifyOperatorInterruptDisposition` that needs a
+ * query, which is why it lives here beside its callers: the classifier stays a
+ * pure decision over facts it is handed.
+ */
+async function hasLiveMatchingLease(
+  sessionId: string,
+  missionRunId: string | null,
+): Promise<boolean> {
+  const lease = await getLease(sessionId);
+  if (lease === null) return false;
+  if (lease.expiresAt <= new Date()) return false;
+  return lease.missionRunId === missionRunId;
+}
 
 /**
  * `QUEUED_INTERRUPT_TEXT` is RETIRED (M6). It was a paragraph returned as
@@ -125,13 +151,20 @@ export async function routeUserMessage(
     // but do NOT fire a new turn here. Approvals resume through their own
     // flow (`approveAndResume`); a running run will pick up the message on
     // its next iteration.
-    // `queued_interrupt` for BOTH statuses this branch covers. `running` looks
-    // like a live turn, but this route (unlike `submitSteeringMessage`) never
-    // established that a runner is actually executing one - `getActiveRunBySession`
-    // reports a row status, not a live loop - and `paused_approval` is
-    // definitively waiting on a human. The weaker, provable claim is the one
-    // the operator gets told.
-    await addOperatorInstruction(sessionId, userInput, "queued_interrupt", {
+    //
+    // The disposition comes from the ONE classifier, which means this route
+    // now ASKS whether a runner is executing instead of assuming it is not.
+    // It previously hardcoded `queued_interrupt` for both statuses, so a
+    // genuinely steered message told the operator it would be read "the next
+    // time it runs" while the loop was about to merge it at the next step.
+    const disposition = classifyOperatorInterruptDisposition({
+      runStatus: activeRun.status,
+      hasLiveMatchingLease: await hasLiveMatchingLease(
+        sessionId,
+        activeRun.id,
+      ),
+    });
+    await addOperatorInstruction(sessionId, userInput, disposition, {
       target: "mission_run",
       runId: activeRun.id,
       runStatus: activeRun.status,
@@ -200,7 +233,17 @@ export async function submitSteeringMessage(
     if (activeRun.status !== "running" && activeRun.status !== "paused_approval") {
       return { outcome: "no_active_turn" };
     }
-    await addOperatorInstruction(sessionId, userInput, "steered", {
+    // The SAME classifier, so this route can no longer disagree with the one
+    // above about the same session. It used to hardcode `steered` for both
+    // statuses, which told the operator that a run parked on an approval - a
+    // run with nothing executing at all - would pick their message up mid-turn.
+    // `paused_approval` now correctly reads `queued_interrupt`, and a `running`
+    // run with a dead lease does too.
+    const disposition = classifyOperatorInterruptDisposition({
+      runStatus: activeRun.status,
+      hasLiveMatchingLease: await hasLiveMatchingLease(sessionId, activeRun.id),
+    });
+    await addOperatorInstruction(sessionId, userInput, disposition, {
       target: "mission_run",
       runId: activeRun.id,
       runStatus: activeRun.status,
@@ -209,17 +252,29 @@ export async function submitSteeringMessage(
       sessionId,
       runId: activeRun.id,
       runStatus: activeRun.status,
+      disposition,
     });
     return { outcome: "queued_live" };
   }
 
-  const { getLease } = await import("@vex-agent/db/repos/runner-leases.js");
-  const lease = await getLease(sessionId);
-  if (lease === null || lease.expiresAt < new Date()) {
-    return { outcome: "no_active_turn" };
-  }
-  await addOperatorInstruction(sessionId, userInput, "steered", { target: "agent_turn" });
-  logger.info("ingress.steer_persisted", { sessionId, target: "agent_turn" });
+  // An agent session has no run row, so `runStatus` is null and the lease is
+  // the whole question. Routed through the same classifier as the mission
+  // paths: one function decides `steered` everywhere, and it can only say so
+  // on a live matching lease.
+  const live = await hasLiveMatchingLease(sessionId, null);
+  if (!live) return { outcome: "no_active_turn" };
+  const disposition = classifyOperatorInterruptDisposition({
+    runStatus: null,
+    hasLiveMatchingLease: live,
+  });
+  await addOperatorInstruction(sessionId, userInput, disposition, {
+    target: "agent_turn",
+  });
+  logger.info("ingress.steer_persisted", {
+    sessionId,
+    target: "agent_turn",
+    disposition,
+  });
   return { outcome: "queued_live" };
 }
 

--- a/src/vex-agent/engine/ingress.ts
+++ b/src/vex-agent/engine/ingress.ts
@@ -42,8 +42,38 @@ import { releaseLeaseAndEmitControlState } from "./runtime/release-and-emit.js";
  * tomorrow, not in a response object that is gone once rendered.
  */
 
-const PAUSED_ERROR_TEXT =
-  "Run is paused after a provider/runtime error. I saved your instruction; use the Recover button to re-attempt.";
+/**
+ * Why the run is parked, per stop reason, for the hint returned to a user who
+ * typed at a `paused_error` run.
+ *
+ * CAUSE-SPECIFIC, because the generic sentence below CLAIMS a provider or
+ * runtime error, and for these two reasons that claim is simply false: nothing
+ * failed at the provider. `restart_orphan` was parked by the reclaim sweep
+ * after Vex died mid-slice (M3); `tool_call_loop` was stopped by the detector
+ * after repeating itself (M4). Keyed by the closed engine stop-reason union, so
+ * an unnamed reason falls through to the generic wording rather than to a
+ * wrong one.
+ */
+const PAUSED_ERROR_CAUSE_TEXT: Readonly<Record<string, string>> = {
+  restart_orphan:
+    "Run is paused because Vex restarted while it was executing. Steps already in flight"
+    + " may or may not have completed.",
+  tool_call_loop:
+    "Run is paused because it repeated the same tool call without making progress.",
+};
+
+const PAUSED_ERROR_GENERIC_TEXT = "Run is paused after a provider/runtime error.";
+
+/** The one shared tail: what was done with the message, and what clears it. */
+const PAUSED_ERROR_TAIL =
+  "I saved your instruction; use the Recover button to re-attempt.";
+
+function pausedErrorText(stopReason: string | null): string {
+  const cause =
+    (stopReason === null ? undefined : PAUSED_ERROR_CAUSE_TEXT[stopReason])
+    ?? PAUSED_ERROR_GENERIC_TEXT;
+  return `${cause} ${PAUSED_ERROR_TAIL}`;
+}
 
 /**
  * Route an incoming user message to the correct runtime. Always cancels any
@@ -84,7 +114,7 @@ export async function routeUserMessage(
       await addOperatorCue(sessionId);
       logger.info("ingress.paused_error_hint", { sessionId, runId: activeRun.id });
       return {
-        text: PAUSED_ERROR_TEXT,
+        text: pausedErrorText(activeRun.stopReason),
         toolCallsMade: 0,
         pendingApprovals: [],
         stopReason: null,

--- a/src/vex-agent/engine/ingress.ts
+++ b/src/vex-agent/engine/ingress.ts
@@ -31,8 +31,16 @@ import {
 import logger from "@utils/logger.js";
 import { releaseLeaseAndEmitControlState } from "./runtime/release-and-emit.js";
 
-const QUEUED_INTERRUPT_TEXT =
-  "Operator instruction queued for the active run. The model will read it at the next safe iteration boundary and continue.";
+/**
+ * `QUEUED_INTERRUPT_TEXT` is RETIRED (M6). It was a paragraph returned as
+ * `TurnResult.text` from three different branches with three different
+ * meanings, and it did not survive a reload. The acknowledgement is now a
+ * durable, user-visible engine notice row written in the same transaction as
+ * the instruction itself, with the disposition typed - see
+ * `core/operator-instructions.ts`. These branches return `text: null` because
+ * the acknowledgement is on the tape where the operator can still find it
+ * tomorrow, not in a response object that is gone once rendered.
+ */
 
 const PAUSED_ERROR_TEXT =
   "Run is paused after a provider/runtime error. I saved your instruction; use the Recover button to re-attempt.";
@@ -65,7 +73,10 @@ export async function routeUserMessage(
       // but return a clear hint instead of letting the shell render the
       // empty-fallback `(no text — stopReason: unknown)` string. The
       // operator drives recovery via the Recover button.
-      await addOperatorInstruction(sessionId, userInput, {
+      // `queued_interrupt`, not `steered`: a run parked on an error is not
+      // executing a turn, so nothing will merge this until the operator
+      // recovers it.
+      await addOperatorInstruction(sessionId, userInput, "queued_interrupt", {
         target: "mission_run",
         runId: activeRun.id,
         runStatus: activeRun.status,
@@ -84,7 +95,13 @@ export async function routeUserMessage(
     // but do NOT fire a new turn here. Approvals resume through their own
     // flow (`approveAndResume`); a running run will pick up the message on
     // its next iteration.
-    await addOperatorInstruction(sessionId, userInput, {
+    // `queued_interrupt` for BOTH statuses this branch covers. `running` looks
+    // like a live turn, but this route (unlike `submitSteeringMessage`) never
+    // established that a runner is actually executing one - `getActiveRunBySession`
+    // reports a row status, not a live loop - and `paused_approval` is
+    // definitively waiting on a human. The weaker, provable claim is the one
+    // the operator gets told.
+    await addOperatorInstruction(sessionId, userInput, "queued_interrupt", {
       target: "mission_run",
       runId: activeRun.id,
       runStatus: activeRun.status,
@@ -95,7 +112,7 @@ export async function routeUserMessage(
       runStatus: activeRun.status,
     });
     return {
-      text: QUEUED_INTERRUPT_TEXT,
+      text: null,
       toolCallsMade: 0,
       pendingApprovals: [],
       stopReason: null,
@@ -153,7 +170,7 @@ export async function submitSteeringMessage(
     if (activeRun.status !== "running" && activeRun.status !== "paused_approval") {
       return { outcome: "no_active_turn" };
     }
-    await addOperatorInstruction(sessionId, userInput, {
+    await addOperatorInstruction(sessionId, userInput, "steered", {
       target: "mission_run",
       runId: activeRun.id,
       runStatus: activeRun.status,
@@ -171,7 +188,7 @@ export async function submitSteeringMessage(
   if (lease === null || lease.expiresAt < new Date()) {
     return { outcome: "no_active_turn" };
   }
-  await addOperatorInstruction(sessionId, userInput, { target: "agent_turn" });
+  await addOperatorInstruction(sessionId, userInput, "steered", { target: "agent_turn" });
   logger.info("ingress.steer_persisted", { sessionId, target: "agent_turn" });
   return { outcome: "queued_live" };
 }
@@ -204,13 +221,17 @@ async function resumeMissionRunWithPreempt(
       runId,
       outcome: claim.outcome,
     });
-    await addOperatorInstruction(sessionId, userInput, {
+    // The preempt lost its race, so the wake was NOT preempted by us and the
+    // run is not ours to resume. `queued_interrupt` is the truthful record of
+    // what this call achieved: the row is on the tape and whoever won the
+    // claim will read it.
+    await addOperatorInstruction(sessionId, userInput, "queued_interrupt", {
       target: "mission_run",
       runId,
       runStatus: "claim_lost",
     });
     return {
-      text: QUEUED_INTERRUPT_TEXT,
+      text: null,
       toolCallsMade: 0,
       pendingApprovals: [],
       stopReason: null,
@@ -227,7 +248,7 @@ async function resumeMissionRunWithPreempt(
     ttlMs: 5 * 60_000,
   });
   try {
-    await addOperatorInstruction(sessionId, userInput, {
+    await addOperatorInstruction(sessionId, userInput, "preempted_wake", {
       target: "mission_run",
       runId,
       preempt: "wake",

--- a/src/vex-agent/engine/mission/restart-with-instruction.ts
+++ b/src/vex-agent/engine/mission/restart-with-instruction.ts
@@ -146,7 +146,11 @@ export async function restartMissionWithInstruction(
 
   if (prepared.outcome === "prepared") {
     try {
-      await addOperatorInstruction(input.sessionId, instruction, {
+      // `queued_interrupt`: the run row exists and its lease is held, but the
+      // turn loop has not started yet (the caller starts it only after this
+      // returns), so the honest claim is that the instruction is waiting for
+      // the run's first turn rather than being merged into a live one.
+      await addOperatorInstruction(input.sessionId, instruction, "queued_interrupt", {
         missionRestart: true,
         missionId: input.missionId,
       });

--- a/src/vex-agent/engine/prompts/tool-call-loop-correction.ts
+++ b/src/vex-agent/engine/prompts/tool-call-loop-correction.ts
@@ -1,0 +1,67 @@
+/**
+ * The tool-call repetition CORRECTION cue - a model-visible prompt artifact.
+ *
+ * NOT a system-prompt layer. It is never assembled into the prompt stack and
+ * never appears in `__promptsnaps__`, which snapshot the static prefix only.
+ * It is a TRANSCRIPT cue, the same class of artifact as
+ * `core/operator-instructions.ts`'s `OPERATOR_INTERRUPT_CUE`: written into the
+ * tape at a specific moment, read by the model on its next round, gone from
+ * every later turn's context once the tape moves on. It lives here because
+ * that is where the repository keeps text the model reads, and because a
+ * versioned prompt artifact needs one home and one reviewed diff surface
+ * (rule 09). Its bytes are pinned by
+ * `src/__tests__/vex-agent/engine/core/runner/tool-call-loop-correction-cue.test.ts`.
+ *
+ * ## What it has to accomplish, and what it must not
+ *
+ * It is emitted on the FIRST strike of the loop detector, after the remainder
+ * of the emitted batch has been drained, so it is the last thing the model
+ * reads before it chooses its next call. One shot to change the trajectory.
+ *
+ * So it states the observation as fact rather than asking a question the model
+ * can answer "yes, I am making progress" to, it names the three concrete exits
+ * (different approach, ask the user, stop), and it says plainly what happens
+ * if the repetition continues - a model that knows the next repeat ends the
+ * turn has a reason to spend its round differently.
+ *
+ * It deliberately does NOT quote the arguments or the repeated result back.
+ * The arguments are the sensitive part by inference (a destination, an amount,
+ * a provider error carrying a fragment of something), they are already in the
+ * transcript the model is reading, and re-printing them would invite the model
+ * to treat them as the thing to reproduce. `{toolName}` and the counts are the
+ * whole interpolation surface.
+ *
+ * It is written as an `[Engine: ...]` marker for the same reason the operator
+ * cue is: the model must be able to tell an engine statement about its own
+ * behaviour from a user's instruction, and must not mistake it for a tool
+ * result it should answer.
+ */
+
+/**
+ * Build the correction cue for one detected repetition.
+ *
+ * `cycleLength` is the detector's k: 1 means the same call over and over, more
+ * than 1 means a cycle of that many calls repeating in order. The sentence
+ * changes shape between those two cases because "the same tool call" is simply
+ * false for an A-B-A-B ping-pong, and a cue that misdescribes what the model
+ * did is a cue it can dismiss.
+ */
+export function buildToolCallLoopCorrectionCue(input: {
+  readonly toolName: string;
+  readonly cycleLength: number;
+  readonly repeatCount: number;
+}): string {
+  const observation = input.cycleLength === 1
+    ? `you have now called ${input.toolName} ${input.repeatCount} times in a row with identical arguments and received an identical result every time`
+    : `your last ${input.cycleLength * input.repeatCount} tool calls are the same cycle of ${input.cycleLength} calls repeated ${input.repeatCount} times, starting with ${input.toolName}, each returning an identical result`;
+
+  return [
+    `[Engine: tool_call_loop_correction - ${observation}.`,
+    "Repeating it again will not change the answer. Do not re-issue that call.",
+    "Do exactly one of these instead: try a genuinely different approach to the same goal,"
+    + " tell the user what is blocking you and ask for the missing decision or input,"
+    + " or stop and summarise what you established so far.",
+    "The remaining tool calls from your last message were not executed."
+    + " If this repetition continues, the turn will be ended for you.]",
+  ].join(" ");
+}

--- a/src/vex-agent/engine/runtime/lease-and-status/claim-run-lease.ts
+++ b/src/vex-agent/engine/runtime/lease-and-status/claim-run-lease.ts
@@ -22,6 +22,8 @@
  * One commit; no inter-statement race window.
  */
 
+import type { PoolClient } from "pg";
+
 import {
   withTransaction,
   queryOneWith,
@@ -38,7 +40,32 @@ import {
 export async function claimRunLeaseAndFlipToRunning(
   input: ClaimRunInput,
 ): Promise<ClaimRunOutcome> {
-  return withTransaction(async (client) => {
+  return withTransaction(async (client) =>
+    claimRunLeaseAndFlipToRunningWith(client, input),
+  );
+}
+
+/**
+ * The same claim, on a transaction the CALLER already owns.
+ *
+ * Exists for one reason: a caller that must decide something ELSE about this
+ * session in the same commit as the claim. The recovery money gate is that
+ * caller - it reads the unresolved money state under the session control lock,
+ * and while the claim ran in its own later transaction a money writer could
+ * commit between the two, so Recover resumed over an outcome nobody had proven.
+ * Joining the caller's transaction is what closes that window; two statements
+ * cannot be one decision from two transactions.
+ *
+ * The wrapper above is unchanged for every other caller, so this is a seam and
+ * not a second implementation - both run this body. Lock ORDER is the caller's
+ * responsibility: the session control lock is taken BEFORE this, never after,
+ * matching every other holder of that lock.
+ */
+export async function claimRunLeaseAndFlipToRunningWith(
+  client: PoolClient,
+  input: ClaimRunInput,
+): Promise<ClaimRunOutcome> {
+  {
     // 1. Lock mission_runs row.
     const run = await queryOneWith<MissionRunRow>(
       client,
@@ -125,5 +152,5 @@ export async function claimRunLeaseAndFlipToRunning(
       lease,
       wakeCancelledCount,
     };
-  });
+  }
 }

--- a/src/vex-agent/engine/runtime/lease-and-status/index.ts
+++ b/src/vex-agent/engine/runtime/lease-and-status/index.ts
@@ -23,7 +23,10 @@ export {
   type ObserveControlOutcome,
 } from "./_types.js";
 
-export { claimRunLeaseAndFlipToRunning } from "./claim-run-lease.js";
+export {
+  claimRunLeaseAndFlipToRunning,
+  claimRunLeaseAndFlipToRunningWith,
+} from "./claim-run-lease.js";
 export {
   claimSessionLease,
   claimSessionLeaseWithClient,

--- a/src/vex-agent/engine/runtime/restart-orphan-reclaim.ts
+++ b/src/vex-agent/engine/runtime/restart-orphan-reclaim.ts
@@ -1,0 +1,356 @@
+/**
+ * Restart-orphan reclaim - the owner of runs left `running` by a dead process.
+ *
+ * ## The state this exists for
+ *
+ * A mission run is `running` only while some process holds the session's runner
+ * lease (every one of the continuation entry points claims the lease in the
+ * same transaction as, or strictly before, the flip to `running` - see
+ * `lease-and-status/claim-run-lease.ts` and `core/runner/mission-run.ts`). When
+ * the app is killed mid-slice, the row stays `running` forever: nothing in the
+ * engine ever revisits it, the composer shows work in progress that no process
+ * is doing, and the operator's only route back is a control that refuses
+ * because the run "is already running".
+ *
+ * ## Why RECURRING, not a boot scan
+ *
+ * The lease outlives the process that died: `runner_leases.expires_at` is
+ * stamped NOW() + ttl (5 minutes on every production claim) and nothing deletes
+ * it when the process is killed. A scan that ran once at boot would therefore
+ * see a LIVE lease for the common case (restart within five minutes) and
+ * conclude, correctly for that instant and wrongly for the run, that someone
+ * owns it. The reclaim must come back after the lease expires, which is what
+ * the recurring handle below is for. It cannot ride the wake worker's
+ * supervisor timer either: that timer is cleared the moment the executor starts
+ * (`vex-app/src/main/agent/wake-worker.ts`).
+ *
+ * ## Why a live lease is absolute
+ *
+ * A run whose session holds an unexpired lease is NEVER reclaimed, at any
+ * stage: it is checked in the candidate query, then re-read `FOR UPDATE` inside
+ * the reclaim transaction, because the first read is a read of the past. A
+ * process that is alive and heartbeating is the authority on its own run; the
+ * reclaim's job is only the runs no process speaks for. Such a candidate is not
+ * dropped, it is simply revisited on the next pass.
+ *
+ * ## Transition discipline (per candidate, one transaction)
+ *
+ *   0. `acquireSessionControlLock` - lock order edge 0, so the decision cannot
+ *      interleave with an operator Stop that has not committed yet;
+ *   1. `gateOnOperatorStopWithClient` - a queued Stop wins over the reclaim and
+ *      is APPLIED here rather than left stranded (the run has no live runner to
+ *      observe it, which is precisely the stranding case that gate exists for);
+ *   2. locked re-read of the run row (`FOR UPDATE`);
+ *   3. locked re-read of the lease row (`FOR UPDATE`);
+ *   4. `updateStatusIfRunning` - the EXACT `WHERE status = 'running'` CAS, never
+ *      the broad `updateStatusIfNotTerminal`: a third party writing about
+ *      someone else's run may only act on the one state it proved.
+ *
+ * Idempotent by construction: a second pass over an already-reclaimed run finds
+ * `paused_error` at step 2 and writes nothing.
+ *
+ * ## What the reclaim does NOT do
+ *
+ * It does not resume anything and it takes no lease. Recovery is an operator
+ * decision on `mission.retry` (same run), gated there by the session's money
+ * state. Reclaiming is only the honest re-labelling of a run nobody is running.
+ */
+
+import type { PoolClient } from "pg";
+
+import logger from "@utils/logger.js";
+import { query, withTransaction, queryOneWith } from "../../db/client.js";
+import { updateStatusIfRunning } from "../../db/repos/mission-runs.js";
+import { emitSessionControlState } from "./emit-control-state.js";
+import { gateOnOperatorStopWithClient } from "./lease-and-status/operator-stop-boundary.js";
+import { acquireSessionControlLock } from "./lease-and-status/session-control-lock.js";
+import type { RuntimeStopReason } from "../types/stop-reasons.js";
+
+/**
+ * Stop reason persisted on a reclaimed run. `satisfies` rather than a bare
+ * literal, so removing the cause from the runtime vocabulary is a compile error
+ * here rather than a persisted row nothing can classify.
+ */
+export const RESTART_ORPHAN_STOP_REASON =
+  "restart_orphan" satisfies RuntimeStopReason;
+
+/**
+ * User-visible summary. Truthful about all three facts an operator needs: what
+ * was interrupted, that nothing is running now, and that the work is not lost.
+ * Cause-specific renderer copy is a separate concern; this string is what a
+ * surface with no cause mapping still shows, so it stands on its own.
+ */
+export const RESTART_ORPHAN_SUMMARY =
+  "This mission run was interrupted before it could finish - Vex stopped while the run was still in progress. Nothing is running now. Review what completed, then use Recover to continue the run.";
+
+/** Default cadence. Well under the 5 minute lease TTL, cheap (one indexed read). */
+const DEFAULT_INTERVAL_MS = 60_000;
+/** Candidates parked per pass. A backlog is drained across passes, not in one. */
+const DEFAULT_LIMIT = 20;
+/**
+ * A run is only a candidate once it has been untouched for this long.
+ *
+ * Not the primary guard (the lease is), but defence in depth against the one
+ * shape the lease cannot describe: a lease row that is ABSENT carries no
+ * timestamp, so "no lease" alone cannot distinguish a crashed run from a row in
+ * the microseconds around a claim. Staleness is a property the run row itself
+ * carries, and it never blocks a genuine orphan - it only delays it.
+ */
+const DEFAULT_MIN_STALE_MS = 60_000;
+
+export type ReclaimOutcome =
+  /** Parked to `paused_error` with cause `restart_orphan`. */
+  | "reclaimed"
+  /** The session holds a live lease. Not an orphan; revisited next pass. */
+  | "lease_live"
+  /** The run moved off `running` (or vanished) before the CAS. */
+  | "not_running"
+  /** A queued operator Stop was found and applied instead. */
+  | "operator_stopped";
+
+export interface OrphanCandidate {
+  readonly runId: string;
+  readonly sessionId: string;
+  /** Expiry of the (expired) lease row, or null when no lease row exists. */
+  readonly leaseExpiresAt: Date | null;
+}
+
+export interface ReclaimPassSummary {
+  readonly candidates: number;
+  readonly reclaimed: number;
+  readonly skipped: number;
+  readonly failed: number;
+}
+
+interface CandidateRow {
+  readonly run_id: string;
+  readonly session_id: string;
+  readonly lease_expires_at: Date | null;
+}
+
+/**
+ * Runs that LOOK orphaned. Advisory only - every fact here is re-read under the
+ * lock before anything is written, so a candidate that goes stale between the
+ * two is a skip, never a bad write.
+ */
+export async function findOrphanCandidates(options: {
+  readonly limit: number;
+  readonly minStaleMs: number;
+}): Promise<readonly OrphanCandidate[]> {
+  const rows = await query<CandidateRow>(
+    `SELECT mr.id AS run_id, mr.session_id, l.expires_at AS lease_expires_at
+       FROM mission_runs mr
+       LEFT JOIN runner_leases l ON l.session_id = mr.session_id
+      WHERE mr.status = 'running'
+        AND (l.session_id IS NULL OR l.expires_at <= NOW())
+        AND GREATEST(mr.started_at, COALESCE(mr.last_checkpoint_at, mr.started_at))
+              < NOW() - ($1::int * interval '1 millisecond')
+      ORDER BY mr.started_at ASC
+      LIMIT $2`,
+    [options.minStaleMs, options.limit],
+  );
+  return rows.map((r) => ({
+    runId: r.run_id,
+    sessionId: r.session_id,
+    leaseExpiresAt: r.lease_expires_at,
+  }));
+}
+
+/**
+ * Reclaim ONE candidate under the session control lock. See the module header
+ * for the ordered discipline; the outcome names exactly which step refused.
+ */
+export async function reclaimOrphanedRun(
+  candidate: OrphanCandidate,
+  now: () => Date = () => new Date(),
+): Promise<ReclaimOutcome> {
+  const outcome = await withTransaction(
+    async (client: PoolClient): Promise<ReclaimOutcome> => {
+      await acquireSessionControlLock(client, candidate.sessionId);
+
+      const stopGate = await gateOnOperatorStopWithClient(client, {
+        sessionId: candidate.sessionId,
+        missionRunId: candidate.runId,
+      });
+      if (stopGate.kind === "stopped") {
+        logger.info("engine.reclaim.operator_stop_applied", {
+          runId: candidate.runId,
+          sessionId: candidate.sessionId,
+          runStatus: stopGate.runStatus,
+        });
+        return "operator_stopped";
+      }
+
+      const run = await queryOneWith<{ status: string }>(
+        client,
+        "SELECT status FROM mission_runs WHERE id = $1 FOR UPDATE",
+        [candidate.runId],
+      );
+      if (run === null || run.status !== "running") return "not_running";
+
+      const lease = await queryOneWith<{ expires_at: Date }>(
+        client,
+        "SELECT expires_at FROM runner_leases WHERE session_id = $1 FOR UPDATE",
+        [candidate.sessionId],
+      );
+      const at = now();
+      if (lease !== null && lease.expires_at > at) return "lease_live";
+
+      const parked = await updateStatusIfRunning(
+        candidate.runId,
+        "paused_error",
+        RESTART_ORPHAN_STOP_REASON,
+        {
+          summary: RESTART_ORPHAN_SUMMARY,
+          evidence: {
+            restartOrphan: {
+              detectedAt: at.toISOString(),
+              leaseObserved: lease !== null,
+              leaseExpiresAt: lease?.expires_at.toISOString() ?? null,
+            },
+          },
+        },
+        client,
+      );
+      // The CAS ran against the row this transaction holds `FOR UPDATE`, so a
+      // false here would mean the lock did not hold. Report it rather than
+      // counting a write that did not happen.
+      return parked ? "reclaimed" : "not_running";
+    },
+  );
+
+  if (outcome === "reclaimed" || outcome === "operator_stopped") {
+    logger.info("engine.reclaim.candidate_settled", {
+      runId: candidate.runId,
+      sessionId: candidate.sessionId,
+      outcome,
+    });
+    // AFTER the commit - no runner is left to tell the renderer anything, so
+    // this is the only notification the reclaimed run will produce. Total by
+    // contract; a failed emit costs at most a stale surface.
+    await emitSessionControlState(candidate.sessionId, {
+      missionRunId: candidate.runId,
+    });
+  }
+  return outcome;
+}
+
+export interface ReclaimPassOptions {
+  readonly limit?: number;
+  readonly minStaleMs?: number;
+  readonly now?: () => Date;
+  /**
+   * Checked between candidates so a shutdown drains promptly instead of working
+   * through a full backlog. Never checked mid-candidate: a started reclaim is
+   * one transaction and either commits or rolls back on its own.
+   */
+  readonly shouldContinue?: () => boolean;
+}
+
+/** One reclaim sweep. Never throws: a per-candidate failure is counted and logged. */
+export async function runRestartOrphanReclaimPass(
+  options: ReclaimPassOptions = {},
+): Promise<ReclaimPassSummary> {
+  const candidates = await findOrphanCandidates({
+    limit: options.limit ?? DEFAULT_LIMIT,
+    minStaleMs: options.minStaleMs ?? DEFAULT_MIN_STALE_MS,
+  });
+  let reclaimed = 0;
+  let skipped = 0;
+  let failed = 0;
+  for (const candidate of candidates) {
+    if (options.shouldContinue && !options.shouldContinue()) break;
+    try {
+      const outcome = await reclaimOrphanedRun(candidate, options.now);
+      if (outcome === "reclaimed") reclaimed += 1;
+      else skipped += 1;
+    } catch (err) {
+      failed += 1;
+      logger.error("engine.reclaim.candidate_failed", {
+        runId: candidate.runId,
+        sessionId: candidate.sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return { candidates: candidates.length, reclaimed, skipped, failed };
+}
+
+// ── Recurring handle ───────────────────────────────────────────────
+
+export interface RestartOrphanReclaimHandle {
+  /** Stop the sweeps. Resolves after the in-flight pass (if any) settles. */
+  stop(): Promise<void>;
+}
+
+export interface StartReclaimOptions extends ReclaimPassOptions {
+  readonly intervalMs?: number;
+  /** Pass override for tests; production uses `runRestartOrphanReclaimPass`. */
+  readonly runPass?: (options: ReclaimPassOptions) => Promise<ReclaimPassSummary>;
+}
+
+/**
+ * Start the recurring reclaim. SINGLE-FLIGHT by construction: the next timer is
+ * armed in the previous pass's `finally`, so a slow pass is never lapped, and
+ * `stop()` awaits whatever is in flight. Idempotent - a second `stop()` clears
+ * nothing and awaits nothing.
+ */
+export function startRestartOrphanReclaim(
+  options: StartReclaimOptions = {},
+): RestartOrphanReclaimHandle {
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const runPass = options.runPass ?? runRestartOrphanReclaimPass;
+
+  let stopped = false;
+  let inFlight: Promise<void> | null = null;
+  let timer: NodeJS.Timeout | null = null;
+
+  const passOptions: ReclaimPassOptions = {
+    ...(options.limit === undefined ? {} : { limit: options.limit }),
+    ...(options.minStaleMs === undefined ? {} : { minStaleMs: options.minStaleMs }),
+    ...(options.now === undefined ? {} : { now: options.now }),
+    shouldContinue: () => !stopped,
+  };
+
+  const runOne = async (): Promise<void> => {
+    try {
+      const summary = await runPass(passOptions);
+      if (summary.reclaimed > 0 || summary.failed > 0) {
+        logger.info("engine.reclaim.pass", { ...summary });
+      }
+    } catch (err) {
+      logger.error("engine.reclaim.pass_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const schedule = (): void => {
+    if (stopped) return;
+    inFlight = runOne().finally(() => {
+      inFlight = null;
+      if (!stopped) timer = setTimeout(schedule, intervalMs);
+    });
+  };
+
+  timer = setTimeout(schedule, intervalMs);
+  logger.info("engine.reclaim.started", { intervalMs });
+
+  return {
+    async stop(): Promise<void> {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (inFlight) {
+        try {
+          await inFlight;
+        } catch {
+          // Already logged inside runOne - shutdown must not throw.
+        }
+      }
+      logger.info("engine.reclaim.stopped");
+    },
+  };
+}

--- a/src/vex-agent/engine/types.ts
+++ b/src/vex-agent/engine/types.ts
@@ -31,6 +31,11 @@ export type {
   RuntimeStopReason,
   StopReason,
 } from "./types/stop-reasons.js";
+export {
+  BUSINESS_STOP_REASONS,
+  RUNTIME_STOP_REASONS,
+  STOP_REASONS,
+} from "./types/stop-reasons.js";
 export type {
   MessageMetadata,
   MessageSource,

--- a/src/vex-agent/engine/types/stop-reasons.ts
+++ b/src/vex-agent/engine/types/stop-reasons.ts
@@ -1,54 +1,108 @@
 /**
- * Stop conditions — why a run stopped.
+ * Stop conditions - why a run stopped.
  *
  * Implementation detail of `engine/types.ts`; import from there.
+ *
+ * ## The tuples are the contract, the unions are derived
+ *
+ * Each union used to be hand-written, and every consumer that needed to
+ * ENUMERATE the members (the runtime classification sets in
+ * `core/stop-conditions.ts`, the strict chat schema in
+ * `vex-app/src/shared/schemas/chat.ts`) re-typed the list by hand. A member
+ * added to one list and forgotten in another is invisible to the compiler,
+ * because a `Set<string>` accepts any string and a `z.enum` of a shorter list
+ * is still a valid enum. That is exactly how `isRuntimePause` ended up
+ * claiming `reason is RuntimeStopReason` while answering `false` for three
+ * real runtime stops.
+ *
+ * So the tuples below are the single source of truth: the unions are derived
+ * from them, the classification sets are built from them, and a cross-package
+ * schema test asserts the chat enum matches `STOP_REASONS` member for member.
+ * Adding a stop reason is one edit here plus whatever the tests then demand.
  */
 
 // ── Stop conditions ─────────────────────────────────────────────
 
-export type BusinessStopReason =
-  | "goal_reached"
-  | "deadline_reached"
-  | "capital_depleted"
-  | "max_loss_hit"
-  | "no_viable_opportunity"
-  | "emergency_stop"
-  | "user_stopped";
+/**
+ * Business stops terminate a run permanently. Model-reported through the
+ * `MissionStop` internal tool, never parsed from text.
+ */
+export const BUSINESS_STOP_REASONS = [
+  "goal_reached",
+  "deadline_reached",
+  "capital_depleted",
+  "max_loss_hit",
+  "no_viable_opportunity",
+  "emergency_stop",
+  "user_stopped",
+] as const;
 
-export type RuntimeStopReason =
-  | "approval_required"
-  | "checkpoint_pause"
-  | "iteration_limit"
-  | "timeout"
-  | "waiting_for_wake"
-  | "waiting_for_compact_commit"
-  | "compact_unable_at_critical"
-  | "system_error"
-  /** User requested pause at the next safe checkpoint (puzzle 03). */
-  | "user_paused"
-  /** Plan-mode: agent wrote/changed a plan that needs user acceptance before
-   *  execution can resume. Resumed only by the `plan.accept` IPC. */
-  | "plan_acceptance_required"
-  /**
-   * §C3b: the agent opened a launch form and the turn is parked until the human
-   * answers it. Sibling of `approval_required` — the call it stopped on has no
-   * transcript result yet, and `resumeAgentAfterUserForm` appends the only one.
-   */
-  | "user_form_required"
-  /**
-   * The model produced a run of rounds that emitted NOTHING - no tool call, no
-   * text - so the turn stalled without consuming its iteration budget in any
-   * meaningful sense.
-   *
-   * Deliberately NOT `iteration_limit`. `iteration_limit` means "the agent did
-   * a lot of work and ran out of room"; this means "the agent did no work at
-   * all and kept asking". They call for different copy, different operator
-   * next steps, and different continuation policy: an exhausted budget is
-   * continuable (a fresh slice makes progress), a stall is NOT - the round that
-   * produced nothing persisted nothing, so the next round sees the identical
-   * input and would stall identically. See
-   * `runner/unproductive-rounds.ts` for the detector and its bound.
-   */
-  | "no_progress";
+export type BusinessStopReason = (typeof BUSINESS_STOP_REASONS)[number];
+
+/**
+ * Runtime stops are engine states, not mission outcomes.
+ *
+ * Per-member notes for the ones whose name does not carry their contract:
+ *
+ * - `user_paused`: user requested a pause at the next safe checkpoint
+ *   (puzzle 03).
+ * - `plan_acceptance_required`: plan-mode; the agent wrote or changed a plan
+ *   that needs user acceptance before execution can resume. Resumed only by
+ *   the `plan.accept` IPC.
+ * - `user_form_required`: §C3b, the agent opened a launch form and the turn is
+ *   parked until the human answers it. Sibling of `approval_required` - the
+ *   call it stopped on has no transcript result yet, and
+ *   `resumeAgentAfterUserForm` appends the only one.
+ * - `no_progress`: the model produced a run of rounds that emitted NOTHING -
+ *   no tool call, no text - so the turn stalled without consuming its
+ *   iteration budget in any meaningful sense. Deliberately NOT
+ *   `iteration_limit`: that means "the agent did a lot of work and ran out of
+ *   room", this means "the agent did no work at all and kept asking". They
+ *   call for different copy, different operator next steps, and different
+ *   continuation policy - an exhausted budget is continuable (a fresh slice
+ *   makes progress), a stall is NOT, because the round that produced nothing
+ *   persisted nothing, so the next round sees the identical input and would
+ *   stall identically. See `runner/unproductive-rounds.ts`.
+ * - `restart_orphan`: the run row said `running`, but the process that owned
+ *   it died and its runner lease expired, so nothing is driving it. The
+ *   reclaim owner parks it truthfully instead of leaving an orphan the
+ *   operator can neither resume nor explain.
+ * - `tool_call_loop`: the model repeated the SAME completed tool call - same
+ *   name, same arguments, same result - enough times to prove it is cycling
+ *   rather than working, and it did so again after being corrected once.
+ *   Deliberately NOT `iteration_limit`: the budget is not the thing that ran
+ *   out, the model is repeating itself. See
+ *   `runner/tool-call-loop-detector.ts` for the signature, the bound, and why
+ *   the first strike only corrects.
+ */
+export const RUNTIME_STOP_REASONS = [
+  "approval_required",
+  "checkpoint_pause",
+  "iteration_limit",
+  "timeout",
+  "waiting_for_wake",
+  "waiting_for_compact_commit",
+  "compact_unable_at_critical",
+  "system_error",
+  "user_paused",
+  "plan_acceptance_required",
+  "user_form_required",
+  "no_progress",
+  "restart_orphan",
+  "tool_call_loop",
+] as const;
+
+export type RuntimeStopReason = (typeof RUNTIME_STOP_REASONS)[number];
+
+/**
+ * Every stop reason, business first then runtime. The ORDER is part of the
+ * artifact: the strict chat schema mirrors it, and the cross-package test
+ * compares the two sequences, not two sets, so a reordering is a reviewed
+ * diff rather than a silent one.
+ */
+export const STOP_REASONS = [
+  ...BUSINESS_STOP_REASONS,
+  ...RUNTIME_STOP_REASONS,
+] as const;
 
 export type StopReason = BusinessStopReason | RuntimeStopReason;

--- a/src/vex-agent/engine/wake/executor.ts
+++ b/src/vex-agent/engine/wake/executor.ts
@@ -60,6 +60,10 @@ import {
   startPriceWatchPoller,
   type PriceWatchPollerHandle,
 } from "./price-watch-poller.js";
+import {
+  startRestartOrphanReclaim,
+  type RestartOrphanReclaimHandle,
+} from "../runtime/restart-orphan-reclaim.js";
 
 export type { ClaimedWakeOutcome, ClaimedWake } from "./executor/tick.js";
 export { tick } from "./executor/tick.js";
@@ -91,6 +95,18 @@ export interface StartOptions {
    * deadlines in a process with no executor to claim them is pure provider cost.
    */
   startPriceWatchPoller?: () => PriceWatchPollerHandle;
+  /**
+   * Restart-orphan reclaim override for tests. Same lifetime argument as the
+   * two above, plus one of its own: the reclaim is the RECURRING sweep for runs
+   * left `running` by a dead process, and the runner lease it waits on outlives
+   * that process by its full TTL. A boot-only scan would see a live lease and
+   * do nothing, so the sweep has to come back - and the host's supervisor timer
+   * cannot carry it, because that timer is cleared the moment this executor
+   * starts. This is the one process-local scheduler with the right lifetime:
+   * started once, after the DB is proven ready, and drained on quit before
+   * Postgres teardown.
+   */
+  startRestartOrphanReclaim?: () => RestartOrphanReclaimHandle;
 }
 
 /**
@@ -109,6 +125,9 @@ export function startWakeExecutor(options: StartOptions = {}): WakeExecutorHandl
   const deps = options.deps ?? buildProductionDeps();
   const promoter = (options.startWatchPromoter ?? startWakeWatchPromoter)();
   const pricePoller = (options.startPriceWatchPoller ?? (() => startPriceWatchPoller()))();
+  const orphanReclaim = (
+    options.startRestartOrphanReclaim ?? (() => startRestartOrphanReclaim())
+  )();
 
   let stopped = false;
   let inFlight: Promise<void> | null = null;
@@ -143,6 +162,9 @@ export function startWakeExecutor(options: StartOptions = {}): WakeExecutorHandl
       promoter.stop();
       // The poller abandons its in-flight wait at once and promotes nothing.
       await pricePoller.stop();
+      // Drains its in-flight pass; a reclaim transaction must finish against a
+      // live DB, and quit sequences this stop() before Postgres teardown.
+      await orphanReclaim.stop();
       if (timer) clearTimeout(timer);
       if (inFlight) {
         try {

--- a/vex-app/src/main/database/__tests__/messages-db.test.ts
+++ b/vex-app/src/main/database/__tests__/messages-db.test.ts
@@ -343,6 +343,92 @@ describe("messages-db mapper", () => {
     expect(result.data.items[0]).not.toHaveProperty("metadata");
   });
 
+  /**
+   * M6. The disposition is the engine's own typed record of what it did, and
+   * the renderer's delivery words are read from it. Flattened away, the row
+   * rendered "Steered - read at the agent's next step" for every interrupt,
+   * including one queued against a run parked on an error whose own
+   * acknowledgement row said the opposite.
+   */
+  it("projects the operator instruction's disposition onto the steering row", async () => {
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 12,
+          session_id: SESSION,
+          role: "user",
+          content: "check the fees first",
+          tool_call_id: null,
+          tool_calls: null,
+          created_at: "2026-08-28T10:00:00.000Z",
+          source: "user",
+          message_type: "operator_interrupt",
+          interrupt_disposition: "queued_interrupt",
+        },
+      ],
+    });
+
+    const result = await getMessageTail(SESSION, 1);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.items[0]!.kind).toBe("steering");
+    expect(result.data.items[0]!.interruptDisposition).toBe("queued_interrupt");
+  });
+
+  it("projects null for an unrecognised disposition rather than a loose string", async () => {
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 13,
+          session_id: SESSION,
+          role: "user",
+          content: "hi",
+          tool_call_id: null,
+          tool_calls: null,
+          created_at: "2026-08-28T10:00:00.000Z",
+          source: "user",
+          message_type: "operator_interrupt",
+          interrupt_disposition: "teleported",
+        },
+      ],
+    });
+
+    const result = await getMessageTail(SESSION, 1);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.items[0]!.interruptDisposition).toBeNull();
+  });
+
+  /**
+   * The ACK row carries the same disposition in its own payload, and its whole
+   * text already states it. Projecting it onto both rows would give the
+   * renderer two places to say one thing and a chance to say them differently.
+   */
+  it("does NOT project a disposition onto the acknowledgement row", async () => {
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 14,
+          session_id: SESSION,
+          role: "system",
+          content: "Saved.",
+          tool_call_id: null,
+          tool_calls: null,
+          created_at: "2026-08-28T10:00:00.000Z",
+          source: "engine",
+          message_type: "operator_interrupt_ack",
+          interrupt_disposition: "queued_interrupt",
+        },
+      ],
+    });
+
+    const result = await getMessageTail(SESSION, 1);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.items[0]!.kind).toBe("operator_ack");
+    expect(result.data.items[0]!.interruptDisposition).toBeNull();
+  });
+
   // M6: the engine's durable acknowledgement of an operator instruction gets
   // its OWN kind, ahead of the catch-all. Flattened into `runtime_notice` it is
   // indistinguishable from a wake banner, and the renderer cannot announce the

--- a/vex-app/src/main/database/__tests__/messages-db.test.ts
+++ b/vex-app/src/main/database/__tests__/messages-db.test.ts
@@ -8,32 +8,28 @@
  * mapper output shape directly.
  */
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockedFunction,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SessionMessageDto } from "@shared/schemas/messages.js";
 
 /**
- * The mock keeps `pg.Client.query`'s call signature AND vitest's mock surface.
- * Casting to the bare function type erased `mockResolvedValueOnce`, so every
- * arrangement in this file was an unchecked type error carried in the ratchet
- * baseline; `MockedFunction` keeps both halves and the arrangements are checked
- * again.
+ * `pg.Client.query`'s call signature, handed to `vi.fn` as its type argument.
+ *
+ * Two earlier shapes were wrong in opposite directions. Casting to the bare
+ * function type erased `mockResolvedValueOnce`, so every arrangement in this
+ * file was an unchecked type error carried in the ratchet baseline. Casting
+ * through `unknown` to `MockedFunction` restored the mock surface but threw
+ * away the checking again - a double assertion tells the compiler nothing was
+ * verified. Passing the signature to `vi.fn` gives both halves with NO cast:
+ * the arrangements are checked, and so are the call sites.
  */
-type QueryFn = MockedFunction<
-  (
-    text: string,
-    params?: readonly unknown[],
-  ) => Promise<{ rows: ReadonlyArray<Record<string, unknown>> }>
->;
+type QuerySignature = (
+  text: string,
+  params?: readonly unknown[],
+) => Promise<{ rows: ReadonlyArray<Record<string, unknown>> }>;
 
 const mocks = vi.hoisted(() => ({
-  query: vi.fn() as unknown as QueryFn,
+  query: vi.fn<QuerySignature>(),
   connect: vi.fn(),
   end: vi.fn(),
   buildPoolConfig: vi.fn(),
@@ -63,6 +59,22 @@ vi.mock("../db-config.js", () => ({
 vi.mock("../../logger/index.js", () => ({ log: mocks.log }));
 
 const { getMessageTail, listMessages } = await import("../messages-db.js");
+
+/**
+ * The one row a single-row tail must have produced, or a failure that says so.
+ *
+ * A non-null assertion here asserts nothing: when the projection returns no
+ * rows the test dies on "cannot read properties of undefined" with no clue
+ * which expectation was being made. This names the missing thing instead, and
+ * narrows honestly.
+ */
+function onlyItem(items: readonly SessionMessageDto[]): SessionMessageDto {
+  const first = items[0];
+  if (first === undefined) {
+    throw new Error("expected the tail to project exactly one row, got none");
+  }
+  return first;
+}
 
 const SESSION = "00000000-0000-4000-8000-00000000abcd";
 
@@ -371,8 +383,9 @@ describe("messages-db mapper", () => {
     const result = await getMessageTail(SESSION, 1);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.data.items[0]!.kind).toBe("steering");
-    expect(result.data.items[0]!.interruptDisposition).toBe("queued_interrupt");
+    const row = onlyItem(result.data.items);
+    expect(row.kind).toBe("steering");
+    expect(row.interruptDisposition).toBe("queued_interrupt");
   });
 
   it("projects null for an unrecognised disposition rather than a loose string", async () => {
@@ -396,7 +409,7 @@ describe("messages-db mapper", () => {
     const result = await getMessageTail(SESSION, 1);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.data.items[0]!.interruptDisposition).toBeNull();
+    expect(onlyItem(result.data.items).interruptDisposition).toBeNull();
   });
 
   /**
@@ -425,8 +438,9 @@ describe("messages-db mapper", () => {
     const result = await getMessageTail(SESSION, 1);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.data.items[0]!.kind).toBe("operator_ack");
-    expect(result.data.items[0]!.interruptDisposition).toBeNull();
+    const ackRow = onlyItem(result.data.items);
+    expect(ackRow.kind).toBe("operator_ack");
+    expect(ackRow.interruptDisposition).toBeNull();
   });
 
   // M6: the engine's durable acknowledgement of an operator instruction gets
@@ -458,7 +472,7 @@ describe("messages-db mapper", () => {
     const result = await getMessageTail(SESSION, 1);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.data.items[0]!.kind).toBe("operator_ack");
+    expect(onlyItem(result.data.items).kind).toBe("operator_ack");
     expect(result.data.items[0]).not.toHaveProperty("metadata");
   });
 

--- a/vex-app/src/main/database/__tests__/messages-db.test.ts
+++ b/vex-app/src/main/database/__tests__/messages-db.test.ts
@@ -8,15 +8,32 @@
  * mapper output shape directly.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockedFunction,
+} from "vitest";
 
-type QueryFn = (
-  text: string,
-  params?: readonly unknown[],
-) => Promise<{ rows: ReadonlyArray<Record<string, unknown>> }>;
+/**
+ * The mock keeps `pg.Client.query`'s call signature AND vitest's mock surface.
+ * Casting to the bare function type erased `mockResolvedValueOnce`, so every
+ * arrangement in this file was an unchecked type error carried in the ratchet
+ * baseline; `MockedFunction` keeps both halves and the arrangements are checked
+ * again.
+ */
+type QueryFn = MockedFunction<
+  (
+    text: string,
+    params?: readonly unknown[],
+  ) => Promise<{ rows: ReadonlyArray<Record<string, unknown>> }>
+>;
 
 const mocks = vi.hoisted(() => ({
-  query: vi.fn() as QueryFn,
+  query: vi.fn() as unknown as QueryFn,
   connect: vi.fn(),
   end: vi.fn(),
   buildPoolConfig: vi.fn(),
@@ -323,6 +340,39 @@ describe("messages-db mapper", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.data.items[0]!.kind).toBe("runtime_notice");
+    expect(result.data.items[0]).not.toHaveProperty("metadata");
+  });
+
+  // M6: the engine's durable acknowledgement of an operator instruction gets
+  // its OWN kind, ahead of the catch-all. Flattened into `runtime_notice` it is
+  // indistinguishable from a wake banner, and the renderer cannot announce the
+  // one notice that answers something the operator just did.
+  it("derives operator_ack from the ack message_type, not the notice catch-all", async () => {
+    mocks.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 11,
+          session_id: SESSION,
+          role: "system",
+          content:
+            "Saved. The agent is not running a turn right now, so it will read this the next time it runs.",
+          tool_call_id: null,
+          tool_calls: null,
+          created_at: "2026-08-28T10:00:00.000Z",
+          source: "engine",
+          message_type: "operator_interrupt_ack",
+          // The typed disposition rides the row's JSONB, which is NEVER
+          // forwarded: the renderer derives everything from `kind` plus the
+          // engine-authored content, and compares no prose.
+          metadata: { payload: { disposition: "queued_interrupt" } },
+        },
+      ],
+    });
+
+    const result = await getMessageTail(SESSION, 1);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.items[0]!.kind).toBe("operator_ack");
     expect(result.data.items[0]).not.toHaveProperty("metadata");
   });
 

--- a/vex-app/src/main/database/__tests__/messages-mapper-board.test.ts
+++ b/vex-app/src/main/database/__tests__/messages-mapper-board.test.ts
@@ -37,6 +37,7 @@ const BASE: Omit<MessageRow, "role" | "board"> = {
   duration_ms: null,
   success: null,
   display_status: null,
+  interrupt_disposition: null,
 };
 
 function row(role: string, board: unknown): MessageRow {

--- a/vex-app/src/main/database/__tests__/messages-mapper-display-status.test.ts
+++ b/vex-app/src/main/database/__tests__/messages-mapper-display-status.test.ts
@@ -28,6 +28,7 @@ const BASE: Omit<MessageRow, "role" | "success" | "display_status"> = {
   reasoning: null,
   duration_ms: null,
   board: null,
+  interrupt_disposition: null,
 };
 
 function row(p: {

--- a/vex-app/src/main/database/__tests__/messages-mapper-explorer-refs.test.ts
+++ b/vex-app/src/main/database/__tests__/messages-mapper-explorer-refs.test.ts
@@ -15,7 +15,14 @@ import {
 
 const BASE: Omit<
   MessageRow,
-  "role" | "explorer_refs" | "reasoning" | "duration_ms" | "success" | "display_status" | "board"
+  | "role"
+  | "explorer_refs"
+  | "reasoning"
+  | "duration_ms"
+  | "success"
+  | "display_status"
+  | "board"
+  | "interrupt_disposition"
 > = {
   id: 1,
   session_id: "00000000-0000-4000-8000-00000000abcd",
@@ -43,6 +50,7 @@ function row(p: {
     success: p.success ?? null,
     display_status: null,
     board: null,
+    interrupt_disposition: null,
   };
 }
 

--- a/vex-app/src/main/database/__tests__/messages-mapper-tool-name-canonical.test.ts
+++ b/vex-app/src/main/database/__tests__/messages-mapper-tool-name-canonical.test.ts
@@ -27,6 +27,7 @@ const BASE: Omit<MessageRow, "tool_calls"> = {
   success: null,
   display_status: null,
   board: null,
+  interrupt_disposition: null,
 };
 
 function callRow(name: string, id = "call_1"): MessageRow {

--- a/vex-app/src/main/database/__tests__/session-control-state.test.ts
+++ b/vex-app/src/main/database/__tests__/session-control-state.test.ts
@@ -9,7 +9,11 @@
 
 import { describe, expect, it } from "vitest";
 
-import { isStoppable, type RuntimeControlFacts } from "../session-control-state.js";
+import {
+  isStoppable,
+  readSessionActivity,
+  type RuntimeControlFacts,
+} from "../session-control-state.js";
 import { INCOMPLETE_APPROVAL_LIFECYCLE_PREDICATE } from "@vex-agent/db/contracts/approval-lifecycle-predicates.js";
 import { OUTSTANDING_USER_FORM_PREDICATE } from "@vex-agent/db/contracts/user-form-lifecycle-predicates.js";
 
@@ -29,6 +33,7 @@ function facts(overrides: Partial<RuntimeControlFacts> = {}): RuntimeControlFact
     leaseExpiresAt: null,
     pendingControlKind: null,
     hasPendingWake: false,
+    sessionWakeDueAt: null,
     hasPendingApproval: false,
     hasIncompleteApprovalLifecycle: false,
     hasOutstandingUserForm: false,
@@ -82,6 +87,61 @@ describe("isStoppable - the control-gating policy", () => {
     expect(isStoppable(facts({ hasActiveRun: false, status: "completed" }))).toBe(
       false,
     );
+  });
+});
+
+/**
+ * M5. The activity projection is the ONE answer the composer strip and the
+ * desk-rule tape both read, so its precedence is pinned here rather than left
+ * to the two surfaces to rediscover.
+ *
+ * The interesting case is the overlap: the executor claims a wake row and takes
+ * the lease before it marks the row consumed, so for one real interval both
+ * facts are true at once. "Running" is the only honest word there - a runner is
+ * attached and spending - and reporting "sleeping until 12:04" over an
+ * executing slice is the same lie the old sawtooth told in the other direction.
+ */
+describe("readSessionActivity - the activity policy", () => {
+  it("reports none for a session with no lease and no session wake", () => {
+    expect(readSessionActivity(facts())).toEqual({ kind: "none" });
+  });
+
+  it("reports running while the lease is held", () => {
+    expect(readSessionActivity(facts({ leaseActive: true }))).toEqual({
+      kind: "running",
+    });
+  });
+
+  it("reports sleeping with the pending wake instant", () => {
+    expect(
+      readSessionActivity(
+        facts({ sessionWakeDueAt: "2026-08-29T12:04:00.000Z" }),
+      ),
+    ).toEqual({ kind: "sleeping", nextWakeAt: "2026-08-29T12:04:00.000Z" });
+  });
+
+  it("prefers running over a wake row the executor has not consumed yet", () => {
+    expect(
+      readSessionActivity(
+        facts({
+          leaseActive: true,
+          sessionWakeDueAt: "2026-08-29T12:04:00.000Z",
+        }),
+      ),
+    ).toEqual({ kind: "running" });
+  });
+
+  /**
+   * `hasPendingWake` counts EVERY pending wake including a mission run's own;
+   * only `sessionWakeDueAt` is narrowed to `mission_run_id IS NULL`. Reading
+   * the broad fact here would make a sleeping mission report session activity
+   * and hand the tape two answers, which is the contradiction the projection
+   * exists to end.
+   */
+  it("ignores hasPendingWake - a mission run's own wake is not session sleep", () => {
+    expect(readSessionActivity(facts({ hasPendingWake: true }))).toEqual({
+      kind: "none",
+    });
   });
 });
 

--- a/vex-app/src/main/database/messages/mappers.ts
+++ b/vex-app/src/main/database/messages/mappers.ts
@@ -168,6 +168,18 @@ const COMPACTION_MARKER_MESSAGE_TYPE = "compaction_committed";
 const CHAT_STOPPED_MESSAGE_TYPE = "chat_stopped";
 
 /**
+ * Engine `message_type` for the durable acknowledgement written beside an
+ * operator instruction (M6). Surfaces as the `operator_ack` kind.
+ *
+ * Mirrors `OPERATOR_INSTRUCTION_ACK_MESSAGE_TYPE` in the engine's
+ * `core/operator-instructions.ts` - the same string-literal mirror the two
+ * constants above already are, because the engine package is not an import
+ * target from the app's DB layer. The wire value is pinned on both sides by
+ * test.
+ */
+const OPERATOR_INSTRUCTION_ACK_MESSAGE_TYPE = "operator_interrupt_ack";
+
+/**
  * Derive renderer-visible `kind` from row shape using the top-level
  * `message_type` column + the (already allow-list-extracted) tool name.
  * `metadata` JSONB is intentionally never selected.
@@ -194,6 +206,18 @@ function deriveKind(row: MessageRow, toolName: string | null): MessageKind {
   // system marker - it renders as a user row with a "steered" register mark.
   if (row.role === "user" && row.message_type === "operator_interrupt") {
     return "steering";
+  }
+  // M6: the engine's acknowledgement of an operator instruction, ahead of the
+  // catch-all that would otherwise flatten it into `runtime_notice`. Role
+  // guard for the same reason the `chat_stopped` arm has one: the engine only
+  // ever writes this through `appendEngineMessage`, whose default role is
+  // "system", and a notice that announces itself out loud should not be
+  // reachable from an unexpected role.
+  if (
+    row.role === "system"
+    && row.message_type === OPERATOR_INSTRUCTION_ACK_MESSAGE_TYPE
+  ) {
+    return "operator_ack";
   }
   if (row.message_type !== null && row.message_type !== "chat") {
     // Other engine markers (wake banners, LEGACY pre-D-4 overflow stubs from

--- a/vex-app/src/main/database/messages/mappers.ts
+++ b/vex-app/src/main/database/messages/mappers.ts
@@ -7,8 +7,9 @@
  * `getMessageAround`). Raw `metadata` JSONB is deliberately never selected in
  * full; every read off that column is a NARROW, individually validated sub-key
  * projection (see `MESSAGE_ROW_COLUMNS`): `explorerRefs`, `success`,
- * `reasoning`, `durationMs`, `displayStatus`, and `board` - six of them today,
- * each with its own fail-to-null schema. The `message_type` top-level column remains the
+ * `reasoning`, `durationMs`, `displayStatus`, `board`, and the operator
+ * instruction's `payload -> 'disposition'` - seven of them today, each with its
+ * own fail-to-null schema. The `message_type` top-level column remains the
  * discriminator for row kind.
  *
  * TOOL NAMES ARE CANONICALIZED HERE. A discovered protocol manifest is called
@@ -24,6 +25,7 @@ import {
   explorerRefsSchema,
   reasoningProjectionSchema,
   toolDurationMsProjectionSchema,
+  operatorInterruptDispositionSchema,
   toolDisplayStatusProjectionSchema,
   toolSuccessProjectionSchema,
   type BoardProjection,
@@ -31,6 +33,7 @@ import {
   type MessageCursor,
   type MessageKind,
   type MessageRole,
+  type OperatorInterruptDispositionDto,
   type SessionMessageDto,
   type ToolCallDisplay,
   type ToolDisplayStatus,
@@ -61,17 +64,28 @@ export interface MessageRow {
   readonly display_status: unknown;
   /** ONLY the `board` sub-key of `messages.metadata` (assistant rows). */
   readonly board: unknown;
+  /**
+   * ONLY `messages.metadata -> 'payload' -> 'disposition'` (operator-interrupt
+   * rows). The engine's typed record of what it did with the instruction.
+   */
+  readonly interrupt_disposition: unknown;
 }
 
 // Raw `metadata` JSONB is still deliberately NOT selected in full — the strict
-// "metadata completely omitted" posture stands. Exactly SIX narrowly
+// "metadata completely omitted" posture stands. Exactly SEVEN narrowly
 // allow-listed sub-key projections exist (`explorerRefs`, `reasoning`,
-// `durationMs`, `success`, `displayStatus`, `board`); the SELECT reaches only
-// those sub-keys and the mapper zod-validates each before it reaches the DTO
+// `durationMs`, `success`, `displayStatus`, `board`, and the operator
+// instruction's `payload -> 'disposition'`); the SELECT reaches only those
+// sub-keys and the mapper zod-validates each before it reaches the DTO
 // (JSONB is untrusted at this boundary). The `message_type` column
 // (migration 002) remains the engine's authoritative marker discriminator.
+//
+// The disposition reaches TWO levels down because that is where the engine
+// writes it (`payload.disposition`), and the narrowness is the point: the
+// sibling `payload` keys - the route's own free-form target and run ids - stay
+// main-side where they belong.
 export const MESSAGE_ROW_COLUMNS =
-  "id, session_id, role, content, tool_call_id, tool_calls, created_at, source, message_type, metadata -> 'explorerRefs' AS explorer_refs, metadata -> 'reasoning' AS reasoning, metadata -> 'durationMs' AS duration_ms, metadata -> 'success' AS success, metadata -> 'displayStatus' AS display_status, metadata -> 'board' AS board";
+  "id, session_id, role, content, tool_call_id, tool_calls, created_at, source, message_type, metadata -> 'explorerRefs' AS explorer_refs, metadata -> 'reasoning' AS reasoning, metadata -> 'durationMs' AS duration_ms, metadata -> 'success' AS success, metadata -> 'displayStatus' AS display_status, metadata -> 'board' AS board, metadata -> 'payload' -> 'disposition' AS interrupt_disposition";
 
 export function toIso(value: string | Date): string {
   return value instanceof Date ? value.toISOString() : value;
@@ -180,6 +194,14 @@ const CHAT_STOPPED_MESSAGE_TYPE = "chat_stopped";
 const OPERATOR_INSTRUCTION_ACK_MESSAGE_TYPE = "operator_interrupt_ack";
 
 /**
+ * Engine `message_type` for the operator instruction row itself. Mirrors
+ * `OPERATOR_INTERRUPT_MESSAGE_TYPE` in the engine's
+ * `core/operator-instructions.ts`, the same string-literal mirror as the
+ * constants above. Pinned on both sides by test.
+ */
+const OPERATOR_INTERRUPT_MESSAGE_TYPE = "operator_interrupt";
+
+/**
  * Derive renderer-visible `kind` from row shape using the top-level
  * `message_type` column + the (already allow-list-extracted) tool name.
  * `metadata` JSONB is intentionally never selected.
@@ -204,7 +226,7 @@ function deriveKind(row: MessageRow, toolName: string | null): MessageKind {
   if (row.message_type === "mission_setup") return "text";
   // A33: a user message steered into a live turn is the user's prose, not a
   // system marker - it renders as a user row with a "steered" register mark.
-  if (row.role === "user" && row.message_type === "operator_interrupt") {
+  if (row.role === "user" && row.message_type === OPERATOR_INTERRUPT_MESSAGE_TYPE) {
     return "steering";
   }
   // M6: the engine's acknowledgement of an operator instruction, ahead of the
@@ -341,7 +363,33 @@ export function toDto(row: MessageRow): SessionMessageDto {
     success: extractSuccess(row),
     displayStatus: extractDisplayStatus(row),
     board: extractBoard(row),
+    interruptDisposition: extractInterruptDisposition(row),
   };
+}
+
+/**
+ * Validate the `metadata -> 'payload' -> 'disposition'` projection. ONLY an
+ * operator-interrupt row carries one.
+ *
+ * The row guard is not decoration: `disposition` also rides the ACK row's
+ * payload, and the ack is a notice whose whole text already states the
+ * disposition. Projecting it onto both rows would give the renderer two places
+ * to render the same fact and an opportunity to render them differently.
+ *
+ * An unrecognised value projects `null` - the enum is closed, this JSONB is
+ * untrusted, and a legacy row written before the disposition existed has none.
+ * `null` renders the neutral mark, never a guessed one.
+ */
+function extractInterruptDisposition(
+  row: MessageRow,
+): OperatorInterruptDispositionDto | null {
+  if (row.role !== "user" || row.message_type !== OPERATOR_INTERRUPT_MESSAGE_TYPE) {
+    return null;
+  }
+  const parsed = operatorInterruptDispositionSchema.safeParse(
+    row.interrupt_disposition,
+  );
+  return parsed.success ? parsed.data : null;
 }
 
 export function nextCursorFor(items: readonly SessionMessageDto[]): MessageCursor | null {

--- a/vex-app/src/main/database/session-control-state.ts
+++ b/vex-app/src/main/database/session-control-state.ts
@@ -41,7 +41,10 @@ import {
   missionRunStatusSchema,
   type MissionRunStatus,
 } from "@shared/schemas/sessions.js";
-import type { RuntimeStateDto } from "@shared/schemas/runtime.js";
+import type {
+  RuntimeActivity,
+  RuntimeStateDto,
+} from "@shared/schemas/runtime.js";
 import {
   engineCauseCodeSchema,
   engineErrorClassSchema,
@@ -90,6 +93,16 @@ export interface RuntimeControlFacts {
   readonly lastError?: RuntimeStateDto["lastError"];
   /** MAIN-INTERNAL. A `loop_defer` / continuation park is live. */
   readonly hasPendingWake: boolean;
+  /**
+   * `due_at` of the earliest pending SESSION-SCOPED wake (`mission_run_id IS
+   * NULL`), or `null`.
+   *
+   * Deliberately narrower than `hasPendingWake`, which counts every pending
+   * wake including a mission run's own. This one answers "is the SESSION
+   * asleep", which is the question the agent-session surfaces ask and the one
+   * `pausedWake` (mission-scoped, status-gated) does not answer.
+   */
+  readonly sessionWakeDueAt: string | null;
   /** MAIN-INTERNAL. The user still owes an approval decision. */
   readonly hasPendingApproval: boolean;
   /** MAIN-INTERNAL. Durable approval work the system still owes (D1). */
@@ -131,6 +144,29 @@ export function isStoppable(facts: RuntimeControlFacts): boolean {
   );
 }
 
+/**
+ * THE activity policy, in one named place (M5), derived from the SAME snapshot
+ * `isStoppable` reads.
+ *
+ * PRECEDENCE, and it is not arbitrary: a held lease outranks a pending wake.
+ * The two overlap for exactly one real interval - the executor claims a wake
+ * row and acquires the lease before it marks the row consumed - and during it
+ * the honest word is "running", because a runner is attached and burning
+ * money. Reporting "sleeping until 12:04" while the slice executes is the
+ * same class of lie the sawtooth produced in the other direction.
+ *
+ * Consumers (the composer strip, the tape word) read THIS, never `leaseActive`
+ * plus a wake read of their own; two derivations is how the strip and the tape
+ * came to disagree.
+ */
+export function readSessionActivity(facts: RuntimeControlFacts): RuntimeActivity {
+  if (facts.leaseActive) return { kind: "running" };
+  if (facts.sessionWakeDueAt !== null) {
+    return { kind: "sleeping", nextWakeAt: facts.sessionWakeDueAt };
+  }
+  return { kind: "none" };
+}
+
 interface ControlFactsRow {
   readonly mission_run_id: string | null;
   readonly status: string | null;
@@ -142,6 +178,7 @@ interface ControlFactsRow {
   readonly lease_expires_at: Date | null;
   readonly pending_control_kind: string | null;
   readonly has_pending_wake: boolean | null;
+  readonly session_wake_due_at: string | Date | null;
   readonly has_pending_approval: boolean | null;
   readonly has_incomplete_approval_lifecycle: boolean | null;
   readonly has_outstanding_user_form: boolean | null;
@@ -179,6 +216,18 @@ const CONTROL_FACTS_SQL = `
          EXISTS (SELECT 1 FROM loop_wake_requests w
                   WHERE w.session_id = s.session_id
                     AND w.status = 'pending')            AS has_pending_wake,
+         -- SESSION-scoped park only (mission_run_id IS NULL, migration 057).
+         -- A mission run's own wake is described by pausedWake under its
+         -- paused_wake status; mixing the two here would make a sleeping
+         -- mission report session activity and give the tape two answers.
+         -- NOTE: no backticks in this comment. The whole statement is a
+         -- template literal, so a backtick here ends the SQL string.
+         (SELECT sw.due_at FROM loop_wake_requests sw
+           WHERE sw.session_id = s.session_id
+             AND sw.status = 'pending'
+             AND sw.mission_run_id IS NULL
+           ORDER BY sw.due_at ASC
+           LIMIT 1)                                      AS session_wake_due_at,
          EXISTS (SELECT 1 FROM approval_queue a
                   WHERE a.session_id = s.session_id
                     AND a.status = 'pending')            AS has_pending_approval,
@@ -255,6 +304,7 @@ function toFacts(sessionId: string, row: ControlFactsRow): RuntimeControlFacts {
     leaseExpiresAt: row.lease_expires_at ? toIso(row.lease_expires_at) : null,
     pendingControlKind: normalisePendingControlKind(row.pending_control_kind),
     hasPendingWake: Boolean(row.has_pending_wake),
+    sessionWakeDueAt: toIsoOrNull(row.session_wake_due_at ?? null),
     hasPendingApproval: Boolean(row.has_pending_approval),
     hasIncompleteApprovalLifecycle: Boolean(
       row.has_incomplete_approval_lifecycle,

--- a/vex-app/src/main/ipc/__tests__/ipc-handler-surface/runtime-mission.test.ts
+++ b/vex-app/src/main/ipc/__tests__/ipc-handler-surface/runtime-mission.test.ts
@@ -201,6 +201,7 @@ describe("runtime handlers", () => {
         leaseExpiresAt: null,
         pendingControlKind: null,
         hasPendingWake: false,
+        sessionWakeDueAt: null,
         hasPendingApproval: false,
         hasIncompleteApprovalLifecycle: false,
         hasOutstandingUserForm: false,

--- a/vex-app/src/main/ipc/__tests__/mission/retry.test.ts
+++ b/vex-app/src/main/ipc/__tests__/mission/retry.test.ts
@@ -26,6 +26,8 @@ const mockClaim = vi.fn();
 const mockCreateLeaseHandle = vi.fn();
 const mockResumeMissionRun = vi.fn();
 const mockRelease = vi.fn();
+const mockAcquireLock = vi.fn();
+const mockMoneyState = vi.fn();
 
 vi.mock("electron", () => {
   const handlers = new Map<
@@ -78,6 +80,19 @@ vi.mock("@vex-agent/db/repos/loop-wake.js", () => ({
 }));
 vi.mock("@vex-agent/engine/runtime/lease-and-status.js", () => ({
   claimRunLeaseAndFlipToRunning: (...a: unknown[]) => mockClaim(...a),
+  acquireSessionControlLock: (...a: unknown[]) => mockAcquireLock(...a),
+}));
+// The RECOVERY money gate reads the session-scoped money state inside a
+// transaction under the session control lock. Both are mocked: what is proven
+// here is that the dispatcher REFUSES on an unclear answer and fails closed on
+// an unreadable one. That the reader itself is correct is proven against real
+// Postgres in the money-state reader's own integration suite.
+vi.mock("@vex-agent/db/client.js", () => ({
+  withTransaction: async (fn: (client: unknown) => Promise<unknown>) =>
+    fn({ query: vi.fn() }),
+}));
+vi.mock("@vex-agent/db/repos/approval-intents/money-state.js", () => ({
+  getUnresolvedMoneyStateForSession: (...a: unknown[]) => mockMoneyState(...a),
 }));
 vi.mock("@vex-agent/engine/runtime/lease-handle.js", () => ({
   createLeaseHandle: (...a: unknown[]) => mockCreateLeaseHandle(...a),
@@ -114,6 +129,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockEnsureEngineDbUrl.mockResolvedValue({ ok: true, data: undefined });
   mockEmitControlStateAfterChange.mockResolvedValue(undefined);
+  mockAcquireLock.mockResolvedValue(undefined);
+  // Default: nothing in flight. Every pre-existing case below is about run
+  // STATE, not money state, so they all start from a clear session.
+  mockMoneyState.mockResolvedValue({ clear: true });
   electronMock.__handlers.clear();
   registerMissionRetryHandler();
 });
@@ -229,6 +248,69 @@ describe("mission.retry", () => {
     await vi.waitFor(() =>
       expect(mockResumeMissionRun).toHaveBeenCalledWith("run-err", "owner-x"),
     );
+  });
+
+  it("refuses with blocked_money_state when the session has unresolved money state", async () => {
+    // The restart-orphan case: the process died mid-slice, so a transfer may be
+    // broadcast with no confirmation yet. Resuming on top of that is how a
+    // double spend happens - an unknown outcome is reconciled, never retried.
+    mockGetLatestRunForSession.mockResolvedValueOnce({
+      ok: true,
+      data: { missionRunId: "run-orphan", status: "paused_error" },
+    });
+    mockMoneyState.mockResolvedValueOnce({
+      clear: false,
+      reasons: [
+        { kind: "wallet_transaction_confirmation_unknown", ref: "intent-1" },
+        { kind: "wallet_transaction_confirmation_unknown", ref: "intent-2" },
+        { kind: "approval_in_flight", ref: "approval-9" },
+      ],
+    });
+
+    const r = await call({ sessionId: SESSION });
+
+    expect(r.data).toEqual({
+      outcome: "blocked_money_state",
+      reasonKinds: [
+        "wallet_transaction_confirmation_unknown",
+        "approval_in_flight",
+      ],
+    });
+    // Nothing with an effect ran: no claim, no resume, and the scheduled
+    // auto-retry wake is left exactly as it was.
+    expect(mockClaim).not.toHaveBeenCalled();
+    expect(mockResumeMissionRun).not.toHaveBeenCalled();
+    expect(mockCancelForSession).not.toHaveBeenCalled();
+    // Structural labels only: no row identifiers reach the renderer.
+    expect(JSON.stringify(r.data)).not.toContain("intent-1");
+  });
+
+  it("takes the session control lock to read the money state", async () => {
+    // Read outside the lock the answer is stale the instant it returns: every
+    // money-state writer serializes on this same lock.
+    mockGetLatestRunForSession.mockResolvedValueOnce({
+      ok: true,
+      data: { missionRunId: "run-orphan", status: "paused_error" },
+    });
+    mockMoneyState.mockResolvedValueOnce({ clear: false, reasons: [] });
+
+    await call({ sessionId: SESSION });
+
+    expect(mockAcquireLock).toHaveBeenCalledWith(expect.anything(), SESSION);
+  });
+
+  it("FAILS CLOSED when the money state cannot be read", async () => {
+    mockGetLatestRunForSession.mockResolvedValueOnce({
+      ok: true,
+      data: { missionRunId: "run-orphan", status: "paused_error" },
+    });
+    mockMoneyState.mockRejectedValueOnce(new Error("db unreachable"));
+
+    const r = await call({ sessionId: SESSION });
+
+    expect(r.ok).toBe(false);
+    expect(mockClaim).not.toHaveBeenCalled();
+    expect(mockResumeMissionRun).not.toHaveBeenCalled();
   });
 
   it("maps lease_busy with a retryAfterMs hint and never leaks the owner id", async () => {

--- a/vex-app/src/main/ipc/__tests__/mission/retry.test.ts
+++ b/vex-app/src/main/ipc/__tests__/mission/retry.test.ts
@@ -76,11 +76,26 @@ vi.mock("@vex-agent/db/repos/runtime-control-requests.js", () => ({
 // Phase 4d: runRetryDispatch cancels pending error_retry wakes before claiming.
 const mockCancelForSession = vi.fn().mockResolvedValue(0);
 vi.mock("@vex-agent/db/repos/loop-wake.js", () => ({
-  cancelForSession: (...a: unknown[]) => mockCancelForSession(...a),
+  cancelForSessionWith: (...a: unknown[]) => mockCancelForSession(...a),
 }));
+// `withSessionControlLock` opens the transaction and takes the lock; the gate
+// runs the money read, the wake cancellation and the claim INSIDE it. The fake
+// records that the lock was taken and hands the body a client, so the unit
+// tests can still assert the dispatcher's branching. That the exclusion is
+// REAL - that no money writer can commit between the read and the claim - is
+// not provable with a mocked lock and is proven against two live Postgres
+// clients in `recovery-money-gate-race.int.test.ts`.
 vi.mock("@vex-agent/engine/runtime/lease-and-status.js", () => ({
-  claimRunLeaseAndFlipToRunning: (...a: unknown[]) => mockClaim(...a),
-  acquireSessionControlLock: (...a: unknown[]) => mockAcquireLock(...a),
+  claimRunLeaseAndFlipToRunningWith: (_client: unknown, ...a: unknown[]) =>
+    mockClaim(...a),
+  withSessionControlLock: async (
+    sessionId: string,
+    fn: (client: unknown) => Promise<unknown>,
+  ) => {
+    const client = { query: vi.fn() };
+    await mockAcquireLock(client, sessionId);
+    return fn(client);
+  },
 }));
 // The RECOVERY money gate reads the session-scoped money state inside a
 // transaction under the session control lock. Both are mocked: what is proven
@@ -258,6 +273,11 @@ describe("mission.retry", () => {
       ok: true,
       data: { missionRunId: "run-orphan", status: "paused_error" },
     });
+    // The audit row is enqueued BEFORE the gate now, so the attempt is on
+    // record ahead of any effect and a money refusal settles it explicitly. A
+    // refusal on the money path is exactly what an operator needs to find
+    // later, so it gets an audit row rather than vanishing.
+    mockEnqueueRequest.mockResolvedValueOnce({ id: "audit-blocked" });
     mockMoneyState.mockResolvedValueOnce({
       clear: false,
       reasons: [
@@ -283,11 +303,17 @@ describe("mission.retry", () => {
     expect(mockCancelForSession).not.toHaveBeenCalled();
     // Structural labels only: no row identifiers reach the renderer.
     expect(JSON.stringify(r.data)).not.toContain("intent-1");
+    expect(mockMarkFailed).toHaveBeenCalledWith(
+      "audit-blocked",
+      "blocked_money_state",
+    );
   });
 
-  it("takes the session control lock to read the money state", async () => {
+  it("takes the session control lock around the money read AND the claim", async () => {
     // Read outside the lock the answer is stale the instant it returns: every
-    // money-state writer serializes on this same lock.
+    // money-state writer serializes on this same lock. The claim runs inside
+    // the same transaction, which is what makes the read a decision boundary
+    // rather than a snapshot of the past.
     mockGetLatestRunForSession.mockResolvedValueOnce({
       ok: true,
       data: { missionRunId: "run-orphan", status: "paused_error" },

--- a/vex-app/src/main/ipc/__tests__/runtime/get-state-paused-wake.test.ts
+++ b/vex-app/src/main/ipc/__tests__/runtime/get-state-paused-wake.test.ts
@@ -85,6 +85,7 @@ function runFacts(status: string) {
     leaseExpiresAt: null,
     pendingControlKind: null,
     hasPendingWake: false,
+    sessionWakeDueAt: null,
     hasPendingApproval: false,
     hasIncompleteApprovalLifecycle: false,
     hasOutstandingUserForm: false,
@@ -222,6 +223,7 @@ describe("runtime.getState stoppable", () => {
       leaseExpiresAt: null,
       pendingControlKind: null,
       hasPendingWake: false,
+      sessionWakeDueAt: null,
       hasPendingApproval: false,
       hasIncompleteApprovalLifecycle: false,
       hasOutstandingUserForm: false,
@@ -287,6 +289,11 @@ describe("runtime.getState stoppable", () => {
     const r = await call();
 
     expect(Object.keys(r.data ?? {}).sort()).toEqual([
+      // M5: `activity` joins the projected set - a DERIVED policy over the
+      // private facts, never one of the private facts itself. `recoveryReady`
+      // is absent because this fixture is not `paused_error`, the one status
+      // it is computed for.
+      "activity",
       "hasActiveRun",
       "iterationCount",
       "lastCheckpointAt",

--- a/vex-app/src/main/ipc/_shared/runtime-retry-dispatch.ts
+++ b/vex-app/src/main/ipc/_shared/runtime-retry-dispatch.ts
@@ -10,8 +10,10 @@
  * Result immediately.
  *
  * Before it claims anything it enforces the RECOVERY MONEY GATE
- * (`readSessionMoneyState` below): a session with an unproven money-path
- * outcome cannot be resumed, and the refusal names the structural reasons.
+ * (`gatedClaimUnderSessionLock` below): a session with an unproven money-path
+ * outcome cannot be resumed, and the refusal names the structural reasons. The
+ * gate and the claim it guards commit as ONE transaction under the session
+ * control lock - two transactions leave a window a money writer commits in.
  *
  * Duplicates ~60% of `runResumeDispatch` by intent (codex review): a shared
  * claim + fire-and-forget helper is only worth extracting once the stop-fix
@@ -27,6 +29,7 @@
 import { randomUUID } from "node:crypto";
 import { ok, err, type Result } from "@shared/ipc/result.js";
 import type { MissionRunStatus } from "@shared/schemas/sessions.js";
+import type { ClaimRunOutcome } from "@vex-agent/engine/runtime/lease-and-status.js";
 import { getLatestRunForSession } from "../../database/mission-runs-db.js";
 import { log } from "../../logger/index.js";
 import { controlFailedError } from "../runtime/_errors.js";
@@ -62,7 +65,10 @@ const LEASE_TTL_MS = 5 * 60_000;
 const RETRY_OWNER_PREFIX = "ipc-retry-";
 
 /**
- * The RECOVERY money gate, enforced here because this is the privileged half.
+ * The gated claim: the RECOVERY money gate and the claim it guards, as ONE
+ * decision in ONE transaction under the session control lock.
+ *
+ * ## The gate
  *
  * Recover resumes a run that stopped in the middle of something. A run parked
  * by the restart-orphan reclaim is the sharpest case - the process died
@@ -73,35 +79,104 @@ const RETRY_OWNER_PREFIX = "ipc-retry-";
  * double spend happens. The rule is the product's own (rule 90): an unknown
  * outcome is reconciled, never retried.
  *
- * Read inside a transaction under the SESSION CONTROL LOCK, which is what makes
- * it a boundary rather than a snapshot of the past: every money-state writer
- * takes the same lock (see the reader's module header). It is released before
- * the claim below, deliberately - nothing may hold that lock across the
- * fire-and-forget resume, and the claim revalidates status and lease under its
- * own row locks anyway.
+ * ## Why one transaction, and what was wrong before
+ *
+ * The gate used to read the money state under the lock, RELEASE it, and then
+ * claim the run in a separate transaction. That is a TOCTOU window, not a
+ * boundary: every money-path writer takes this same lock, so a writer blocked
+ * behind the read would commit an unresolved intent the instant the read
+ * released it, and the claim - which takes row locks on `mission_runs` and
+ * `runner_leases` but never the session control lock - would then resume the
+ * run over exactly the outcome the gate exists to refuse. The window was small
+ * and the loss is a double spend, which is the trade this rule does not make.
+ *
+ * So the read, the auto-retry wake cancellation and the claim now commit
+ * together or not at all. A money writer either commits before the read (and
+ * the gate sees it and refuses) or waits behind the lock until the claim is
+ * durable. There is no third ordering, which is what the two-client
+ * integration test asserts.
+ *
+ * ## The hold is still short
+ *
+ * The lock is held across three statements and NO inference: the fire-and-
+ * forget `resumeMissionRun` starts after this transaction commits, exactly as
+ * before. Holding the session control lock across a model turn is the failure
+ * this module's lock discipline forbids, and nothing here does it.
  *
  * FAIL-CLOSED: a throw propagates to the caller's catch and the retry is
  * refused. An unreadable money state is not a clear one.
  *
- * The renderer's Recover affordance must gate on the same fact, but that is a
- * display concern; this check is the enforcement and does not trust it.
+ * The renderer's Recover affordance gates on a MIRROR of the same fact, but
+ * that is a display concern; this is the enforcement and does not trust it.
+ *
+ * EXPORTED for its integration test, which drives this exact function from two
+ * real clients to prove the interleaving is impossible. The alternative was a
+ * test that re-composed the same three calls, which would prove only that the
+ * copy is safe. It is not part of the IPC surface and has no other caller.
  */
-async function readSessionMoneyState(
-  sessionId: string,
-): Promise<
-  | { readonly clear: true }
-  | { readonly clear: false; readonly reasons: readonly { kind: string }[] }
-> {
-  const { withTransaction } = await import("@vex-agent/db/client.js");
-  const { acquireSessionControlLock } = await import(
+type GatedClaimOutcome =
+  | {
+    readonly kind: "blocked_money_state";
+    readonly reasonKinds: readonly string[];
+  }
+  | { readonly kind: "claimed"; readonly claim: ClaimRunOutcome };
+
+export async function gatedClaimUnderSessionLock(input: {
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly status: MissionRunStatus;
+  readonly ownerId: string;
+}): Promise<GatedClaimOutcome> {
+  const { withSessionControlLock } = await import(
+    "@vex-agent/engine/runtime/lease-and-status.js"
+  );
+  const { claimRunLeaseAndFlipToRunningWith } = await import(
     "@vex-agent/engine/runtime/lease-and-status.js"
   );
   const { getUnresolvedMoneyStateForSession } = await import(
     "@vex-agent/db/repos/approval-intents/money-state.js"
   );
-  return withTransaction(async (client) => {
-    await acquireSessionControlLock(client, sessionId);
-    return getUnresolvedMoneyStateForSession(client, sessionId);
+  const { cancelForSessionWith } = await import(
+    "@vex-agent/db/repos/loop-wake.js"
+  );
+
+  return withSessionControlLock(input.sessionId, async (client) => {
+    const money = await getUnresolvedMoneyStateForSession(
+      client,
+      input.sessionId,
+    );
+    if (!money.clear) {
+      return {
+        kind: "blocked_money_state",
+        reasonKinds: [...new Set(money.reasons.map((r) => r.kind))],
+      };
+    }
+
+    if (input.status === "paused_error") {
+      // A human Recover supersedes any scheduled auto-retry. Inside the gate,
+      // so a refused or lost claim does not leave the run with its retry
+      // cancelled AND no recovery performed. A wake already CONSUMED by the
+      // executor cannot be cancelled; there `claimRunForAutoRetry`'s own
+      // atomic re-check is the authority and will skip.
+      await cancelForSessionWith(
+        client,
+        input.sessionId,
+        "superseded_by_manual_recover",
+      );
+    }
+
+    const claim = await claimRunLeaseAndFlipToRunningWith(client, {
+      sessionId: input.sessionId,
+      missionRunId: input.runId,
+      // `[status]` - either `["paused_error"]` (the normal Recover path) or
+      // `["running"]` (the dead-lease reclaim path). Never both: only one of
+      // the two branches reaches here for a given call.
+      fromStatuses: [input.status],
+      ownerId: input.ownerId,
+      processKind: "electron_main",
+      ttlMs: LEASE_TTL_MS,
+    });
+    return { kind: "claimed", claim };
   });
 }
 
@@ -152,31 +227,15 @@ export async function runRetryDispatch(
       return ok({ outcome: "not_recoverable", status });
     }
 
-    // Money gate BEFORE anything with an effect. Placed ahead of the wake
-    // cancellation below so a refused Recover leaves the run exactly as it was,
-    // scheduled auto-retry included.
-    const money = await readSessionMoneyState(input.sessionId);
-    if (!money.clear) {
-      const reasonKinds = [...new Set(money.reasons.map((r) => r.kind))];
-      log.info(
-        `[ipc:${ctx.channelLabel}] retry refused on unresolved money state runId=${runId} reasons=${reasonKinds.join(",")}`,
-      );
-      return ok({ outcome: "blocked_money_state", reasonKinds });
-    }
-
-    if (status === "paused_error") {
-      // Phase 4d: a human Recover supersedes any scheduled auto-retry — cancel
-      // the pending error_retry wake so it can't fire later. A wake already
-      // CONSUMED by the executor can't be cancelled; there, claimRunForAutoRetry's
-      // atomic re-check (status/unsafe/attempt) is the authority and will skip.
-      const { cancelForSession } = await import(
-        "@vex-agent/db/repos/loop-wake.js"
-      );
-      await cancelForSession(input.sessionId, "superseded_by_manual_recover");
-    }
-
-    // status === "paused_error", or "running" with a DEAD lease — claim +
-    // flip + fire-and-forget resume.
+    // status === "paused_error", or "running" with a DEAD lease: money gate +
+    // wake cancellation + claim + flip, then fire-and-forget resume.
+    //
+    // The audit request is enqueued BEFORE the gated claim so the attempt is
+    // recorded ahead of any effect (rule 09: request before dispatch, exactly
+    // one correlated outcome after settlement). A money-blocked Recover
+    // therefore leaves an audit row settled `blocked_money_state`, which is
+    // the point - a refusal on the money path is precisely what an operator
+    // needs to find later.
     const { enqueueRequest, markObserved, markCleared, markFailed } =
       await import("@vex-agent/db/repos/runtime-control-requests.js");
     const auditRequest = await enqueueRequest({
@@ -186,20 +245,23 @@ export async function runRetryDispatch(
       requestedBy: "user",
       correlationId: ctx.requestId,
     });
-    const { claimRunLeaseAndFlipToRunning } = await import(
-      "@vex-agent/engine/runtime/lease-and-status.js"
-    );
-    const claim = await claimRunLeaseAndFlipToRunning({
+    const gated = await gatedClaimUnderSessionLock({
       sessionId: input.sessionId,
-      missionRunId: runId,
-      // `[status]` — either `["paused_error"]` (the normal Recover path) or
-      // `["running"]` (the dead-lease reclaim path above). Never both: only
-      // one of the two branches above reaches here for a given call.
-      fromStatuses: [status],
+      runId,
+      status,
       ownerId: `${RETRY_OWNER_PREFIX}${randomUUID()}`,
-      processKind: "electron_main",
-      ttlMs: LEASE_TTL_MS,
     });
+    if (gated.kind === "blocked_money_state") {
+      await markFailed(auditRequest.id, "blocked_money_state");
+      log.info(
+        `[ipc:${ctx.channelLabel}] retry refused on unresolved money state runId=${runId} reasons=${gated.reasonKinds.join(",")}`,
+      );
+      return ok({
+        outcome: "blocked_money_state",
+        reasonKinds: gated.reasonKinds,
+      });
+    }
+    const claim = gated.claim;
     if (claim.outcome === "lease_busy") {
       await markFailed(auditRequest.id, "lease_busy");
       const retryAfterMs = Math.max(

--- a/vex-app/src/main/ipc/_shared/runtime-retry-dispatch.ts
+++ b/vex-app/src/main/ipc/_shared/runtime-retry-dispatch.ts
@@ -9,6 +9,10 @@
  * flips status, kicks off `resumeMissionRun` asynchronously, and returns a
  * Result immediately.
  *
+ * Before it claims anything it enforces the RECOVERY MONEY GATE
+ * (`readSessionMoneyState` below): a session with an unproven money-path
+ * outcome cannot be resumed, and the refusal names the structural reasons.
+ *
  * Duplicates ~60% of `runResumeDispatch` by intent (codex review): a shared
  * claim + fire-and-forget helper is only worth extracting once the stop-fix
  * slice proves the shape is stable.
@@ -48,10 +52,58 @@ export type RetryFlowResult =
   | { readonly outcome: "blocked_terminal"; readonly status: MissionRunStatus }
   | { readonly outcome: "not_recoverable"; readonly status: MissionRunStatus }
   | { readonly outcome: "status_changed" }
+  | {
+    readonly outcome: "blocked_money_state";
+    readonly reasonKinds: readonly string[];
+  }
   | { readonly outcome: "lease_busy"; readonly retryAfterMs?: number };
 
 const LEASE_TTL_MS = 5 * 60_000;
 const RETRY_OWNER_PREFIX = "ipc-retry-";
+
+/**
+ * The RECOVERY money gate, enforced here because this is the privileged half.
+ *
+ * Recover resumes a run that stopped in the middle of something. A run parked
+ * by the restart-orphan reclaim is the sharpest case - the process died
+ * mid-slice, so a wallet intent may be `consuming`, a transaction may be
+ * broadcast with no confirmation yet, an approval may be `dispatching` - but it
+ * is not a special case: every `paused_error` pause is a decision made from an
+ * interrupted state, and resuming on top of an unproven money outcome is how a
+ * double spend happens. The rule is the product's own (rule 90): an unknown
+ * outcome is reconciled, never retried.
+ *
+ * Read inside a transaction under the SESSION CONTROL LOCK, which is what makes
+ * it a boundary rather than a snapshot of the past: every money-state writer
+ * takes the same lock (see the reader's module header). It is released before
+ * the claim below, deliberately - nothing may hold that lock across the
+ * fire-and-forget resume, and the claim revalidates status and lease under its
+ * own row locks anyway.
+ *
+ * FAIL-CLOSED: a throw propagates to the caller's catch and the retry is
+ * refused. An unreadable money state is not a clear one.
+ *
+ * The renderer's Recover affordance must gate on the same fact, but that is a
+ * display concern; this check is the enforcement and does not trust it.
+ */
+async function readSessionMoneyState(
+  sessionId: string,
+): Promise<
+  | { readonly clear: true }
+  | { readonly clear: false; readonly reasons: readonly { kind: string }[] }
+> {
+  const { withTransaction } = await import("@vex-agent/db/client.js");
+  const { acquireSessionControlLock } = await import(
+    "@vex-agent/engine/runtime/lease-and-status.js"
+  );
+  const { getUnresolvedMoneyStateForSession } = await import(
+    "@vex-agent/db/repos/approval-intents/money-state.js"
+  );
+  return withTransaction(async (client) => {
+    await acquireSessionControlLock(client, sessionId);
+    return getUnresolvedMoneyStateForSession(client, sessionId);
+  });
+}
 
 export async function runRetryDispatch(
   input: RetryFlowInput,
@@ -98,6 +150,18 @@ export async function runRetryDispatch(
     ) {
       // Not an error pause → Continue (runResumeDispatch) owns these.
       return ok({ outcome: "not_recoverable", status });
+    }
+
+    // Money gate BEFORE anything with an effect. Placed ahead of the wake
+    // cancellation below so a refused Recover leaves the run exactly as it was,
+    // scheduled auto-retry included.
+    const money = await readSessionMoneyState(input.sessionId);
+    if (!money.clear) {
+      const reasonKinds = [...new Set(money.reasons.map((r) => r.kind))];
+      log.info(
+        `[ipc:${ctx.channelLabel}] retry refused on unresolved money state runId=${runId} reasons=${reasonKinds.join(",")}`,
+      );
+      return ok({ outcome: "blocked_money_state", reasonKinds });
     }
 
     if (status === "paused_error") {

--- a/vex-app/src/main/ipc/_shared/runtime-retry-dispatch.ts
+++ b/vex-app/src/main/ipc/_shared/runtime-retry-dispatch.ts
@@ -90,11 +90,21 @@ const RETRY_OWNER_PREFIX = "ipc-retry-";
  * run over exactly the outcome the gate exists to refuse. The window was small
  * and the loss is a double spend, which is the trade this rule does not make.
  *
- * So the read, the auto-retry wake cancellation and the claim now commit
+ * So the read, the claim and the auto-retry wake cancellation now commit
  * together or not at all. A money writer either commits before the read (and
  * the gate sees it and refuses) or waits behind the lock until the claim is
  * durable. There is no third ordering, which is what the two-client
  * integration test asserts.
+ *
+ * ## Lock ORDER inside that transaction
+ *
+ * The claim runs BEFORE the wake cancellation, matching the order every other
+ * claimant uses: `mission_runs`, then `runner_leases`, then
+ * `loop_wake_requests`. Cancelling first inverted that order and made a real
+ * deadlock reachable whenever the run advanced to `paused_wake` between this
+ * dispatcher's outside read and the transaction. `gatedClaimUnderSessionLock`
+ * spells out the interleaving; the regression is pinned live in
+ * `recovery-reverse-lock-order.int.test.ts`.
  *
  * ## The hold is still short
  *
@@ -152,30 +162,57 @@ export async function gatedClaimUnderSessionLock(input: {
       };
     }
 
-    if (input.status === "paused_error") {
-      // A human Recover supersedes any scheduled auto-retry. Inside the gate,
-      // so a refused or lost claim does not leave the run with its retry
-      // cancelled AND no recovery performed. A wake already CONSUMED by the
-      // executor cannot be cancelled; there `claimRunForAutoRetry`'s own
-      // atomic re-check is the authority and will skip.
+    // THE CLAIM COMES FIRST, and the order is load-bearing, not stylistic.
+    //
+    // `claimRunLeaseAndFlipToRunningWith` locks the `mission_runs` row, then
+    // the lease row, then pending `loop_wake_requests` rows - in that order,
+    // and every other claimant in the system follows it. Cancelling the
+    // auto-retry wake BEFORE the claim took those wake rows first and inverted
+    // it, which is a textbook lock-order inversion with a reachable deadlock:
+    //
+    //   1. this dispatcher reads `paused_error` OUTSIDE the transaction;
+    //   2. the run advances to `paused_wake` before the gate opens;
+    //   3. a wake or Continue claimant locks the run row and moves toward the
+    //      wake rows;
+    //   4. this transaction, still carrying the stale `paused_error`, locks
+    //      the pending wake row and then waits on the run row;
+    //   5. the claimant waits on the wake row this transaction holds.
+    //
+    // Postgres breaks that cycle by aborting one side, which turns an ordinary
+    // lost race into a failed control action. Claiming first removes the cycle
+    // entirely: a stale Recover simply loses the status check and returns
+    // `status_mismatch` having touched no wake row at all.
+    const claim = await claimRunLeaseAndFlipToRunningWith(client, {
+      sessionId: input.sessionId,
+      missionRunId: input.runId,
+      // `[status]` - either `["paused_error"]` (the normal Recover path) or
+      // `["running"]` (the dead-lease reclaim path). Never both: only one of
+      // the two branches reaches here for a given call. This is also the
+      // revalidation that makes the outside read safe to be stale.
+      fromStatuses: [input.status],
+      ownerId: input.ownerId,
+      processKind: "electron_main",
+      ttlMs: LEASE_TTL_MS,
+    });
+
+    // A human Recover supersedes any scheduled auto-retry - but ONLY once the
+    // claim has actually won, and only for a run that really was parked on an
+    // error. `previousStatus` is what the claim OBSERVED under the row lock,
+    // never the status this dispatcher read outside the transaction; keying on
+    // the latter is what let a stale call cancel a wake belonging to a
+    // different scheduling cycle.
+    //
+    // A `paused_wake` claim needs nothing here: the claim cancels that run's
+    // own wake itself, under the same lock order. And a wake already CONSUMED
+    // by the executor cannot be cancelled by anyone - there
+    // `claimRunForAutoRetry`'s atomic re-check is the authority and will skip.
+    if (claim.outcome === "claimed" && claim.previousStatus === "paused_error") {
       await cancelForSessionWith(
         client,
         input.sessionId,
         "superseded_by_manual_recover",
       );
     }
-
-    const claim = await claimRunLeaseAndFlipToRunningWith(client, {
-      sessionId: input.sessionId,
-      missionRunId: input.runId,
-      // `[status]` - either `["paused_error"]` (the normal Recover path) or
-      // `["running"]` (the dead-lease reclaim path). Never both: only one of
-      // the two branches reaches here for a given call.
-      fromStatuses: [input.status],
-      ownerId: input.ownerId,
-      processKind: "electron_main",
-      ttlMs: LEASE_TTL_MS,
-    });
     return { kind: "claimed", claim };
   });
 }

--- a/vex-app/src/main/ipc/runtime/get-state.ts
+++ b/vex-app/src/main/ipc/runtime/get-state.ts
@@ -18,13 +18,17 @@ import {
   runtimeRequestInputSchema,
   runtimeStateDtoSchema,
   type RuntimePausedWake,
+  MONEY_STATE_UNREADABLE,
+  type RuntimeRecoveryReadiness,
   type RuntimeStateDto,
 } from "@shared/schemas/runtime.js";
 import {
   isStoppable,
+  readSessionActivity,
   readSessionControlFacts,
   type RuntimeControlFacts,
 } from "../../database/session-control-state.js";
+import { ensureEngineDbUrl } from "./_ensure-engine-db-url.js";
 import { getPendingWakeForSession } from "../../database/wake-db.js";
 import { log } from "../../logger/index.js";
 import { registerHandler } from "../register-handler.js";
@@ -49,7 +53,8 @@ export function registerRuntimeGetStateHandler(): () => void {
       }
       const facts = outcome.data;
       const pausedWake = await readPausedWake(facts);
-      const dto = projectRuntimeStateDto(facts, pausedWake);
+      const recoveryReady = await readRecoveryReadiness(facts, ctx.requestId);
+      const dto = projectRuntimeStateDto(facts, pausedWake, recoveryReady);
       log.info(
         `[ipc:vex:runtime:getState] ok sessionId=${input.sessionId} ` +
           `hasActiveRun=${facts.hasActiveRun} ` +
@@ -63,6 +68,8 @@ export function registerRuntimeGetStateHandler(): () => void {
           // Metadata only — the agent-authored reason text stays out of the
           // log line; `dueAt` is what makes a mis-timed wake diagnosable.
           `pausedWakeDueAt=${pausedWake?.dueAt ?? "none"} ` +
+          `activity=${dto.activity.kind} ` +
+          `recoveryReady=${recoveryReady?.kind ?? "n/a"} ` +
           `correlationId=${ctx.requestId}`,
       );
       return { ok: true, data: dto };
@@ -85,6 +92,7 @@ export function registerRuntimeGetStateHandler(): () => void {
 function projectRuntimeStateDto(
   facts: RuntimeControlFacts,
   pausedWake: RuntimePausedWake | null,
+  recoveryReady: RuntimeRecoveryReadiness | null,
 ): RuntimeStateDto {
   return {
     sessionId: facts.sessionId,
@@ -99,9 +107,57 @@ function projectRuntimeStateDto(
     leaseExpiresAt: facts.leaseExpiresAt,
     pendingControlKind: facts.pendingControlKind,
     stoppable: isStoppable(facts),
+    activity: readSessionActivity(facts),
     ...(facts.lastError === undefined ? {} : { lastError: facts.lastError }),
     ...(pausedWake === null ? {} : { pausedWake }),
+    ...(recoveryReady === null ? {} : { recoveryReady }),
   };
+}
+
+/**
+ * The Recover affordance's money-state mirror, or `null` for every status
+ * where Recover is not offered.
+ *
+ * READS THE SAME OWNER as the enforcement. `getUnresolvedMoneyStateForSession`
+ * is the single source of that answer; re-implementing its eleven predicates
+ * here would create a second, quietly diverging one, and the surface that
+ * diverged would be the one telling the operator it is safe to press.
+ *
+ * WITHOUT the session control lock, and that is deliberate. The lock is what
+ * makes the retry dispatcher's read a decision boundary; taking it on a
+ * read-only IPC that fires on every control-state push would put a poll in
+ * front of the operator's Stop, which is precisely the inversion the lock's own
+ * module forbids. So this answer is a possibly-stale MIRROR, which is all a
+ * button state may ever be: `runtime-retry-dispatch.ts` re-reads under the lock
+ * and refuses on its own answer.
+ *
+ * FAIL-CLOSED: any failure - unset DB url, connect error, malformed row -
+ * projects `blocked`, because an unreadable money state is not a clear one.
+ */
+async function readRecoveryReadiness(
+  facts: RuntimeControlFacts,
+  correlationId: string,
+): Promise<RuntimeRecoveryReadiness | null> {
+  if (facts.status !== "paused_error") return null;
+  try {
+    const dbUrl = await ensureEngineDbUrl(correlationId);
+    if (!dbUrl.ok) return { kind: "blocked", reasonKinds: [MONEY_STATE_UNREADABLE] };
+    const { withTransaction } = await import("@vex-agent/db/client.js");
+    const { getUnresolvedMoneyStateForSession } = await import(
+      "@vex-agent/db/repos/approval-intents/money-state.js"
+    );
+    const money = await withTransaction(async (client) =>
+      getUnresolvedMoneyStateForSession(client, facts.sessionId),
+    );
+    if (money.clear) return { kind: "ready" };
+    return {
+      kind: "blocked",
+      reasonKinds: [...new Set(money.reasons.map((reason) => reason.kind))],
+    };
+  } catch (cause) {
+    log.warn("[ipc:vex:runtime:getState] money-state mirror read failed", cause);
+    return { kind: "blocked", reasonKinds: [MONEY_STATE_UNREADABLE] };
+  }
 }
 
 /**

--- a/vex-app/src/main/sessions/__tests__/markdown-export.test.ts
+++ b/vex-app/src/main/sessions/__tests__/markdown-export.test.ts
@@ -40,6 +40,7 @@ function message(
     success: null,
     displayStatus: null,
     board: null,
+    interruptDisposition: null,
     ...overrides,
   };
 }

--- a/vex-app/src/renderer/features/appShell/ComposerSendControl.tsx
+++ b/vex-app/src/renderer/features/appShell/ComposerSendControl.tsx
@@ -26,6 +26,12 @@ export interface ComposerSendControlProps {
    * the runtime state is unknown. Do NOT re-derive it here.
    */
   readonly stopAvailable: boolean;
+  /**
+   * The Stop key's accessible name, resolved per session mode by the owner's
+   * `resolveStopAffordance` ("Stop mission" / "Stop agent"). Named by TARGET,
+   * because the key stops a run or an autonomous session, not a generation.
+   */
+  readonly stopLabel: string;
   readonly stopRequested: boolean;
   readonly onStop: () => void;
   readonly submitDisabled: boolean;
@@ -41,6 +47,7 @@ export interface ComposerSendControlProps {
 
 export function ComposerSendControl({
   stopAvailable,
+  stopLabel,
   stopRequested,
   onStop,
   submitDisabled,
@@ -67,7 +74,7 @@ export function ComposerSendControl({
         type="button"
         onClick={onStop}
         onMouseDown={onKeepFocus}
-        aria-label="Stop generating"
+        aria-label={stopLabel}
         className={cn(
           SEND_KEY_BASE,
           "bg-button-accent text-ink-on-button-accent hover:bg-button-accent-hover",

--- a/vex-app/src/renderer/features/appShell/DeskRuleTapeState.tsx
+++ b/vex-app/src/renderer/features/appShell/DeskRuleTapeState.tsx
@@ -34,6 +34,7 @@ import { useRuntimeState } from "../../lib/api/runtime.js";
 import { useStreamPreview } from "../../stores/streamStore.js";
 import { useUiStore } from "../../stores/uiStore.js";
 import { cn } from "../../lib/utils.js";
+import { readSessionActivityReadout } from "./session-activity-readout.js";
 
 export function DeskRuleTapeState(): JSX.Element | null {
   const activeSessionId = useUiStore((s) => s.activeSessionId);
@@ -53,6 +54,15 @@ export function DeskRuleTapeState(): JSX.Element | null {
   const hasActiveRun = run?.hasActiveRun === true;
   const paused = hasActiveRun && (run?.status?.startsWith("paused") ?? false);
 
+  // M5: the tail of the precedence chain is no longer "no run row ⇒ Idle".
+  // A full-autonomy AGENT session has no run row at all, so wake-driven work
+  // reported Idle while the agent was mid-slice. The activity projection is
+  // the authoritative answer for that case, read through the SAME selector the
+  // composer strip reads so the two words cannot disagree. Mission precedence
+  // above is untouched: a mission session's activity is `none` (the projection
+  // is session-scoped), so it never reaches this arm.
+  const activityReadout =
+    run === null ? null : readSessionActivityReadout(run.activity);
   const state = hasPending
     ? "awaiting"
     : live
@@ -61,7 +71,7 @@ export function DeskRuleTapeState(): JSX.Element | null {
         ? "paused"
         : hasActiveRun
           ? "running"
-          : "idle";
+          : (activityReadout?.state ?? "idle");
   const label =
     state === "awaiting"
       ? "Awaiting"
@@ -71,7 +81,9 @@ export function DeskRuleTapeState(): JSX.Element | null {
           ? "Paused"
           : state === "running"
             ? "Running"
-            : "Idle";
+            : state === "sleeping"
+              ? "Sleeping"
+              : "Idle";
   const lit = state !== "idle";
 
   // `.vex-micro` is the register's small-caps stamp; the

--- a/vex-app/src/renderer/features/appShell/MissionControls.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionControls.tsx
@@ -82,6 +82,8 @@ import {
 } from "../../lib/api/mission.js";
 import { useRuntimeState } from "../../lib/api/runtime.js";
 import { cn } from "../../lib/utils.js";
+import { readStopAvailability } from "./composer-submit/stop-availability.js";
+import { resolveStopAffordance } from "./composer-submit/stop-affordance.js";
 import { MissionRestartAffordance } from "./MissionRestartAffordance.js";
 import { MissionErrorAlert } from "./MissionControls/MissionErrorAlert.js";
 import { useUiStore } from "../../stores/uiStore.js";
@@ -166,6 +168,12 @@ function noticeFor(r: Result<{ readonly outcome: string }>): string | null {
       return "No inference provider - unlock Vex or set up a provider.";
     case "status_changed":
       return "Mission state changed - re-check and retry.";
+    case "blocked_money_state":
+      // The wave-1 recovery money gate. NOT a generic failure: the run is
+      // recoverable, but something on the money path has no proven outcome
+      // yet, and resuming on top of it is how a double spend happens. Say
+      // that, and say what clears it, without naming rows or providers.
+      return "Recover is blocked: a wallet or approval action from this session has no confirmed outcome yet. It clears once that settles.";
     default:
       return "Couldn't complete the action. Re-check the mission state.";
   }
@@ -298,8 +306,23 @@ export function MissionControls({
   if (runtime.hasActiveRun) {
     const status = runtime.status;
     const canContinue = status === "paused_wake" || status === "paused_user";
-    const canRecover = status === "paused_error";
+    // M3/M5: the money gate is enforced in the privileged retry IPC and
+    // MIRRORED here. `recoveryReady` is present exactly for `paused_error`, so
+    // an absent value on this branch means the mirror was not computed and the
+    // button stays offered - the IPC still refuses and names the reason. A
+    // present `blocked` disables it with that reason stated up front, instead
+    // of a click that can only fail.
+    const recoveryBlocked = runtime.recoveryReady?.kind === "blocked";
+    const canRecover = status === "paused_error" && !recoveryBlocked;
     const canEdit = status !== "paused_approval";
+    // The same selector the composer's send/stop key reads (M6). Both surfaces
+    // reach `runStopDispatch`: `mission.stop` and `runtime.requestStop` are two
+    // channel names for that one dispatcher.
+    const stopAffordance = resolveStopAffordance(
+      readStopAvailability(sessionId, runtimeQuery.data, runtimeQuery.isError),
+      "mission",
+      false,
+    );
     return (
       <>
         {canRecover ? (
@@ -333,10 +356,14 @@ export function MissionControls({
           />
           <ControlButton
             label="Stop"
+            ariaLabel={stopAffordance.label}
             tone="danger"
-            disabled={disabled}
+            disabled={disabled || !stopAffordance.offered}
             onClick={() => void run(() => stop.mutateAsync({ sessionId }))}
           />
+          {recoveryBlocked ? (
+            <ControlNoticeLine text={RECOVERY_BLOCKED_TEXT} tone="warning" />
+          ) : null}
           {notice !== null ? <ControlNoticeLine text={notice.text} /> : null}
         </div>
       </>
@@ -652,9 +679,34 @@ function ControlButton({
   );
 }
 
-function ControlNoticeLine({ text }: { readonly text: string }): JSX.Element {
+/**
+ * Why Recover is disabled, stated where the disabled button is (rule 08: a
+ * control that refuses must say what it is waiting for, and the disabled
+ * attribute alone says nothing to anyone).
+ *
+ * Structural only. The blocking `reasonKinds` are internal labels for the
+ * audit log, never operator copy, and naming a row would leak money-path
+ * detail into the renderer for no gain.
+ */
+const RECOVERY_BLOCKED_TEXT =
+  "Recover is unavailable: a wallet or approval action from this session has no confirmed outcome yet. It re-enables once that settles.";
+
+function ControlNoticeLine({
+  text,
+  tone,
+}: {
+  readonly text: string;
+  /** `error` (default) speaks as an alert; `warning` is a standing status. */
+  readonly tone?: "error" | "warning";
+}): JSX.Element {
   return (
-    <p role="alert" className="w-full text-xs text-destructive">
+    <p
+      role={tone === "warning" ? "status" : "alert"}
+      className={cn(
+        "w-full text-xs",
+        tone === "warning" ? "text-warning" : "text-destructive",
+      )}
+    >
       {text}
     </p>
   );

--- a/vex-app/src/renderer/features/appShell/MissionControls.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionControls.tsx
@@ -66,7 +66,10 @@ import type {
   MissionGetRenewableSourceResult,
   MissionRenewResult,
 } from "@shared/schemas/mission.js";
-import type { RuntimeStateDto } from "@shared/schemas/runtime.js";
+import {
+  MONEY_STATE_UNREADABLE,
+  type RuntimeStateDto,
+} from "@shared/schemas/runtime.js";
 import { useIsChatSubmitting } from "../../lib/api/chat.js";
 import {
   useEditMission,
@@ -307,13 +310,24 @@ export function MissionControls({
     const status = runtime.status;
     const canContinue = status === "paused_wake" || status === "paused_user";
     // M3/M5: the money gate is enforced in the privileged retry IPC and
-    // MIRRORED here. `recoveryReady` is present exactly for `paused_error`, so
-    // an absent value on this branch means the mirror was not computed and the
-    // button stays offered - the IPC still refuses and names the reason. A
-    // present `blocked` disables it with that reason stated up front, instead
-    // of a click that can only fail.
-    const recoveryBlocked = runtime.recoveryReady?.kind === "blocked";
-    const canRecover = status === "paused_error" && !recoveryBlocked;
+    // MIRRORED here. FAIL-CLOSED, and it is worth being exact about why.
+    //
+    // The mirror's own schema calls itself fail-closed - an unreadable money
+    // state projects `blocked`. This branch used to undo that by reading an
+    // ABSENT field as permission: `!blocked` is true for `undefined`, so the
+    // one case the mirror could not answer was the one case the button was
+    // offered for. An affordance granted on a fact nobody computed is exactly
+    // the "unknown read as clear" the money rules forbid.
+    //
+    // So Recover now requires the POSITIVE answer. Absent is unknown, unknown
+    // is not ready, and the operator is told which of the two it is rather
+    // than being handed a click that can only fail. The IPC remains the
+    // authority and refuses on its own read regardless of any of this.
+    const isPausedError = status === "paused_error";
+    const recovery = runtime.recoveryReady;
+    const recoveryBlocked = isPausedError && recovery?.kind === "blocked";
+    const recoveryUnknown = isPausedError && recovery === undefined;
+    const canRecover = isPausedError && recovery?.kind === "ready";
     const canEdit = status !== "paused_approval";
     // The same selector the composer's send/stop key reads (M6). Both surfaces
     // reach `runStopDispatch`: `mission.stop` and `runtime.requestStop` are two
@@ -325,7 +339,13 @@ export function MissionControls({
     );
     return (
       <>
-        {canRecover ? (
+        {/* Keyed on the PAUSE, never on the button. The alert explains why the
+            run stopped - the restart, the repeated tool call, the provider
+            error - and that explanation is most needed precisely when recovery
+            is blocked. Gating it on `canRecover` meant a blocked money state
+            silently removed the only account of what happened, leaving a
+            disabled button and no reason for either fact. */}
+        {isPausedError ? (
           <MissionErrorAlert
             stopReason={runtime.stopReason}
             lastError={runtime.lastError}
@@ -362,7 +382,13 @@ export function MissionControls({
             onClick={() => void run(() => stop.mutateAsync({ sessionId }))}
           />
           {recoveryBlocked ? (
-            <ControlNoticeLine text={RECOVERY_BLOCKED_TEXT} tone="warning" />
+            <ControlNoticeLine
+              text={recoveryBlockedText(recovery)}
+              tone="warning"
+            />
+          ) : null}
+          {recoveryUnknown ? (
+            <ControlNoticeLine text={RECOVERY_UNKNOWN_TEXT} tone="warning" />
           ) : null}
           {notice !== null ? <ControlNoticeLine text={notice.text} /> : null}
         </div>
@@ -690,6 +716,56 @@ function ControlButton({
  */
 const RECOVERY_BLOCKED_TEXT =
   "Recover is unavailable: a wallet or approval action from this session has no confirmed outcome yet. It re-enables once that settles.";
+
+/**
+ * The DIFFERENT sentence for "we could not check".
+ *
+ * These are two genuinely different situations and collapsing them was a lie
+ * in one direction: the copy above asserts that an action exists and is
+ * settling, which tells an operator to wait for something that may not be
+ * there. `money_state_unreadable` means the mirror could not read the state at
+ * all - a database that did not answer - and the honest thing to say is that
+ * nothing is known, not to invent a pending action.
+ *
+ * It still fails closed: unreadable disables Recover exactly as blocked does
+ * (rule 90 - an unknown outcome is not a clear one). Only the words differ,
+ * because only the words were wrong.
+ */
+const RECOVERY_UNREADABLE_TEXT =
+  "Recover is unavailable: Vex could not check this session's wallet and approval state. Retry once the local services are responding.";
+
+/**
+ * The third sentence: `paused_error` with NO mirror computed at all.
+ *
+ * Distinct from unreadable, which is main having tried and failed. This is the
+ * field simply absent - an older main, a state pushed before the mirror
+ * existed, a projection that did not run. Same fail-closed outcome, and again
+ * the operator is told which unknown this is instead of being shown a blocked
+ * reason that was never reported.
+ */
+const RECOVERY_UNKNOWN_TEXT =
+  "Recover is unavailable: Vex has not confirmed this session's wallet and approval state yet.";
+
+/**
+ * Blocked copy by REASON, mapping the reader's structural labels to the two
+ * sentences the operator can act on.
+ *
+ * `reasonKinds` is an OPEN set by contract - the money-state reader gains kinds
+ * as the money path gains state machines - so this maps the one kind whose
+ * meaning is categorically different and keeps a total default for the rest.
+ * A future kind is an unresolved outcome until someone decides otherwise,
+ * which is the safe way for this default to be wrong.
+ */
+function recoveryBlockedText(
+  recovery: RuntimeStateDto["recoveryReady"],
+): string {
+  if (recovery === undefined || recovery.kind !== "blocked") {
+    return RECOVERY_BLOCKED_TEXT;
+  }
+  return recovery.reasonKinds.includes(MONEY_STATE_UNREADABLE)
+    ? RECOVERY_UNREADABLE_TEXT
+    : RECOVERY_BLOCKED_TEXT;
+}
 
 function ControlNoticeLine({
   text,

--- a/vex-app/src/renderer/features/appShell/MissionControls/MissionErrorAlert.tsx
+++ b/vex-app/src/renderer/features/appShell/MissionControls/MissionErrorAlert.tsx
@@ -19,6 +19,46 @@ import {
 } from "@shared/engine-error-copy.js";
 import type { RuntimeStateDto } from "@shared/schemas/runtime.js";
 
+interface CauseCopy {
+  /** Rendered as `Mission paused - <title>`, so it completes that sentence. */
+  readonly title: string;
+  readonly body: string;
+}
+
+/**
+ * Copy for the stop reasons that NAME their own cause (M3, M4).
+ *
+ * These two pauses carry no provider or runtime evidence - nothing failed at
+ * the provider - so `classifyEngineFailure` has nothing to classify and both
+ * would otherwise land on "an unexpected error". That is the one thing rule 08
+ * forbids for a state the system understands exactly.
+ *
+ * Keyed by stop reason, which is a CLOSED engine union: an unknown key simply
+ * falls through to the classifier, so a future cause degrades to today's
+ * behaviour rather than to a crash.
+ *
+ * Both bodies keep the honest uncertainty rule 90 requires. Neither pause can
+ * promise that the work already dispatched did nothing, so both send the
+ * operator to the transcript BEFORE recovering instead of implying the run is
+ * safe to resume blind.
+ */
+const CAUSE_COPY: Readonly<Record<string, CauseCopy>> = {
+  restart_orphan: {
+    title: "interrupted by a restart",
+    body:
+      "Vex restarted while this run was executing, so the run was parked instead of left"
+      + " running with nothing driving it. Steps that were already in flight may or may not"
+      + " have completed - review the transcript before recovering.",
+  },
+  tool_call_loop: {
+    title: "repeated the same tool call",
+    body:
+      "The mission called the same tool with the same result over and over without making"
+      + " progress, so it was stopped rather than left looping. Review the transcript before"
+      + " recovering; earlier steps may have completed.",
+  },
+};
+
 /**
  * Standing paused_error alert (issue #42): while the recover-eligible pause
  * persists, the mission is silently NOT monitoring the market or positions —
@@ -62,12 +102,21 @@ export function MissionErrorAlert({
   const remedyHint =
     signals === null ? null : engineErrorRemedyHint(classifyEngineRemedy(signals));
 
+  // CAUSE-SPECIFIC COPY WINS over the classifier and over the generic arms.
+  // `restart_orphan` and `tool_call_loop` are NAMED causes with a known story:
+  // the classifier reads provider/runtime evidence, which these two pauses do
+  // not have (nothing failed at the provider), so without this arm both landed
+  // on "an unexpected error" - the one thing rule 08 forbids for a state the
+  // system understands perfectly well.
+  const causeCopy = CAUSE_COPY[stopReason ?? ""] ?? null;
   const body =
-    copy !== null
-      ? copy.body
-      : stopReason === "provider_error"
-        ? "The mission paused after an inference or runtime error."
-        : "The mission paused after an unexpected error.";
+    causeCopy !== null
+      ? causeCopy.body
+      : copy !== null
+        ? copy.body
+        : stopReason === "provider_error"
+          ? "The mission paused after an inference or runtime error."
+          : "The mission paused after an unexpected error.";
 
   // Bounded codes for a bug report — never prose. `errorMessage` and
   // `stop_summary` stay server-side by construction; the DTO has no field for
@@ -92,7 +141,11 @@ export function MissionErrorAlert({
       className="mb-2 w-full rounded-xl border border-[var(--vex-rule)] bg-danger-wash px-3 py-2"
     >
       <p className="vex-micro font-medium text-danger">
-        {copy !== null ? `Mission paused - ${copy.title}` : "Mission paused - error"}
+        {causeCopy !== null
+          ? `Mission paused - ${causeCopy.title}`
+          : copy !== null
+            ? `Mission paused - ${copy.title}`
+            : "Mission paused - error"}
       </p>
       <p className="mt-1 text-xs text-[var(--vex-text-1)]">{body}</p>
       {remedyHint !== null ? (

--- a/vex-app/src/renderer/features/appShell/SessionComposer.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionComposer.tsx
@@ -24,6 +24,7 @@ import { cn } from "../../lib/utils.js";
 import {
   CHAT_STOPPED_NOTICE_TEXT,
   placeholderFor,
+  readActivity,
   readRunStatus,
 } from "./composer-helpers.js";
 import { PostStopRedirectHint } from "./PostStopRedirectHint.js";
@@ -115,6 +116,7 @@ export function SessionComposer({
     submitPending,
     stopRequested,
     stopAvailable,
+    stopLabel,
     awaitingApproval,
     onSubmit,
     onRetry,
@@ -142,6 +144,7 @@ export function SessionComposer({
   const setThemePreference = useUiStore((s) => s.setThemePreference);
   const runtimeQuery = useRuntimeState(sessionId);
   const runStatus = readRunStatus(runtimeQuery.data);
+  const runtimeActivity = readActivity(runtimeQuery.data);
   const planQuery = useSessionPlan(sessionId);
   const plan = planQuery.data?.ok ? planQuery.data.data : null;
   const [planOpen, setPlanOpen] = useState(false);
@@ -283,10 +286,15 @@ export function SessionComposer({
           />
         ) : null}
 
-        {sessionId !== null && activeSession?.mode === "mission" ? (
+        {/* M5: the strip is no longer mission-only. An AGENT session in full
+            autonomy runs and sleeps with no run row at all, and this band is
+            where the operator sees that it is still working. */}
+        {sessionId !== null && activeSession !== null ? (
           <ComposerMissionStrip
             sessionId={sessionId}
+            mode={activeSession.mode === "mission" ? "mission" : "agent"}
             missionStatus={runStatus}
+            activity={runtimeActivity}
           />
         ) : null}
         {sessionId !== null ? (
@@ -431,6 +439,7 @@ export function SessionComposer({
               ) : null}
               <ComposerSendControl
                 stopAvailable={stopAvailable}
+                stopLabel={stopLabel}
                 stopRequested={stopRequested}
                 onStop={onStop}
                 submitDisabled={submitDisabled}

--- a/vex-app/src/renderer/features/appShell/SessionComposer/ComposerMissionStrip.tsx
+++ b/vex-app/src/renderer/features/appShell/SessionComposer/ComposerMissionStrip.tsx
@@ -1,13 +1,27 @@
 /**
- * Mission plan strip (A28): a quiet one-line band above the composer while a
- * mission run is active, naming the run state and - when the session carries
- * an enabled action plan - opening the read-only plan review. Read-only:
- * mission controls stay in `MissionControls`; this strip never mutates.
+ * Run-state strip (A28, generalized in M5): a quiet one-line band above the
+ * composer while the session is doing something, naming that state and - for a
+ * mission session carrying an enabled action plan - opening the read-only plan
+ * review. Read-only: mission controls stay in `MissionControls`; this strip
+ * never mutates.
+ *
+ * TWO SOURCES, ONE BAND. A mission session reads the run STATUS (its states are
+ * run-lifecycle states, and `paused_wake` already has its own rich sleeping
+ * banner). An agent session has no run row at all, so it reads the session
+ * ACTIVITY projection - which is why a full-autonomy agent used to show
+ * nothing here while it was mid-run or parked on a wake. Mission rendering is
+ * unchanged, deliberately: the status word grammar below is the one the rest of
+ * the mission surfaces speak.
  */
 
 import { lazy, Suspense, useState, type JSX } from "react";
+import type { RuntimeActivity } from "@shared/schemas/runtime.js";
 import type { MissionRunStatus } from "@shared/schemas/sessions.js";
 import { useSessionPlan } from "../../../lib/api/sessions.js";
+import {
+  formatWakeTime,
+  readSessionActivityReadout,
+} from "../session-activity-readout.js";
 
 // Lazy: the plan modal pulls the markdown pipeline - loaded on first open.
 const PlanDisplayModal = lazy(async () => ({
@@ -39,25 +53,37 @@ const SETTLED: ReadonlySet<MissionRunStatus> = new Set([
 
 export function ComposerMissionStrip({
   sessionId,
+  mode,
   missionStatus,
+  activity,
 }: {
   readonly sessionId: string;
+  /** Session mode - decides which of the two sources names the state. */
+  readonly mode: "mission" | "agent";
   readonly missionStatus: MissionRunStatus | null;
+  readonly activity: RuntimeActivity | null;
 }): JSX.Element | null {
   const [planOpen, setPlanOpen] = useState(false);
-  const planQuery = useSessionPlan(sessionId);
+  // Only a MISSION session has an action plan to review, and now that the strip
+  // renders for agent sessions too, asking for one on every agent session would
+  // be an IPC round trip per session whose answer this band never reads. The
+  // hook self-gates on a null id (`enabled`), which is this repo's existing way
+  // to say "not for this session".
+  const planQuery = useSessionPlan(mode === "mission" ? sessionId : null);
   const plan = planQuery.data?.ok ? planQuery.data.data : null;
-  if (missionStatus === null || SETTLED.has(missionStatus)) return null;
+  const band = resolveBand(mode, missionStatus, activity);
+  if (band === null) return null;
   return (
     <div
       data-vex-area="composer-mission-strip"
-      data-status={missionStatus}
+      data-status={band.dataStatus}
+      data-vex-activity={band.activityState ?? undefined}
       className="mb-2 flex items-center justify-between gap-3 rounded-lg bg-interactive-hover px-3 py-1 text-[12px] leading-[18px] text-ink-secondary"
     >
       <span className="vex-micro-label vex-micro-label--wide uppercase text-ink-secondary">
-        Mission · {STATUS_WORD[missionStatus]}
+        {band.text}
       </span>
-      {plan !== null && plan.enabled ? (
+      {missionStatus !== null && plan !== null && plan.enabled ? (
         <>
           <button
             type="button"
@@ -81,4 +107,51 @@ export function ComposerMissionStrip({
       ) : null}
     </div>
   );
+}
+
+interface StripBand {
+  /** The band's copy, in the strip's status-as-word grammar. */
+  readonly text: string;
+  /** `data-status` - the mission run status, or the activity state. */
+  readonly dataStatus: string;
+  /** `data-vex-activity` - present only on the activity-driven band. */
+  readonly activityState: string | null;
+}
+
+/**
+ * WHICH band to show, or none.
+ *
+ * Mission: unchanged - a live run's status word, nothing while settled or
+ * absent. Agent: the activity word, and nothing at all while idle, because a
+ * band that says "IDLE" over an idle composer is chrome, not information.
+ */
+function resolveBand(
+  mode: "mission" | "agent",
+  missionStatus: MissionRunStatus | null,
+  activity: RuntimeActivity | null,
+): StripBand | null {
+  if (mode === "mission") {
+    if (missionStatus === null || SETTLED.has(missionStatus)) return null;
+    return {
+      text: `Mission · ${STATUS_WORD[missionStatus]}`,
+      dataStatus: missionStatus,
+      activityState: null,
+    };
+  }
+  if (activity === null || activity.kind === "none") return null;
+  const readout = readSessionActivityReadout(activity);
+  // Unreadable state: no band at all, rather than a band that guesses a word.
+  if (readout === null) return null;
+  const wakeAt =
+    readout.nextWakeAt === null ? null : formatWakeTime(readout.nextWakeAt);
+  return {
+    // The wake time is appended only when it is readable: the state word alone
+    // is still true, and "SLEEPING · until Invalid Date" is not.
+    text:
+      wakeAt === null
+        ? `Agent · ${readout.label.toUpperCase()}`
+        : `Agent · ${readout.label.toUpperCase()} · until ${wakeAt}`,
+    dataStatus: readout.state,
+    activityState: readout.state,
+  };
 }

--- a/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
+++ b/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
@@ -37,6 +37,7 @@ import { ToolActRow } from "./ToolLedger/ToolActRow.js";
 import { ExplorerRefLinks } from "./ToolLedger/ExplorerRefLinks.js";
 import { ToolGroupRow } from "./ToolLedger/ToolGroupRow.js";
 import { ToolDisclosure } from "./ToolDisclosure.js";
+import type { OperatorInterruptDispositionDto } from "@shared/schemas/messages.js";
 import type {
   ToolCallActView,
   TranscriptEntry,
@@ -280,15 +281,21 @@ export const TranscriptMessage = memo(function TranscriptMessage({
           <div className="max-w-[min(525px,82%)] whitespace-pre-wrap break-words rounded-[22px] bg-surface-bubble px-4 py-2.5 text-[16px] leading-6 text-ink-primary">
             {row.content}
           </div>
-          {/* A33 - a steered message says WHEN it reaches the model, in
-              words: delivery happens at the live loop's next tool-step
-              boundary, never mid tool call. */}
+          {/* A33 - an operator instruction says WHEN it reaches the model, in
+              words. The words come from the engine's own typed disposition
+              (M6), never from the row kind: the kind means only "this is an
+              operator instruction", and three different things can have
+              happened to one. Hardcoding the steered wording told a user whose
+              message was queued against a parked run that it would be read at
+              the agent's next step, contradicting the acknowledgement written
+              beside it in the very same transaction. */}
           {row.steering === true ? (
             <span
               data-vex-steering-mark=""
+              data-vex-disposition={row.interruptDisposition}
               className="vex-micro-label mt-1 text-ink-secondary"
             >
-              Steered · read at the agent's next step
+              {steeringMarkText(row.interruptDisposition)}
             </span>
           ) : null}
           {/* Same C2 human-caption register as the assistant stamp. */}
@@ -488,6 +495,36 @@ function resolveActs(row: TranscriptRowModel): readonly ToolCallActView[] {
  * runtime notice (wake banners and the rest) stays silent, which is why this
  * needed its own tone rather than an `aria-live` on the whole variant.
  */
+/**
+ * The register mark under an operator instruction, per disposition.
+ *
+ * Each says WHEN the agent reads the message, because that is the only thing
+ * the operator actually wants from this mark and the one thing the old single
+ * string got wrong for two of the three cases. The wording is deliberately
+ * close to the engine's own acknowledgement text: the two rows describe one
+ * event and are written from one typed value, so they must not read as two
+ * different claims.
+ *
+ * A total default, not an exhaustive switch: the disposition is absent on
+ * legacy rows and could gain a fourth member engine-side. The neutral "Sent"
+ * makes no claim about timing at all, which is the only safe thing to say
+ * when the record does not tell us.
+ */
+function steeringMarkText(
+  disposition: OperatorInterruptDispositionDto | undefined,
+): string {
+  switch (disposition) {
+    case "steered":
+      return "Steered \u00b7 read at the agent's next step";
+    case "queued_interrupt":
+      return "Queued \u00b7 read the next time the agent runs";
+    case "preempted_wake":
+      return "Sent \u00b7 the agent is resuming now to read it";
+    default:
+      return "Sent to the agent";
+  }
+}
+
 function NoticeBody({
   tone,
   children,

--- a/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
+++ b/vex-app/src/renderer/features/appShell/TranscriptMessage.tsx
@@ -480,12 +480,19 @@ function resolveActs(row: TranscriptRowModel): readonly ToolCallActView[] {
  * notice wears the turn-error ROW grammar (A20 — in the flow, not a box):
  * error dot / bold "Error" title / the persisted sanitized message at 13/20.
  * The session-level banner remains the session-scope surface.
+ *
+ * `ack` (M6) is the runtime stamp plus a POLITE live region. It is the engine's
+ * durable answer to an operator instruction, so it is the one notice a screen
+ * reader should hear on arrival - politely, because it reports what already
+ * happened and must never cut across the operator's own typing. Every other
+ * runtime notice (wake banners and the rest) stays silent, which is why this
+ * needed its own tone rather than an `aria-live` on the whole variant.
  */
 function NoticeBody({
   tone,
   children,
 }: {
-  readonly tone: "runtime" | "error";
+  readonly tone: "runtime" | "error" | "ack";
   readonly children: ReactNode;
 }): JSX.Element {
   if (tone === "error") {
@@ -504,7 +511,13 @@ function NoticeBody({
     );
   }
   return (
-    <div className="max-w-[80%] whitespace-pre-wrap break-words rounded-[6px] bg-interactive-hover px-3 py-2 text-center font-mono text-[10px] uppercase tracking-[0.28em] text-[var(--vex-text-3)]">
+    <div
+      {...(tone === "ack"
+        ? { role: "status" as const, "aria-live": "polite" as const }
+        : {})}
+      data-vex-notice-tone={tone}
+      className="max-w-[80%] whitespace-pre-wrap break-words rounded-[6px] bg-interactive-hover px-3 py-2 text-center font-mono text-[10px] uppercase tracking-[0.28em] text-[var(--vex-text-3)]"
+    >
       {children}
     </div>
   );

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-console.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-console.test.tsx
@@ -250,7 +250,7 @@ describe("composer capsule - send key", () => {
     expect(pending).not.toBeNull();
     expect(pending?.querySelector(".vex-composer-pending-dot")).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
-    expect(screen.getByRole("button", { name: "Stop generating" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Stop agent" })).toBeTruthy();
   });
 });
 

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-micro-interactions.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-micro-interactions.test.tsx
@@ -157,7 +157,7 @@ describe("composer micro-interactions - keep focus", () => {
     render(<SessionComposer activeSession={agentRow()} activeSessionId={SESSION} />);
     const field = draftField();
     field.blur();
-    const stop = screen.getByRole("button", { name: "Stop generating" });
+    const stop = screen.getByRole("button", { name: "Stop agent" });
     const prevented = !fireEvent.mouseDown(stop);
     expect(prevented).toBe(true);
     expect(document.activeElement).toBe(field);
@@ -182,13 +182,13 @@ describe("composer micro-interactions - clear as commit and the stop morph", () 
       <SessionComposer activeSession={agentRow()} activeSessionId={SESSION} />,
     );
     expect(screen.getByRole("button", { name: "Send message" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Stop generating" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Stop agent" })).toBeNull();
     idle.unmount();
 
     mockSubmitChat.isPending = true;
     render(<SessionComposer activeSession={agentRow()} activeSessionId={SESSION} />);
     // One key in the slot: Stop replaced Send, it did not join it.
-    expect(screen.getByRole("button", { name: "Stop generating" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Stop agent" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Send message" })).toBeNull();
   });
 });

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop-send-guards.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-retry-stop-send-guards.test.tsx
@@ -264,7 +264,7 @@ describe("AppShell", () => {
     fireEvent.change(draft, { target: { value: "Long-running research" } });
     fireEvent.click(screen.getByRole("button", { name: "Send message" }));
 
-    const stopBtn = await screen.findByRole("button", { name: "Stop generating" });
+    const stopBtn = await screen.findByRole("button", { name: "Stop agent" });
     await waitFor(() =>
       expect(
         container.querySelector('[data-vex-tape-state="live"]'),

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-send.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/composer-send.test.tsx
@@ -370,7 +370,7 @@ describe("AppShell", () => {
     fireEvent.change(draft, { target: { value: "first" } });
     fireEvent.keyDown(draft, { key: "Enter" });
     await waitFor(() => expect(chatSubmitMock).toHaveBeenCalledTimes(1));
-    await screen.findByRole("button", { name: "Stop generating" });
+    await screen.findByRole("button", { name: "Stop agent" });
 
     // Type a NEW non-empty draft (so the empty-message guard is NOT what blocks)
     // and press Enter again — the pending guard must keep it at one submit.

--- a/vex-app/src/renderer/features/appShell/__tests__/AppShell/welcome-create-retry.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/AppShell/welcome-create-retry.test.tsx
@@ -358,7 +358,7 @@ describe("AppShell", () => {
     // mount-effect replay unsubscribes the observer mid-flight (detaching it
     // from the in-flight mutation with no reattach). Without the reset() guard
     // in useSubmitChat, the observer misses the settle and `isPending` freezes
-    // at true → the composer is stuck as a dead "Stop generating" button and
+    // at true → the composer is stuck as a dead "Stop agent" button and
     // the next message can never be sent. Use the no-provider error so the
     // submit settles immediately (the engine cannot be the slow part).
     sessionsListMock.mockResolvedValueOnce({ ok: true, data: [] });
@@ -392,6 +392,6 @@ describe("AppShell", () => {
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Send message" })).toBeTruthy(),
     );
-    expect(screen.queryByRole("button", { name: "Stop generating" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Stop agent" })).toBeNull();
   });
 });

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
@@ -499,7 +499,15 @@ describe("MissionControls", () => {
 
   it("paused_error: Recover enabled (dispatches mission.retry), Continue disabled", async () => {
     getStateMock.mockResolvedValue(
-      runtimeState({ hasActiveRun: true, status: "paused_error", missionRunId: "r1" }),
+      runtimeState({
+        hasActiveRun: true,
+        status: "paused_error",
+        missionRunId: "r1",
+        // Recover requires the POSITIVE answer now. Main computes this mirror
+        // for every `paused_error` state it pushes, so a ready one is the
+        // ordinary shape; the absent case is its own test below.
+        recoveryReady: { kind: "ready" },
+      }),
     );
     getDraftMock.mockResolvedValue(draftReady());
     getDiffMock.mockResolvedValue(diffAccepted(true));
@@ -518,8 +526,8 @@ describe("MissionControls", () => {
 
   // M3/M5: the money gate. `recoveryReady` is a display MIRROR of the reader
   // the privileged retry IPC enforces with; these pin that the mirror is
-  // OBEYED and, just as importantly, that its absence does not silently hide
-  // Recover on a session whose mirror was never computed.
+  // OBEYED and that it FAILS CLOSED - an answer nobody computed is not
+  // permission.
   it("paused_error with a blocked money state: Recover disabled, and it says why", async () => {
     getStateMock.mockResolvedValue(
       runtimeState({
@@ -544,6 +552,89 @@ describe("MissionControls", () => {
     // Disabled means NOT dispatched: the click must not reach the IPC at all.
     fireEvent.click(recoverBtn);
     expect(retryMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * THE fail-closed case, and the one that regressed. `!blocked` is true for
+   * `undefined`, so an absent mirror - the one answer nobody computed - was
+   * read as permission and Recover was offered on it. Unknown is not ready.
+   */
+  it("paused_error with NO mirror at all: Recover disabled and says it is unconfirmed", async () => {
+    getStateMock.mockResolvedValue(
+      runtimeState({ hasActiveRun: true, status: "paused_error", missionRunId: "r1" }),
+    );
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(true));
+    renderControls();
+
+    const recoverBtn = await screen.findByRole("button", { name: "Recover mission" });
+    expect((recoverBtn as HTMLButtonElement).disabled).toBe(true);
+    const why = await screen.findByRole("status");
+    expect(why.textContent).toContain("has not confirmed");
+    fireEvent.click(recoverBtn);
+    expect(retryMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * "Could not check" is a different sentence from "something is settling".
+   * The unresolved-outcome copy asserts an action EXISTS and is in flight,
+   * which tells an operator to wait for something that may not be there.
+   */
+  it("an unreadable money state says it could not check, not that work is pending", async () => {
+    getStateMock.mockResolvedValue(
+      runtimeState({
+        hasActiveRun: true,
+        status: "paused_error",
+        missionRunId: "r1",
+        recoveryReady: {
+          kind: "blocked",
+          reasonKinds: ["money_state_unreadable"],
+        },
+      }),
+    );
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(true));
+    renderControls();
+
+    const recoverBtn = await screen.findByRole("button", { name: "Recover mission" });
+    expect((recoverBtn as HTMLButtonElement).disabled).toBe(true);
+    const why = await screen.findByRole("status");
+    expect(why.textContent).toContain("could not check");
+    expect(why.textContent).not.toContain("no confirmed outcome yet");
+    expect(why.textContent).not.toContain("money_state_unreadable");
+  });
+
+  /**
+   * Blocking recovery must not delete the ACCOUNT of what happened. The alert
+   * was gated on the button's availability, so a blocked money state removed
+   * the restart-orphan / tool-call-loop explanation entirely and left a
+   * disabled control with no reason for either fact.
+   */
+  it("keeps the cause alert visible while recovery is blocked", async () => {
+    getStateMock.mockResolvedValue(
+      runtimeState({
+        hasActiveRun: true,
+        status: "paused_error",
+        missionRunId: "r1",
+        stopReason: "restart_orphan",
+        recoveryReady: {
+          kind: "blocked",
+          reasonKinds: ["wallet_intent_live"],
+        },
+      }),
+    );
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(true));
+    renderControls();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.getAttribute("data-vex-area")).toBe("mission-error-alert");
+    expect(alert.textContent).toMatch(/interrupted by a restart/i);
+    expect(
+      (
+        await screen.findByRole("button", { name: "Recover mission" })
+      ) as HTMLButtonElement,
+    ).toHaveProperty("disabled", true);
   });
 
   it("paused_error with a ready money state: Recover stays enabled", async () => {
@@ -640,7 +731,12 @@ describe("MissionControls", () => {
     // getDraft returns null for the whole active run. The toolbar must key off
     // runtime alone — this pins the gate fix.
     getStateMock.mockResolvedValue(
-      runtimeState({ hasActiveRun: true, status: "paused_error", missionRunId: "r1" }),
+      runtimeState({
+        hasActiveRun: true,
+        status: "paused_error",
+        missionRunId: "r1",
+        recoveryReady: { kind: "ready" },
+      }),
     );
     getDraftMock.mockResolvedValue(ok(null));
     renderControls();
@@ -830,6 +926,8 @@ describe("MissionControls - paused_error standing alert (issue #42)", () => {
         status: "paused_error",
         missionRunId: "r1",
         stopReason: "provider_error",
+        // Clicking Recover requires the mirror to say ready.
+        recoveryReady: { kind: "ready" },
       }),
     );
     getDraftMock.mockResolvedValue(draftReady());
@@ -869,6 +967,7 @@ describe("MissionControls - paused_error standing alert (issue #42)", () => {
         status: "paused_error",
         missionRunId: "r1",
         stopReason: "provider_error",
+        recoveryReady: { kind: "ready" },
       }),
     );
     getDraftMock.mockResolvedValue(draftReady());

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionControls.test.tsx
@@ -91,6 +91,13 @@ function runtimeState(over: Record<string, unknown>) {
     leaseActive: false,
     leaseExpiresAt: null,
     pendingControlKind: null,
+    // Wave 2 (M5/M6): both are REQUIRED on the DTO, so a stub without them is
+    // not a valid `runtime.getState` response. They default to the quiet
+    // answer - not stoppable, doing nothing - and each test that needs the
+    // other answer says so, which is what makes the Stop assertions below
+    // mean something instead of riding on an absent field.
+    stoppable: false,
+    activity: { kind: "none" },
     ...over,
   });
 }
@@ -459,7 +466,16 @@ describe("MissionControls", () => {
 
   it("running: Stop + Edit enabled, Continue + Recover disabled", async () => {
     getStateMock.mockResolvedValue(
-      runtimeState({ hasActiveRun: true, status: "running", missionRunId: "r1" }),
+      runtimeState({
+        hasActiveRun: true,
+        status: "running",
+        missionRunId: "r1",
+        // M6: Stop is offered from main's `stoppable`, not from "a run row
+        // exists" - the same answer the composer's Stop key reads.
+        stoppable: true,
+        leaseActive: true,
+        activity: { kind: "running" },
+      }),
     );
     getDraftMock.mockResolvedValue(draftReady());
     getDiffMock.mockResolvedValue(diffAccepted(true));
@@ -496,6 +512,56 @@ describe("MissionControls", () => {
       (screen.getByRole("button", { name: "Continue mission" }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
+    fireEvent.click(recoverBtn);
+    await waitFor(() => expect(retryMock).toHaveBeenCalledWith({ sessionId: SESSION }));
+  });
+
+  // M3/M5: the money gate. `recoveryReady` is a display MIRROR of the reader
+  // the privileged retry IPC enforces with; these pin that the mirror is
+  // OBEYED and, just as importantly, that its absence does not silently hide
+  // Recover on a session whose mirror was never computed.
+  it("paused_error with a blocked money state: Recover disabled, and it says why", async () => {
+    getStateMock.mockResolvedValue(
+      runtimeState({
+        hasActiveRun: true,
+        status: "paused_error",
+        missionRunId: "r1",
+        recoveryReady: { kind: "blocked", reasonKinds: ["wallet_intent_live"] },
+      }),
+    );
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(true));
+    renderControls();
+
+    const recoverBtn = await screen.findByRole("button", { name: "Recover mission" });
+    expect((recoverBtn as HTMLButtonElement).disabled).toBe(true);
+    // A disabled attribute says nothing to anyone (rule 08), so the reason is
+    // on screen as a standing status - and it names no row, provider or
+    // internal reason kind.
+    const why = await screen.findByRole("status");
+    expect(why.textContent).toContain("no confirmed outcome yet");
+    expect(why.textContent).not.toContain("wallet_intent_live");
+    // Disabled means NOT dispatched: the click must not reach the IPC at all.
+    fireEvent.click(recoverBtn);
+    expect(retryMock).not.toHaveBeenCalled();
+  });
+
+  it("paused_error with a ready money state: Recover stays enabled", async () => {
+    getStateMock.mockResolvedValue(
+      runtimeState({
+        hasActiveRun: true,
+        status: "paused_error",
+        missionRunId: "r1",
+        recoveryReady: { kind: "ready" },
+      }),
+    );
+    getDraftMock.mockResolvedValue(draftReady());
+    getDiffMock.mockResolvedValue(diffAccepted(true));
+    retryMock.mockResolvedValue(ok({ outcome: "resumed", runId: "r1" }));
+    renderControls();
+
+    const recoverBtn = await screen.findByRole("button", { name: "Recover mission" });
+    expect((recoverBtn as HTMLButtonElement).disabled).toBe(false);
     fireEvent.click(recoverBtn);
     await waitFor(() => expect(retryMock).toHaveBeenCalledWith({ sessionId: SESSION }));
   });

--- a/vex-app/src/renderer/features/appShell/__tests__/MissionErrorAlert-lastError.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/MissionErrorAlert-lastError.test.tsx
@@ -81,3 +81,49 @@ describe("MissionErrorAlert - without durable evidence", () => {
     expect(alert.textContent).toContain("an unexpected error");
   });
 });
+
+/**
+ * M3/M4. `restart_orphan` and `tool_call_loop` are pauses the system
+ * understands exactly, and NEITHER carries provider or runtime evidence -
+ * nothing failed at the provider. So the classifier has nothing to classify
+ * and both used to land on "an unexpected error", which rule 08 forbids for a
+ * named cause.
+ */
+describe("MissionErrorAlert - causes that name themselves", () => {
+  it("explains a restart-orphaned run instead of calling it unexpected", () => {
+    const alert = renderAlert(undefined, "restart_orphan");
+    expect(alert.textContent).toContain("Vex restarted while this run was executing");
+    expect(alert.textContent).not.toContain("an unexpected error");
+    // Rule 90 honest uncertainty: the reclaim cannot promise that work already
+    // dispatched did nothing, so it must not imply a blind resume is safe.
+    expect(alert.textContent).toContain("review the transcript before recovering");
+  });
+
+  it("explains a detected tool-call loop instead of calling it unexpected", () => {
+    const alert = renderAlert(undefined, "tool_call_loop");
+    expect(alert.textContent).toContain("same tool with the same result");
+    expect(alert.textContent).not.toContain("an unexpected error");
+    expect(alert.textContent).toContain("earlier steps may have completed");
+  });
+
+  // The cause copy OUTRANKS the classifier: a run reclaimed after a restart is
+  // explained by the restart, even when a stale provider signal happens to sit
+  // on the row from an earlier failure.
+  it("wins over durable provider evidence for a named cause", () => {
+    const alert = renderAlert(
+      { errorType: "rate_limit_exceeded", statusCode: 429 },
+      "restart_orphan",
+    );
+    expect(alert.textContent).toContain("Vex restarted while this run was executing");
+    expect(alert.textContent).not.toContain("rate-limited");
+    // The bounded code trailer still carries the evidence for a bug report.
+    expect(alert.textContent).toContain("rate_limit_exceeded");
+  });
+
+  // An unnamed reason must degrade to today's behaviour, never to a crash.
+  it("leaves an unnamed stop reason on the generic wording", () => {
+    expect(renderAlert(undefined, "some_future_reason").textContent).toContain(
+      "an unexpected error",
+    );
+  });
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionTranscript/transcript-harness.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionTranscript/transcript-harness.ts
@@ -58,6 +58,7 @@ export function msg(p: {
     success: null,
     displayStatus: null,
     board: null,
+    interruptDisposition: null,
   };
 }
 

--- a/vex-app/src/renderer/features/appShell/__tests__/TranscriptMessage.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/TranscriptMessage.test.tsx
@@ -544,3 +544,45 @@ describe("TranscriptMessage tool card duration", () => {
     }
   });
 });
+
+/**
+ * M6. The operator-instruction acknowledgement is the engine's durable answer
+ * to something the operator just did, and it is the ONLY notice that is. A
+ * screen-reader user must learn their instruction landed without going looking
+ * for the row - politely, because it reports what already happened and must
+ * never cut across the operator's own typing.
+ */
+describe("TranscriptMessage operator acknowledgement (M6)", () => {
+  const ACK =
+    "Sent to the agent. It is mid-turn, so it will pick this up at its next step and keep going.";
+
+  it("announces the ack notice politely", () => {
+    const { container } = render(
+      createElement(TranscriptMessage, {
+        row: { ...row({ variant: "notice", content: ACK }), noticeTone: "ack" },
+      }),
+    );
+    const node = container.querySelector('[data-vex-notice-tone="ack"]');
+    expect(node).not.toBeNull();
+    expect(node?.getAttribute("role")).toBe("status");
+    // POLITE, never assertive: an interrupting announcement over a composer the
+    // operator is still typing in is the rude failure this tone exists to avoid.
+    expect(node?.getAttribute("aria-live")).toBe("polite");
+    expect(node?.textContent).toBe(ACK);
+  });
+
+  it("leaves every other runtime notice silent", () => {
+    const { container } = render(
+      createElement(TranscriptMessage, {
+        row: {
+          ...row({ variant: "notice", content: "Run resumed" }),
+          noticeTone: "runtime",
+        },
+      }),
+    );
+    const node = container.querySelector('[data-vex-notice-tone="runtime"]');
+    expect(node).not.toBeNull();
+    expect(node?.getAttribute("role")).toBeNull();
+    expect(node?.getAttribute("aria-live")).toBeNull();
+  });
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/composer-board-ask.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/composer-board-ask.test.tsx
@@ -219,8 +219,11 @@ describe("board Ask VEX through the resident composer", () => {
     expect(mockMutateAsync).not.toHaveBeenCalled();
   });
 
-  it("4. a mission run refuses free text, and says so instead of sending", async () => {
-    runtimeState("running");
+  it("4. a PARKED mission run refuses free text, and says so instead of sending", async () => {
+    // M6 flip: the gated set no longer contains `running`. It still contains
+    // every state where the run is PARKED and free text cannot answer what it
+    // is parked on, which is what this scenario was always really pinning.
+    runtimeState("paused_approval");
     const { result } = mountComposer();
     await act(async () => {
       useBoardAskIntentStore.getState().publishBoardAskIntent(askIntent());
@@ -232,14 +235,15 @@ describe("board Ask VEX through the resident composer", () => {
     expect(readQueue(SESSION)).toHaveLength(0);
   });
 
-  it("4b. a mission run WITH a turn in flight refuses the question, and does not steer or queue it", async () => {
+  it("4b. a PARKED mission run WITH a turn in flight refuses the question, and does not steer or queue it", async () => {
     // The regression. `submitPending` sends a typed message down the steering
     // branch; before the fix that branch returned before the gate was ever
     // read, so the mission run received the board's free text as an interrupt.
     // Refusal is the whole point of the gate and it cannot depend on whether a
-    // turn happens to be running.
+    // turn happens to be running. Retargeted to a still-gated status by the M6
+    // flip; the branch coverage is what mattered, not the status name.
     submitPending = true;
-    runtimeState("running");
+    runtimeState("paused_approval");
     const { result } = mountComposer();
     await act(async () => {
       useBoardAskIntentStore.getState().publishBoardAskIntent(askIntent());
@@ -250,6 +254,42 @@ describe("board Ask VEX through the resident composer", () => {
     expect(mockSteer).not.toHaveBeenCalled();
     expect(readQueue(SESSION)).toHaveLength(0);
     expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  // M6 (owner decision), the OTHER half of the flip. Steering a RUNNING mission
+  // is the designed path: `ingress.ts` persists the message as an operator
+  // instruction the loop merges at its next tool-step boundary, and the engine
+  // acknowledges it durably. The composer gate refused exactly that, which left
+  // Stop as the operator's only lever over a running run. These two pin that a
+  // board question now REACHES a running mission on both branches.
+  it("4c. a RUNNING mission accepts the question and sends it", async () => {
+    runtimeState("running");
+    const { result } = mountComposer();
+    await act(async () => {
+      useBoardAskIntentStore.getState().publishBoardAskIntent(askIntent());
+    });
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalled();
+    });
+    expect(result.current.notice?.tone).not.toBe("error");
+    expect(readQueue(SESSION)).toHaveLength(0);
+  });
+
+  it("4d. a RUNNING mission with a turn in flight receives the question as steering", async () => {
+    submitPending = true;
+    runtimeState("running");
+    mountComposer();
+    await act(async () => {
+      useBoardAskIntentStore.getState().publishBoardAskIntent(askIntent());
+    });
+    await waitFor(() => {
+      expect(mockSteer).toHaveBeenCalledTimes(1);
+    });
+    expect(mockSteer.mock.calls[0]?.[0]).toEqual({
+      sessionId: SESSION,
+      message: ENVELOPE,
+    });
+    expect(readQueue(SESSION)).toHaveLength(0);
   });
 
   it("5. a retryable failure arms Retry with the SAME envelope", async () => {
@@ -318,7 +358,9 @@ describe("board Ask VEX through the resident composer", () => {
 
 describe("the typed-message path is unchanged by the hand-off", () => {
   it("still keeps the draft when a mission run gates the send", async () => {
-    runtimeState("running");
+    // A still-gated status after the M6 flip: what this pins is that a REFUSED
+    // send preserves what the user typed, not which status does the refusing.
+    runtimeState("paused_approval");
     const { result } = mountComposer();
     act(() => {
       result.current.setDraft("hello");
@@ -393,7 +435,8 @@ describe("a gated send never eats the draft, busy or idle", () => {
     // the top of the dispatch means the busy path is refused too, so a guard
     // that still cleared the field first would delete what the user wrote.
     submitPending = busy;
-    runtimeState("running");
+    // Still-gated status after the M6 flip - see the note above.
+    runtimeState("paused_approval");
     render(createElement(ComposerForm), { wrapper });
     await typeAndSubmit("hello");
     expect(latestComposer?.notice?.tone).toBe("error");

--- a/vex-app/src/renderer/features/appShell/__tests__/composer-helpers.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/composer-helpers.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ChatSubmitResult } from "@shared/schemas/chat.js";
+import { err, ok } from "@shared/ipc/result.js";
+import type {
+  RuntimeActivity,
+  RuntimeStateDto,
+} from "@shared/schemas/runtime.js";
 import {
   FREE_TEXT_DISALLOWED,
   gatedReason,
@@ -176,11 +181,34 @@ describe("free-text gate", () => {
   });
 });
 
+/**
+ * A REAL runtime DTO, not a partial cast to `never`. The cast let a fixture
+ * omit every field the reader might grow to touch and still type-check, which
+ * is exactly the drift a projection test exists to catch.
+ */
+function runtimeState(activity: RuntimeActivity): RuntimeStateDto {
+  return {
+    sessionId: "00000000-0000-4000-8000-0000000000a1",
+    hasActiveRun: false,
+    missionRunId: null,
+    status: null,
+    stopReason: null,
+    lastCheckpointAt: null,
+    startedAt: null,
+    iterationCount: null,
+    leaseActive: activity.kind === "running",
+    leaseExpiresAt: null,
+    pendingControlKind: null,
+    stoppable: activity.kind !== "none",
+    activity,
+  };
+}
+
 describe("readActivity", () => {
   it("reads the projection main decided", () => {
-    expect(
-      readActivity({ ok: true, data: { activity: { kind: "running" } } as never }),
-    ).toEqual({ kind: "running" });
+    expect(readActivity(ok(runtimeState({ kind: "running" })))).toEqual({
+      kind: "running",
+    });
   });
 
   // NULL IS NOT IDLE. An unread or failed runtime state must not let a surface
@@ -189,7 +217,17 @@ describe("readActivity", () => {
   it("returns null - never an idle activity - when the state is unread or failed", () => {
     expect(readActivity(undefined)).toBeNull();
     expect(
-      readActivity({ ok: false, error: { code: "x", message: "y" } } as never),
+      readActivity(
+        err({
+          code: "internal.unexpected",
+          domain: "runtime",
+          message: "Unable to load runtime state.",
+          retryable: true,
+          userActionable: false,
+          redacted: true,
+          correlationId: "corr-1",
+        }),
+      ),
     ).toBeNull();
   });
 });

--- a/vex-app/src/renderer/features/appShell/__tests__/composer-helpers.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/composer-helpers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ChatSubmitResult } from "@shared/schemas/chat.js";
 import {
+  FREE_TEXT_DISALLOWED,
+  gatedReason,
+  readActivity,
   submitFailureNotice,
   submitSuccessText,
 } from "../composer-helpers.js";
@@ -111,4 +114,82 @@ describe("composer outcome copy", () => {
       expect(notice?.text).toContain("earlier steps may have completed");
     },
   );
+
+  // M2. A continued full-autonomy turn is NOT a failure: the slice ended
+  // because the next one is already scheduled. A terminal banner here is the
+  // renderer calling a healthy hand-off an error, which is the defect the
+  // honest stop reason was introduced to expose rather than create.
+  it("shows no terminal banner when the turn was continued to a scheduled wake", () => {
+    expect(submitFailureNotice(outcome({ stopReason: "waiting_for_wake" }))).toBeNull();
+    // Not an artefact of the zero-tool default arm: a continued turn that DID
+    // dispatch tool calls is still not a failure.
+    expect(
+      submitFailureNotice(
+        outcome({ stopReason: "waiting_for_wake", toolCallsMade: 4 }),
+      ),
+    ).toBeNull();
+  });
+
+  // M4. The detector's stop reason must reach the operator. Without its own
+  // arm it fell through `default: null` and the turn ended in silence - the
+  // loop stopped and nothing on screen said why.
+  it("names a tool-call loop and never offers one-click retry", () => {
+    const notice = submitFailureNotice(outcome({ stopReason: "tool_call_loop" }));
+    expect(notice?.text).toContain("repeated the same tool call");
+    // Unconditionally non-retryable, and deliberately NOT routed through
+    // `incompleteTurnNotice`: reaching this stop reason MEANS identical tool
+    // calls executed, so `toolCallsMade === 0` is unreachable and a
+    // count-gated retry arm would be dead code posing as a safety check.
+    expect(notice?.retryable).toBe(false);
+    expect(notice?.text).toContain("earlier steps may have completed");
+    expect(
+      submitFailureNotice(outcome({ stopReason: "tool_call_loop", toolCallsMade: 9 }))
+        ?.retryable,
+    ).toBe(false);
+  });
+});
+
+// M6 (owner decision). Steering a RUNNING mission is the designed path:
+// `ingress.ts` persists the message as an operator instruction that the loop
+// merges at its next tool-step boundary. The composer gate refused exactly
+// that, leaving Stop as the operator's only lever over a running run.
+describe("free-text gate", () => {
+  it("allows free text into a running mission", () => {
+    expect(FREE_TEXT_DISALLOWED.has("running")).toBe(false);
+  });
+
+  // The gate still holds where free text genuinely cannot answer what the run
+  // is parked on, and each of those states still names its own control.
+  it.each(["paused_approval", "paused_user", "paused_wake"] as const)(
+    "still gates %s and explains which control clears it",
+    (status) => {
+      expect(FREE_TEXT_DISALLOWED.has(status)).toBe(true);
+      expect(gatedReason(status).length).toBeGreaterThan(0);
+    },
+  );
+
+  // The reason string is only ever read for a GATED status. A `running` arm
+  // surviving here would be unreachable copy asserting the opposite of the
+  // contract above.
+  it("no longer carries a reason for running", () => {
+    expect(gatedReason("running")).not.toContain("Stop button");
+  });
+});
+
+describe("readActivity", () => {
+  it("reads the projection main decided", () => {
+    expect(
+      readActivity({ ok: true, data: { activity: { kind: "running" } } as never }),
+    ).toEqual({ kind: "running" });
+  });
+
+  // NULL IS NOT IDLE. An unread or failed runtime state must not let a surface
+  // assert the session is doing nothing - that is how a running agent was
+  // reported Idle in the first place.
+  it("returns null - never an idle activity - when the state is unread or failed", () => {
+    expect(readActivity(undefined)).toBeNull();
+    expect(
+      readActivity({ ok: false, error: { code: "x", message: "y" } } as never),
+    ).toBeNull();
+  });
 });

--- a/vex-app/src/renderer/features/appShell/__tests__/composer-steering.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/composer-steering.test.tsx
@@ -136,7 +136,28 @@ describe("mid-turn submit steers the live turn", () => {
 });
 
 describe("the steered row in the transcript", () => {
-  it("wears its delivery words - the user reads WHEN the agent sees it", () => {
+  /**
+   * M6. The mark's WORDS come from the engine's typed disposition, never from
+   * the row kind. Every operator-interrupt row used to render the steered
+   * sentence, so a message queued against a parked run claimed it would be
+   * read at the agent's next step - directly beside the acknowledgement row,
+   * written in the SAME transaction from the SAME value, saying the agent was
+   * not running. These are the four states the transcript can show.
+   */
+  it.each([
+    [
+      "steered" as const,
+      "Steered \u00b7 read at the agent's next step",
+    ],
+    [
+      "queued_interrupt" as const,
+      "Queued \u00b7 read the next time the agent runs",
+    ],
+    [
+      "preempted_wake" as const,
+      "Sent \u00b7 the agent is resuming now to read it",
+    ],
+  ])("a %s row wears that disposition's delivery words", (disposition, words) => {
     const { container, getByText } = render(
       <TranscriptMessage
         row={{
@@ -147,11 +168,37 @@ describe("the steered row in the transcript", () => {
           createdAt: "2026-08-20T10:00:00.000Z",
           reasoning: null,
           steering: true,
+          interruptDisposition: disposition,
+        }}
+      />,
+    );
+    const mark = container.querySelector("[data-vex-steering-mark]");
+    expect(mark).not.toBeNull();
+    expect(mark?.getAttribute("data-vex-disposition")).toBe(disposition);
+    expect(getByText(words)).toBeTruthy();
+  });
+
+  /**
+   * A legacy interrupt row, written before the disposition existed. It makes
+   * the neutral claim - the one thing that is true whatever happened - rather
+   * than guessing the optimistic one.
+   */
+  it("a row with no recorded disposition makes no timing claim", () => {
+    const { container, getByText } = render(
+      <TranscriptMessage
+        row={{
+          id: 44,
+          variant: "user",
+          label: null,
+          content: "legacy interrupt",
+          createdAt: "2026-08-20T10:00:00.000Z",
+          reasoning: null,
+          steering: true,
         }}
       />,
     );
     expect(container.querySelector("[data-vex-steering-mark]")).not.toBeNull();
-    expect(getByText("Steered · read at the agent's next step")).toBeTruthy();
+    expect(getByText("Sent to the agent")).toBeTruthy();
   });
 
   it("an ordinary user row wears no steering mark", () => {

--- a/vex-app/src/renderer/features/appShell/__tests__/composer-stop-routing.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/composer-stop-routing.test.tsx
@@ -325,6 +325,9 @@ describe("ComposerSendControl", () => {
         globalModelId: null,
         onReasoningPick: vi.fn(),
         stopAvailable: false,
+        // M6: the key is named by TARGET now. The owner resolves the words
+        // through `resolveStopAffordance`; this control only renders them.
+        stopLabel: "Stop agent",
         stopRequested: false,
         onStop: vi.fn(),
         submitDisabled: false,

--- a/vex-app/src/renderer/features/appShell/__tests__/session-activity-agreement.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/session-activity-agreement.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * M5: the composer strip and the desk-rule tape word must NEVER disagree about
+ * what an autonomous agent session is doing.
+ *
+ * This is the regression this whole projection exists for. The two surfaces
+ * used to answer the question from different inputs - the tape from "is there
+ * a mission run row", the strip from the mission status - so a full-autonomy
+ * agent session, which has no run row at all, read RUNNING on neither and
+ * "Idle" on the tape while it was mid-slice or parked on a wake. Both now read
+ * `RuntimeStateDto.activity` through the one selector, and this test drives
+ * BOTH real components over the same DTO to prove it.
+ *
+ * Deliberately NOT a unit test of `readSessionActivityReadout`: that function
+ * agreeing with itself proves nothing. The contract is that two rendered
+ * surfaces show the same state for the same fact.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { RuntimeActivity } from "@shared/schemas/runtime.js";
+
+const SESSION = "00000000-0000-4000-8000-0000000000a1";
+
+const runtimeData = vi.hoisted(() => ({ current: null as unknown }));
+
+vi.mock("../../../lib/api/runtime.js", () => ({
+  useRuntimeState: () => ({ data: runtimeData.current, isError: false }),
+}));
+vi.mock("../../../lib/api/approvals.js", () => ({
+  usePendingApprovals: () => ({ data: { ok: true, data: [] } }),
+}));
+vi.mock("../../../lib/api/chat.js", () => ({
+  useIsChatSubmitting: () => false,
+}));
+vi.mock("../../../lib/api/sessions.js", () => ({
+  useSessionPlan: () => ({ data: { ok: true, data: null } }),
+}));
+vi.mock("../../../stores/streamStore.js", () => ({
+  useStreamPreview: () => null,
+}));
+vi.mock("../../../stores/uiStore.js", () => ({
+  useUiStore: (select: (s: { activeSessionId: string }) => unknown) =>
+    select({ activeSessionId: SESSION }),
+}));
+
+const { DeskRuleTapeState } = await import("../DeskRuleTapeState.js");
+const { ComposerMissionStrip } = await import(
+  "../SessionComposer/ComposerMissionStrip.js"
+);
+
+/**
+ * An AGENT session's runtime state: no mission run row, which is exactly the
+ * shape that used to read Idle on the tape no matter what the agent was doing.
+ */
+function agentState(activity: RuntimeActivity) {
+  return {
+    ok: true as const,
+    data: {
+      sessionId: SESSION,
+      hasActiveRun: false,
+      missionRunId: null,
+      status: null,
+      stopReason: null,
+      lastCheckpointAt: null,
+      startedAt: null,
+      iterationCount: null,
+      leaseActive: activity.kind === "running",
+      leaseExpiresAt: null,
+      pendingControlKind: null,
+      stoppable: activity.kind !== "none",
+      activity,
+    },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  runtimeData.current = null;
+});
+
+describe("strip and tape agree about session activity", () => {
+  it.each([
+    ["running", { kind: "running" } as RuntimeActivity, "Running", "RUNNING"],
+    [
+      "sleeping",
+      {
+        kind: "sleeping",
+        nextWakeAt: "2026-08-28T12:04:00.000Z",
+      } as RuntimeActivity,
+      "Sleeping",
+      "SLEEPING",
+    ],
+  ])(
+    "both name a %s agent session",
+    (_label, activity, tapeWord, stripWord) => {
+      runtimeData.current = agentState(activity);
+      render(
+        <>
+          <DeskRuleTapeState />
+          <ComposerMissionStrip
+            sessionId={SESSION}
+            mode="agent"
+            missionStatus={null}
+            activity={activity}
+          />
+        </>,
+      );
+      // The tape prints the sentence-case word; the strip prints it uppercased
+      // in its own micro-label grammar. Same state, two registers - which is
+      // why the machine label below is the real agreement assertion.
+      expect(screen.getByText(tapeWord)).toBeTruthy();
+      const strip = document.querySelector("[data-vex-area='composer-mission-strip']");
+      expect(strip?.textContent).toContain(stripWord);
+      expect(strip?.getAttribute("data-vex-activity")).toBe(
+        activity.kind === "running" ? "running" : "sleeping",
+      );
+    },
+  );
+
+  // At rest the two surfaces say the same thing in different ways, and both
+  // are correct: the tape always shows a word, so it shows Idle; the strip is
+  // a band that only exists when there is something to report, so it shows
+  // nothing rather than parking "IDLE" over an idle composer.
+  it("agree that an idle agent session is idle", () => {
+    const activity: RuntimeActivity = { kind: "none" };
+    runtimeData.current = agentState(activity);
+    render(
+      <>
+        <DeskRuleTapeState />
+        <ComposerMissionStrip
+          sessionId={SESSION}
+          mode="agent"
+          missionStatus={null}
+          activity={activity}
+        />
+      </>,
+    );
+    expect(screen.getByText("Idle")).toBeTruthy();
+    expect(
+      document.querySelector("[data-vex-area='composer-mission-strip']"),
+    ).toBeNull();
+  });
+
+  // The projection is session-scoped, so a MISSION session's activity is
+  // `none` and the tape must keep reading its run status - not fall through to
+  // Idle and contradict the strip, which still speaks mission grammar.
+  it("leave mission rendering to the mission status", () => {
+    runtimeData.current = {
+      ok: true as const,
+      data: {
+        ...agentState({ kind: "none" }).data,
+        hasActiveRun: true,
+        status: "running",
+        missionRunId: "r1",
+        stoppable: true,
+      },
+    };
+    render(
+      <>
+        <DeskRuleTapeState />
+        <ComposerMissionStrip
+          sessionId={SESSION}
+          mode="mission"
+          missionStatus="running"
+          activity={{ kind: "none" }}
+        />
+      </>,
+    );
+    expect(screen.getByText("Running")).toBeTruthy();
+    const strip = document.querySelector("[data-vex-area='composer-mission-strip']");
+    expect(strip?.textContent).toContain("Mission");
+    expect(strip?.getAttribute("data-status")).toBe("running");
+  });
+});

--- a/vex-app/src/renderer/features/appShell/__tests__/transcriptRowModel.test.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/transcriptRowModel.test.ts
@@ -72,6 +72,23 @@ describe("toTranscriptRow", () => {
     );
   });
 
+  // M6: the operator-instruction acknowledgement is a notice like any other to
+  // look at, but it carries the `ack` tone so the renderer can announce it.
+  // The tone is what separates it from a wake banner - WITHOUT it the row is
+  // indistinguishable from every other runtime notice, and then either nothing
+  // is announced or everything is.
+  it("maps the operator_ack kind to an announced notice (M6)", () => {
+    const row = toTranscriptRow(
+      dto({ role: "system", kind: "operator_ack", content: "Saved." }),
+    );
+    expect(row.variant).toBe("notice");
+    expect(row.noticeTone).toBe("ack");
+    // Every other runtime notice stays silent.
+    expect(
+      toTranscriptRow(dto({ role: "system", kind: "runtime_notice" })).noticeTone,
+    ).toBe("runtime");
+  });
+
   it("maps the compaction kind to the compaction variant (no label) (8-4)", () => {
     const row = toTranscriptRow(
       dto({

--- a/vex-app/src/renderer/features/appShell/__tests__/transcriptRowModel/message-dto-fixture.ts
+++ b/vex-app/src/renderer/features/appShell/__tests__/transcriptRowModel/message-dto-fixture.ts
@@ -31,6 +31,7 @@ export function dto(p: {
   readonly durationMs?: SessionMessageDto["durationMs"];
   readonly success?: SessionMessageDto["success"];
   readonly board?: SessionMessageDto["board"];
+  readonly interruptDisposition?: SessionMessageDto["interruptDisposition"];
   readonly id?: number;
 }): SessionMessageDto {
   return {
@@ -49,6 +50,9 @@ export function dto(p: {
     success: p.success ?? null,
     displayStatus: null,
     board: p.board ?? null,
+    // M6: the engine's record of what it did with an operator instruction.
+    // Overridable so a fixture can build each of the three steering rows.
+    interruptDisposition: p.interruptDisposition ?? null,
   };
 }
 

--- a/vex-app/src/renderer/features/appShell/composer-helpers.ts
+++ b/vex-app/src/renderer/features/appShell/composer-helpers.ts
@@ -9,14 +9,29 @@
 
 import type { Result } from "@shared/ipc/result.js";
 import type { ChatSubmitResult } from "@shared/schemas/chat.js";
-import type { RuntimeStateDto } from "@shared/schemas/runtime.js";
+import type {
+  RuntimeActivity,
+  RuntimeStateDto,
+} from "@shared/schemas/runtime.js";
 import type {
   MissionRunStatus,
   SessionListItem,
 } from "@shared/schemas/sessions.js";
 
+/**
+ * Statuses in which free text cannot reach the run.
+ *
+ * `running` IS DELIBERATELY ABSENT (M6, owner decision). Steering a running
+ * mission is the DESIGNED path: `ingress.ts` persists a mid-run user message
+ * as an operator instruction that the loop merges at its next tool-step
+ * boundary, and the engine acknowledges it with a durable disposition row. The
+ * composer gate contradicted the product - it refused the one thing the engine
+ * was built to accept, and the operator's only remaining lever over a running
+ * mission was Stop. The remaining members are all states where the run is
+ * PARKED and free text genuinely cannot answer what it is parked on; each has
+ * its own control, named in `gatedReason`.
+ */
 export const FREE_TEXT_DISALLOWED: ReadonlySet<MissionRunStatus> = new Set([
-  "running",
   "paused_approval",
   "paused_user",
   "paused_wake",
@@ -35,10 +50,30 @@ export function readRunStatus(
   return data.data.status;
 }
 
+/**
+ * The session's activity projection, or `null` when the runtime state has not
+ * been read (or failed to read).
+ *
+ * NULL IS NOT IDLE. A surface that cannot read the state must say nothing
+ * rather than assert the session is doing nothing - the same distinction
+ * `StopAvailability` draws for the Stop key.
+ *
+ * The `?? null` is not dead code over a required DTO field: this value crossed
+ * the IPC boundary, so what arrived is unknown until checked (rule 04), and the
+ * sibling readout draws the same line for the same reason. The cost of being
+ * wrong is asymmetric - an absent field must not throw out of the composer and
+ * take the surrounding surface down with it, which is what an unguarded read
+ * did here.
+ */
+export function readActivity(
+  data: Result<RuntimeStateDto> | undefined,
+): RuntimeActivity | null {
+  if (!data || !data.ok) return null;
+  return data.data.activity ?? null;
+}
+
 export function gatedReason(status: MissionRunStatus | null): string {
   switch (status) {
-    case "running":
-      return "Mission is running. Use the Stop button first, or wait for the next paused state.";
     case "paused_approval":
       return "Mission is paused for approval. Resolve the approval first.";
     case "paused_user":
@@ -147,6 +182,19 @@ export function submitFailureNotice(
         data,
         "Vex stopped before completing the task because of an internal error.",
       );
+    case "tool_call_loop":
+      // NEVER one-click retryable, and not through `incompleteTurnNotice`:
+      // reaching this stop reason MEANS tool calls executed - five identical
+      // ones, plus everything before them - so `toolCallsMade === 0` is not a
+      // reachable state here and a retry arm gated on it would be dead code
+      // pretending to be a safety check. Same policy as the tool-activity arm
+      // above, stated unconditionally.
+      return {
+        text:
+          "Vex stopped because it repeated the same tool call without making progress. "
+          + "Review the transcript before trying again; earlier steps may have completed.",
+        retryable: false,
+      };
     case "compact_unable_at_critical":
       return {
         text: "Vex stopped because this conversation ran out of usable context. Start a new session or try a narrower request.",

--- a/vex-app/src/renderer/features/appShell/composer-submit.ts
+++ b/vex-app/src/renderer/features/appShell/composer-submit.ts
@@ -36,6 +36,7 @@ import { showToast } from "../../lib/toast.js";
 import { useUiStore } from "../../stores/uiStore.js";
 import { useBoardAskIntentStore } from "./Board/board-ask-intent.js";
 import { readStopAvailability } from "./composer-submit/stop-availability.js";
+import { resolveStopAffordance } from "./composer-submit/stop-affordance.js";
 import {
   STEERED_TOAST_TEXT,
   trySteerLiveTurn,
@@ -90,6 +91,11 @@ export interface ComposerSubmit {
    * does not KNOW. See `StopAvailability`.
    */
   readonly stopAvailable: boolean;
+  /**
+   * The Stop key's accessible name for THIS session's mode ("Stop mission" /
+   * "Stop agent"), from the one selector `MissionControls` also reads.
+   */
+  readonly stopLabel: string;
   readonly awaitingApproval: boolean;
   readonly onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
   readonly onRetry: () => void;
@@ -181,6 +187,13 @@ export function useComposerSubmit(
    * SHOWING Stop — see `StopAvailability`.
    */
   const stopKnownUnavailable = availability === "known-unavailable";
+  // ONE selector for the offer and the words; `MissionControls` reads the same
+  // one so the two Stop surfaces cannot disagree about either.
+  const stopAffordance = resolveStopAffordance(
+    availability,
+    activeSession?.mode === "mission" ? "mission" : "agent",
+    submitPending,
+  );
   const handedOffRef = useRef<string | null>(null);
 
   // Per-session draft (B1): the store keyed by session survives switching
@@ -608,7 +621,8 @@ export function useComposerSubmit(
     notice,
     submitPending,
     stopRequested,
-    stopAvailable: submitPending || !stopKnownUnavailable,
+    stopAvailable: stopAffordance.offered,
+    stopLabel: stopAffordance.label,
     awaitingApproval,
     onSubmit,
     onRetry,

--- a/vex-app/src/renderer/features/appShell/composer-submit/stop-affordance.ts
+++ b/vex-app/src/renderer/features/appShell/composer-submit/stop-affordance.ts
@@ -1,0 +1,77 @@
+/**
+ * THE stop affordance, named once and read by BOTH surfaces that offer Stop:
+ * the composer's send/stop key and the `MissionControls` toolbar button (M6).
+ *
+ * ## Why one selector
+ *
+ * The two surfaces answered "should Stop be offered, and what is it called?"
+ * separately - one from `stoppable` through `StopAvailability`, the other from
+ * "a run row exists" - so they could contradict each other on the same session,
+ * and neither said WHAT would be stopped. This resolves both questions in one
+ * place; neither surface may re-derive them.
+ *
+ * ## Both dispatch the same route
+ *
+ * The composer fires `runtime.requestStop` and the toolbar fires
+ * `mission.stop`. Those are two channel names for ONE dispatcher:
+ * `main/ipc/mission/stop.ts` and `main/ipc/runtime/request-stop.ts` both
+ * delegate to `runStopDispatch`, which owns the audit row and the control-state
+ * emit. So the surfaces already agree about the EFFECT, and this module makes
+ * them agree about the offer and the words.
+ *
+ * ## The three states, unchanged
+ *
+ * `StopAvailability` keeps its fail-open posture (`readStopAvailability`).
+ * `unknown` means the engine was ASKED and did not answer, and it still fails
+ * toward SHOWING the key: nothing will push an errored read back to the truth,
+ * and a hidden Stop over a spending agent is the worse failure. The M5 activity
+ * push does not change that reasoning - it makes `unknown` rarer, not safer.
+ * The pre-first-read case stays `known-unavailable` (a session whose state was
+ * never asked for has no work of ours in it), because reading it as unknown put
+ * a Stop key where Send belongs on every session open.
+ *
+ * PRESENTATION ONLY: no authority. Main decides `stoppable`; the privileged
+ * dispatcher decides what a Stop actually does.
+ */
+
+import type { StopAvailability } from "./stop-availability.js";
+
+/** What the operator is stopping - the session's own vocabulary. */
+export type StopTargetMode = "mission" | "agent";
+
+export interface StopAffordance {
+  /** Whether a Stop control should be offered at all. */
+  readonly offered: boolean;
+  /**
+   * The accessible name. Named by TARGET, never "Stop generating": the key
+   * stops a mission run or an autonomous agent session, and both outlive the
+   * generation the old label described.
+   */
+  readonly label: string;
+  /** The availability this was resolved from, for surfaces that stamp it. */
+  readonly availability: StopAvailability;
+}
+
+const LABEL: Readonly<Record<StopTargetMode, string>> = {
+  mission: "Stop mission",
+  agent: "Stop agent",
+};
+
+/**
+ * @param availability main's answer, read through `readStopAvailability`.
+ * @param mode the session's mode; decides the words, never the offer.
+ * @param foregroundTurnPending a chat turn this window owns is in flight. It
+ *   is an INDEPENDENT reason to offer Stop: the window can always cancel its
+ *   own request, whatever the durable state says about the session.
+ */
+export function resolveStopAffordance(
+  availability: StopAvailability,
+  mode: StopTargetMode,
+  foregroundTurnPending: boolean,
+): StopAffordance {
+  return {
+    offered: foregroundTurnPending || availability !== "known-unavailable",
+    label: LABEL[mode],
+    availability,
+  };
+}

--- a/vex-app/src/renderer/features/appShell/session-activity-readout.ts
+++ b/vex-app/src/renderer/features/appShell/session-activity-readout.ts
@@ -1,0 +1,75 @@
+/**
+ * ONE readout of `RuntimeStateDto.activity` for every surface that names what
+ * a session is doing (M5).
+ *
+ * WHY A SHARED SELECTOR. Two surfaces answer this question in two places - the
+ * status strip above the composer and the desk-rule tape word - and before the
+ * activity projection existed they answered it from different inputs, so a
+ * wake-driven agent turn read RUNNING on one and Idle on the other. The DTO
+ * ended the disagreement about the FACT; this module ends the disagreement
+ * about the WORD. Neither surface may re-derive either.
+ *
+ * PRESENTATION ONLY. No authority, no policy: the activity was decided in main
+ * (`session-control-state.ts`), and this turns it into a word plus a machine
+ * label for tests and styling hooks.
+ */
+
+import type { RuntimeActivity } from "@shared/schemas/runtime.js";
+
+/** Machine label - the `data-` attribute both surfaces stamp. */
+export type SessionActivityState = "running" | "sleeping" | "idle";
+
+export interface SessionActivityReadout {
+  readonly state: SessionActivityState;
+  /** Sentence-case word for assistive tech and the tape. */
+  readonly label: string;
+  /**
+   * The scheduled wake instant, `null` unless sleeping. The CALLER formats it:
+   * the tape has no room for a time and the strip does.
+   */
+  readonly nextWakeAt: string | null;
+}
+
+/**
+ * `undefined` in, `null` out - and NOT an idle readout.
+ *
+ * The DTO declares `activity` required and main always projects it, so this is
+ * not a state production is expected to reach. It is handled because the value
+ * crosses a process boundary (rule 04: what crossed IPC is unknown until
+ * checked) and the cost of being wrong is asymmetric: an absent field must not
+ * throw out of a status strip and take the surrounding surface down with it.
+ * Callers already read `null` as "say nothing", which is the honest answer to
+ * an unreadable state - never "idle", which would ASSERT the session is doing
+ * nothing.
+ */
+export function readSessionActivityReadout(
+  activity: RuntimeActivity | undefined,
+): SessionActivityReadout | null {
+  if (activity === undefined) return null;
+  switch (activity.kind) {
+    case "running":
+      return { state: "running", label: "Running", nextWakeAt: null };
+    case "sleeping":
+      return {
+        state: "sleeping",
+        label: "Sleeping",
+        nextWakeAt: activity.nextWakeAt,
+      };
+    case "none":
+      return { state: "idle", label: "Idle", nextWakeAt: null };
+  }
+}
+
+/**
+ * The wake instant as a local wall-clock time.
+ *
+ * A TIME, not a countdown: a countdown is a second clock that has to be kept
+ * ticking and re-rendered, and it goes stale silently the moment the query
+ * stops refreshing. An unparseable value degrades to `null` so the caller
+ * prints the state word alone rather than "Invalid Date".
+ */
+export function formatWakeTime(iso: string): string | null {
+  const at = new Date(iso);
+  if (Number.isNaN(at.getTime())) return null;
+  return at.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}

--- a/vex-app/src/renderer/features/appShell/transcriptRowModel.ts
+++ b/vex-app/src/renderer/features/appShell/transcriptRowModel.ts
@@ -15,6 +15,7 @@ import type {
   ExplorerRef,
   MessageKind,
   MessageRole,
+  OperatorInterruptDispositionDto,
   SessionMessageDto,
   ToolCallDisplay,
   ToolDisplayStatus,
@@ -54,11 +55,23 @@ export interface TranscriptRowModel {
    */
   readonly noticeTone?: "runtime" | "error" | "ack";
   /**
-   * User rows only (A33): the message was steered into a LIVE turn
-   * (`operator_interrupt`) and is delivered at the loop's next tool-batch
-   * boundary - the row wears a register mark saying so in words.
+   * User rows only (A33): the message is an operator instruction and the row
+   * wears a register mark saying WHEN the agent reads it.
    */
   readonly steering?: true;
+  /**
+   * What the engine DID with that instruction, when it recorded one.
+   *
+   * The mark's WORDS come from here, never from the `steering` kind. The kind
+   * says only "this is an operator instruction"; three different things can
+   * have happened to one, and the row used to claim the most optimistic of
+   * them for all three - a message queued against a run parked on an error
+   * rendered "Steered - read at the agent's next step" directly beside an
+   * acknowledgement saying the agent was not running. `undefined` on a legacy
+   * row written before the disposition existed, which renders the neutral
+   * mark rather than a guess.
+   */
+  readonly interruptDisposition?: OperatorInterruptDispositionDto;
   /**
    * Tool rows only. `"call"` → `content` is assistant prose and `toolCalls`
    * carries the per-call param disclosures; `"result"` → `content` is the
@@ -313,6 +326,11 @@ export function toTranscriptRow(
     // A33: the steered mark survives into the row so the user row can wear
     // its "read at the agent's next step" register stamp.
     ...(dto.kind === "steering" ? { steering: true as const } : {}),
+    // Carried only when the engine recorded one. A null disposition leaves the
+    // field absent, and the mark falls back to its neutral wording.
+    ...(dto.kind === "steering" && dto.interruptDisposition !== null
+      ? { interruptDisposition: dto.interruptDisposition }
+      : {}),
   };
 }
 

--- a/vex-app/src/renderer/features/appShell/transcriptRowModel.ts
+++ b/vex-app/src/renderer/features/appShell/transcriptRowModel.ts
@@ -46,8 +46,13 @@ export interface TranscriptRowModel {
   /**
    * Notice rows only (S3): `error`-kind notices keep the destructive tone;
    * everything else that lands on the notice variant stays neutral.
+   *
+   * `ack` (M6) is visually identical to `runtime` and differs only in that it
+   * is ANNOUNCED: it is the engine answering something the operator just did,
+   * so a screen-reader user learns their instruction landed without having to
+   * go looking for the row.
    */
-  readonly noticeTone?: "runtime" | "error";
+  readonly noticeTone?: "runtime" | "error" | "ack";
   /**
    * User rows only (A33): the message was steered into a LIVE turn
    * (`operator_interrupt`) and is delivered at the loop's next tool-batch
@@ -160,6 +165,7 @@ function resolveVariant(
     case "tool_result":
       return "tool";
     case "runtime_notice":
+    case "operator_ack":
     case "error":
       return "notice";
     case "compaction":
@@ -285,7 +291,12 @@ export function toTranscriptRow(
       label: null,
       content: dto.content,
       createdAt: dto.createdAt,
-      noticeTone: dto.kind === "error" ? "error" : "runtime",
+      noticeTone:
+        dto.kind === "error"
+          ? "error"
+          : dto.kind === "operator_ack"
+            ? "ack"
+            : "runtime",
     };
   }
   return {

--- a/vex-app/src/renderer/lib/api/__tests__/messages.test.ts
+++ b/vex-app/src/renderer/lib/api/__tests__/messages.test.ts
@@ -185,6 +185,7 @@ function msg(id: number): SessionMessageDto {
     success: null,
     displayStatus: null,
     board: null,
+    interruptDisposition: null,
   };
 }
 

--- a/vex-app/src/shared/schemas/__tests__/messages-board-projection.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/messages-board-projection.test.ts
@@ -33,6 +33,7 @@ const DTO_BASE = {
   durationMs: null,
   success: null,
   displayStatus: null,
+  interruptDisposition: null,
 };
 
 describe("board DTO projection", () => {

--- a/vex-app/src/shared/schemas/__tests__/messages.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/messages.test.ts
@@ -68,6 +68,7 @@ describe("messages schemas", () => {
       success: null,
       displayStatus: null,
       board: null,
+      interruptDisposition: null,
     });
     expect(parsed.success).toBe(true);
   });
@@ -92,6 +93,7 @@ describe("messages schemas", () => {
       success: null,
       displayStatus: null,
       board: null,
+      interruptDisposition: null,
     });
     expect(parsed.success).toBe(true);
   });
@@ -116,6 +118,7 @@ describe("messages schemas", () => {
       success: true,
       displayStatus: null,
       board: null,
+      interruptDisposition: null,
     });
     expect(parsed.success).toBe(true);
   });
@@ -141,6 +144,7 @@ describe("messages schemas", () => {
       success: null,
       displayStatus: null,
       board: null,
+      interruptDisposition: null,
     });
     expect(parsed.success).toBe(false);
   });
@@ -162,6 +166,7 @@ describe("messages schemas", () => {
       success: null,
       displayStatus: null,
       board: null,
+      interruptDisposition: null,
     });
     expect(parsed.success).toBe(false);
   });
@@ -182,6 +187,7 @@ describe("messages schemas", () => {
       success: null,
       displayStatus: null,
       board: null,
+      interruptDisposition: null,
     };
     expect(
       sessionMessageDtoSchema.safeParse({ ...base, reasoning: "thought…" })
@@ -215,6 +221,7 @@ describe("messages schemas", () => {
       durationMs: null,
       success: false,
       board: null,
+      interruptDisposition: null,
     };
     expect(
       sessionMessageDtoSchema.safeParse({ ...base, displayStatus: "pending" })
@@ -249,6 +256,7 @@ describe("messages schemas", () => {
       success: null,
       displayStatus: null,
       board: null,
+      interruptDisposition: null,
     };
     expect(
       sessionMessageDtoSchema.safeParse({ ...base, durationMs: -1 }).success,
@@ -288,6 +296,7 @@ describe("messages schemas", () => {
       success: null,
       displayStatus: null,
       board: null,
+      interruptDisposition: null,
     });
     expect(
       sessionMessageDtoSchema.safeParse(row("a".repeat(2001))).success,
@@ -362,6 +371,7 @@ describe("messages schemas", () => {
       success: null,
       displayStatus: null,
       board: null,
+      interruptDisposition: null,
     });
     expect(parsed.success).toBe(false);
   });

--- a/vex-app/src/shared/schemas/__tests__/messages.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/messages.test.ts
@@ -25,9 +25,14 @@ describe("messages schemas", () => {
     }
     for (const k of [
       "text",
+      // Pre-existing gap: this list was not total. `steering` (A33) and
+      // `operator_ack` (M6) are named here so the enumeration matches the
+      // schema and a kind added without a wire pin becomes visible.
+      "steering",
       "tool_call",
       "tool_result",
       "runtime_notice",
+      "operator_ack",
       "error",
       "compaction",
       "recall",

--- a/vex-app/src/shared/schemas/__tests__/runtime.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/runtime.test.ts
@@ -30,6 +30,8 @@ describe("runtime schemas", () => {
       leaseExpiresAt: null,
       pendingControlKind: null,
       stoppable: false,
+      // M5: required on the DTO alongside `stoppable`.
+      activity: { kind: "none" },
     });
     expect(parsed.success).toBe(true);
   });
@@ -48,6 +50,8 @@ describe("runtime schemas", () => {
       leaseExpiresAt: ISO,
       pendingControlKind: null,
       stoppable: false,
+      // M5: required on the DTO alongside `stoppable`.
+      activity: { kind: "none" },
     });
     expect(parsed.success).toBe(true);
   });
@@ -66,6 +70,8 @@ describe("runtime schemas", () => {
       leaseExpiresAt: null,
       pendingControlKind: null,
       stoppable: false,
+      // M5: required on the DTO alongside `stoppable`.
+      activity: { kind: "none" },
     });
     expect(parsed.success).toBe(true);
   });
@@ -84,6 +90,8 @@ describe("runtime schemas", () => {
       leaseExpiresAt: ISO,
       pendingControlKind: null,
       stoppable: false,
+      // M5: required on the DTO alongside `stoppable`.
+      activity: { kind: "none" },
     });
     expect(parsed.success).toBe(true);
     // OPTIONAL, not nullable: a state that is not sleeping carries no key at
@@ -105,6 +113,8 @@ describe("runtime schemas", () => {
       leaseExpiresAt: null,
       pendingControlKind: null,
       stoppable: false,
+      // M5: required on the DTO alongside `stoppable`.
+      activity: { kind: "none" },
       pausedWake: {
         dueAt: ISO,
         reason: "waiting for the ETH funding window",
@@ -130,6 +140,8 @@ describe("runtime schemas", () => {
       leaseExpiresAt: ISO,
       pendingControlKind: null,
       stoppable: false,
+      // M5: required on the DTO alongside `stoppable`.
+      activity: { kind: "none" },
       pausedWake: { dueAt: ISO, reason: null, watchSummary: null },
     });
     expect(parsed.success).toBe(false);
@@ -149,6 +161,8 @@ describe("runtime schemas", () => {
       leaseExpiresAt: null,
       pendingControlKind: null,
       stoppable: false,
+      // M5: required on the DTO alongside `stoppable`.
+      activity: { kind: "none" },
     });
     expect(parsed.success).toBe(true);
   });
@@ -167,6 +181,8 @@ describe("runtime schemas", () => {
       leaseExpiresAt: null,
       pendingControlKind: null,
       stoppable: false,
+      // M5: required on the DTO alongside `stoppable`.
+      activity: { kind: "none" },
     };
     expect(
       runtimeStateDtoSchema.safeParse({
@@ -202,6 +218,8 @@ describe("runtime schemas", () => {
       leaseExpiresAt: null,
       pendingControlKind: null,
       stoppable: false,
+      // M5: required on the DTO alongside `stoppable`.
+      activity: { kind: "none" },
     };
     expect(
       runtimeStateDtoSchema.safeParse({
@@ -399,6 +417,94 @@ describe("controlStateEventSchema", () => {
       controlStateEventSchema.safeParse({
         ...VALID,
         leaseOwnerId: "internal-owner",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+/**
+ * M5/M6 DTO invariants. Both exist so the DTO cannot carry two answers to one
+ * question - the exact failure the activity projection was introduced to end.
+ */
+describe("runtimeStateDto wave-2 invariants", () => {
+  const BASE = {
+    sessionId: SESSION,
+    hasActiveRun: false,
+    missionRunId: null,
+    status: null,
+    stopReason: null,
+    lastCheckpointAt: null,
+    startedAt: null,
+    iterationCount: null,
+    leaseActive: false,
+    leaseExpiresAt: null,
+    pendingControlKind: null,
+    stoppable: false,
+    activity: { kind: "none" as const },
+  };
+
+  it("rejects a running activity without the lease it is derived from", () => {
+    const parsed = runtimeStateDtoSchema.safeParse({
+      ...BASE,
+      activity: { kind: "running" },
+      leaseActive: false,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("accepts a running activity backed by a live lease", () => {
+    expect(
+      runtimeStateDtoSchema.safeParse({
+        ...BASE,
+        activity: { kind: "running" },
+        leaseActive: true,
+      }).success,
+    ).toBe(true);
+  });
+
+  // The CONVERSE is deliberately not enforced: a lease held for a mission run's
+  // slice is legitimately active while the SESSION-scoped activity is `none`.
+  it("allows a live lease with no session-scoped activity (a mission run's slice)", () => {
+    expect(
+      runtimeStateDtoSchema.safeParse({ ...BASE, leaseActive: true }).success,
+    ).toBe(true);
+  });
+
+  it("requires an offset-bearing instant on the sleeping arm", () => {
+    expect(
+      runtimeStateDtoSchema.safeParse({
+        ...BASE,
+        activity: { kind: "sleeping", nextWakeAt: "2026-08-28T12:04:00.000Z" },
+      }).success,
+    ).toBe(true);
+    expect(
+      runtimeStateDtoSchema.safeParse({
+        ...BASE,
+        activity: { kind: "sleeping", nextWakeAt: "soon" },
+      }).success,
+    ).toBe(false);
+  });
+
+  // Recovery readiness gates a button that only exists on `paused_error`.
+  // Present anywhere else would let a surface enable or disable Recover from a
+  // fact that was never computed for that state.
+  it("accepts recoveryReady only on paused_error", () => {
+    expect(
+      runtimeStateDtoSchema.safeParse({
+        ...BASE,
+        hasActiveRun: true,
+        status: "paused_error",
+        missionRunId: "r1",
+        recoveryReady: { kind: "blocked", reasonKinds: ["wallet_intent_live"] },
+      }).success,
+    ).toBe(true);
+    expect(
+      runtimeStateDtoSchema.safeParse({
+        ...BASE,
+        hasActiveRun: true,
+        status: "running",
+        missionRunId: "r1",
+        recoveryReady: { kind: "ready" },
       }).success,
     ).toBe(false);
   });

--- a/vex-app/src/shared/schemas/chat.ts
+++ b/vex-app/src/shared/schemas/chat.ts
@@ -98,6 +98,16 @@ export const chatSteerResultSchema = z
   .strict();
 export type ChatSteerResult = z.infer<typeof chatSteerResultSchema>;
 
+/**
+ * Hand-mirrored from the engine's canonical `STOP_REASONS` tuple
+ * (`src/vex-agent/engine/types/stop-reasons.ts`), business members first then
+ * runtime, in that exact order. `check:boundaries` forbids this package from
+ * importing the engine, so the list cannot be derived here; the sequence is
+ * pinned instead by the cross-package drift guard
+ * `src/__tests__/vex-agent/engine/stop-reason-vocabulary-drift.test.ts`.
+ * A reason missing here makes an honest engine stop fail strict validation at
+ * the IPC boundary, which is why the guard compares sequences and not sets.
+ */
 export const chatStopReasonSchema = z.enum([
   "goal_reached",
   "deadline_reached",
@@ -118,6 +128,8 @@ export const chatStopReasonSchema = z.enum([
   "plan_acceptance_required",
   "user_form_required",
   "no_progress",
+  "restart_orphan",
+  "tool_call_loop",
 ]);
 export type ChatStopReason = z.infer<typeof chatStopReasonSchema>;
 

--- a/vex-app/src/shared/schemas/messages.ts
+++ b/vex-app/src/shared/schemas/messages.ts
@@ -50,6 +50,23 @@ export type MessageRole = z.infer<typeof messageRoleSchema>;
  *     cancelled mid-response (engine `message_type` "chat_stopped"),
  *     rendered as the normal assistant bubble plus a "Stopped" badge.
  */
+/**
+ * What the engine did with an operator instruction, mirrored from the engine's
+ * `OperatorInterruptDisposition` (`core/operator-instructions.ts`).
+ *
+ * A string-literal mirror rather than an import, like the `message_type`
+ * constants in the DB mapper: the engine package is not an import target from
+ * the app's shared contracts. Both sides are pinned by test.
+ */
+export const operatorInterruptDispositionSchema = z.enum([
+  "steered",
+  "queued_interrupt",
+  "preempted_wake",
+]);
+export type OperatorInterruptDispositionDto = z.infer<
+  typeof operatorInterruptDispositionSchema
+>;
+
 export const messageKindSchema = z.enum([
   "text",
   // A33: a user message steered into a LIVE turn (`operator_interrupt`) -
@@ -317,6 +334,25 @@ export const sessionMessageDtoSchema = z
      * prose always stands alone.
      */
     board: boardProjectionSchema.nullable(),
+    /**
+     * What the engine DID with an operator instruction (validated projection of
+     * `messages.metadata -> 'payload' -> 'disposition'`). Required and `null` on
+     * every non-`steering` row, and on legacy interrupt rows written before the
+     * disposition existed.
+     *
+     * WHY IT CROSSES. Without it the renderer had one word for three different
+     * events: every `operator_interrupt` row rendered "Steered - read at the
+     * agent's next step", including a message queued against a run parked on an
+     * error, which sat directly beside an acknowledgement saying the opposite.
+     * The two rows are written in ONE transaction from ONE typed value, so the
+     * only way they can disagree is if the renderer invents one of them.
+     *
+     * Bounded and closed: the enum is the engine's own union, and an
+     * unrecognised value projects `null` rather than crossing as a loose
+     * string. The renderer maps what it knows and keeps a total default, so a
+     * fourth disposition degrades to the neutral mark instead of a wrong claim.
+     */
+    interruptDisposition: operatorInterruptDispositionSchema.nullable(),
   })
   .strict();
 export type SessionMessageDto = z.infer<typeof sessionMessageDtoSchema>;

--- a/vex-app/src/shared/schemas/messages.ts
+++ b/vex-app/src/shared/schemas/messages.ts
@@ -58,6 +58,15 @@ export const messageKindSchema = z.enum([
   "tool_call",
   "tool_result",
   "runtime_notice",
+  // M6: the engine's own durable acknowledgement of an operator instruction
+  // (`message_type` "operator_interrupt_ack"). A runtime notice in every
+  // visual respect, but SEPARATE from the catch-all so the renderer can
+  // announce it politely: it is the answer to something the operator just did,
+  // and it is the only notice kind that is. The wording per disposition is
+  // decided in the engine (`operator-instructions.ts`); this kind carries only
+  // the fact that the row IS an acknowledgement, so nothing here compares
+  // prose.
+  "operator_ack",
   "error",
   "compaction",
   "recall",

--- a/vex-app/src/shared/schemas/mission/run-lifecycle.ts
+++ b/vex-app/src/shared/schemas/mission/run-lifecycle.ts
@@ -201,6 +201,18 @@ export const missionRetryResultSchema = z.discriminatedUnion("outcome", [
     })
     .strict(),
   z.object({ outcome: z.literal("status_changed") }).strict(),
+  // The session still carries money-path work whose outcome is not proven (an
+  // undecided approval, a broadcast awaiting confirmation, a wallet intent in
+  // flight). Resuming would run the mission on top of an unresolved money
+  // state, so Recover refuses and names the structural reasons. Fail-closed and
+  // decided by the privileged handler, never by the renderer.
+  z
+    .object({
+      outcome: z.literal("blocked_money_state"),
+      /** Structural `MoneyStateReason.kind` labels only, never row content. */
+      reasonKinds: z.array(z.string()).max(50),
+    })
+    .strict(),
   z
     .object({
       outcome: z.literal("lease_busy"),

--- a/vex-app/src/shared/schemas/runtime.ts
+++ b/vex-app/src/shared/schemas/runtime.ts
@@ -71,6 +71,92 @@ export const runtimePausedWakeSchema = z
   .strict();
 export type RuntimePausedWake = z.infer<typeof runtimePausedWakeSchema>;
 
+// ── Session activity projection (M5) ────────────────────────────────
+
+/**
+ * ONE discriminated answer to "is this session doing anything right now, and
+ * if it is asleep, until when".
+ *
+ * WHY IT EXISTS. A full-autonomy agent session alternates between lease-held
+ * slices and lease-less parks on a pending wake. Every surface that wanted to
+ * say what the session was doing had to re-derive that from `leaseActive` (a
+ * sawtooth) plus a wake read it did not have, so the tape reported wake-driven
+ * agent work as "Idle" while the agent was mid-run. This is the derived fact,
+ * computed once in main from the same snapshot that answers `stoppable`.
+ *
+ * NOT A DUPLICATE OF `leaseActive`. `leaseActive` stays exactly what it was -
+ * the raw lease summary. `activity` is the POLICY over it, and every consumer
+ * reads the policy rather than re-deriving one of its own.
+ *
+ * SESSION-SCOPED ONLY. The sleeping arm is derived from the pending wake row
+ * with `mission_run_id IS NULL`. A mission run's own wake keeps its dedicated,
+ * richer channel (`pausedWake` + `status === "paused_wake"`), so a mission
+ * session never reports `sleeping` here and the two surfaces cannot contradict
+ * each other.
+ */
+export const runtimeActivitySchema = z.discriminatedUnion("kind", [
+  /** No lease and no session-scoped wake: nothing of this session's own is running. */
+  z.object({ kind: z.literal("none") }).strict(),
+  /** A runner holds this session's lease right now. */
+  z.object({ kind: z.literal("running") }).strict(),
+  /**
+   * Parked on a session-scoped wake. `nextWakeAt` is the pending row's
+   * `due_at` - the ONE machine-readable fact of the park, exactly as
+   * `pausedWake.dueAt` is for a mission run. No reason text rides here: the
+   * agent-authored reason is display text with its own bound and its own
+   * channel, and this projection gates a status word.
+   */
+  z
+    .object({
+      kind: z.literal("sleeping"),
+      nextWakeAt: z.string().datetime({ offset: true }),
+    })
+    .strict(),
+]);
+export type RuntimeActivity = z.infer<typeof runtimeActivitySchema>;
+
+/**
+ * Whether the operator's Recover affordance may be offered, mirrored from the
+ * SAME unresolved-money-state reader the privileged retry IPC enforces with
+ * (`approval-intents/money-state.ts`).
+ *
+ * DISPLAY MIRROR, NEVER AUTHORITY. `runtime-retry-dispatch.ts` re-reads this
+ * fact under the session control lock and refuses on its own answer; this field
+ * exists so the button can be honest BEFORE the click instead of offering an
+ * action the engine will refuse. A renderer that ignored it would be rude, not
+ * unsafe.
+ *
+ * FAIL-CLOSED and PRESENT ONLY for a `paused_error` run - the one status where
+ * Recover is offered. An unreadable money state projects as `blocked`, because
+ * an unknown money outcome is not a clear one (rule 90).
+ *
+ * `reasonKinds` are the reader's own STRUCTURAL labels (`wallet_intent_live`,
+ * `approval_in_flight`, ...) - never a provider message, a row id or user
+ * content. They are an open set: the reader gains kinds as the money path
+ * gains state machines, so a consumer maps what it knows and keeps a total
+ * default branch.
+ */
+/**
+ * The one reason kind the DTO adds on top of the money-state reader's own set:
+ * the state could not be read at all. Named rather than silent, so the surface
+ * says "could not check" instead of inventing a blocking reason the reader
+ * never reported.
+ */
+export const MONEY_STATE_UNREADABLE = "money_state_unreadable";
+
+export const runtimeRecoveryReadinessSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("ready") }).strict(),
+  z
+    .object({
+      kind: z.literal("blocked"),
+      reasonKinds: z.array(z.string().max(64)).max(50),
+    })
+    .strict(),
+]);
+export type RuntimeRecoveryReadiness = z.infer<
+  typeof runtimeRecoveryReadinessSchema
+>;
+
 // ── DTO returned by runtime.getState ────────────────────────────────
 
 export const runtimeStateDtoSchema = z
@@ -166,6 +252,19 @@ export const runtimeStateDtoSchema = z
      * renderer ship in one bundle, so a required field is safe here.
      */
     stoppable: z.boolean(),
+    /**
+     * What this session is doing right now (see `runtimeActivitySchema`).
+     *
+     * REQUIRED, like `stoppable`, and for the same reason: main and renderer
+     * ship in one bundle, and an absent value read as "none" would report a
+     * running agent as idle - the exact defect this field closes.
+     */
+    activity: runtimeActivitySchema,
+    /**
+     * Present ONLY while `status === "paused_error"` - the one state where the
+     * Recover control is offered. See `runtimeRecoveryReadinessSchema`.
+     */
+    recoveryReady: runtimeRecoveryReadinessSchema.optional(),
   })
   .strict()
   /**
@@ -185,6 +284,32 @@ export const runtimeStateDtoSchema = z
         message: 'pausedWake is only valid when status is "paused_wake"',
       });
     }
+    /**
+     * `activity: running` is DERIVED from the live lease, so the two must agree
+     * or the DTO carries two answers to one question. The converse is NOT
+     * enforced: a lease held for a mission run's slice is legitimately
+     * `running` here too, and a lease that expires between the two column
+     * reads of one snapshot cannot happen (they come from the same row).
+     */
+    if (state.activity.kind === "running" && !state.leaseActive) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["activity"],
+        message: 'activity "running" requires an active lease',
+      });
+    }
+    /**
+     * Recover readiness is meaningless without the pause it gates. Present on
+     * any other status would mean a surface could disable (or enable) Recover
+     * from a fact that was never computed for that state.
+     */
+    if (state.recoveryReady !== undefined && state.status !== "paused_error") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["recoveryReady"],
+        message: 'recoveryReady is only valid when status is "paused_error"',
+      });
+    }
   });
 export type RuntimeStateDto = z.infer<typeof runtimeStateDtoSchema>;
 
@@ -193,13 +318,14 @@ export type RuntimeStateDto = z.infer<typeof runtimeStateDtoSchema>;
  * are composed at the IPC boundary rather than read from the run.
  *
  * `mission-runs-db.ts` reports these facts and must not know about wakes or the
- * control-gating policy; `stoppable` is decided by the aggregate and
- * `pausedWake` by a separate, status-gated read. Naming the subset keeps a
- * required DTO field from silently becoming that helper's problem.
+ * control-gating policy; `stoppable` and `activity` are decided by the
+ * aggregate, and `pausedWake` / `recoveryReady` by separate, status-gated
+ * reads. Naming the subset keeps a required DTO field from silently becoming
+ * that helper's problem.
  */
 export type RuntimeRunStateFacts = Omit<
   RuntimeStateDto,
-  "stoppable" | "pausedWake"
+  "stoppable" | "pausedWake" | "activity" | "recoveryReady"
 >;
 
 // ── Inputs ──────────────────────────────────────────────────────────

--- a/vitest/studio-postgres.config.ts
+++ b/vitest/studio-postgres.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
       "@utils": resolve(root, "src/utils"),
       "@config": resolve(root, "src/config"),
       "@vex-agent": resolve(root, "src/vex-agent"),
+      // The control-state aggregate lives in the desktop main process but its
+      // one hand-written statement runs against THIS schema, so its live proof
+      // belongs in this lane. Reaching that module means resolving the shared
+      // contracts it imports.
+      "@shared": resolve(root, "vex-app/src/shared"),
     },
   },
   test: {
@@ -20,6 +25,7 @@ export default defineConfig({
       "src/__tests__/integration/migrations/096-wallet-wrap-intents.int.test.ts",
       "src/__tests__/integration/engine/studio-*.int.test.ts",
       "src/__tests__/integration/repos/money-state-reader.int.test.ts",
+      "src/__tests__/integration/repos/session-control-state-wake.int.test.ts",
       "src/__tests__/integration/repos/wallet-transaction-*.int.test.ts",
       "src/__tests__/integration/repos/wallet-wrap-*.int.test.ts",
       "src/__tests__/integration/repos/swap-prequotes-claim.int.test.ts",

--- a/vitest/studio-postgres.config.ts
+++ b/vitest/studio-postgres.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       "src/__tests__/integration/engine/studio-*.int.test.ts",
       "src/__tests__/integration/repos/money-state-reader.int.test.ts",
       "src/__tests__/integration/repos/session-control-state-wake.int.test.ts",
+      "src/__tests__/integration/repos/recovery-money-gate-race.int.test.ts",
       "src/__tests__/integration/repos/wallet-transaction-*.int.test.ts",
       "src/__tests__/integration/repos/wallet-wrap-*.int.test.ts",
       "src/__tests__/integration/repos/swap-prequotes-claim.int.test.ts",

--- a/vitest/studio-postgres.config.ts
+++ b/vitest/studio-postgres.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       "src/__tests__/integration/repos/money-state-reader.int.test.ts",
       "src/__tests__/integration/repos/session-control-state-wake.int.test.ts",
       "src/__tests__/integration/repos/recovery-money-gate-race.int.test.ts",
+      "src/__tests__/integration/repos/recovery-reverse-lock-order.int.test.ts",
       "src/__tests__/integration/repos/wallet-transaction-*.int.test.ts",
       "src/__tests__/integration/repos/wallet-wrap-*.int.test.ts",
       "src/__tests__/integration/repos/swap-prequotes-claim.int.test.ts",


### PR DESCRIPTION
Production incidents on 0.2.7 (steering confusion with a phantom Stop button, a 10-minute false-terminal timeout, crash-orphaned running missions, a seven-call tool loop) traced to their owners and fixed as one arc.

- mission-finalize split into one policy per module behind a routing-table facade (move-only first, behavior after)
- turn wall clock 10 -> 30 minutes; a successfully continued full-autonomy turn reports waiting_for_wake instead of a false terminal
- tool-call loop detector: sha256 result-aware signatures, cycle detection, corrective cue at strike one, honest stop at strike two with lane-specific consumers
- recurring restart_orphan reclaim for crash-orphaned running missions (exact running-only CAS under the session lock); recovery claims the run before cancelling its wake, closing a reverse-lock-order deadlock reproduced live as 40P01, and a fail-closed money-state gate on retry proven by forced-interleaving two-client Postgres tests
- one activity projection (running / sleeping with next wake) pushed to both the composer strip and the desk tape; steering unblocked (running leaves the free-text gate) with one named stop-affordance owner; typed operator-interrupt dispositions with a durable acknowledgement row; cause-specific copy for every named pause

Verification: root suite 16,693/0; vex-app 7,750/0 clean on a quiet machine; studio-postgres lane incl. new live-Postgres tests for the activity SQL, the recovery race and the reverse lock order; build, lint, ratchet, em-dash gates green. External review: plan 3 turns to GREEN LIGHT, final 3 turns to GREEN LIGHT (thread harness-mission-autonomy).