### PR TITLE
fix(board): responsive board layout owned by container queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,13 +280,13 @@ jobs:
       - name: Build (e2e needs the bundled main + preload + renderer)
         run: pnpm run build
 
-      - name: Install Playwright system libraries
-        # Electron-only test — we drive the built bundle via
-        # `_electron.launch`, not a chromium binary. `install-deps`
-        # (vs the more common `install --with-deps chromium`) pulls
-        # just the system libs Playwright's runtime needs, without
-        # downloading a browser binary we never use.
-        run: pnpm exec playwright install-deps chromium
+      - name: Install Playwright chromium + system libraries
+        # Two projects run here: the Electron smoke (drives the built
+        # bundle via `_electron.launch`) and the board-layout geometry
+        # suite, which needs the real chromium headless-shell binary to
+        # measure computed grid tracks against the production stylesheet.
+        # `install --with-deps` pulls the browser AND the system libs.
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Playwright smoke (xvfb)
         # xvfb provides the X server Electron needs on headless

--- a/vex-app/e2e/board-layout-harness.d.ts
+++ b/vex-app/e2e/board-layout-harness.d.ts
@@ -1,0 +1,20 @@
+/**
+ * The board layout harness control surface, as the spec sees it.
+ *
+ * The implementation is `src/renderer/dev/board-layout/harness.tsx`, which
+ * declares the same shape for the renderer program. The two programs never
+ * share a `lib.dom` instance, so the declaration exists on both sides rather
+ * than in one shared file neither tsconfig includes.
+ */
+declare global {
+  interface Window {
+    readonly __vexBoardLayoutHarness: {
+      /** Open or close the Ask VEX drawer without a reload. */
+      readonly setDrawer: (open: boolean) => void;
+      /** Settle the held safety read on the longest verdict in the table. */
+      readonly settleSafety: () => void;
+    };
+  }
+}
+
+export {};

--- a/vex-app/e2e/board-layout.spec.ts
+++ b/vex-app/e2e/board-layout.spec.ts
@@ -440,16 +440,35 @@ test.describe("board grid geometry", () => {
       await open(page, {
         width: at.width,
         board: "wide",
-        pools: 3,
+        pools: 4,
         ...(at.plate === undefined ? {} : { plate: at.plate }),
       });
       expect(await ellipsizedRegions(page, CLIPPED_BY_DESIGN)).toEqual([]);
       expect(await verticallyClippedRegions(page)).toEqual([]);
-      // And every one of them says it shortened, rather than being silently
-      // clipped by the card.
-      await expect(
-        page.locator('[data-vex-area="board-token-ticker"]').first(),
-      ).toHaveAttribute("data-shortened", "true");
+      // And EVERY one of them says it shortened, rather than being silently
+      // clipped by the card. All four rows are over their budget: the CJK
+      // ticker, the emoji sequences, the combining marks, and `WWWWWWWW` -
+      // which is plain Latin-1, eight characters long, and still 94.56px of
+      // glyphs in an 88px column.
+      const tickers = await page.evaluate(() =>
+        [
+          ...document.querySelectorAll('[data-vex-area="board-token-ticker"]'),
+        ].map((node) => ({
+          text: node.textContent ?? "",
+          shortened: node.getAttribute("data-shortened") ?? "none",
+        })),
+      );
+      expect(tickers).toHaveLength(4);
+      expect(tickers.map((t) => t.shortened)).toEqual([
+        "true",
+        "true",
+        "true",
+        "true",
+      ]);
+      // The wide-Latin row exactly, because it is the one whose width a
+      // character count claimed to know: four `W`s at 11.82px is 47.28px,
+      // where eight would have been 94.56 in an 88px column.
+      expect(tickers[2]?.text).toBe("WWWW…");
     });
   }
 
@@ -459,7 +478,7 @@ test.describe("board grid geometry", () => {
     // THE PERSISTENCE BOUNDARY, not only the pixels. A cut between the two
     // halves of a surrogate pair produces an ill-formed string; a cut inside
     // a ZWJ sequence produces a different token than the provider sent.
-    await open(page, { width: 1440, board: "wide", pools: 3 });
+    await open(page, { width: 1440, board: "wide", pools: 4 });
     const findings = await page.evaluate(() => {
       const bad: string[] = [];
       for (const node of document.querySelectorAll(

--- a/vex-app/e2e/board-layout.spec.ts
+++ b/vex-app/e2e/board-layout.spec.ts
@@ -1,0 +1,652 @@
+/**
+ * BOARD GEOMETRY, measured in a real engine at real widths.
+ *
+ * WHY A BROWSER PROJECT AND NOT THE ELECTRON FIXTURE. `smoke.spec.ts` says it
+ * itself: nothing past SystemCheck is reachable without a live Docker daemon,
+ * a migrated Postgres and an unlocked vault, so the board modal cannot be
+ * opened there at all. Board geometry is decided entirely by the renderer's
+ * own container queries over the real production stylesheet, and
+ * `vite.board-layout.config.ts` serves exactly that against the real
+ * `BoardModalHost` / `BoardGrid` / `TokenCardV3`. The only thing faked is the
+ * preload bridge, which is the process boundary and nothing above it.
+ *
+ * WHAT THESE ASSERTIONS ARE. Contract-level and mode-independent: they say
+ * what a reader must never be shown, not which threshold produces it. A
+ * threshold is CSS's to own (`global-css/board-layout.css`); these tests are
+ * what makes that ownership falsifiable.
+ *
+ * The derivation of every number quoted below lives in
+ * `src/renderer/features/appShell/Board/board-layout-measurements.md`.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Regions that are DELIBERATELY clipped and must be exempt from the overflow
+ * assertion.
+ *
+ * `sr-only` and the photo's absence line are one-pixel boxes on purpose: they
+ * carry text for assistive technology and are not meant to be seen. The token
+ * NAME keeps its ellipsis by product decision (the whole string stays in the
+ * `title` and in the card's accessible name), so it is exempt too - and it is
+ * the ONLY visible element that is.
+ */
+const CLIPPED_BY_DESIGN = [
+  "board-token-photo-absence",
+  "board-token-name",
+];
+
+interface OverflowingRegion {
+  readonly card: string;
+  readonly area: string;
+  readonly text: string;
+  readonly scrollWidth: number;
+  readonly clientWidth: number;
+}
+
+async function open(
+  page: Page,
+  options: {
+    readonly width: number;
+    readonly drawer?: boolean;
+    readonly board?: string;
+    readonly pools?: number;
+    readonly view?: "grid" | "spotlight";
+    /** Pin the grid plate's container inline size exactly, for a seam case. */
+    readonly plate?: number;
+    /** Pin the spotlight plate's container inline size exactly. */
+    readonly spotlightPlate?: number;
+  },
+): Promise<void> {
+  await page.setViewportSize({ width: options.width, height: 1200 });
+  const params = new URLSearchParams({
+    board: options.board ?? "realistic",
+    pools: String(options.pools ?? 6),
+  });
+  if (options.drawer === true) params.set("drawer", "1");
+  if (options.view !== undefined) params.set("view", options.view);
+  if (options.plate !== undefined) params.set("plate", String(options.plate));
+  if (options.spotlightPlate !== undefined) {
+    params.set("spotlightPlate", String(options.spotlightPlate));
+  }
+  await page.goto(`/?${params.toString()}`);
+  await page.waitForSelector(
+    options.view === "spotlight"
+      ? '[data-vex-area="board-spotlight-hero"]'
+      : '[data-vex-area="board-token-card-v3"]',
+  );
+  // THE FONT, THEN THE DIALOG'S OWN ANIMATION, THEN THE FRAME.
+  //
+  // Every number this file asserts is a text measurement, and the display
+  // face arrives asynchronously: measuring before `document.fonts.ready`
+  // reads the fallback's metrics and produces heights that differ between
+  // cards purely by load timing.
+  //
+  // The board dialog also opens with a scale, and a residual
+  // `matrix(0.998275, ...)` on the `<dialog>` scales every
+  // `getBoundingClientRect` beneath it while `getComputedStyle`'s grid tracks
+  // stay unscaled - which reads as a card that misses its track by two
+  // pixels, invented entirely by WHEN the measurement happened.
+  //
+  // So the gate is the PRECONDITION ITSELF - the dialog carrying no transform
+  // - polled per frame, and not a clock and not `Animation.finished`: the
+  // page also runs animations that never finish by design, and awaiting those
+  // hangs until the test times out. The deadline below is a safety net that
+  // turns a hang into a measured failure, never the thing being waited on.
+  // Two frames after that, so the container query and the layout it triggers
+  // have both landed.
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    await new Promise<void>((resolve) => {
+      const deadline = performance.now() + 2000;
+      const settled = (): void => {
+        const dialog = document.querySelector("dialog");
+        if (
+          dialog === null ||
+          getComputedStyle(dialog).transform === "none" ||
+          performance.now() > deadline
+        ) {
+          resolve();
+          return;
+        }
+        requestAnimationFrame(settled);
+      };
+      requestAnimationFrame(settled);
+    });
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          resolve(null);
+        });
+      });
+    });
+  });
+}
+
+/** Every element inside a card whose text is cut horizontally. */
+async function ellipsizedRegions(
+  page: Page,
+  exempt: readonly string[],
+): Promise<readonly OverflowingRegion[]> {
+  return page.evaluate((exemptAreas) => {
+    const found: OverflowingRegion[] = [];
+    for (const card of document.querySelectorAll(
+      '[data-vex-area="board-token-card-v3"]',
+    )) {
+      const name =
+        card.querySelector('[data-vex-area="board-token-name"]')?.textContent ??
+        "?";
+      for (const element of card.querySelectorAll("*")) {
+        if (!(element instanceof HTMLElement)) continue;
+        if (element.clientWidth === 0) continue;
+        if (element.classList.contains("sr-only")) continue;
+        const area = element.getAttribute("data-vex-area");
+        if (area !== null && exemptAreas.includes(area)) continue;
+        if (
+          element.closest(
+            exemptAreas.map((a) => `[data-vex-area="${a}"]`).join(","),
+          ) !== null
+        ) {
+          continue;
+        }
+        if (element.scrollWidth > element.clientWidth + 0.5) {
+          found.push({
+            card: name,
+            area: area ?? element.tagName.toLowerCase(),
+            text: element.textContent ?? "",
+            scrollWidth: element.scrollWidth,
+            clientWidth: element.clientWidth,
+          });
+        }
+      }
+    }
+    return found;
+  }, [...exempt]);
+}
+
+/** Card boxes and their grid tracks, as the engine actually laid them out. */
+async function geometry(page: Page): Promise<{
+  readonly tracks: readonly number[];
+  readonly cardWidths: readonly number[];
+  readonly cardHeights: readonly number[];
+}> {
+  return page.evaluate(() => {
+    const grid = document.querySelector("ul[data-vex-area='board-grid']");
+    const tracks =
+      grid === null
+        ? []
+        : getComputedStyle(grid)
+            .gridTemplateColumns.split(" ")
+            .filter((part) => part !== "" && part !== "none")
+            .map((part) => Math.round(Number.parseFloat(part)));
+    const cards = [...document.querySelectorAll(
+      '[data-vex-area="board-token-card-v3"]',
+    )];
+    return {
+      tracks,
+      cardWidths: cards.map((card) =>
+        Math.round(card.getBoundingClientRect().width),
+      ),
+      cardHeights: cards.map((card) =>
+        Math.round(card.getBoundingClientRect().height),
+      ),
+    };
+  });
+}
+
+/** Regions that wrap onto a line their fixed height cannot show. */
+async function verticallyClippedRegions(page: Page): Promise<readonly string[]> {
+  return page.evaluate(() => {
+    const cut: string[] = [];
+    for (const card of document.querySelectorAll(
+      '[data-vex-area="board-token-card-v3"]',
+    )) {
+      const name =
+        card.querySelector('[data-vex-area="board-token-name"]')?.textContent ??
+        "?";
+      for (const area of [
+        "board-token-price-row",
+        "board-token-stats",
+        "board-token-card-v3",
+      ]) {
+        const region = card.matches(`[data-vex-area="${area}"]`)
+          ? card
+          : card.querySelector(`[data-vex-area="${area}"]`);
+        if (!(region instanceof HTMLElement)) continue;
+        // The region itself, and the content box inside it: a flex child that
+        // wraps taller than its fixed-height parent is the defect, and the
+        // parent's own scrollHeight does not always report it.
+        for (const node of [region, ...region.children]) {
+          if (!(node instanceof HTMLElement)) continue;
+          const room =
+            node === region
+              ? node.clientHeight
+              : region.clientHeight;
+          if (node.scrollHeight > room + 0.5) {
+            cut.push(`${name}/${area}: ${String(node.scrollHeight)} in ${String(room)}`);
+          }
+        }
+      }
+    }
+    return cut;
+  });
+}
+
+/** Computed grid tracks and the mode the query published, for one selector. */
+async function modeOf(
+  page: Page,
+  selector: string,
+): Promise<{ readonly tracks: number; readonly mode: string }> {
+  return page.evaluate((sel) => {
+    const element = document.querySelector(sel);
+    if (element === null) return { tracks: -1, mode: "missing" };
+    const style = getComputedStyle(element);
+    return {
+      tracks: style.gridTemplateColumns
+        .split(" ")
+        .filter((part) => part !== "" && part !== "none").length,
+      mode: style.getPropertyValue("--vex-board-mode").trim(),
+    };
+  }, selector);
+}
+
+/**
+ * THE LADDER, AS ADVERTISED. This table is the head comment of
+ * `global-css/board-layout.css` transcribed into assertions - not a second
+ * owner of the numbers, but the thing that makes the stylesheet's ownership
+ * falsifiable. A permanent one-column regression, or a mode that stopped
+ * switching, fails every row of it.
+ */
+const COLUMN_LADDER: readonly {
+  readonly min: number;
+  readonly columns: number;
+  readonly mode: string;
+}[] = [
+  { min: 1538, columns: 3, mode: "wide" },
+  { min: 1106, columns: 3, mode: "compact" },
+  { min: 1020, columns: 2, mode: "wide" },
+  { min: 732, columns: 2, mode: "compact" },
+  { min: 502, columns: 1, mode: "wide" },
+  { min: 0, columns: 1, mode: "compact" },
+];
+
+function expectedAt(container: number): { columns: number; mode: string } {
+  for (const step of COLUMN_LADDER) {
+    if (container >= step.min) return { columns: step.columns, mode: step.mode };
+  }
+  return { columns: 1, mode: "compact" };
+}
+
+/** Exact, minus one, plus one, and a fractional hair under the threshold. */
+function seamsOf(threshold: number): readonly number[] {
+  return [threshold - 1, threshold, threshold + 1, threshold - 0.02];
+}
+
+const GRID_THRESHOLDS = [358, 502, 732, 1020, 1106, 1538] as const;
+
+const WIDTHS = [800, 1000, 1280, 1366, 1440, 1920] as const;
+
+test.describe("board grid geometry", () => {
+  for (const width of WIDTHS) {
+    for (const drawer of [false, true]) {
+      const label = `${String(width)}px${drawer ? " with the Ask VEX drawer" : ""}`;
+
+      test(`cuts no figure, label, badge or action at ${label}`, async ({ page }) => {
+        await open(page, { width, drawer });
+        expect(await ellipsizedRegions(page, CLIPPED_BY_DESIGN)).toEqual([]);
+      });
+
+      test(`shows every card at its full height at ${label}`, async ({ page }) => {
+        await open(page, { width, drawer });
+        expect(await verticallyClippedRegions(page)).toEqual([]);
+      });
+
+      test(`gives every card in the grid the same box at ${label}`, async ({ page }) => {
+        await open(page, { width, drawer });
+        const { tracks, cardWidths, cardHeights } = await geometry(page);
+        // EQUAL CARDS ARE A CONTRACT (TokenCardV3's own head note). One width
+        // and one height across the whole grid, and the card fills its track
+        // rather than shrinking to its content inside it.
+        expect(new Set(cardWidths).size).toBe(1);
+        expect(new Set(cardHeights).size).toBe(1);
+        // Within one pixel, because a fractional container divided by three
+        // leaves the engine rounding the track and the card's border box
+        // independently (1280 with the drawer gives a 371.6px track). The
+        // assertion that matters is the two above: one width, one height.
+        expect(
+          Math.abs((cardWidths[0] ?? 0) - (tracks[0] ?? 0)),
+        ).toBeLessThanOrEqual(1);
+      });
+    }
+  }
+
+  test("picks columns from the container, not the viewport", async ({ page }) => {
+    // The defect this arc exists for: the drawer removes 360px from the
+    // CONTAINER while a viewport ladder keeps asking for the same columns.
+    await open(page, { width: 1440, drawer: false });
+    const wide = await geometry(page);
+    await open(page, { width: 1440, drawer: true });
+    const narrow = await geometry(page);
+    // Same viewport, smaller container: either fewer columns, or the same
+    // columns at a width that still clears every region floor. What must
+    // never happen is the tracks staying put while the cards are squeezed
+    // below what their content needs.
+    expect(narrow.cardWidths[0]).toBeGreaterThanOrEqual(358);
+    expect(wide.cardWidths[0]).toBeGreaterThanOrEqual(358);
+  });
+
+  test("survives the longest safety verdict landing late, with the drawer open", async ({
+    page,
+  }) => {
+    // The async overlay case. Every card starts on "Checking" (95px) and
+    // settles on "Checks unavailable in this response" (242px), which is the
+    // widest string the frozen chip table can produce. Neither state may cut
+    // a label, and the grid must not reflow the reader's cards under them.
+    await open(page, { width: 1440, drawer: true });
+    const before = await geometry(page);
+    expect(await ellipsizedRegions(page, CLIPPED_BY_DESIGN)).toEqual([]);
+
+    await page.evaluate(() => {
+      window.__vexBoardLayoutHarness.settleSafety();
+    });
+    await expect(
+      page.locator('[data-vex-area="board-status-chip"]').first(),
+    ).toHaveText(/Checks unavailable in this response/);
+
+    expect(await ellipsizedRegions(page, CLIPPED_BY_DESIGN)).toEqual([]);
+    expect(await verticallyClippedRegions(page)).toEqual([]);
+    const after = await geometry(page);
+    expect(after.cardHeights).toEqual(before.cardHeights);
+  });
+
+  test("keeps a schema extreme recoverable rather than silently cut", async ({
+    page,
+  }) => {
+    // A 40-character decimal and a 512-character symbol both parse
+    // (`BOARD_DECIMAL_MAX_CHARS`, `BOARD_TOKEN_LABEL_MAX_CHARS`). Neither can
+    // fit any card, so the recovery path must be VISIBLE and reachable by
+    // keyboard - a hover-only `title` is not a recovery path.
+    await open(page, { width: 1440, board: "extreme", pools: 3 });
+    const disclosure = page
+      .locator('[data-vex-area="board-token-full-value"]')
+      .first();
+    await expect(disclosure).toBeVisible();
+    await disclosure.focus();
+    await page.keyboard.press("Enter");
+    await expect(
+      page.locator('[data-vex-area="board-token-full-value-popover"]'),
+    ).toBeVisible();
+  });
+
+  for (const at of [
+    { label: "1440px", width: 1440 },
+    { label: "the compact floor", width: 1440, plate: 356 },
+  ]) {
+    test(`cuts no extreme figure silently at ${at.label}`, async ({ page }) => {
+      // THE EXTREME CASE RUNS THE SAME ASSERTION SET AS EVERY OTHER WIDTH.
+      // A card that clips a `whitespace-nowrap` figure against
+      // `overflow-hidden` shows a reader half a number with nothing saying
+      // so, which is the silent loss the disclosure exists to prevent - and
+      // it stays silent until this assertion is allowed to run here.
+      await open(page, {
+        width: at.width,
+        board: "extreme",
+        pools: 3,
+        ...(at.plate === undefined ? {} : { plate: at.plate }),
+      });
+      expect(await ellipsizedRegions(page, CLIPPED_BY_DESIGN)).toEqual([]);
+      expect(await verticallyClippedRegions(page)).toEqual([]);
+    });
+  }
+
+  test("names the cut state on the card that shortened a value", async ({
+    page,
+  }) => {
+    // NAMED, NOT GENERIC. "Show the full values" tells a reader a panel
+    // exists; it does not tell them the figure in front of them is not the
+    // whole figure. The affordance has to say the second thing.
+    await open(page, { width: 1440, board: "extreme", pools: 3 });
+    const extreme = page
+      .locator('[data-vex-area="board-token-card-v3"]')
+      .first();
+    await expect(
+      extreme.locator('[data-vex-area="board-token-full-value"]'),
+    ).toHaveAttribute("aria-label", /shortened/i);
+    await expect(
+      extreme.locator('[data-vex-area="board-token-price"]'),
+    ).toHaveAttribute("data-shortened", "true");
+
+    // And it is NOT claimed where nothing was cut: a realistic row keeps the
+    // plain affordance, so the named state stays informative.
+    await open(page, { width: 1440, board: "realistic", pools: 6 });
+    await expect(
+      page.locator('[data-vex-area="board-token-full-value"]').first(),
+    ).not.toHaveAttribute("aria-label", /shortened/i);
+  });
+
+  test("contains the disclosure's tab sequence and restores focus", async ({
+    page,
+  }) => {
+    // THE OVERLAY IS A `role="dialog"` OVER OBSCURED CONTROLS. Per the WAI
+    // modal-dialog pattern its tab sequence must stay inside it: a Tab that
+    // reaches the card underneath puts focus on a control the reader cannot
+    // see, and an Escape from there closes the WHOLE board.
+    await open(page, { width: 1440, board: "realistic", pools: 6 });
+    const trigger = page
+      .locator('[data-vex-area="board-token-full-value"]')
+      .first();
+    await trigger.focus();
+    await page.keyboard.press("Enter");
+    const popover = page.locator(
+      '[data-vex-area="board-token-full-value-popover"]',
+    );
+    await expect(popover).toBeVisible();
+
+    const inside = async (): Promise<boolean> =>
+      page.evaluate(
+        () =>
+          document.activeElement?.closest(
+            '[data-vex-area="board-token-full-value-popover"]',
+          ) !== null &&
+          document.activeElement?.closest(
+            '[data-vex-area="board-token-full-value-popover"]',
+          ) !== undefined,
+      );
+
+    expect(await inside()).toBe(true);
+    for (let step = 0; step < 4; step += 1) {
+      await page.keyboard.press("Tab");
+      expect(await inside()).toBe(true);
+    }
+    for (let step = 0; step < 4; step += 1) {
+      await page.keyboard.press("Shift+Tab");
+      expect(await inside()).toBe(true);
+    }
+
+    // Escape closes ONLY the overlay, and focus comes back to the button
+    // that opened it. The board stays open behind it.
+    await page.keyboard.press("Escape");
+    await expect(popover).toHaveCount(0);
+    expect(
+      await page.evaluate(
+        () =>
+          document.activeElement?.getAttribute("data-vex-area") ?? "none",
+      ),
+    ).toBe("board-token-full-value");
+    await expect(
+      page.locator('[data-vex-surface="board-modal"]'),
+    ).toBeVisible();
+  });
+
+  test("moves no geometry under prefers-reduced-motion", async ({ browser }) => {
+    const context = await browser.newContext({ reducedMotion: "reduce" });
+    const page = await context.newPage();
+    await open(page, { width: 1440, drawer: true });
+    const before = await geometry(page);
+    await page.evaluate(() => {
+      window.__vexBoardLayoutHarness.setDrawer(false);
+    });
+    await page.waitForTimeout(50);
+    const settled = await geometry(page);
+    // No transition on a geometric property: the new layout is the layout,
+    // immediately, with nothing animating between the two.
+    const midflight = await geometry(page);
+    expect(midflight).toEqual(settled);
+    expect(before.cardWidths.length).toBeGreaterThan(0);
+    await context.close();
+  });
+});
+
+/**
+ * THE LADDER ITSELF, at every seam the stylesheet advertises.
+ *
+ * Driven through `?plate=`, which pins the container's CONTENT box - the box
+ * `container-type: inline-size` measures - so a case can sit one hundredth of
+ * a pixel under a threshold instead of wherever a viewport width happened to
+ * land after the dialog cap and two paddings.
+ */
+test.describe("board grid threshold seams", () => {
+  for (const threshold of GRID_THRESHOLDS) {
+    for (const container of seamsOf(threshold)) {
+      const want = expectedAt(container);
+      test(`gives ${String(container)}px ${String(want.columns)} ${want.mode} column(s)`, async ({
+        page,
+      }) => {
+        await open(page, { width: 1920, plate: container });
+        const measured = await modeOf(page, "ul[data-vex-area='board-grid']");
+        expect(measured).toEqual({
+          tracks: want.columns,
+          mode: want.mode,
+        });
+      });
+    }
+  }
+
+  test("pins the track at the compact floor below it and side-scrolls", async ({
+    page,
+  }) => {
+    await open(page, { width: 1920, plate: 300 });
+    const { tracks, cardWidths } = await geometry(page);
+    expect(tracks.length).toBe(1);
+    // The track REFUSES to shrink below the compact floor; the scroller takes
+    // over rather than a figure being cut.
+    expect(cardWidths[0]).toBeGreaterThanOrEqual(358);
+    expect(await ellipsizedRegions(page, CLIPPED_BY_DESIGN)).toEqual([]);
+    const scrolls = await page.evaluate(() => {
+      const scroller = document.querySelector(
+        '[data-vex-area="board-grid-scroller"]',
+      );
+      return scroller === null
+        ? false
+        : scroller.scrollWidth > scroller.clientWidth;
+    });
+    expect(scrolls).toBe(true);
+  });
+});
+
+/**
+ * THE SPOTLIGHT'S OWN REGIONS. Each threshold below is named in
+ * `board-layout.css` for the content that binds it, and none of them is a
+ * card threshold.
+ */
+test.describe("board spotlight region seams", () => {
+  const REGIONS = [
+    {
+      area: "board-spotlight-hero",
+      threshold: 884,
+      below: 2,
+      above: 4,
+    },
+    {
+      area: "board-spotlight-chart-row",
+      threshold: 856,
+      below: 1,
+      above: 2,
+    },
+    {
+      area: "board-spotlight-factual-row",
+      threshold: 576,
+      below: 1,
+      above: 2,
+    },
+    {
+      area: "board-spotlight-factual-row",
+      threshold: 872,
+      below: 2,
+      above: 3,
+    },
+    {
+      area: "board-spotlight-plus-row",
+      threshold: 656,
+      below: 1,
+      above: 2,
+    },
+  ] as const;
+
+  for (const region of REGIONS) {
+    for (const container of seamsOf(region.threshold)) {
+      const want = container >= region.threshold ? region.above : region.below;
+      test(`${region.area} takes ${String(want)} track(s) at ${String(container)}px`, async ({
+        page,
+      }) => {
+        await open(page, {
+          width: 1920,
+          view: "spotlight",
+          spotlightPlate: container,
+        });
+        const measured = await modeOf(page, `[data-vex-area="${region.area}"]`);
+        expect(measured.tracks).toBe(want);
+      });
+    }
+  }
+
+  test("stacks the compact hero instead of crushing the price into 88px", async ({
+    page,
+  }) => {
+    // THE DEFECT: below 884 the hero is `88px 1fr` and its four children are
+    // auto-placed, which puts the price block in row 2 COLUMN 1 - the 88px
+    // photo track - and the Spotlight toggle beside it. The price is the
+    // largest type on the surface; 88px is not a price.
+    await open(page, { width: 1920, view: "spotlight", spotlightPlate: 800 });
+    const boxes = await page.evaluate(() => {
+      const read = (area: string): { left: number; width: number } | null => {
+        const element = document.querySelector(`[data-vex-area="${area}"]`);
+        if (!(element instanceof HTMLElement)) return null;
+        const rect = element.getBoundingClientRect();
+        return { left: Math.round(rect.left), width: Math.round(rect.width) };
+      };
+      return {
+        photo: read("board-spotlight-photo"),
+        price: read("board-spotlight-price-block"),
+        toggle: read("board-spotlight-toggle"),
+      };
+    });
+    expect(boxes.photo).not.toBeNull();
+    expect(boxes.price).not.toBeNull();
+    expect(boxes.toggle).not.toBeNull();
+    // Both stacked rows start at the hero's own left edge and the price gets
+    // the whole inline size, not the photo's track.
+    expect(boxes.price?.left).toBe(boxes.photo?.left);
+    expect(boxes.toggle?.left).toBe(boxes.photo?.left);
+    expect(boxes.price?.width ?? 0).toBeGreaterThan(600);
+  });
+
+  test("keeps the four-track hero above the threshold", async ({ page }) => {
+    await open(page, { width: 1920, view: "spotlight", spotlightPlate: 1000 });
+    const boxes = await page.evaluate(() => {
+      const read = (area: string): { left: number } | null => {
+        const element = document.querySelector(`[data-vex-area="${area}"]`);
+        if (!(element instanceof HTMLElement)) return null;
+        return { left: Math.round(element.getBoundingClientRect().left) };
+      };
+      return {
+        photo: read("board-spotlight-photo"),
+        price: read("board-spotlight-price-block"),
+        toggle: read("board-spotlight-toggle"),
+      };
+    });
+    // Wide mode puts all four on ONE row, so nothing shares the photo's left.
+    expect(boxes.price?.left ?? 0).toBeGreaterThan(boxes.photo?.left ?? 0);
+    expect(boxes.toggle?.left ?? 0).toBeGreaterThan(boxes.price?.left ?? 0);
+  });
+});

--- a/vex-app/e2e/board-layout.spec.ts
+++ b/vex-app/e2e/board-layout.spec.ts
@@ -380,7 +380,7 @@ test.describe("board grid geometry", () => {
 
   for (const at of [
     { label: "1440px", width: 1440 },
-    { label: "the compact floor", width: 1440, plate: 356 },
+    { label: "the compact floor", width: 1440, plate: 358 },
   ]) {
     test(`cuts no extreme figure silently at ${at.label}`, async ({ page }) => {
       // THE EXTREME CASE RUNS THE SAME ASSERTION SET AS EVERY OTHER WIDTH.
@@ -424,55 +424,246 @@ test.describe("board grid geometry", () => {
     ).not.toHaveAttribute("aria-label", /shortened/i);
   });
 
-  test("contains the disclosure's tab sequence and restores focus", async ({
+  for (const at of [
+    { label: "1440px", width: 1440 },
+    { label: "the compact floor", width: 1440, plate: 358 },
+  ]) {
+    test(`cuts no wide-glyph ticker silently at ${at.label}`, async ({
+      page,
+    }) => {
+      // SCHEMA-VALID UNICODE IS ITS OWN AXIS. `baseTokenSymbol` admits 512
+      // UTF-16 code units of anything: a ten-character CJK ticker is twice
+      // the width of the Latin string the budget was measured against, so a
+      // budget counted in CHARACTERS passed it and the column overflowed with
+      // nothing reporting the cut. This board is CJK, emoji ZWJ sequences and
+      // combining marks, and it runs the whole assertion set.
+      await open(page, {
+        width: at.width,
+        board: "wide",
+        pools: 3,
+        ...(at.plate === undefined ? {} : { plate: at.plate }),
+      });
+      expect(await ellipsizedRegions(page, CLIPPED_BY_DESIGN)).toEqual([]);
+      expect(await verticallyClippedRegions(page)).toEqual([]);
+      // And every one of them says it shortened, rather than being silently
+      // clipped by the card.
+      await expect(
+        page.locator('[data-vex-area="board-token-ticker"]').first(),
+      ).toHaveAttribute("data-shortened", "true");
+    });
+  }
+
+  test("never renders a lone surrogate or half a grapheme in a ticker", async ({
     page,
   }) => {
-    // THE OVERLAY IS A `role="dialog"` OVER OBSCURED CONTROLS. Per the WAI
-    // modal-dialog pattern its tab sequence must stay inside it: a Tab that
-    // reaches the card underneath puts focus on a control the reader cannot
-    // see, and an Escape from there closes the WHOLE board.
+    // THE PERSISTENCE BOUNDARY, not only the pixels. A cut between the two
+    // halves of a surrogate pair produces an ill-formed string; a cut inside
+    // a ZWJ sequence produces a different token than the provider sent.
+    await open(page, { width: 1440, board: "wide", pools: 3 });
+    const findings = await page.evaluate(() => {
+      const bad: string[] = [];
+      for (const node of document.querySelectorAll(
+        '[data-vex-area="board-token-ticker"]',
+      )) {
+        const text = node.textContent ?? "";
+        for (let index = 0; index < text.length; index += 1) {
+          const unit = text.charCodeAt(index);
+          const high = unit >= 0xd800 && unit <= 0xdbff;
+          const low = unit >= 0xdc00 && unit <= 0xdfff;
+          if (!high && !low) continue;
+          const next = text.charCodeAt(index + 1);
+          const paired =
+            high && next >= 0xdc00 && next <= 0xdfff;
+          if (paired) {
+            index += 1;
+            continue;
+          }
+          bad.push(`lone surrogate at ${String(index)} in ${text}`);
+        }
+        // A trailing zero-width joiner is half a sequence.
+        const withoutMark = text.endsWith("…") ? text.slice(0, -1) : text;
+        if (withoutMark.endsWith("‍")) {
+          bad.push(`dangling ZWJ in ${text}`);
+        }
+      }
+      return bad;
+    });
+    expect(findings).toEqual([]);
+  });
+
+  test("is a disclosure, not a dialog, and leaves the board interactive", async ({
+    page,
+  }) => {
+    // `aria-modal` WOULD BE A LIE HERE: nothing outside this panel is inert.
+    // So it is what it is - a labelled group a button expands - and the rest
+    // of the board stays as reachable as the markup says it is.
+    await open(page, { width: 1440, board: "realistic", pools: 6 });
+    const triggers = page.locator('[data-vex-area="board-token-full-value"]');
+    const first = triggers.nth(0);
+    await first.focus();
+    await page.keyboard.press("Enter");
+
+    const panel = page.locator(
+      '[data-vex-area="board-token-full-value-popover"]',
+    );
+    await expect(panel).toHaveCount(1);
+    await expect(panel).toHaveAttribute("role", "group");
+    expect(await panel.getAttribute("aria-modal")).toBeNull();
+    await expect(first).toHaveAttribute("aria-expanded", "true");
+    // The trigger points AT the panel it expanded.
+    expect(await first.getAttribute("aria-controls")).toBe(
+      await panel.getAttribute("id"),
+    );
+
+    // POINTER: another card is not blocked by anything. Its Spotlight really
+    // fires, which is the proof `aria-modal` had no right to claim otherwise.
+    const otherCard = page
+      .locator('[data-vex-area="board-token-card-v3"]')
+      .nth(1);
+    await otherCard.locator('[data-vex-area="board-card-spotlight"]').click();
+    await expect(
+      page.locator('[data-vex-area="board-spotlight-hero"]'),
+    ).toBeVisible();
+  });
+
+  test("tabs out of the card entirely, never onto a covered control", async ({
+    page,
+  }) => {
+    // THE POINT OF NOT TRAPPING, PROVEN WHERE FOCUS REALLY MOVES. The panel is
+    // opaque and covers its whole card, so that card's own buttons cannot be
+    // seen while it is open - and they carry `tabIndex="-1"` for exactly that
+    // long. Tab out of the panel therefore leaves the CARD, not merely the
+    // panel, and never lands on something the reader cannot see (rule 08).
+    await open(page, { width: 1440, board: "realistic", pools: 6 });
+    const owner = page
+      .locator('[data-vex-area="board-token-card-v3"]')
+      .nth(2);
+    const trigger = owner.locator('[data-vex-area="board-token-full-value"]');
+    const panel = owner.locator(
+      '[data-vex-area="board-token-full-value-popover"]',
+    );
+
+    await trigger.focus();
+    await page.keyboard.press("Enter");
+    await expect(panel).toBeVisible();
+
+    // Every covered control has left the tab order AND kept its accessible
+    // name - which is the whole difference between this and `inert`.
+    expect(
+      await owner.evaluate((card) =>
+        [
+          "board-token-full-value",
+          "board-card-spotlight",
+          "board-token-dexscreener-link",
+          "board-card-ask",
+        ].map((name) => {
+          const node = card.querySelector(`[data-vex-area="${name}"]`);
+          return `${name}=${node?.getAttribute("tabindex") ?? "none"}/${
+            (node?.getAttribute("aria-label") ?? "") === "" ? "unnamed" : "named"
+          }`;
+        }),
+      ),
+    ).toEqual([
+      "board-token-full-value=-1/named",
+      "board-card-spotlight=-1/named",
+      "board-token-dexscreener-link=-1/named",
+      "board-card-ask=-1/named",
+    ]);
+
+    /** Which card holds focus, and on what, right now. */
+    const focus = async (): Promise<string> =>
+      page.evaluate(() => {
+        const active = document.activeElement;
+        const card = active?.closest(
+          '[data-vex-area="board-token-card-v3"]',
+        );
+        if (card === null || card === undefined) return "outside any card";
+        const cards = [
+          ...document.querySelectorAll('[data-vex-area="board-token-card-v3"]'),
+        ];
+        return `card ${String(cards.indexOf(card))}: ${
+          active?.getAttribute("data-vex-area") ?? "?"
+        }`;
+      });
+
+    // FORWARD, out of the panel's last focusable element.
+    await page.keyboard.press("Tab");
+    expect(await focus()).not.toContain("card 2:");
+
+    // BACKWARD, out of its first, from a fresh open.
+    await trigger.focus();
+    await page.keyboard.press("Enter");
+    await expect(panel).toBeVisible();
+    await page.keyboard.press("Shift+Tab");
+    expect(await focus()).not.toContain("card 2:");
+
+    // And Escape from INSIDE the panel - the only place a reader can press it
+    // from, since everything else on this card has left the tab order - hands
+    // focus back to the trigger, which is `tabIndex="-1"` at the moment it is
+    // asked to take it. That is precisely what `inert` would have made
+    // impossible, and it is why this is `tabIndex` and not `inert`.
+    await owner
+      .locator('[data-vex-area="board-token-full-value-close"]')
+      .focus();
+    await page.keyboard.press("Escape");
+    await expect(panel).toHaveCount(0);
+    expect(await focus()).toBe("card 2: board-token-full-value");
+    // The attributes come back with the state.
+    expect(
+      await owner
+        .locator('[data-vex-area="board-card-spotlight"]')
+        .getAttribute("tabindex"),
+    ).toBeNull();
+  });
+
+  test("lets two cards show their values at once", async ({ page }) => {
+    // MULTIPLE OPEN IS THE DEFINED BEHAVIOUR, not an accident: comparing two
+    // pools' raw decimals side by side is the reason to have this at all.
+    await open(page, { width: 1440, board: "realistic", pools: 6 });
+    const triggers = page.locator('[data-vex-area="board-token-full-value"]');
+    await triggers.nth(0).click();
+    await triggers.nth(1).click();
+    await expect(
+      page.locator('[data-vex-area="board-token-full-value-popover"]'),
+    ).toHaveCount(2);
+    // Two distinct panels, each pointed at by its own trigger.
+    expect(await triggers.nth(0).getAttribute("aria-controls")).not.toBe(
+      await triggers.nth(1).getAttribute("aria-controls"),
+    );
+  });
+
+  test("closes on Escape, restores focus, and leaves the board open", async ({
+    page,
+  }) => {
     await open(page, { width: 1440, board: "realistic", pools: 6 });
     const trigger = page
       .locator('[data-vex-area="board-token-full-value"]')
       .first();
     await trigger.focus();
     await page.keyboard.press("Enter");
-    const popover = page.locator(
+    const panel = page.locator(
       '[data-vex-area="board-token-full-value-popover"]',
     );
-    await expect(popover).toBeVisible();
-
-    const inside = async (): Promise<boolean> =>
-      page.evaluate(
-        () =>
-          document.activeElement?.closest(
-            '[data-vex-area="board-token-full-value-popover"]',
-          ) !== null &&
-          document.activeElement?.closest(
-            '[data-vex-area="board-token-full-value-popover"]',
-          ) !== undefined,
-      );
-
-    expect(await inside()).toBe(true);
-    for (let step = 0; step < 4; step += 1) {
-      await page.keyboard.press("Tab");
-      expect(await inside()).toBe(true);
-    }
-    for (let step = 0; step < 4; step += 1) {
-      await page.keyboard.press("Shift+Tab");
-      expect(await inside()).toBe(true);
-    }
-
-    // Escape closes ONLY the overlay, and focus comes back to the button
-    // that opened it. The board stays open behind it.
-    await page.keyboard.press("Escape");
-    await expect(popover).toHaveCount(0);
+    await expect(panel).toBeVisible();
+    // Focus MOVES into the panel on open. Not a modal obligation - this panel
+    // paints over its own card, so focus left behind it would be operating a
+    // control the reader can no longer see.
     expect(
       await page.evaluate(
-        () =>
-          document.activeElement?.getAttribute("data-vex-area") ?? "none",
+        () => document.activeElement?.getAttribute("data-vex-area") ?? "none",
+      ),
+    ).toBe("board-token-full-value-close");
+
+    await page.keyboard.press("Escape");
+    await expect(panel).toHaveCount(0);
+    expect(
+      await page.evaluate(
+        () => document.activeElement?.getAttribute("data-vex-area") ?? "none",
       ),
     ).toBe("board-token-full-value");
+    await expect(trigger).toHaveAttribute("aria-expanded", "false");
+    // The board `<dialog>` listens for the same key and must not have taken
+    // it: closing a panel is not closing the board.
     await expect(
       page.locator('[data-vex-surface="board-modal"]'),
     ).toBeVisible();

--- a/vex-app/playwright.config.ts
+++ b/vex-app/playwright.config.ts
@@ -37,10 +37,40 @@ export default defineConfig({
     screenshot: "only-on-failure",
     video: "off",
   },
+  // The board layout harness is a Vite dev server, not the Electron app, and
+  // only the `board-layout` project uses it. Playwright starts it on demand
+  // and reuses an already-running one locally.
+  webServer: {
+    command: "pnpm exec vite --config vite.board-layout.config.ts",
+    url: "http://127.0.0.1:5273/",
+    reuseExistingServer: !isCI,
+    timeout: 120_000,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
   projects: [
     {
       name: "electron-smoke",
       testMatch: /.*\.spec\.ts$/,
+      testIgnore: /board-layout\.spec\.ts$/,
+    },
+    /**
+     * BOARD GEOMETRY, in a real engine at real widths.
+     *
+     * Chromium rather than Electron because the board modal is unreachable
+     * from the Electron fixture (see `e2e/smoke.spec.ts`: everything past
+     * SystemCheck needs a live Docker daemon and an unlocked vault), and
+     * because geometry is decided entirely by the renderer's own container
+     * queries over the real production stylesheet - which is exactly what
+     * `vite.board-layout.config.ts` serves.
+     */
+    {
+      name: "board-layout",
+      testMatch: /board-layout\.spec\.ts$/,
+      use: {
+        browserName: "chromium",
+        baseURL: "http://127.0.0.1:5273/",
+      },
     },
   ],
 });

--- a/vex-app/src/renderer/dev/board-layout/harness.css
+++ b/vex-app/src/renderer/dev/board-layout/harness.css
@@ -1,0 +1,10 @@
+/* The renderer's own stylesheet, verbatim, plus the source glob Tailwind
+ * would otherwise infer from the Vite root.
+ *
+ * `vite.board-layout.config.ts` roots the dev server at THIS directory, so
+ * Tailwind's automatic content detection would scan only the harness and emit
+ * none of the utilities the board's components carry - which would measure a
+ * layout the product does not have. `@source` points it back at the whole
+ * renderer tree, which is exactly what `vite.renderer.config.ts` gives it. */
+@import "../../styles/globals.css";
+@source "../../";

--- a/vex-app/src/renderer/dev/board-layout/harness.tsx
+++ b/vex-app/src/renderer/dev/board-layout/harness.tsx
@@ -16,7 +16,8 @@
  * preload bridge. Faking anything above it would prove a layout the product
  * does not have.
  *
- * THE CONTROL SURFACE. The URL decides the board (`?board=realistic|extreme`,
+ * THE CONTROL SURFACE. The URL decides the board
+ * (`?board=realistic|extreme|wide`,
  * `?pools=N`), which view is mounted (`?view=grid|spotlight`) and, for the
  * seam matrix, the EXACT inline size of a query container (`?plate=C`,
  * `?spotlightPlate=C`). `window.__vexBoardLayoutHarness` decides what changes
@@ -252,6 +253,57 @@ const EXTREME_ROWS: readonly Partial<BoardHydratedRow>[] = [
   ...REALISTIC_ROWS.slice(0, 2),
 ];
 
+/**
+ * SCHEMA-VALID UNICODE, which is a different axis from schema-valid LENGTH.
+ *
+ * `baseTokenSymbol` is `z.string().min(1).max(512)` - 512 UTF-16 CODE UNITS of
+ * ANY Unicode, not 512 Latin letters. A full-width CJK character is about
+ * twice the width of the Latin one the budgets were measured against, an emoji
+ * ZWJ sequence is ONE grapheme built from seven code points, and a combining
+ * mark is a code point with no width of its own. Each row below is one of
+ * those, and the overflow assertions run over all of them at the compact
+ * floor - the case a length-in-characters budget passed while overflowing.
+ */
+const WIDE_ROWS: readonly Partial<BoardHydratedRow>[] = [
+  {
+    // Ten full-width characters: twenty slots, and short enough in CHARACTERS
+    // to have sat under a ten-character budget while overflowing its column.
+    baseTokenSymbol: "比特币现金交易所代币",
+    baseTokenName: "比特币现金交易所代币",
+    priceUsd: "104238.9174",
+    priceChange: { h1: "-1.73", h24: "-12.48" },
+    liquidityUsd: "495612.34",
+    volumeH24Usd: "12456789.01",
+    txns: { buys: 12345, sells: 9876 },
+    pairAgeSeconds: 31_536_000,
+  },
+  {
+    // A ZWJ family, a tag-sequence flag, a regional-indicator pair: one
+    // grapheme each, several code points each. A cut inside any of them
+    // renders half a sequence, which is a different token than the one sent.
+    baseTokenSymbol: "👨‍👩‍👧‍👦🏴󠁧󠁢󠁳󠁣󠁴󠁿👩‍💻🇯🇵🧑‍🚀👨‍👩‍👧‍👦🇯🇵",
+    baseTokenName: "Emoji Sequence Token",
+    priceUsd: "0.00000123",
+    priceChange: { h1: "4.10", h24: "661" },
+    liquidityUsd: "75189.01",
+    volumeH24Usd: "464284.04",
+    txns: { buys: 1235, sells: 856 },
+    pairAgeSeconds: 259_200,
+  },
+  {
+    // Base characters carrying combining marks, then astral code points whose
+    // surrogate pairs a code-unit slice would split down the middle.
+    baseTokenSymbol: "ZÁLGO̰TOKÉN\u{1D400}\u{1D401}\u{1D402}",
+    baseTokenName: "Combining Marks Token",
+    priceUsd: "1.2345",
+    priceChange: { h1: "-0.5", h24: "8.31" },
+    liquidityUsd: "18400000",
+    volumeH24Usd: "3210987.65",
+    txns: { buys: 8888, sells: 7777 },
+    pairAgeSeconds: 1800,
+  },
+];
+
 function row(overrides: Partial<BoardHydratedRow>): BoardHydratedRow {
   return {
     baseTokenSymbol: "PEPE",
@@ -272,7 +324,12 @@ function row(overrides: Partial<BoardHydratedRow>): BoardHydratedRow {
 }
 
 function harnessSpec(kind: string, poolCount: number): BoardSpecV1 {
-  const source = kind === "extreme" ? EXTREME_ROWS : REALISTIC_ROWS;
+  const source =
+    kind === "extreme"
+      ? EXTREME_ROWS
+      : kind === "wide"
+        ? WIDE_ROWS
+        : REALISTIC_ROWS;
   const rows: BoardHydratedRow[] = [];
   for (let index = 0; index < poolCount; index += 1) {
     rows.push(row(source[index % source.length] ?? {}));

--- a/vex-app/src/renderer/dev/board-layout/harness.tsx
+++ b/vex-app/src/renderer/dev/board-layout/harness.tsx
@@ -291,6 +291,22 @@ const WIDE_ROWS: readonly Partial<BoardHydratedRow>[] = [
     pairAgeSeconds: 259_200,
   },
   {
+    // WIDE LATIN, which is not an exotic case at all. The ticker renders in
+    // PROPORTIONAL uppercase Inter Tight, where `W` advances 11.82px at 13px
+    // against a slot of 8.8px: eight of them are 94.56px inside an 88px
+    // column while costing only eight of ten CHARACTERS. Latin-1, short, and
+    // it overflowed anyway - the case that proves a character count is not a
+    // width on this surface.
+    baseTokenSymbol: "WWWWWWWW",
+    baseTokenName: "Wide Latin Token",
+    priceUsd: "0.0084213",
+    priceChange: { h1: "0", h24: "-0.42" },
+    liquidityUsd: "2341000.55",
+    volumeH24Usd: "998877.10",
+    txns: { buys: 998, sells: 1_240_000 },
+    pairAgeSeconds: 7200,
+  },
+  {
     // Base characters carrying combining marks, then astral code points whose
     // surrogate pairs a code-unit slice would split down the middle.
     baseTokenSymbol: "ZÁLGO̰TOKÉN\u{1D400}\u{1D401}\u{1D402}",

--- a/vex-app/src/renderer/dev/board-layout/harness.tsx
+++ b/vex-app/src/renderer/dev/board-layout/harness.tsx
@@ -1,0 +1,451 @@
+/**
+ * BOARD LAYOUT HARNESS - the page `e2e/board-layout.spec.ts` drives.
+ *
+ * DEV SCAFFOLDING, NEVER A SHIPPED SURFACE. Nothing in `src/renderer/main.tsx`
+ * imports this module and `vite.renderer.config.ts` has a single rollup input
+ * (`src/renderer/index.html`), so no byte of this file can reach a packaged
+ * build. It exists because board geometry is decided by the renderer's own
+ * container queries and can only be MEASURED in a real engine at real widths;
+ * the Electron smoke fixture cannot reach the board modal at all (its head
+ * note: everything past SystemCheck needs a live Docker daemon and an
+ * unlocked vault).
+ *
+ * IT MOUNTS THE REAL THING. The real `BoardModalHost`, the real `BoardGrid`,
+ * the real `TokenCardV3`, and `styles/globals.css` verbatim. What is faked is
+ * exactly the process boundary: `window.vex`, which in the product is the
+ * preload bridge. Faking anything above it would prove a layout the product
+ * does not have.
+ *
+ * THE CONTROL SURFACE. The URL decides the board (`?board=realistic|extreme`,
+ * `?pools=N`), which view is mounted (`?view=grid|spotlight`) and, for the
+ * seam matrix, the EXACT inline size of a query container (`?plate=C`,
+ * `?spotlightPlate=C`). `window.__vexBoardLayoutHarness` decides what changes
+ * DURING a test: the drawer, and the moment the safety read settles. The async
+ * verdict case is the whole reason the settle is a control rather than a
+ * fixture - a verdict that lands late is the layout event the production
+ * screenshot caught mid-flight.
+ *
+ * WHY THE CONTAINER IS DRIVEN DIRECTLY AND NOT THROUGH THE VIEWPORT. Every
+ * threshold in `global-css/board-layout.css` is a question about a container's
+ * inline size, and the chain from a viewport width to that number runs through
+ * the dialog's `min(94vw, ...)` cap, the modal body and two paddings. A seam
+ * case has to land ON the number - 727.98px, not "whatever 1100px of window
+ * happened to leave" - so `?plate=` pins the container's CONTENT box with
+ * `box-sizing: content-box`, which is the box `container-type: inline-size`
+ * measures. Nothing but the width is overridden: the padding, the border and
+ * every rule under test are the product's own.
+ */
+
+import { StrictMode, useEffect, useState, type JSX } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type {
+  BoardHydratedRow,
+  BoardPoolInput,
+  BoardSpecV1,
+} from "@vex-lib/board/index.js";
+import { BOARD_STALE_AFTER_MS } from "@vex-lib/board/index.js";
+import { BoardGrid } from "../../features/appShell/Board/BoardGrid.js";
+import { BoardModalHost } from "../../features/appShell/Board/BoardModalHost.js";
+import { BoardSpotlight } from "../../features/appShell/Board/BoardSpotlight.js";
+import { boardRefOf } from "../../features/appShell/Board/board-surface-contracts.js";
+import { useBoardSurfaceStore } from "../../features/appShell/Board/board-surface-store.js";
+import "./harness.css";
+
+const FETCHED_AT = 1_783_172_700_000;
+
+/* ------------------------------------------------------------------ */
+/* The fake process boundary                                           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * The safety read, held open until the test settles it.
+ *
+ * `unavailable`/`transport` with no cached evidence classifies as the
+ * `unavailable` state, whose chip label - "Checks unavailable in this
+ * response" - is the LONGEST string the frozen chip table can produce. That
+ * is deliberate: the footer has to survive its own worst case, and a test
+ * that settled on "Clean checks" would prove nothing about the case the
+ * production screenshot broke on.
+ */
+let settleSafety: (() => void) | null = null;
+
+function installFakeBridge(pools: readonly BoardPoolInput[]): void {
+  const safetyPromise = new Promise<unknown>((resolve) => {
+    settleSafety = () => {
+      resolve({
+        ok: true,
+        data: {
+          entries: pools.map((pool) => ({
+            key: `${pool.chain}:${pool.pairAddress}`,
+            subject: { chain: pool.chain, pairAddress: pool.pairAddress },
+            outcome: { kind: "unavailable", reason: "transport" },
+          })),
+        },
+      });
+    };
+  });
+
+  Object.defineProperty(window, "vex", {
+    configurable: true,
+    writable: true,
+    value: {
+      boardIcons: {
+        // A settled absence: every card wears its monogram, which is the
+        // common case on a real board and the one that costs no network.
+        read: (input: { readonly iconId: string }) =>
+          Promise.resolve({
+            ok: true,
+            data: {
+              iconId: input.iconId,
+              icon: { kind: "absent", reason: "not_found" },
+            },
+          }),
+      },
+      boardSparkline: {
+        hydrate: () => ({
+          promise: Promise.resolve({
+            ok: true,
+            data: { entries: [], deadlineHit: false },
+          }),
+          cancel: () => undefined,
+        }),
+      },
+      boardDetails: {
+        prefetch: () => ({ promise: safetyPromise, cancel: () => undefined }),
+        read: () => unavailable(),
+      },
+      // THE SPOTLIGHT'S SIX CHANNELS, ALL REFUSING. Every section renders its
+      // own unavailable state, which is a DESIGNED state of the same elements
+      // (the sections' contract) and therefore a layout the product really
+      // has. It is also the widest of the settled states in the factual row,
+      // so the region thresholds are measured against their own worst case
+      // rather than against an empty frame.
+      boardSpotlight: {
+        topTraders: () => unavailable(),
+        momentum: () => unavailable(),
+        context: () => unavailable(),
+        otherPools: () => unavailable(),
+        tapePoll: () => unavailable(),
+      },
+    },
+  });
+}
+
+/** A settled refusal in the bridge's own `Result` shape. */
+function unavailable(): {
+  readonly promise: Promise<unknown>;
+  readonly cancel: () => void;
+} {
+  return {
+    promise: Promise.resolve({
+      ok: false,
+      error: {
+        code: "provider.unavailable",
+        message: "The board layout harness serves no provider data.",
+        correlationId: "board-layout-harness",
+      },
+    }),
+    cancel: () => undefined,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Fixtures                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * REALISTIC COMPACT OUTPUT - the widest string each region renders in normal
+ * service, not the widest the schema permits.
+ *
+ * Every figure here is a real DexScreener shape: a five-figure price, a
+ * hundreds-of-thousands liquidity, a tens-of-millions volume, a five-digit
+ * trade tally and a year-old pair. These are what the mode floors are sized
+ * against; the schema extremes below are what the disclosure exists for.
+ */
+const REALISTIC_ROWS: readonly Partial<BoardHydratedRow>[] = [
+  {
+    baseTokenSymbol: "WBTC",
+    baseTokenName: "Wrapped Bitcoin",
+    priceUsd: "104238.9174",
+    priceChange: { h1: "-1.73", h24: "-12.48" },
+    liquidityUsd: "495612.34",
+    volumeH24Usd: "12456789.01",
+    txns: { buys: 12345, sells: 9876 },
+    pairAgeSeconds: 31_536_000,
+  },
+  {
+    baseTokenSymbol: "PEPE",
+    baseTokenName: "Pepe the Frog",
+    priceUsd: "0.00000123",
+    priceChange: { h1: "4.10", h24: "661" },
+    liquidityUsd: "75189.01",
+    volumeH24Usd: "464284.04",
+    txns: { buys: 1235, sells: 856 },
+    pairAgeSeconds: 259_200,
+  },
+  {
+    baseTokenSymbol: "DEGEN",
+    baseTokenName: "Degen Chain Token",
+    priceUsd: "0.0084213",
+    priceChange: { h1: "0", h24: "-0.42" },
+    liquidityUsd: "2341000.55",
+    volumeH24Usd: "998877.10",
+    txns: { buys: 998, sells: 1_240_000 },
+    pairAgeSeconds: 7200,
+  },
+  {
+    baseTokenSymbol: "USDC",
+    baseTokenName: "USD Coin",
+    priceUsd: "0.9998",
+    priceChange: { h1: "0", h24: "0" },
+    liquidityUsd: "1234567890.12",
+    volumeH24Usd: "9876543210.99",
+    txns: { buys: 450_000, sells: 449_999 },
+    pairAgeSeconds: 94_608_000,
+  },
+  {
+    baseTokenSymbol: "AERO",
+    baseTokenName: "Aerodrome Finance",
+    priceUsd: "1.2345",
+    priceChange: { h1: "-0.5", h24: "8.31" },
+    liquidityUsd: "18400000",
+    volumeH24Usd: "3210987.65",
+    txns: { buys: 8888, sells: 7777 },
+    pairAgeSeconds: 1800,
+  },
+  {
+    baseTokenSymbol: "TOSHI",
+    baseTokenName: "Toshi",
+    priceUsd: "0.00019234",
+    priceChange: { h1: "2.2", h24: "-33.19" },
+    liquidityUsd: "8912345.67",
+    volumeH24Usd: "45678.90",
+    txns: { buys: 60, sells: 41 },
+    pairAgeSeconds: 300,
+  },
+];
+
+/**
+ * SCHEMA-REACHABLE EXTREMES - the widest a VALID board document can be.
+ *
+ * `BOARD_DECIMAL_MAX_CHARS` is 40 and `BOARD_TOKEN_LABEL_MAX_CHARS` is 512
+ * (`src/lib/board/spec.ts`), so both of these parse. Neither can fit any
+ * card at any width, which is precisely the case the full-value disclosure
+ * owns: the cut becomes recoverable rather than silent.
+ */
+const EXTREME_PRICE = "1234567890123456789012345678901234.5678";
+const EXTREME_SYMBOL = "X".repeat(512);
+const EXTREME_NAME = "Wrapped ".repeat(60) + "Token";
+
+const EXTREME_ROWS: readonly Partial<BoardHydratedRow>[] = [
+  {
+    baseTokenSymbol: EXTREME_SYMBOL,
+    baseTokenName: EXTREME_NAME,
+    priceUsd: EXTREME_PRICE,
+    priceChange: { h1: "-1.73", h24: "-98765.4321" },
+    liquidityUsd: "1234567890123456789012345678901234.5678",
+    volumeH24Usd: "1234567890123456789012345678901234.5678",
+    txns: { buys: 999_999_999, sells: 999_999_999 },
+    pairAgeSeconds: 999_999_999,
+  },
+  ...REALISTIC_ROWS.slice(0, 2),
+];
+
+function row(overrides: Partial<BoardHydratedRow>): BoardHydratedRow {
+  return {
+    baseTokenSymbol: "PEPE",
+    baseTokenName: "Pepe the Frog",
+    quoteTokenSymbol: "WETH",
+    chainId: "base",
+    dexId: "uniswap",
+    priceUsd: "0.00000123",
+    priceChange: { h1: "-1.73", h24: "113" },
+    liquidityUsd: "75189.01",
+    volumeH24Usd: "464284.04",
+    txns: { buys: 1235, sells: 856 },
+    pairAgeSeconds: 259_200,
+    iconId: null,
+    description: null,
+    ...overrides,
+  };
+}
+
+function harnessSpec(kind: string, poolCount: number): BoardSpecV1 {
+  const source = kind === "extreme" ? EXTREME_ROWS : REALISTIC_ROWS;
+  const rows: BoardHydratedRow[] = [];
+  for (let index = 0; index < poolCount; index += 1) {
+    rows.push(row(source[index % source.length] ?? {}));
+  }
+  const pools: BoardPoolInput[] = rows.map((_, index) => ({
+    chain: "base",
+    pairAddress: `0x${String(index).padStart(6, "a")}`,
+    analysis: null,
+  }));
+  return {
+    version: 1,
+    title: "Board layout harness",
+    pools,
+    hydration: {
+      rows,
+      candles: null,
+      unmatchedMarkerAtMs: null,
+      analysisCreatedAt: FETCHED_AT - 30_000,
+      marketDataFetchedAt: FETCHED_AT,
+      provenance: {
+        transport: "http",
+        sourceObservation: "board layout harness",
+      },
+      staleAfterMs: BOARD_STALE_AFTER_MS,
+    },
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* The page                                                            */
+/* ------------------------------------------------------------------ */
+
+/** A drawer body of the real width, with none of the panel's own channels. */
+function AskStub(): JSX.Element {
+  return (
+    <div data-vex-area="board-ask-stub" className="pt-6 text-[13px] text-ink-secondary">
+      Ask VEX
+    </div>
+  );
+}
+
+/**
+ * The exact-container override for a seam case.
+ *
+ * `content-box` because `container-type: inline-size` measures the CONTENT
+ * box: with it, `width: 727.98px` IS the number the `@container` query sees,
+ * so a seam case can sit one hundredth of a pixel below a threshold. `flex:
+ * none` and `max-width: none` stop the modal's own flex column from taking
+ * the width back. Absent the parameter, not one byte of this is emitted.
+ */
+function containerOverride(
+  selector: string,
+  width: number | null,
+): string {
+  if (width === null) return "";
+  return `${selector} { box-sizing: content-box; width: ${String(width)}px; max-width: none; flex: none; }`;
+}
+
+function widthParam(params: URLSearchParams, key: string): number | null {
+  const raw = params.get(key);
+  if (raw === null) return null;
+  const value = Number.parseFloat(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+function Harness(): JSX.Element {
+  const openBoardModal = useBoardSurfaceStore((s) => s.openBoardModal);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const kind = params.get("board") ?? "realistic";
+    const poolCount = Number.parseInt(params.get("pools") ?? "6", 10);
+    const spec = harnessSpec(kind, Number.isFinite(poolCount) ? poolCount : 6);
+    installFakeBridge(spec.pools);
+    // THE BOARD IS RE-ASSERTED, NOT TIMED OPEN.
+    //
+    // `BoardModalHost` registers an unmount teardown that clears every board
+    // surface, and StrictMode's development double-invoke runs that cleanup
+    // once - so a board opened synchronously here is closed again before the
+    // first paint. Deferring the open by a timer papered over that and turned
+    // it into a race that lost about one run in thirty under load, which is a
+    // flaky spec rather than a fixed one.
+    //
+    // Subscribing instead makes it a fixed point: whenever the store reports
+    // no bound board, this binds one, so no ordering of mount, cleanup and
+    // remount can leave the page empty. The product never needs this, because
+    // nothing opens a board during the shell's own mount.
+    const board = boardRefOf("harness-session", 1, spec);
+    const drawer = params.get("drawer") === "1";
+    const spotlight = params.get("view") === "spotlight";
+    const ensure = (): void => {
+      const store = useBoardSurfaceStore.getState();
+      if (store.modalBoard === null) {
+        store.openBoardModal(board);
+        if (spotlight) useBoardSurfaceStore.getState().openBoardSpotlight(0);
+        if (drawer) useBoardSurfaceStore.getState().setBoardAskOpen(true);
+      } else {
+        if (spotlight && store.view !== "spotlight") {
+          store.openBoardSpotlight(0);
+        }
+        if (drawer && !store.askPanelOpen) store.setBoardAskOpen(true);
+      }
+      setReady(true);
+    };
+    const unsubscribe = useBoardSurfaceStore.subscribe(ensure);
+    ensure();
+    return unsubscribe;
+  }, [openBoardModal]);
+
+  return (
+    <>
+      <BoardModalHost
+        gridSlot={BoardGrid}
+        spotlightSlot={BoardSpotlight}
+        askSlot={AskStub}
+      />
+      {ready ? <div data-vex-area="board-harness-ready" /> : null}
+    </>
+  );
+}
+
+declare global {
+  interface Window {
+    readonly __vexBoardLayoutHarness: {
+      readonly setDrawer: (open: boolean) => void;
+      readonly settleSafety: () => void;
+    };
+  }
+}
+
+/* The seam override is written ONCE, before the first render and outside any
+ * effect: StrictMode double-invokes effects, and a second copy of the rule
+ * would be a second answer to how wide the container is. */
+{
+  const params = new URLSearchParams(window.location.search);
+  const css =
+    containerOverride(".vex-board-plate", widthParam(params, "plate")) +
+    containerOverride(
+      ".vex-board-spotlight-plate",
+      widthParam(params, "spotlightPlate"),
+    );
+  if (css !== "") {
+    const style = document.createElement("style");
+    style.dataset["vexHarness"] = "container-override";
+    style.textContent = css;
+    document.head.append(style);
+  }
+}
+
+Object.defineProperty(window, "__vexBoardLayoutHarness", {
+  configurable: true,
+  value: {
+    setDrawer: (open: boolean) => {
+      useBoardSurfaceStore.getState().setBoardAskOpen(open);
+    },
+    settleSafety: () => {
+      settleSafety?.();
+    },
+  },
+});
+
+const client = new QueryClient({
+  defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+});
+
+const host = document.getElementById("root");
+if (host !== null) {
+  createRoot(host).render(
+    <StrictMode>
+      <QueryClientProvider client={client}>
+        <Harness />
+      </QueryClientProvider>
+    </StrictMode>,
+  );
+}

--- a/vex-app/src/renderer/dev/board-layout/index.html
+++ b/vex-app/src/renderer/dev/board-layout/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en" data-vex-theme="chronos">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vex board layout harness</title>
+    <link
+      rel="preload"
+      href="/fonts/inter-tight-latin-wght.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./harness.tsx"></script>
+  </body>
+</html>

--- a/vex-app/src/renderer/features/appShell/Board/BoardGrid.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/BoardGrid.tsx
@@ -133,7 +133,13 @@ export function BoardGrid({ board }: BoardGridSlotProps): JSX.Element {
         data-vex-area="board-grid-plate"
         data-count={total}
         data-visible={visible.length}
-        className="vex-board-surface flex flex-col gap-4 rounded-2xl border border-line-1 p-4"
+        // THE PLATE IS THE CONTAINER. `vex-board-plate` declares
+        // `container-type: inline-size`, so every column and mode threshold in
+        // `global-css/board-layout.css` is a question about the width the
+        // cards actually get. The Ask VEX drawer takes 360px out of this
+        // element without moving the window by a pixel, which is exactly the
+        // measurement a viewport media query could not see.
+        className="vex-board-surface vex-board-plate flex flex-col gap-4 rounded-2xl border border-line-1 p-4"
       >
         {/* THE FILTER IS THE PLATE'S FIRST ROW, labelled, and only when it
           * can change something. It used to float unlabelled at the top
@@ -153,35 +159,56 @@ export function BoardGrid({ board }: BoardGridSlotProps): JSX.Element {
             No pool on this board matches the current filter.
           </p>
         ) : (
-          <ul
-            data-vex-area="board-grid"
-            data-count={total}
-            aria-label={boardGridLabel(total, visible.length)}
-            className="grid grid-cols-1 items-stretch gap-4 md:grid-cols-2 xl:grid-cols-3"
+          /* THE SCROLLER, not the plate. Below the compact floor the track
+           * refuses to shrink and this element side-scrolls, so a reader
+           * reaches a figure by scrolling instead of being shown a truncated
+           * one. It is a wrapper rather than a property on the plate because
+           * `overflow-x: auto` would compute the plate's `overflow-y` to
+           * `auto` too and put a second vertical scroll region inside the
+           * modal body that already owns the board's scrolling. */
+          <div
+            data-vex-area="board-grid-scroller"
+            className="vex-board-grid-scroller"
           >
-            {visible.map(({ card, index }) => (
-              <li key={card.key} className={cn("flex min-w-0")}>
-                <TokenCardV3
-                  card={card}
-                  verdict={verdicts[index] ?? boardSafetyVerdict("pending")}
-                  sparkline={sparklines[index] ?? BOARD_SPARKLINE_PENDING}
-                  selected={view === "spotlight" && selectedPoolIndex === index}
-                  live={isBoardLiveHeld(readout.mode)}
-                  onSpotlight={() => {
-                    openBoardSpotlight(index);
-                  }}
-                  onAsk={() => {
-                    // Selection first, then the panel: the Ask surface reads
-                    // the SELECTED pool, so opening it before pointing it at
-                    // this card would show the panel about another token for
-                    // one commit.
-                    selectBoardPool(index);
-                    setBoardAskOpen(true);
-                  }}
-                />
-              </li>
-            ))}
-          </ul>
+            <ul
+              data-vex-area="board-grid"
+              data-count={total}
+              aria-label={boardGridLabel(total, visible.length)}
+              // Columns come from `board-layout.css` alone. No Tailwind
+              // viewport ladder here: it was the defect.
+              className="vex-board-grid"
+            >
+              {visible.map(({ card, index }) => (
+                // `min-w-0` so a track may be narrower than its content wants,
+                // and the card itself carries `w-full`, which is what makes
+                // every card in the grid the same box. Without it each
+                // `<article>` shrank to its own content inside an equal track:
+                // 382 / 369 / 406 / 345 / 407 / 342 across one 388px grid.
+                <li key={card.key} className={cn("flex min-w-0")}>
+                  <TokenCardV3
+                    card={card}
+                    verdict={verdicts[index] ?? boardSafetyVerdict("pending")}
+                    sparkline={sparklines[index] ?? BOARD_SPARKLINE_PENDING}
+                    selected={
+                      view === "spotlight" && selectedPoolIndex === index
+                    }
+                    live={isBoardLiveHeld(readout.mode)}
+                    onSpotlight={() => {
+                      openBoardSpotlight(index);
+                    }}
+                    onAsk={() => {
+                      // Selection first, then the panel: the Ask surface reads
+                      // the SELECTED pool, so opening it before pointing it at
+                      // this card would show the panel about another token for
+                      // one commit.
+                      selectBoardPool(index);
+                      setBoardAskOpen(true);
+                    }}
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
       </div>
       <BoardDataNotes content={authored} verdicts={verdicts} />

--- a/vex-app/src/renderer/features/appShell/Board/BoardModalHost.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/BoardModalHost.tsx
@@ -140,8 +140,26 @@ export function BoardModalHost({
     >
       <DialogContent
         size="board"
-        className="vex-board-dialog"
+        // THE DRAWER IS PAID FOR BY THE DIALOG, NOT BY THE CARDS. The Ask VEX
+        // panel is a fixed 360px taken out of the board's own width, and at
+        // the `board` size's 1280px cap that came straight off the cards: at a
+        // 1440px window every card fell to 268px, below what a stat column or
+        // a price row needs. Opening the drawer therefore widens the box by
+        // exactly the drawer, capped at 94vw so it can never exceed the window
+        // it lives in.
+        //
+        // THE POLICY IS THE HOST'S, THE MECHANISM IS THE PRIMITIVE'S.
+        // `components/ui/dialog.tsx` stays generic and knows nothing about Ask
+        // VEX; `cn` runs tailwind-merge over the result, so these utilities
+        // REPLACE the size family's own width classes rather than fighting
+        // them for specificity.
+        className={
+          askPanelOpen
+            ? "vex-board-dialog w-[min(94vw,1640px)] max-w-[min(94vw,1640px)]"
+            : "vex-board-dialog"
+        }
         data-vex-surface="board-modal"
+        data-vex-drawer={askPanelOpen ? "open" : "closed"}
       >
         {/* The visible header is ours below; the screen reader still gets a
          * real title and description carrying the dialog's context ids. */}

--- a/vex-app/src/renderer/features/appShell/Board/BoardSpotlight.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/BoardSpotlight.tsx
@@ -267,7 +267,12 @@ export function BoardSpotlight({
         </Pill>
       </div>
 
-      <div className="vex-board-surface flex min-h-0 flex-col gap-4 rounded-2xl border border-line-1 p-4">
+      {/* THE SPOTLIGHT PLATE IS ITS OWN CONTAINER, and every region below
+        * carries a class whose threshold `global-css/board-layout.css` names
+        * for the content that binds it. A TokenCard threshold never decides a
+        * region here: the two surfaces hold different content in the same
+        * shrinking container, and the Ask VEX drawer shrinks this one too. */}
+      <div className="vex-board-surface vex-board-spotlight-plate flex min-h-0 flex-col gap-4 rounded-2xl border border-line-1 p-4">
         <Hero
           heading={heading}
           ticker={ticker}
@@ -290,7 +295,10 @@ export function BoardSpotlight({
         {/* CHART beside the metrics column, as the mockup has them. The
           * chart's FRAME is this file's; its canvas, tabs and caption are the
           * chart's own. */}
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div
+          data-vex-area="board-spotlight-chart-row"
+          className="vex-board-spotlight-chart-row"
+        >
           <div
             data-vex-area="board-spotlight-chart-card"
             className="min-h-[340px] min-w-0 rounded-2xl border border-line-2 bg-board-card p-4"
@@ -331,7 +339,10 @@ export function BoardSpotlight({
         />
 
         {/* THE FACTUAL ROW. */}
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div
+          data-vex-area="board-spotlight-factual-row"
+          className="vex-board-spotlight-row-3"
+        >
           <BuySellSection buys={row?.txns.buys ?? null} sells={row?.txns.sells ?? null} />
           <LockSection details={details} />
           <SafetyChecksSection
@@ -342,7 +353,10 @@ export function BoardSpotlight({
         </div>
 
         {/* SPOTLIGHT+ - the same grammar, one row of context per section. */}
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div
+          data-vex-area="board-spotlight-plus-row"
+          className="vex-board-spotlight-row-2"
+        >
           <SmartMoneySection read={traders} />
           <TapeSection
             read={tape}
@@ -351,7 +365,10 @@ export function BoardSpotlight({
             live={live}
           />
         </div>
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div
+          data-vex-area="board-spotlight-context-row"
+          className="vex-board-spotlight-row-2"
+        >
           <MomentumSection read={momentum} />
           <PromotionSection read={context} />
         </div>
@@ -398,7 +415,7 @@ function Hero(props: {
   return (
     <header
       data-vex-area="board-spotlight-hero"
-      className="grid grid-cols-[88px_minmax(0,1fr)_auto_auto] items-center gap-x-6 gap-y-3"
+      className="vex-board-spotlight-hero"
     >
       <TokenPhotoFrame
         view={photo}
@@ -454,7 +471,15 @@ function Hero(props: {
         )}
       </div>
 
-      <div className="flex min-w-0 flex-col gap-1.5">
+      {/* THE PRICE BLOCK IS PLACED, NOT AUTO-PLACED. Below the hero's own
+        * threshold the grid is `88px 1fr` and auto-placement would drop this
+        * into row 2 COLUMN 1 - the 88px photo track - with the toggle beside
+        * it. `board-layout.css` spans both stacked rows across the hero and
+        * resets the placement in the four-track window. */}
+      <div
+        data-vex-area="board-spotlight-price-block"
+        className="vex-board-spotlight-hero-price flex min-w-0 flex-col gap-1.5"
+      >
         <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
           <span
             data-vex-area="board-spotlight-price"
@@ -513,7 +538,7 @@ function Hero(props: {
         aria-pressed
         aria-label={`Leave the spotlight on ${props.ticker}`}
         onClick={props.onLeave}
-        className="inline-flex h-7 shrink-0 items-center gap-1.5 self-start rounded-capsule border border-accent-primary/40 bg-accent-wash px-3 text-[13px] font-medium text-accent-primary transition-colors duration-150 hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"
+        className="vex-board-spotlight-hero-action inline-flex h-7 shrink-0 items-center gap-1.5 self-start rounded-capsule border border-accent-primary/40 bg-accent-wash px-3 text-[13px] font-medium text-accent-primary transition-colors duration-150 hover:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"
       >
         <IconFullscreen size={14} />
         {SPOTLIGHT_PILL_LABEL}
@@ -609,7 +634,12 @@ function StatRow(props: {
       <span aria-hidden className="flex shrink-0 items-center text-ink-tertiary">
         {props.icon}
       </span>
-      <dt className="min-w-0 flex-1 truncate text-[14px] leading-[20px] text-ink-secondary">
+      {/* NOT TRUNCATED. The metrics track is a fixed 360px whenever it is
+        * beside the chart, and the widest label in it is "24h Volume"; below
+        * that threshold the column takes the full plate width. Either way
+        * there is room, so an ellipsis here could only ever hide a label a
+        * reader needs to know which figure they are looking at. */}
+      <dt className="min-w-0 flex-1 whitespace-nowrap text-[14px] leading-[20px] text-ink-secondary">
         {props.label}
       </dt>
       {props.value === null ? (

--- a/vex-app/src/renderer/features/appShell/Board/BoardStatusChip.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/BoardStatusChip.tsx
@@ -94,13 +94,21 @@ export function BoardStatusChip({
       data-chip={newPair ? "new-pair" : "safety"}
       data-tone={tone}
       data-safety-state={verdict.state}
-      // The whole label on hover, because the visible run is `truncate`d by
-      // CSS on a narrow card: the string itself is never cut.
+      // The whole label, for the pointer. It is no longer the RECOVERY path:
+      // the label below is not clamped at all any more.
       title={label}
       className={cn("font-medium", className)}
     >
       <ToneIcon tone={tone} />
-      <span className="min-w-0 truncate">{label}</span>
+      {/* NO ELLIPSIS. A verdict that reads "Checks unavai..." is worse than
+        * no chip: a reader cannot tell an unavailable check from an
+        * unverified token from a check that describes another token, and
+        * those are three different things to do next. The widest label the
+        * frozen table can produce is 242px ("Checks unavailable in this
+        * response"), and that number is a term in the footer floors in
+        * `global-css/board-layout.css` - which is why the footer STACKS in
+        * compact mode rather than cutting this. */}
+      <span className="whitespace-nowrap">{label}</span>
     </Pill>
   );
 }

--- a/vex-app/src/renderer/features/appShell/Board/TokenCardV3.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/TokenCardV3.tsx
@@ -155,7 +155,15 @@ export function TokenCardV3({
   // budgets belong to `boardCardValueBudget.ts`; the accessible name below
   // and the disclosure panel both keep the WHOLE strings, so nothing here
   // removes a value from the reader - it decides which copy is on the plate.
-  const printedTicker = boardCardValue(ticker, BOARD_CARD_TICKER_MAX_SLOTS);
+  // The ticker is the card's one PROPORTIONAL surface: it renders in uppercase
+  // Inter Tight, where `W` advances four times as far as `I`, so it is weighed
+  // per glyph rather than counted. Everything below renders `tabular-nums`,
+  // where a count of digits genuinely is a width.
+  const printedTicker = boardCardValue(
+    ticker,
+    BOARD_CARD_TICKER_MAX_SLOTS,
+    "proportional",
+  );
   const printedPrice = boardCardValue(priceLabel, BOARD_CARD_PRICE_MAX_SLOTS);
   const printedDelta = boardCardValue(deltaLabel, BOARD_CARD_DELTA_MAX_SLOTS);
   const stats: readonly {

--- a/vex-app/src/renderer/features/appShell/Board/TokenCardV3.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/TokenCardV3.tsx
@@ -48,30 +48,25 @@
  *
  * NOTHING IS RECOVERED BY HOVER. `title` is a pointer convenience and never
  * the only way back to a cut string, so every card carries one always-present
- * `FullValueDisclosure` button: a real `<button>`, in the tab order, that
- * opens the whole name, the whole ticker and the RAW provider decimals, and
- * whose own tab sequence is contained the way a `role="dialog"` over obscured
- * controls must be. It is present unconditionally on purpose - a card is
- * always rounding something - but it is not SILENT about the difference
- * between rounding and cutting: when the card printed a shortened copy of a
- * value it says so, in the button's accessible name, in the button's own
- * treatment, and again at the top of the panel.
+ * `FullValueDisclosure` button: a real `<button>` with `aria-expanded` and
+ * `aria-controls`, in the tab order, that opens the whole name, the whole
+ * ticker and the RAW provider decimals. A DISCLOSURE and never a dialog - the
+ * long form of why is on the component itself. It is present unconditionally
+ * on purpose - a card is always rounding something - but it is not SILENT
+ * about the difference between rounding and cutting: when the card printed a
+ * shortened copy of a value it says so, in the button's accessible name, in
+ * the button's own treatment, and again at the top of the panel.
  *
  * WHAT DECIDES "SHORTENED" IS THE DATA, NOT THE LAYOUT. `boardCardValueBudget
- * .ts` owns a character budget per region, derived from the same measurement
- * matrix the CSS floors come from, and it runs before layout exists. No
+ * .ts` owns a per-region budget in SLOTS - grapheme clusters weighted by the
+ * width class of their code points - derived from the same measurement matrix
+ * the CSS floors come from, and it runs before layout exists. No
  * JavaScript here reads a width back, and no threshold leaves the stylesheet:
  * a budget decides how much of a string is worth printing, never how many
  * columns the board has or which anatomy a card wears.
  */
 
-import {
-  useEffect,
-  useRef,
-  useState,
-  type JSX,
-  type KeyboardEvent as ReactKeyboardEvent,
-} from "react";
+import { useEffect, useId, useRef, useState, type JSX } from "react";
 import {
   IconArrowUpRight,
   IconClose,
@@ -100,10 +95,10 @@ import {
 import {
   anyShortened,
   boardCardValue,
-  BOARD_CARD_DELTA_MAX_CHARS,
-  BOARD_CARD_PRICE_MAX_CHARS,
-  BOARD_CARD_STAT_MAX_CHARS,
-  BOARD_CARD_TICKER_MAX_CHARS,
+  BOARD_CARD_DELTA_MAX_SLOTS,
+  BOARD_CARD_PRICE_MAX_SLOTS,
+  BOARD_CARD_STAT_MAX_SLOTS,
+  BOARD_CARD_TICKER_MAX_SLOTS,
   type BoardCardValue,
 } from "./boardCardValueBudget.js";
 import type { BoardCardModel } from "./boardModel.js";
@@ -160,9 +155,9 @@ export function TokenCardV3({
   // budgets belong to `boardCardValueBudget.ts`; the accessible name below
   // and the disclosure panel both keep the WHOLE strings, so nothing here
   // removes a value from the reader - it decides which copy is on the plate.
-  const printedTicker = boardCardValue(ticker, BOARD_CARD_TICKER_MAX_CHARS);
-  const printedPrice = boardCardValue(priceLabel, BOARD_CARD_PRICE_MAX_CHARS);
-  const printedDelta = boardCardValue(deltaLabel, BOARD_CARD_DELTA_MAX_CHARS);
+  const printedTicker = boardCardValue(ticker, BOARD_CARD_TICKER_MAX_SLOTS);
+  const printedPrice = boardCardValue(priceLabel, BOARD_CARD_PRICE_MAX_SLOTS);
+  const printedDelta = boardCardValue(deltaLabel, BOARD_CARD_DELTA_MAX_SLOTS);
   const stats: readonly {
     readonly label: string;
     readonly printed: BoardCardValue;
@@ -172,7 +167,7 @@ export function TokenCardV3({
       label: "Liquidity",
       printed: boardCardValue(
         formatBoardUsdCompact(row?.liquidityUsd ?? null),
-        BOARD_CARD_STAT_MAX_CHARS,
+        BOARD_CARD_STAT_MAX_SLOTS,
       ),
       title: row?.liquidityUsd ?? undefined,
     },
@@ -180,7 +175,7 @@ export function TokenCardV3({
       label: "24h Volume",
       printed: boardCardValue(
         formatBoardUsdCompact(row?.volumeH24Usd ?? null),
-        BOARD_CARD_STAT_MAX_CHARS,
+        BOARD_CARD_STAT_MAX_SLOTS,
       ),
       title: row?.volumeH24Usd ?? undefined,
     },
@@ -190,7 +185,7 @@ export function TokenCardV3({
         row === null
           ? BOARD_EMPTY
           : formatBoardTradeTotal(row.txns.buys, row.txns.sells),
-        BOARD_CARD_STAT_MAX_CHARS,
+        BOARD_CARD_STAT_MAX_SLOTS,
       ),
       title: undefined,
     },
@@ -198,7 +193,7 @@ export function TokenCardV3({
       label: "Pair age",
       printed: boardCardValue(
         formatBoardAge(row?.pairAgeSeconds ?? null),
-        BOARD_CARD_STAT_MAX_CHARS,
+        BOARD_CARD_STAT_MAX_SLOTS,
       ),
       title: undefined,
     },
@@ -212,6 +207,27 @@ export function TokenCardV3({
     printedDelta,
     ...stats.map((stat) => stat.printed),
   ]);
+
+  /**
+   * THE DISCLOSURE'S STATE LIVES ON THE CARD, and it has to.
+   *
+   * The panel is opaque and covers the whole card, so while it is open every
+   * interactive element underneath it is INVISIBLE - and an invisible control
+   * that can still be reached by Tab is exactly what rule 08 forbids ("focus
+   * is visible and not obscured"). Withdrawing them is therefore the CARD's
+   * job, because the card is what owns them; a component inside the header
+   * could not reach the footer's buttons without reaching up out of itself.
+   *
+   * `tabIndex={-1}` AND NOT `inert`, deliberately. `inert` removes a subtree
+   * from the accessibility tree, which would take the trigger's own
+   * `aria-expanded="true"` with it - the panel would be open and nothing
+   * would be able to say so. `tabIndex={-1}` removes an element from the TAB
+   * ORDER only: it stays in the tree, it still reports its state, and it can
+   * still be focused programmatically, which is what the Escape restore below
+   * relies on. The attributes revert with this flag, in the same commit that
+   * removes the panel.
+   */
+  const [fullValueOpen, setFullValueOpen] = useState(false);
 
   return (
     <article
@@ -258,11 +274,14 @@ export function TokenCardV3({
             heading={heading}
             row={row}
             shortened={shortened}
+            open={fullValueOpen}
+            onOpenChange={setFullValueOpen}
           />
           <SpotlightAction
             symbol={ticker}
             selected={selected}
             onSpotlight={onSpotlight}
+            covered={fullValueOpen}
           />
         </div>
       </header>
@@ -376,12 +395,20 @@ export function TokenCardV3({
           pairAgeSeconds={row?.pairAgeSeconds ?? null}
         />
         <div className="flex shrink-0 items-center gap-2">
-          <DexscreenerLink chain={card.chain} pairAddress={card.pairAddress} ticker={ticker} />
+          <DexscreenerLink
+            chain={card.chain}
+            pairAddress={card.pairAddress}
+            ticker={ticker}
+            covered={fullValueOpen}
+          />
             <button
             type="button"
             data-vex-area="board-card-ask"
             onClick={onAsk}
             aria-label={`Ask VEX about ${ticker}`}
+            // Covered by the full-value panel: out of the tab order, still in
+            // the accessibility tree. See `fullValueOpen` above.
+            tabIndex={fullValueOpen ? -1 : undefined}
             className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-line-2 px-2.5 text-[12.5px] font-medium text-ink-secondary transition-colors duration-150 hover:border-line-3 hover:bg-interactive-hover hover:text-ink-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"
           >
             <IconSparkle size={14} />
@@ -407,11 +434,14 @@ export function DexscreenerLink({
   pairAddress,
   ticker,
   className,
+  covered = false,
 }: {
   readonly chain: string;
   readonly pairAddress: string;
   readonly ticker: string;
   readonly className?: string;
+  /** True while an opaque overlay covers this link: out of the tab order. */
+  readonly covered?: boolean;
 }): JSX.Element {
   return (
     <a
@@ -420,6 +450,7 @@ export function DexscreenerLink({
       rel="noopener noreferrer"
       data-vex-area="board-token-dexscreener-link"
       aria-label={`Open ${ticker} on DexScreener`}
+      tabIndex={covered ? -1 : undefined}
       className={cn(
         "inline-flex h-8 shrink-0 items-center gap-1 rounded-lg px-1.5 text-[12.5px] font-medium text-ink-tertiary transition-colors duration-150 hover:text-ink-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none",
         className,
@@ -476,10 +507,13 @@ function SpotlightAction({
   symbol,
   selected,
   onSpotlight,
+  covered = false,
 }: {
   readonly symbol: string;
   readonly selected: boolean;
   readonly onSpotlight: () => void;
+  /** True while the full-value panel covers this button. */
+  readonly covered?: boolean;
 }): JSX.Element {
   return (
     <button
@@ -488,6 +522,7 @@ function SpotlightAction({
       data-selected={selected ? "true" : "false"}
       aria-pressed={selected}
       aria-label={`Spotlight ${symbol}`}
+      tabIndex={covered ? -1 : undefined}
       onClick={onSpotlight}
       className={cn(
         "inline-flex h-7 shrink-0 items-center gap-1.5 self-start rounded-capsule border px-3 text-[13px] font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none",
@@ -579,38 +614,74 @@ export const BOARD_FULL_VALUE_SHORTENED_LABEL =
  * This is a real `<button>`, so Enter and Space work with no key handler of
  * our own, and the panel it opens is an ordinary absolutely-positioned
  * overlay INSIDE the card rather than a portal: the board modal's native
- * `<dialog>` already owns the focus trap, and a portal to `document.body`
- * would put the panel outside it. Initial focus goes to the close button,
- * Escape closes, and focus returns to the trigger - the three obligations a
- * dialog-nested disclosure has, met without touching the dialog primitive.
+ * `<dialog>` already owns the modal layer, and a portal to `document.body`
+ * would put the panel outside it.
  *
- * Escape is stopped from propagating while the panel is open, so closing the
- * panel does not also close the board behind it.
+ * IT IS A DISCLOSURE, NOT A DIALOG, and the difference is not cosmetic. This
+ * panel carried `role="dialog"` with `aria-modal="true"` and a focus trap,
+ * and every part of that claim was false: nothing outside it was inert, a
+ * pointer reached every other card on the board while it was open, and two of
+ * them could be "modal" at the same time. `aria-modal` promises a reader that
+ * the rest of the page is unavailable, and a promise the code does not keep
+ * is worse than no promise - a screen-reader user would have been told the
+ * board was gone while a sighted user was clicking it.
  *
- * AND ITS TAB SEQUENCE IS CONTAINED, which a `role="dialog"` over obscured
- * controls owes its reader (WAI modal-dialog pattern). The panel covers the
- * card, but the card's own buttons - the Spotlight trigger, DexScreener, Ask
- * VEX - are still in the document after it, so without the trap below a Tab
- * from the close button lands on a control nobody can see, and an Escape from
- * there is no longer this panel's to stop: it reaches the board `<dialog>`
- * and closes the whole board.
+ * So it is what it actually is: a button with `aria-expanded` and
+ * `aria-controls`, and a labelled group it points at. Consequences, all
+ * deliberate:
+ *
+ *   - NO FOCUS TRAP. A non-modal surface must not trap; Tab runs through the
+ *     panel's content and then ONWARD, out of this card entirely - because
+ *     the controls it covers leave the tab order for as long as it covers
+ *     them. That is `tabIndex={-1}` on the card's own buttons and NOT
+ *     `inert`: `inert` would take the whole subtree out of the accessibility
+ *     tree, including the trigger's `aria-expanded="true"`, so the panel
+ *     would be open with nothing able to say so. `tabIndex={-1}` removes an
+ *     element from the tab order alone - it still reports its state, and it
+ *     can still be focused programmatically, which is what the Escape
+ *     restore depends on. `TokenCardV3` owns that flag; see `fullValueOpen`.
+ *   - MANY MAY BE OPEN. Two cards showing their values at once is legitimate
+ *     for a disclosure - it is how a reader compares two pools - so it is
+ *     TESTED rather than left accidental, and opening one never closes
+ *     another.
+ *   - THE REST OF THE BOARD STAYS LIVE. Another card's Spotlight is one click
+ *     away while this panel is open, which is also tested.
+ *
+ * Focus still MOVES into the panel on open and RETURNS to the trigger on
+ * close. That is not a modal obligation, it is this panel's own: it paints
+ * over the card it belongs to, so a reader whose focus stayed behind it would
+ * be operating a control they can no longer see. Escape closes it, and is
+ * stopped from propagating so that closing the panel does not also close the
+ * board `<dialog>` listening for the same key.
  */
 function FullValueDisclosure({
   ticker,
   heading,
   row,
   shortened,
+  open,
+  onOpenChange,
 }: {
   readonly ticker: string;
   readonly heading: string;
   readonly row: BoardCardModel["row"];
   /** True when the card printed a shortened copy of at least one value. */
   readonly shortened: boolean;
+  /**
+   * CONTROLLED BY THE CARD, because the card is what has to react to it: the
+   * panel covers the Spotlight button, the DexScreener link and Ask VEX, and
+   * those have to leave the tab order while they cannot be seen. State owned
+   * privately here could not reach them.
+   */
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
 }): JSX.Element {
-  const [open, setOpen] = useState(false);
+  const setOpen = onOpenChange;
   const trigger = useRef<HTMLButtonElement | null>(null);
   const close = useRef<HTMLButtonElement | null>(null);
-  const panel = useRef<HTMLDivElement | null>(null);
+  // The panel's id is the other half of `aria-controls`, and `useId` is what
+  // keeps it unique across a board of eight cards without a counter of ours.
+  const panelId = useId();
 
   useEffect(() => {
     if (!open) return;
@@ -620,43 +691,6 @@ function FullValueDisclosure({
   const dismiss = (): void => {
     setOpen(false);
     trigger.current?.focus();
-  };
-
-  /**
-   * The trap. It lives on the panel's own `keydown`, so it can only run while
-   * focus is already inside: there is no document listener to leak, nothing
-   * to unregister, and a card whose panel is closed costs nothing.
-   */
-  const trap = (event: ReactKeyboardEvent<HTMLDivElement>): void => {
-    if (event.key !== "Tab") return;
-    const host = panel.current;
-    if (host === null) return;
-    const focusable = [
-      ...host.querySelectorAll<HTMLElement>(
-        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      ),
-    ];
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    if (first === undefined || last === undefined) {
-      // Nothing to move to, so the only correct move is not to move: letting
-      // Tab through would put focus on the card behind the panel.
-      event.preventDefault();
-      return;
-    }
-    const active = document.activeElement;
-    const inside = active instanceof Node && host.contains(active);
-    if (event.shiftKey) {
-      if (!inside || active === first) {
-        event.preventDefault();
-        last.focus();
-      }
-      return;
-    }
-    if (!inside || active === last) {
-      event.preventDefault();
-      first.focus();
-    }
   };
 
   const entries: readonly FullValueEntry[] = [
@@ -676,6 +710,11 @@ function FullValueDisclosure({
         data-vex-area="board-token-full-value"
         data-shortened={shortened ? "true" : undefined}
         aria-expanded={open}
+        aria-controls={panelId}
+        // The trigger is under the panel too. Out of the tab order while it
+        // is covered, and still focusable programmatically - which is exactly
+        // what `dismiss` needs and what `inert` would have taken away.
+        tabIndex={open ? -1 : undefined}
         // NAMED, NOT GENERIC, once the card has actually cut something.
         aria-label={
           shortened
@@ -705,16 +744,15 @@ function FullValueDisclosure({
       </button>
       {open ? (
         <div
-          ref={panel}
+          id={panelId}
           data-vex-area="board-token-full-value-popover"
-          role="dialog"
-          aria-modal="true"
+          // A LABELLED GROUP, which is what this is. Not `role="dialog"`, and
+          // emphatically not `aria-modal`: see the head note above. The
+          // trigger's `aria-expanded` plus `aria-controls` is the whole
+          // relationship a disclosure needs.
+          role="group"
           aria-label={`${BOARD_FULL_VALUE_TITLE} for ${ticker}`}
           onKeyDown={(event) => {
-            if (event.key === "Tab") {
-              trap(event);
-              return;
-            }
             if (event.key !== "Escape") return;
             // The board dialog is listening for Escape too, and it would
             // close the whole board behind this panel.

--- a/vex-app/src/renderer/features/appShell/Board/TokenCardV3.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/TokenCardV3.tsx
@@ -35,12 +35,48 @@
  * NO ICON SITS ON A DISC. The chain mark, the chip's glyph and the Ask VEX
  * sparkle are bare `currentColor` glyphs; the one round container on the
  * card is the token photo itself.
+ *
+ * TWO ANATOMIES, ONE CARD, AND CSS PICKS. The board plate is a container
+ * query container and `global-css/board-layout.css` owns every threshold; the
+ * card carries the classes and reads the mode's values out of custom
+ * properties. In WIDE mode the sparkline sits in the price row, the stats are
+ * four columns and the footer is one line. In COMPACT mode the sparkline
+ * moves to its own full-width slot, the stats go 2x2 and the footer stacks
+ * the chip above the actions. Nothing here knows a pixel: there is no solver,
+ * no ResizeObserver and no window read, so opening the Ask VEX drawer changes
+ * the layout in the same paint that changes the container.
+ *
+ * NOTHING IS RECOVERED BY HOVER. `title` is a pointer convenience and never
+ * the only way back to a cut string, so every card carries one always-present
+ * `FullValueDisclosure` button: a real `<button>`, in the tab order, that
+ * opens the whole name, the whole ticker and the RAW provider decimals, and
+ * whose own tab sequence is contained the way a `role="dialog"` over obscured
+ * controls must be. It is present unconditionally on purpose - a card is
+ * always rounding something - but it is not SILENT about the difference
+ * between rounding and cutting: when the card printed a shortened copy of a
+ * value it says so, in the button's accessible name, in the button's own
+ * treatment, and again at the top of the panel.
+ *
+ * WHAT DECIDES "SHORTENED" IS THE DATA, NOT THE LAYOUT. `boardCardValueBudget
+ * .ts` owns a character budget per region, derived from the same measurement
+ * matrix the CSS floors come from, and it runs before layout exists. No
+ * JavaScript here reads a width back, and no threshold leaves the stylesheet:
+ * a budget decides how much of a string is worth printing, never how many
+ * columns the board has or which anatomy a card wears.
  */
 
-import { useRef, type JSX } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type JSX,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import {
   IconArrowUpRight,
+  IconClose,
   IconFullscreen,
+  IconInfo,
   IconSparkle,
 } from "../../../components/icons/index.js";
 import { ChainSlugIcon } from "../../../components/common/ChainIcon.js";
@@ -61,6 +97,15 @@ import {
   formatBoardUsdCompact,
   type BoardTrend,
 } from "./boardFormat.js";
+import {
+  anyShortened,
+  boardCardValue,
+  BOARD_CARD_DELTA_MAX_CHARS,
+  BOARD_CARD_PRICE_MAX_CHARS,
+  BOARD_CARD_STAT_MAX_CHARS,
+  BOARD_CARD_TICKER_MAX_CHARS,
+  type BoardCardValue,
+} from "./boardCardValueBudget.js";
 import type { BoardCardModel } from "./boardModel.js";
 import type { BoardSafetyVerdict } from "./board-surface-contracts.js";
 
@@ -75,7 +120,7 @@ import type { BoardSafetyVerdict } from "./board-surface-contracts.js";
  * plate: the plate is not focusable, and a ring around a non-target is noise.
  */
 const CARD_CLASS =
-  "vex-board-card group flex h-full flex-col rounded-2xl border bg-board-card px-5 py-5 " +
+  "vex-board-card group relative flex h-full w-full min-w-0 flex-col overflow-hidden rounded-2xl border bg-board-card px-5 py-5 " +
   "transition-[background-color,border-color,box-shadow] duration-150 " +
   "hover:border-line-3 hover:bg-board-card-hover hover:shadow-lv2 motion-reduce:transition-none";
 
@@ -111,6 +156,63 @@ export function TokenCardV3({
   const statusLabel = boardStatusChipLabel(verdict, row?.pairAgeSeconds ?? null);
   const tick = useLiveTick(live, row?.priceUsd ?? null, row?.priceChange.h24 ?? null);
 
+  // WHAT THE CARD WILL PRINT, and what it had to shorten to print it. The
+  // budgets belong to `boardCardValueBudget.ts`; the accessible name below
+  // and the disclosure panel both keep the WHOLE strings, so nothing here
+  // removes a value from the reader - it decides which copy is on the plate.
+  const printedTicker = boardCardValue(ticker, BOARD_CARD_TICKER_MAX_CHARS);
+  const printedPrice = boardCardValue(priceLabel, BOARD_CARD_PRICE_MAX_CHARS);
+  const printedDelta = boardCardValue(deltaLabel, BOARD_CARD_DELTA_MAX_CHARS);
+  const stats: readonly {
+    readonly label: string;
+    readonly printed: BoardCardValue;
+    readonly title: string | undefined;
+  }[] = [
+    {
+      label: "Liquidity",
+      printed: boardCardValue(
+        formatBoardUsdCompact(row?.liquidityUsd ?? null),
+        BOARD_CARD_STAT_MAX_CHARS,
+      ),
+      title: row?.liquidityUsd ?? undefined,
+    },
+    {
+      label: "24h Volume",
+      printed: boardCardValue(
+        formatBoardUsdCompact(row?.volumeH24Usd ?? null),
+        BOARD_CARD_STAT_MAX_CHARS,
+      ),
+      title: row?.volumeH24Usd ?? undefined,
+    },
+    {
+      label: "Trades",
+      printed: boardCardValue(
+        row === null
+          ? BOARD_EMPTY
+          : formatBoardTradeTotal(row.txns.buys, row.txns.sells),
+        BOARD_CARD_STAT_MAX_CHARS,
+      ),
+      title: undefined,
+    },
+    {
+      label: "Pair age",
+      printed: boardCardValue(
+        formatBoardAge(row?.pairAgeSeconds ?? null),
+        BOARD_CARD_STAT_MAX_CHARS,
+      ),
+      title: undefined,
+    },
+  ];
+  // The NAME is deliberately not in this list: it keeps its CSS ellipsis by
+  // product decision, and its whole string is in the `title`, in the card's
+  // accessible name and in the disclosure.
+  const shortened = anyShortened([
+    printedTicker,
+    printedPrice,
+    printedDelta,
+    ...stats.map((stat) => stat.printed),
+  ]);
+
   return (
     <article
       data-vex-area="board-token-card-v3"
@@ -135,9 +237,11 @@ export function TokenCardV3({
           </span>
           <span
             data-vex-area="board-token-ticker"
+            data-shortened={printedTicker.shortened ? "true" : undefined}
             className="truncate text-[13px] uppercase leading-[16px] text-ink-tertiary"
+            title={ticker}
           >
-            {ticker}
+            {printedTicker.text}
           </span>
           <span
             data-vex-area="board-token-chain"
@@ -148,11 +252,19 @@ export function TokenCardV3({
             <span className="sr-only">{card.chain}</span>
           </span>
         </div>
-        <SpotlightAction
-          symbol={ticker}
-          selected={selected}
-          onSpotlight={onSpotlight}
-        />
+        <div className="flex shrink-0 items-center gap-2 self-start">
+          <FullValueDisclosure
+            ticker={ticker}
+            heading={heading}
+            row={row}
+            shortened={shortened}
+          />
+          <SpotlightAction
+            symbol={ticker}
+            selected={selected}
+            onSpotlight={onSpotlight}
+          />
+        </div>
       </header>
 
       {/* PRICE. The hero numeral, the qualified delta, and the sparkline in
@@ -165,36 +277,66 @@ export function TokenCardV3({
         data-tick={tick}
         className="mt-4 flex h-[44px] items-end gap-3 rounded-md"
       >
-        <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2.5 gap-y-0.5">
+        {/* NOWRAP, and that is the fix for a defect the matrix caught at
+          * 1920px with no drawer at all: with `flex-wrap` the browser pushed
+          * the delta and its `24h` window onto a second line rather than
+          * shrinking the price, and the row's fixed 44px had no room for it.
+          * Nowrap makes the price the one element that concedes width - the
+          * right priority, because the delta and the window are short, fixed
+          * and meaningless apart, and because the disclosure in the header
+          * carries the whole decimal string either way. */}
+        <div className="flex min-w-0 flex-1 flex-nowrap items-baseline gap-x-2.5">
           <span
             data-vex-area="board-token-price"
+            data-shortened={printedPrice.shortened ? "true" : undefined}
             className="min-w-0 truncate font-display text-[28px] font-bold leading-[34px] tracking-[-0.02em] tabular-nums text-ink-primary"
             // The WHOLE decimal string, so no digit the provider reported is
-            // lost to the display precision above it.
+            // lost to the display precision above it. The KEYBOARD path to
+            // the same string is the header's disclosure; this is the
+            // pointer's shortcut, never the only way back.
             title={row?.priceUsd ?? undefined}
           >
-            {priceLabel}
+            {printedPrice.text}
           </span>
           <span
             data-vex-area="board-token-delta"
             data-trend={card.trendH24}
+            data-shortened={printedDelta.shortened ? "true" : undefined}
             className={cn(
-              "text-[15px] font-semibold leading-[20px] tabular-nums",
+              "shrink-0 text-[15px] font-semibold leading-[20px] tabular-nums",
               deltaToneClass(card.trendH24),
             )}
+            title={printedDelta.shortened ? deltaLabel : undefined}
           >
-            {deltaLabel}
+            {printedDelta.text}
           </span>
           <span
             data-vex-area="board-token-delta-window"
-            className="text-[13px] leading-[18px] text-ink-tertiary"
+            className="shrink-0 text-[13px] leading-[18px] text-ink-tertiary"
           >
             24h
           </span>
         </div>
-        <div className="h-[44px] w-[30%] shrink-0">
+        {/* WIDE mode only. `board-layout.css` gives this a fixed 132px rather
+          * than a percentage: a percentage shrinks the figures' budget faster
+          * than the card shrinks, which is what pushed the delta out of the
+          * row in the first place. */}
+        <div
+          data-vex-area="board-token-sparkline-inline"
+          className="vex-board-card-sparkline-inline"
+        >
           <BoardSparkline data={sparkline} trend={card.trendH24} />
         </div>
+      </div>
+
+      {/* COMPACT mode only, and this is why compact loses no data: the line
+        * is not deleted when it will not fit beside the figures, it moves
+        * under them into a slot of its own. */}
+      <div
+        data-vex-area="board-token-sparkline-slot"
+        className="vex-board-card-sparkline-slot w-full"
+      >
+        <BoardSparkline data={sparkline} trend={card.trendH24} />
       </div>
 
       <div className="mt-4 h-px w-full bg-line-2" aria-hidden />
@@ -205,36 +347,30 @@ export function TokenCardV3({
         * any one value renders. */}
       <dl
         data-vex-area="board-token-stats"
-        className="mt-4 grid h-[46px] grid-cols-4 gap-x-3"
+        className="vex-board-card-stats mt-4"
       >
-        <Stat
-          label="Liquidity"
-          value={formatBoardUsdCompact(row?.liquidityUsd ?? null)}
-          title={row?.liquidityUsd ?? undefined}
-        />
-        <Stat
-          label="24h Volume"
-          value={formatBoardUsdCompact(row?.volumeH24Usd ?? null)}
-          title={row?.volumeH24Usd ?? undefined}
-        />
-        <Stat
-          label="Trades"
-          value={
-            row === null
-              ? BOARD_EMPTY
-              : formatBoardTradeTotal(row.txns.buys, row.txns.sells)
-          }
-        />
-        <Stat
-          label="Pair age"
-          value={formatBoardAge(row?.pairAgeSeconds ?? null)}
-        />
+        {stats.map((stat) => (
+          <Stat
+            key={stat.label}
+            label={stat.label}
+            printed={stat.printed}
+            title={stat.title}
+          />
+        ))}
       </dl>
 
       {/* FOOTER. `mt-auto` pins this row to the bottom of the plate, so a
         * row of cards has its chips and its buttons on one line whatever
         * happens above them. */}
-      <div className="mt-auto flex items-center justify-between gap-3 pt-4">
+      {/* In WIDE mode this is one line with the chip against the actions; in
+        * COMPACT it stacks, which is what lets the chip print
+        * "Checks unavailable in this response" - 242px, the widest string the
+        * frozen safety table can produce - beside nothing instead of
+        * ellipsizing beside two buttons. `board-layout.css` owns the switch. */}
+      <div
+        data-vex-area="board-token-footer"
+        className="vex-board-card-footer mt-auto pt-4"
+      >
         <BoardStatusChip
           verdict={verdict}
           pairAgeSeconds={row?.pairAgeSeconds ?? null}
@@ -374,24 +510,261 @@ function deltaToneClass(trend: BoardTrend): string {
 
 function Stat({
   label,
-  value,
+  printed,
   title,
 }: {
   readonly label: string;
-  readonly value: string;
+  readonly printed: BoardCardValue;
   readonly title?: string | undefined;
 }): JSX.Element {
+  // NEITHER LINE ELLIPSIZES IN CSS, and that is why the value arrives already
+  // decided. A stat label is fixed product copy and a stat value is a figure
+  // a reader is about to act on; the mode floors in `board-layout.css` are
+  // sized so every realistic pair fits whole (binding label "24h Volume" at
+  // 66px, binding value "$998.8K" at 63px). A schema extreme that cannot fit
+  // is shortened by `boardCardValueBudget.ts` BEFORE it gets here, so what
+  // reaches this cell always fits and always says whether it is the whole
+  // figure - rather than being clipped by the card with nothing reporting it.
   return (
     <div className="flex min-w-0 flex-col gap-1">
-      <dt className="truncate text-[13px] leading-[16px] text-ink-tertiary">
+      <dt className="whitespace-nowrap text-[13px] leading-[16px] text-ink-tertiary">
         {label}
       </dt>
       <dd
-        className="truncate text-[15px] font-semibold leading-[20px] tabular-nums text-ink-primary"
+        data-shortened={printed.shortened ? "true" : undefined}
+        className="whitespace-nowrap text-[15px] font-semibold leading-[20px] tabular-nums text-ink-primary"
         title={title}
       >
-        {value}
+        {printed.text}
       </dd>
     </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* The full-value disclosure                                           */
+/* ------------------------------------------------------------------ */
+
+/** What the card is showing in a clamped form, and the whole string for it. */
+interface FullValueEntry {
+  readonly label: string;
+  readonly value: string;
+}
+
+export const BOARD_FULL_VALUE_LABEL = "Show the full values";
+export const BOARD_FULL_VALUE_TITLE = "Full values";
+
+/**
+ * WHAT THE AFFORDANCE SAYS WHEN THE CARD ACTUALLY CUT SOMETHING.
+ *
+ * "Show the full values" says a panel exists; it does not say that the figure
+ * in front of the reader is not the whole figure. That difference is the
+ * whole point of a reported bound, so a card that shortened a value names the
+ * cut state in the button's accessible name and again, visibly, at the top of
+ * the panel.
+ */
+export const BOARD_FULL_VALUE_SHORTENED_LABEL =
+  "Some values on this card are shortened";
+
+/**
+ * THE RECOVERY PATH FOR EVERY CLAMPED STRING ON THE CARD.
+ *
+ * A 40-character decimal and a 512-character symbol are both schema-valid
+ * (`BOARD_DECIMAL_MAX_CHARS`, `BOARD_TOKEN_LABEL_MAX_CHARS`) and neither can
+ * be made to fit any card at any width. The display formatters also round
+ * every price by design. So the card always clamps SOMETHING, and until now
+ * the only way back was a `title` - unreachable by keyboard and by touch,
+ * which rule 08 does not accept for anything a reader may need.
+ *
+ * This is a real `<button>`, so Enter and Space work with no key handler of
+ * our own, and the panel it opens is an ordinary absolutely-positioned
+ * overlay INSIDE the card rather than a portal: the board modal's native
+ * `<dialog>` already owns the focus trap, and a portal to `document.body`
+ * would put the panel outside it. Initial focus goes to the close button,
+ * Escape closes, and focus returns to the trigger - the three obligations a
+ * dialog-nested disclosure has, met without touching the dialog primitive.
+ *
+ * Escape is stopped from propagating while the panel is open, so closing the
+ * panel does not also close the board behind it.
+ *
+ * AND ITS TAB SEQUENCE IS CONTAINED, which a `role="dialog"` over obscured
+ * controls owes its reader (WAI modal-dialog pattern). The panel covers the
+ * card, but the card's own buttons - the Spotlight trigger, DexScreener, Ask
+ * VEX - are still in the document after it, so without the trap below a Tab
+ * from the close button lands on a control nobody can see, and an Escape from
+ * there is no longer this panel's to stop: it reaches the board `<dialog>`
+ * and closes the whole board.
+ */
+function FullValueDisclosure({
+  ticker,
+  heading,
+  row,
+  shortened,
+}: {
+  readonly ticker: string;
+  readonly heading: string;
+  readonly row: BoardCardModel["row"];
+  /** True when the card printed a shortened copy of at least one value. */
+  readonly shortened: boolean;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const trigger = useRef<HTMLButtonElement | null>(null);
+  const close = useRef<HTMLButtonElement | null>(null);
+  const panel = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    close.current?.focus();
+  }, [open]);
+
+  const dismiss = (): void => {
+    setOpen(false);
+    trigger.current?.focus();
+  };
+
+  /**
+   * The trap. It lives on the panel's own `keydown`, so it can only run while
+   * focus is already inside: there is no document listener to leak, nothing
+   * to unregister, and a card whose panel is closed costs nothing.
+   */
+  const trap = (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+    if (event.key !== "Tab") return;
+    const host = panel.current;
+    if (host === null) return;
+    const focusable = [
+      ...host.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ];
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (first === undefined || last === undefined) {
+      // Nothing to move to, so the only correct move is not to move: letting
+      // Tab through would put focus on the card behind the panel.
+      event.preventDefault();
+      return;
+    }
+    const active = document.activeElement;
+    const inside = active instanceof Node && host.contains(active);
+    if (event.shiftKey) {
+      if (!inside || active === first) {
+        event.preventDefault();
+        last.focus();
+      }
+      return;
+    }
+    if (!inside || active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const entries: readonly FullValueEntry[] = [
+    { label: "Name", value: heading },
+    { label: "Ticker", value: ticker },
+    { label: "Price, USD", value: row?.priceUsd ?? BOARD_EMPTY },
+    { label: "24h change, percent", value: row?.priceChange.h24 ?? BOARD_EMPTY },
+    { label: "Liquidity, USD", value: row?.liquidityUsd ?? BOARD_EMPTY },
+    { label: "24h volume, USD", value: row?.volumeH24Usd ?? BOARD_EMPTY },
+  ];
+
+  return (
+    <>
+      <button
+        ref={trigger}
+        type="button"
+        data-vex-area="board-token-full-value"
+        data-shortened={shortened ? "true" : undefined}
+        aria-expanded={open}
+        // NAMED, NOT GENERIC, once the card has actually cut something.
+        aria-label={
+          shortened
+            ? `${BOARD_FULL_VALUE_SHORTENED_LABEL}. ${BOARD_FULL_VALUE_LABEL} for ${ticker}`
+            : `${BOARD_FULL_VALUE_LABEL} for ${ticker}`
+        }
+        title={
+          shortened
+            ? `${BOARD_FULL_VALUE_SHORTENED_LABEL}. ${BOARD_FULL_VALUE_LABEL}.`
+            : BOARD_FULL_VALUE_LABEL
+        }
+        onClick={() => {
+          setOpen(true);
+        }}
+        className={cn(
+          "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border text-ink-tertiary transition-colors duration-150 hover:border-line-3 hover:bg-interactive-hover hover:text-ink-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none",
+          // The cut is VISIBLE on the control itself, in the one treatment
+          // the card already uses to mean "this needs your attention", so a
+          // reader who never opens the panel still sees that this card is
+          // showing them less than the provider sent.
+          shortened
+            ? "border-accent-primary/40 bg-accent-wash text-accent-primary"
+            : "border-line-2",
+        )}
+      >
+        <IconInfo size={14} />
+      </button>
+      {open ? (
+        <div
+          ref={panel}
+          data-vex-area="board-token-full-value-popover"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`${BOARD_FULL_VALUE_TITLE} for ${ticker}`}
+          onKeyDown={(event) => {
+            if (event.key === "Tab") {
+              trap(event);
+              return;
+            }
+            if (event.key !== "Escape") return;
+            // The board dialog is listening for Escape too, and it would
+            // close the whole board behind this panel.
+            event.stopPropagation();
+            event.preventDefault();
+            dismiss();
+          }}
+          className="absolute inset-0 z-10 flex flex-col gap-3 overflow-y-auto rounded-2xl border border-line-2 bg-board-card px-5 py-5"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <p className="font-display text-[15px] font-semibold leading-[20px] text-ink-primary">
+              {BOARD_FULL_VALUE_TITLE}
+            </p>
+            <button
+              ref={close}
+              type="button"
+              data-vex-area="board-token-full-value-close"
+              onClick={dismiss}
+              aria-label={`Close the full values for ${ticker}`}
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-ink-tertiary hover:bg-interactive-hover hover:text-ink-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <IconClose size={14} />
+            </button>
+          </div>
+          {shortened ? (
+            <p
+              data-vex-area="board-token-full-value-notice"
+              className="text-[12px] leading-[16px] text-ink-secondary"
+            >
+              {BOARD_FULL_VALUE_SHORTENED_LABEL}. Every value below is the
+              whole one.
+            </p>
+          ) : null}
+          <dl className="flex flex-col gap-2">
+            {entries.map((entry) => (
+              <div key={entry.label} className="flex flex-col gap-0.5">
+                <dt className="text-[12px] leading-[16px] text-ink-tertiary">
+                  {entry.label}
+                </dt>
+                {/* `break-all` and no clamp of any kind: this is the one place
+                  * on the card where the WHOLE string is the point, so a
+                  * 512-character symbol wraps and the panel scrolls. */}
+                <dd className="break-all text-[13px] leading-[18px] text-ink-primary">
+                  {entry.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      ) : null}
+    </>
   );
 }

--- a/vex-app/src/renderer/features/appShell/Board/__tests__/TokenCardV3.test.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/__tests__/TokenCardV3.test.tsx
@@ -21,7 +21,14 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { TokenCardV3 } from "../TokenCardV3.js";
@@ -391,9 +398,53 @@ describe("TokenCardV3 - equal cards and designed data states", () => {
     render(mount());
     // Fixed heights, not content-driven ones: this is what makes a grid of
     // cards line up regardless of name length, missing artwork or absent bars.
+    // The stat block's height is now PER MODE and therefore CSS's
+    // (`vex-board-card-stats` in global-css/board-layout.css, 46px wide /
+    // 92px compact); what this file still owns is that the card carries the
+    // class at all, so the mode has something to act on. The heights
+    // themselves are proven where they are observable, in
+    // `e2e/board-layout.spec.ts`.
     expect(area("board-token-card-v3").className).toContain("h-full");
-    expect(area("board-token-stats").className).toContain("h-[46px]");
+    expect(area("board-token-card-v3").className).toContain("w-full");
+    expect(area("board-token-stats").className).toContain(
+      "vex-board-card-stats",
+    );
+    expect(area("board-token-footer").className).toContain(
+      "vex-board-card-footer",
+    );
+    // THE NAME KEEPS ITS ELLIPSIS, and this pin stays deliberate: a token
+    // name is prose, it is the one string on the card that may be clamped,
+    // and the whole of it is still in the `title`, in the card's accessible
+    // name and in the full-value disclosure.
     expect(area("board-token-name").className).toContain("truncate");
+    expect(area("board-token-name").getAttribute("title")).toBe("UBERCAT");
+  });
+
+  it("clamps no figure, stat label or chip label", () => {
+    render(mount());
+    // The counterpart of the pin above. Everything that is not the name is a
+    // figure or a fixed piece of product copy, and the mode floors in
+    // `board-layout.css` are sized so each one fits whole; an ellipsis here
+    // would be a silent cut with no recovery in the layout.
+    const stats = area("board-token-stats");
+    for (const cell of [...stats.querySelectorAll("dt, dd")]) {
+      expect(cell.className).not.toContain("truncate");
+      expect(cell.className).toContain("whitespace-nowrap");
+    }
+    const chipLabel = area("board-status-chip").querySelector("span");
+    expect(chipLabel?.className).not.toContain("truncate");
+  });
+
+  it("keeps the sparkline in BOTH anatomies rather than dropping it", () => {
+    render(mount());
+    // Compact mode moves the line, it never deletes it. Both slots are in the
+    // DOM and CSS shows exactly one; a reader on a narrow card still gets the
+    // shape of the last 24 hours.
+    expect(area("board-token-sparkline-inline")).toBeTruthy();
+    expect(area("board-token-sparkline-slot")).toBeTruthy();
+    expect(
+      document.querySelectorAll('[data-vex-area="board-sparkline"]'),
+    ).toHaveLength(2);
   });
 
   it("renders every element for an UNHYDRATED pool, with dashes not gaps", () => {
@@ -483,5 +534,211 @@ describe("TokenCardV3 - actions", () => {
       expect(node.className).not.toContain("opacity-0");
       expect(node.className).toContain("focus-visible:ring");
     }
+  });
+});
+
+
+/**
+ * THE FULL-VALUE DISCLOSURE.
+ *
+ * The card clamps by necessity - the formatters round every price, the name
+ * ellipsizes, and a 512-character symbol is schema-valid - and until this
+ * control existed the only way back to the whole string was a `title`, which
+ * a keyboard reader and a touch reader never reach.
+ *
+ * WHAT THIS FILE PROVES AND WHAT IT DOES NOT. jsdom does not synthesize a
+ * click from a keypress, so "Enter opens it" cannot be an honest assertion
+ * here; the browser does that natively and only for real buttons, so what is
+ * asserted below is the semantics that EARN the native behaviour, plus the
+ * focus contract, which is real DOM state. The Enter press itself is driven
+ * against a real engine in `e2e/board-layout.spec.ts`.
+ */
+describe("TokenCardV3 - the full-value disclosure", () => {
+  const RAW_PRICE = "1234567890123456789012345678901234.5678";
+
+  function openPanel(): HTMLElement {
+    const trigger = area("board-token-full-value");
+    fireEvent.click(trigger);
+    return trigger;
+  }
+
+  it("is a real button, which is what makes Enter and Space work natively", () => {
+    render(mount());
+    const trigger = area("board-token-full-value");
+    // `<button type="button">`, not a `div` with `role="button"`: the native
+    // element is what activates on BOTH keys with no handler of ours, and
+    // what keeps it in the tab order with no `tabindex` of ours.
+    expect(trigger.tagName).toBe("BUTTON");
+    expect(trigger.getAttribute("type")).toBe("button");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger.getAttribute("aria-label")).toContain("UBERCAT");
+  });
+
+  it("shows the WHOLE provider string the hero price rounded away", () => {
+    render(
+      mount({ card: card({ row: hydratedRow({ priceUsd: RAW_PRICE }) }) }),
+    );
+    openPanel();
+    const popover = area("board-token-full-value-popover");
+    expect(popover.getAttribute("role")).toBe("dialog");
+    expect(area("board-token-full-value").getAttribute("aria-expanded")).toBe(
+      "true",
+    );
+    // The 40-character decimal, entire. This is the whole point: the hero row
+    // shows `$1234567890123456789012345678901234.56` and every digit the
+    // formatter dropped is here rather than lost.
+    expect(popover.textContent).toContain(RAW_PRICE);
+  });
+
+  it("carries the whole name and ticker, which the identity row clamps", () => {
+    const symbol = "X".repeat(512);
+    render(
+      mount({
+        card: card({
+          row: hydratedRow({ baseTokenSymbol: symbol, baseTokenName: symbol }),
+        }),
+      }),
+    );
+    openPanel();
+    expect(area("board-token-full-value-popover").textContent).toContain(
+      symbol,
+    );
+  });
+
+  it("gives the panel initial focus, so a keyboard reader lands inside it", async () => {
+    render(mount());
+    openPanel();
+    await waitFor(() => {
+      expect(document.activeElement).toBe(area("board-token-full-value-close"));
+    });
+  });
+
+  it("closes on Escape and restores focus to the trigger", async () => {
+    render(mount());
+    const trigger = openPanel();
+    await waitFor(() => {
+      expect(document.activeElement).toBe(area("board-token-full-value-close"));
+    });
+
+    fireEvent.keyDown(area("board-token-full-value-popover"), {
+      key: "Escape",
+    });
+    expect(
+      document.querySelector('[data-vex-area="board-token-full-value-popover"]'),
+    ).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("does not let its own Escape close the board behind it", () => {
+    // The board modal is a native `<dialog>` listening for the same key. An
+    // Escape that propagated would take the whole board down with it, which
+    // is a reader losing their place to a control they opened to read one
+    // number.
+    const onBoardEscape = vi.fn();
+    render(
+      <div
+        onKeyDown={(event) => {
+          if (event.key === "Escape") onBoardEscape();
+        }}
+      >
+        {mount()}
+      </div>,
+    );
+    openPanel();
+    fireEvent.keyDown(area("board-token-full-value-popover"), {
+      key: "Escape",
+    });
+    expect(onBoardEscape).not.toHaveBeenCalled();
+  });
+
+  it("keeps Tab and Shift+Tab inside the panel", async () => {
+    // THE PANEL IS A `role="dialog"` PAINTED OVER THE CARD'S OWN BUTTONS,
+    // which are still in the document after it. Without containment, Tab from
+    // the close button lands on the Spotlight trigger the reader cannot see -
+    // and an Escape from THERE is no longer this panel's to stop, so it
+    // reaches the board and closes it. This is the WAI modal-dialog pattern.
+    render(mount());
+    openPanel();
+    const popover = area("board-token-full-value-popover");
+    await waitFor(() => {
+      expect(document.activeElement).toBe(area("board-token-full-value-close"));
+    });
+
+    // jsdom does not move focus on a synthetic Tab, so what is observable
+    // HERE is the panel REFUSING to let the browser do it: the default action
+    // is prevented and focus is placed by the panel instead. The sequence
+    // itself is measured where a real engine can move focus, in
+    // `e2e/board-layout.spec.ts`.
+    for (const shiftKey of [false, true]) {
+      const moved = fireEvent.keyDown(document.activeElement ?? popover, {
+        key: "Tab",
+        shiftKey,
+        cancelable: true,
+      });
+      expect(moved).toBe(false);
+      expect(popover.contains(document.activeElement)).toBe(true);
+    }
+
+    // A key the panel does not own is left alone, so the trap cannot become a
+    // swallow-everything handler.
+    expect(
+      fireEvent.keyDown(document.activeElement ?? popover, {
+        key: "ArrowDown",
+        cancelable: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("says the values are shortened only when the card shortened one", () => {
+    // NAMED, NOT GENERIC. On a card that cut nothing the plain label is the
+    // truth; on one that did, "Show the full values" would leave a reader
+    // believing the figure in front of them is the figure.
+    render(mount());
+    expect(
+      area("board-token-full-value").getAttribute("aria-label"),
+    ).not.toMatch(/shortened/i);
+    expect(area("board-token-full-value").hasAttribute("data-shortened")).toBe(
+      false,
+    );
+
+    cleanup();
+    render(
+      mount({
+        card: card({
+          row: hydratedRow({
+            priceUsd: RAW_PRICE,
+            baseTokenSymbol: "X".repeat(512),
+          }),
+        }),
+      }),
+    );
+    const trigger = area("board-token-full-value");
+    expect(trigger.getAttribute("aria-label")).toMatch(/shortened/i);
+    expect(trigger.getAttribute("data-shortened")).toBe("true");
+    // The cut is marked where it happened, not only on the affordance.
+    expect(area("board-token-price").getAttribute("data-shortened")).toBe(
+      "true",
+    );
+    expect(area("board-token-ticker").getAttribute("data-shortened")).toBe(
+      "true",
+    );
+    // And the panel repeats it visibly, above the whole values.
+    fireEvent.click(trigger);
+    expect(area("board-token-full-value-notice").textContent).toMatch(
+      /shortened/i,
+    );
+  });
+
+  it("closes on its own close button too, and restores focus", async () => {
+    render(mount());
+    const trigger = openPanel();
+    await waitFor(() => {
+      expect(document.activeElement).toBe(area("board-token-full-value-close"));
+    });
+    fireEvent.click(area("board-token-full-value-close"));
+    expect(
+      document.querySelector('[data-vex-area="board-token-full-value-popover"]'),
+    ).toBeNull();
+    expect(document.activeElement).toBe(trigger);
   });
 });

--- a/vex-app/src/renderer/features/appShell/Board/__tests__/TokenCardV3.test.tsx
+++ b/vex-app/src/renderer/features/appShell/Board/__tests__/TokenCardV3.test.tsx
@@ -580,7 +580,10 @@ describe("TokenCardV3 - the full-value disclosure", () => {
     );
     openPanel();
     const popover = area("board-token-full-value-popover");
-    expect(popover.getAttribute("role")).toBe("dialog");
+    // The panel's ROLE is asserted where it is the subject, in "is a labelled
+    // disclosure and claims no modality it does not have" below. It is a
+    // `group`, not a `dialog`: an INTENTIONAL contract change, because
+    // `aria-modal` promised an inertness this overlay never had.
     expect(area("board-token-full-value").getAttribute("aria-expanded")).toBe(
       "true",
     );
@@ -651,42 +654,91 @@ describe("TokenCardV3 - the full-value disclosure", () => {
     expect(onBoardEscape).not.toHaveBeenCalled();
   });
 
-  it("keeps Tab and Shift+Tab inside the panel", async () => {
-    // THE PANEL IS A `role="dialog"` PAINTED OVER THE CARD'S OWN BUTTONS,
-    // which are still in the document after it. Without containment, Tab from
-    // the close button lands on the Spotlight trigger the reader cannot see -
-    // and an Escape from THERE is no longer this panel's to stop, so it
-    // reaches the board and closes it. This is the WAI modal-dialog pattern.
+  it("is a labelled disclosure and claims no modality it does not have", () => {
+    // `role="dialog"` WITH `aria-modal="true"` WAS A LIE. Nothing outside this
+    // panel was ever inert: a pointer reached every other card while it was
+    // open, and two of them could be "modal" at once. A promise the code does
+    // not keep is worse than no promise, so the panel is what it is - a group
+    // a button expands - and the trigger carries the whole relationship.
     render(mount());
-    openPanel();
-    const popover = area("board-token-full-value-popover");
-    await waitFor(() => {
-      expect(document.activeElement).toBe(area("board-token-full-value-close"));
-    });
+    const trigger = area("board-token-full-value");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    const controls = trigger.getAttribute("aria-controls");
+    expect(controls).not.toBeNull();
 
-    // jsdom does not move focus on a synthetic Tab, so what is observable
-    // HERE is the panel REFUSING to let the browser do it: the default action
-    // is prevented and focus is placed by the panel instead. The sequence
-    // itself is measured where a real engine can move focus, in
-    // `e2e/board-layout.spec.ts`.
-    for (const shiftKey of [false, true]) {
-      const moved = fireEvent.keyDown(document.activeElement ?? popover, {
-        key: "Tab",
-        shiftKey,
-        cancelable: true,
-      });
-      expect(moved).toBe(false);
-      expect(popover.contains(document.activeElement)).toBe(true);
+    openPanel();
+    const panel = area("board-token-full-value-popover");
+    expect(panel.getAttribute("role")).toBe("group");
+    expect(panel.hasAttribute("aria-modal")).toBe(false);
+    expect(panel.getAttribute("id")).toBe(controls);
+    expect(panel.getAttribute("aria-label")).toContain("UBERCAT");
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("takes every covered control out of the tab order while open", () => {
+    // THE PANEL IS OPAQUE AND COVERS THE WHOLE CARD, so a control underneath
+    // it cannot be seen - and a Tab that lands there puts focus somewhere
+    // invisible, which rule 08 forbids ("focus is visible and not obscured").
+    // Withdrawing them is the CARD's job, because the card owns them.
+    //
+    // `tabIndex={-1}` and NOT `inert`: `inert` removes the subtree from the
+    // accessibility tree along with the trigger's own `aria-expanded`, so the
+    // panel would be open with nothing able to report that it was.
+    render(mount());
+    const covered = [
+      "board-token-full-value",
+      "board-card-spotlight",
+      "board-token-dexscreener-link",
+      "board-card-ask",
+    ];
+    for (const name of covered) {
+      expect(area(name).hasAttribute("tabindex")).toBe(false);
     }
 
-    // A key the panel does not own is left alone, so the trap cannot become a
-    // swallow-everything handler.
-    expect(
-      fireEvent.keyDown(document.activeElement ?? popover, {
-        key: "ArrowDown",
-        cancelable: true,
-      }),
-    ).toBe(true);
+    openPanel();
+    for (const name of covered) {
+      expect(area(name).getAttribute("tabindex")).toBe("-1");
+      // STILL IN THE TREE, which is the entire reason this is not `inert`:
+      // each one keeps its accessible name, and the trigger keeps its state.
+      expect(area(name).getAttribute("aria-label")).not.toBeNull();
+    }
+    expect(area("board-token-full-value").getAttribute("aria-expanded")).toBe(
+      "true",
+    );
+    // The panel's own control keeps its natural place in the order.
+    expect(area("board-token-full-value-close").hasAttribute("tabindex")).toBe(
+      false,
+    );
+
+    // It reverts with the state flip, in the same commit that removes the
+    // panel, and the trigger still takes focus back although it was
+    // `tabIndex={-1}` at the moment it was asked to.
+    fireEvent.keyDown(area("board-token-full-value-popover"), {
+      key: "Escape",
+    });
+    for (const name of covered) {
+      expect(area(name).hasAttribute("tabindex")).toBe(false);
+    }
+    expect(document.activeElement).toBe(area("board-token-full-value"));
+  });
+
+  it("does not trap Tab, because a non-modal surface must not", () => {
+    // The counterpart of the assertion above. A trap on a surface that is not
+    // modal steals a key the rest of the page is entitled to; the browser's
+    // own sequence is the correct behaviour, and the E2E measures where it
+    // actually lands.
+    render(mount());
+    openPanel();
+    const panel = area("board-token-full-value-popover");
+    for (const shiftKey of [false, true]) {
+      expect(
+        fireEvent.keyDown(document.activeElement ?? panel, {
+          key: "Tab",
+          shiftKey,
+          cancelable: true,
+        }),
+      ).toBe(true);
+    }
   });
 
   it("says the values are shortened only when the card shortened one", () => {

--- a/vex-app/src/renderer/features/appShell/Board/__tests__/boardCardValueBudget.test.ts
+++ b/vex-app/src/renderer/features/appShell/Board/__tests__/boardCardValueBudget.test.ts
@@ -12,11 +12,12 @@
 import { describe, expect, it } from "vitest";
 import {
   anyShortened,
+  boardCardValueSlots,
   boardCardValue,
-  BOARD_CARD_DELTA_MAX_CHARS,
-  BOARD_CARD_PRICE_MAX_CHARS,
-  BOARD_CARD_STAT_MAX_CHARS,
-  BOARD_CARD_TICKER_MAX_CHARS,
+  BOARD_CARD_DELTA_MAX_SLOTS,
+  BOARD_CARD_PRICE_MAX_SLOTS,
+  BOARD_CARD_STAT_MAX_SLOTS,
+  BOARD_CARD_TICKER_MAX_SLOTS,
 } from "../boardCardValueBudget.js";
 
 describe("boardCardValue", () => {
@@ -26,16 +27,16 @@ describe("boardCardValue", () => {
     // itself of a cut it did not make, and the budget would be wrong rather
     // than the value.
     for (const [text, budget] of [
-      ["$0.000001230", BOARD_CARD_PRICE_MAX_CHARS],
-      ["$104238.92", BOARD_CARD_PRICE_MAX_CHARS],
-      ["+661.00%", BOARD_CARD_DELTA_MAX_CHARS],
-      ["-12.48%", BOARD_CARD_DELTA_MAX_CHARS],
-      ["$998.8K", BOARD_CARD_STAT_MAX_CHARS],
-      ["$1234.5B", BOARD_CARD_STAT_MAX_CHARS],
-      ["1095d", BOARD_CARD_STAT_MAX_CHARS],
-      ["-", BOARD_CARD_STAT_MAX_CHARS],
-      ["DEGEN", BOARD_CARD_TICKER_MAX_CHARS],
-      ["WBTC", BOARD_CARD_TICKER_MAX_CHARS],
+      ["$0.000001230", BOARD_CARD_PRICE_MAX_SLOTS],
+      ["$104238.92", BOARD_CARD_PRICE_MAX_SLOTS],
+      ["+661.00%", BOARD_CARD_DELTA_MAX_SLOTS],
+      ["-12.48%", BOARD_CARD_DELTA_MAX_SLOTS],
+      ["$998.8K", BOARD_CARD_STAT_MAX_SLOTS],
+      ["$1234.5B", BOARD_CARD_STAT_MAX_SLOTS],
+      ["1095d", BOARD_CARD_STAT_MAX_SLOTS],
+      ["-", BOARD_CARD_STAT_MAX_SLOTS],
+      ["DEGEN", BOARD_CARD_TICKER_MAX_SLOTS],
+      ["WBTC", BOARD_CARD_TICKER_MAX_SLOTS],
     ] as const) {
       expect(boardCardValue(text, budget)).toEqual({ text, shortened: false });
     }
@@ -45,42 +46,135 @@ describe("boardCardValue", () => {
     // A 40-character decimal and a 512-character symbol both parse.
     const price = boardCardValue(
       "$1234567890123456789012345678901234.56",
-      BOARD_CARD_PRICE_MAX_CHARS,
+      BOARD_CARD_PRICE_MAX_SLOTS,
     );
     expect(price.shortened).toBe(true);
     // One character short of the budget, because the ellipsis is charged two
     // slots for a glyph that is nearly two digits wide.
-    expect(price.text).toHaveLength(BOARD_CARD_PRICE_MAX_CHARS - 1);
+    expect(price.text).toHaveLength(BOARD_CARD_PRICE_MAX_SLOTS - 1);
     expect(price.text.endsWith("…")).toBe(true);
 
-    const ticker = boardCardValue("X".repeat(512), BOARD_CARD_TICKER_MAX_CHARS);
+    const ticker = boardCardValue("X".repeat(512), BOARD_CARD_TICKER_MAX_SLOTS);
     expect(ticker.shortened).toBe(true);
-    expect(ticker.text).toHaveLength(BOARD_CARD_TICKER_MAX_CHARS - 1);
+    expect(ticker.text).toHaveLength(BOARD_CARD_TICKER_MAX_SLOTS - 1);
   });
 
   it("never exceeds the budget, at the boundary or one past it", () => {
-    for (const budget of [2, 8, 10, 11, 12]) {
+    // Every budget the card actually uses is 8 or more. The one exception to
+    // "never exceeds" is the documented clamp - one cluster plus the mark
+    // survives even when the budget cannot pay for both - and it is asserted
+    // as itself rather than smuggled past this loop.
+    for (const budget of [8, 10, 11, 12]) {
       for (const length of [budget - 1, budget, budget + 1, budget + 400]) {
         const value = boardCardValue("9".repeat(length), budget);
-        expect(value.text.length).toBeLessThanOrEqual(budget);
+        expect(boardCardValueSlots(value.text)).toBeLessThanOrEqual(budget);
         expect(value.shortened).toBe(length > budget);
       }
     }
   });
 
-  it("keeps one character visible even at an absurd budget", () => {
+  it("keeps one cluster visible even at an absurd budget", () => {
     // The shortest honest output is something plus the mark that says there
-    // was more, never the mark alone.
-    const value = boardCardValue("123456", 1);
-    expect(value.text).toBe("1…");
-    expect(value.shortened).toBe(true);
+    // was more, never the mark alone - so at a budget too small to pay for
+    // both, the clamp deliberately spends one slot more rather than printing
+    // a value that names nothing. No card uses a budget this small.
+    for (const budget of [1, 2, 3]) {
+      const value = boardCardValue("123456", budget);
+      expect(value.text).toBe("1…");
+      expect(value.shortened).toBe(true);
+    }
+    // And the clamp keeps a WHOLE cluster, never half of one.
+    const emoji = boardCardValue("👨‍👩‍👧‍👦👩‍💻", 1);
+    expect(emoji.text).toBe("👨‍👩‍👧‍👦…");
+    expect(emoji.text).toBe(emoji.text.toWellFormed());
+  });
+});
+
+/**
+ * SCHEMA-VALID UNICODE. `baseTokenSymbol` is `z.string().min(1).max(512)`:
+ * 512 UTF-16 code units of anything at all. These are the cases a budget
+ * counted in `String.length` and cut with `String.slice` got wrong.
+ */
+describe("boardCardValue over non-Latin tickers", () => {
+  const CJK = "比特币现金交易所代币";
+  const FAMILY = "👨‍👩‍👧‍👦";
+  const FLAG = "🇯🇵";
+  const COMBINING = "é"; // e + combining acute, one cluster
+
+  it("charges a wide character two slots, so a short CJK ticker is cut", () => {
+    // THE DEFECT: ten CJK characters are ten `String.length` and sat under a
+    // ten-character budget while rendering at twice the width the budget was
+    // measured against - overflowing the column with `shortened` false.
+    expect(CJK.length).toBe(10);
+    expect(boardCardValueSlots(CJK)).toBe(20);
+    const printed = boardCardValue(CJK, BOARD_CARD_TICKER_MAX_SLOTS);
+    expect(printed.shortened).toBe(true);
+    expect(boardCardValueSlots(printed.text)).toBeLessThanOrEqual(
+      BOARD_CARD_TICKER_MAX_SLOTS,
+    );
+  });
+
+  it("never splits a grapheme cluster", () => {
+    // A ZWJ family is ONE cluster of seven code points and eleven code units.
+    // Cutting inside it renders a different token than the provider sent.
+    const printed = boardCardValue(
+      FAMILY.repeat(6),
+      BOARD_CARD_TICKER_MAX_SLOTS,
+    );
+    expect(printed.shortened).toBe(true);
+    const withoutMark = printed.text.slice(0, -1);
+    expect(withoutMark).toBe(FAMILY.repeat(withoutMark.length / FAMILY.length));
+
+    // A regional-indicator flag is one cluster of two astral code points.
+    const flags = boardCardValue(FLAG.repeat(8), BOARD_CARD_TICKER_MAX_SLOTS);
+    expect(flags.text.slice(0, -1).length % FLAG.length).toBe(0);
+
+    // A combining mark never outlives the base character it belongs to.
+    const marks = boardCardValue(
+      COMBINING.repeat(20),
+      BOARD_CARD_TICKER_MAX_SLOTS,
+    );
+    expect(marks.text.startsWith(COMBINING)).toBe(true);
+    expect(marks.text.slice(0, -1).length % COMBINING.length).toBe(0);
+  });
+
+  it("never emits a lone surrogate, at any budget or any boundary", () => {
+    // THE PERSISTENCE BOUNDARY, not only the pixels: an ill-formed string is
+    // what a code-unit slice through a surrogate pair produces, and it travels
+    // on into jsonb. Every budget from 1 up is walked over strings whose
+    // clusters straddle every possible cut point.
+    const subjects = [
+      "𝐀𝐁𝐂𝐃𝐄𝐅",
+      `A${FAMILY}B${FLAG}C`,
+      `${CJK}${FLAG}`,
+      `${COMBINING}𝐀${FAMILY}`,
+    ];
+    for (const subject of subjects) {
+      for (let budget = 1; budget <= 24; budget += 1) {
+        const { text } = boardCardValue(subject, budget);
+        expect(text).toBe(text.toWellFormed());
+        // And nothing is invented: what survives is a prefix of the original.
+        const body = text.endsWith("…") ? text.slice(0, -1) : text;
+        expect(subject.startsWith(body)).toBe(true);
+      }
+    }
+  });
+
+  it("leaves a Latin ticker exactly where it was", () => {
+    // The realistic path must not move because the Unicode path was fixed.
+    for (const symbol of ["WBTC", "PEPE", "DEGEN", "TOSHI", "USDC"]) {
+      expect(boardCardValue(symbol, BOARD_CARD_TICKER_MAX_SLOTS)).toEqual({
+        text: symbol,
+        shortened: false,
+      });
+    }
   });
 });
 
 describe("anyShortened", () => {
   it("is true when any one value conceded, and false when none did", () => {
-    const whole = boardCardValue("WBTC", BOARD_CARD_TICKER_MAX_CHARS);
-    const cut = boardCardValue("X".repeat(64), BOARD_CARD_TICKER_MAX_CHARS);
+    const whole = boardCardValue("WBTC", BOARD_CARD_TICKER_MAX_SLOTS);
+    const cut = boardCardValue("X".repeat(64), BOARD_CARD_TICKER_MAX_SLOTS);
     expect(anyShortened([whole, whole])).toBe(false);
     expect(anyShortened([whole, cut])).toBe(true);
     expect(anyShortened([])).toBe(false);

--- a/vex-app/src/renderer/features/appShell/Board/__tests__/boardCardValueBudget.test.ts
+++ b/vex-app/src/renderer/features/appShell/Board/__tests__/boardCardValueBudget.test.ts
@@ -163,10 +163,89 @@ describe("boardCardValue over non-Latin tickers", () => {
   it("leaves a Latin ticker exactly where it was", () => {
     // The realistic path must not move because the Unicode path was fixed.
     for (const symbol of ["WBTC", "PEPE", "DEGEN", "TOSHI", "USDC"]) {
-      expect(boardCardValue(symbol, BOARD_CARD_TICKER_MAX_SLOTS)).toEqual({
-        text: symbol,
-        shortened: false,
-      });
+      expect(
+        boardCardValue(symbol, BOARD_CARD_TICKER_MAX_SLOTS, "proportional"),
+      ).toEqual({ text: symbol, shortened: false });
+    }
+  });
+});
+
+/**
+ * THE PROPORTIONAL SURFACE. The ticker is not `tabular-nums`: it renders in
+ * uppercase Inter Tight, whose advances measured at the ticker's own 13px run
+ * from `I` at 2.95px to `W` at 11.82px against a slot of 8.8px. Counting
+ * characters there is not measuring width, and this is what says so.
+ */
+describe("boardCardValue on the proportional surface", () => {
+  it("charges a wide Latin glyph two slots and a narrow one one", () => {
+    // Measured: W 11.82, M 10.84, % 9.85, C/D/G/H/N/O/Q/U 8.86 - every one
+    // past the 8.8px slot. E 6.90, A 7.88, I 2.95 - every one inside it.
+    for (const wide of ["W", "M", "C", "D", "G", "H", "N", "O", "Q", "U", "%"]) {
+      expect(boardCardValueSlots(wide, "proportional")).toBe(2);
+    }
+    for (const narrow of ["A", "B", "E", "F", "I", "L", "S", "T", "Z", "1"]) {
+      expect(boardCardValueSlots(narrow, "proportional")).toBe(1);
+    }
+    // The SAME characters cost one slot on the tabular surface, because there
+    // every digit really does advance by the same width.
+    expect(boardCardValueSlots("WWWWWWWW", "tabular")).toBe(8);
+  });
+
+  it("shortens WWWWWWWW, which a character count let through", () => {
+    // THE DEFECT: eight characters, eight of ten slots under the old model,
+    // and 94.56px of glyphs inside an 88px column - clipped, with `shortened`
+    // false and a neutral affordance saying nothing had been cut.
+    expect(boardCardValueSlots("WWWWWWWW", "proportional")).toBe(16);
+    const printed = boardCardValue(
+      "WWWWWWWW",
+      BOARD_CARD_TICKER_MAX_SLOTS,
+      "proportional",
+    );
+    expect(printed.shortened).toBe(true);
+    expect(printed.text).toBe("WWWW…");
+    // 4 x 11.82 is 47.28px, comfortably inside the column.
+    expect(
+      boardCardValueSlots(printed.text.slice(0, -1), "proportional"),
+    ).toBeLessThanOrEqual(BOARD_CARD_TICKER_MAX_SLOTS - 2);
+  });
+
+  it("uppercases before weighing, because the CSS does", () => {
+    // `text-transform: uppercase` means a lowercase `w` occupies a `W`. A
+    // model that weighed the SOURCE string would charge it as narrow and let
+    // the rendered glyph overflow anyway.
+    expect(boardCardValueSlots("wwwwwwww", "proportional")).toBe(16);
+    expect(
+      boardCardValue("wwwwwwww", BOARD_CARD_TICKER_MAX_SLOTS, "proportional")
+        .shortened,
+    ).toBe(true);
+  });
+
+  it("charges an unmeasured Latin-1 glyph the wide weight", () => {
+    // The class is an ALLOWLIST of glyphs measured inside a slot, so a
+    // character the schema admits and nobody measured is charged two rather
+    // than assumed innocent.
+    for (const unmeasured of ["@", "&", "#", "é", "Ñ", "©"]) {
+      expect(boardCardValueSlots(unmeasured, "proportional")).toBe(2);
+    }
+  });
+
+  it("keeps every realistic ticker whole at its own budget", () => {
+    // The over-charging must not turn into a cut on tickers a real market
+    // actually uses - a false "shortened" is its own kind of dishonesty.
+    for (const symbol of [
+      "WBTC",
+      "PEPE",
+      "DEGEN",
+      "TOSHI",
+      "USDC",
+      "AERO",
+      "MATIC",
+      "PENDLE",
+      "BITCOIN",
+    ]) {
+      expect(
+        boardCardValue(symbol, BOARD_CARD_TICKER_MAX_SLOTS, "proportional"),
+      ).toEqual({ text: symbol, shortened: false });
     }
   });
 });

--- a/vex-app/src/renderer/features/appShell/Board/__tests__/boardCardValueBudget.test.ts
+++ b/vex-app/src/renderer/features/appShell/Board/__tests__/boardCardValueBudget.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The content budget, tested where it is decidable: on the DATA.
+ *
+ * Whether a budgeted string then fits its region is a layout fact and belongs
+ * to `e2e/board-layout.spec.ts`, which measures it in a real engine over the
+ * schema-extreme board at the compact floor. What this file owns is the
+ * contract every one of those measurements depends on: the value that leaves
+ * this module is never longer than the budget, and it always reports whether
+ * it is the whole value.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  anyShortened,
+  boardCardValue,
+  BOARD_CARD_DELTA_MAX_CHARS,
+  BOARD_CARD_PRICE_MAX_CHARS,
+  BOARD_CARD_STAT_MAX_CHARS,
+  BOARD_CARD_TICKER_MAX_CHARS,
+} from "../boardCardValueBudget.js";
+
+describe("boardCardValue", () => {
+  it("prints a realistic value whole and does not claim a cut", () => {
+    // The four strings the floors in `board-layout.css` were derived from.
+    // If any of these ever reported `shortened`, the card would be accusing
+    // itself of a cut it did not make, and the budget would be wrong rather
+    // than the value.
+    for (const [text, budget] of [
+      ["$0.000001230", BOARD_CARD_PRICE_MAX_CHARS],
+      ["$104238.92", BOARD_CARD_PRICE_MAX_CHARS],
+      ["+661.00%", BOARD_CARD_DELTA_MAX_CHARS],
+      ["-12.48%", BOARD_CARD_DELTA_MAX_CHARS],
+      ["$998.8K", BOARD_CARD_STAT_MAX_CHARS],
+      ["$1234.5B", BOARD_CARD_STAT_MAX_CHARS],
+      ["1095d", BOARD_CARD_STAT_MAX_CHARS],
+      ["-", BOARD_CARD_STAT_MAX_CHARS],
+      ["DEGEN", BOARD_CARD_TICKER_MAX_CHARS],
+      ["WBTC", BOARD_CARD_TICKER_MAX_CHARS],
+    ] as const) {
+      expect(boardCardValue(text, budget)).toEqual({ text, shortened: false });
+    }
+  });
+
+  it("shortens a schema extreme to the budget and says it did", () => {
+    // A 40-character decimal and a 512-character symbol both parse.
+    const price = boardCardValue(
+      "$1234567890123456789012345678901234.56",
+      BOARD_CARD_PRICE_MAX_CHARS,
+    );
+    expect(price.shortened).toBe(true);
+    // One character short of the budget, because the ellipsis is charged two
+    // slots for a glyph that is nearly two digits wide.
+    expect(price.text).toHaveLength(BOARD_CARD_PRICE_MAX_CHARS - 1);
+    expect(price.text.endsWith("…")).toBe(true);
+
+    const ticker = boardCardValue("X".repeat(512), BOARD_CARD_TICKER_MAX_CHARS);
+    expect(ticker.shortened).toBe(true);
+    expect(ticker.text).toHaveLength(BOARD_CARD_TICKER_MAX_CHARS - 1);
+  });
+
+  it("never exceeds the budget, at the boundary or one past it", () => {
+    for (const budget of [2, 8, 10, 11, 12]) {
+      for (const length of [budget - 1, budget, budget + 1, budget + 400]) {
+        const value = boardCardValue("9".repeat(length), budget);
+        expect(value.text.length).toBeLessThanOrEqual(budget);
+        expect(value.shortened).toBe(length > budget);
+      }
+    }
+  });
+
+  it("keeps one character visible even at an absurd budget", () => {
+    // The shortest honest output is something plus the mark that says there
+    // was more, never the mark alone.
+    const value = boardCardValue("123456", 1);
+    expect(value.text).toBe("1…");
+    expect(value.shortened).toBe(true);
+  });
+});
+
+describe("anyShortened", () => {
+  it("is true when any one value conceded, and false when none did", () => {
+    const whole = boardCardValue("WBTC", BOARD_CARD_TICKER_MAX_CHARS);
+    const cut = boardCardValue("X".repeat(64), BOARD_CARD_TICKER_MAX_CHARS);
+    expect(anyShortened([whole, whole])).toBe(false);
+    expect(anyShortened([whole, cut])).toBe(true);
+    expect(anyShortened([])).toBe(false);
+  });
+});

--- a/vex-app/src/renderer/features/appShell/Board/board-layout-measurements.md
+++ b/vex-app/src/renderer/features/appShell/Board/board-layout-measurements.md
@@ -226,11 +226,49 @@ It also retires hover as a recovery path. `title` stays on the token name for
 the pointer, but the name's ellipsis now has a real, keyboard-reachable way
 back to the whole string.
 
-Its own tab sequence is CONTAINED (WAI modal-dialog pattern). The panel is a
-`role="dialog"` painted over the card's own buttons, which remain in the
-document after it; without the trap, Tab from its close button lands on a
-control the reader cannot see, and Escape from there reaches the board
-`<dialog>` and closes the whole board rather than the panel.
+It is a DISCLOSURE, not a dialog. It carried `role="dialog"` with
+`aria-modal="true"` and a focus trap, and none of that was true: nothing
+outside the panel was inert, a pointer reached every other card on the board
+while it was open, and two of them could be "modal" at once. `aria-modal`
+promises a reader that the rest of the page is unavailable, so a screen-reader
+user was told the board was gone while a sighted user was clicking it. A
+promise the code does not keep is worse than no promise.
+
+What it is instead: a button carrying `aria-expanded` and `aria-controls`, and
+a labelled `role="group"` it points at. Consequences, each of them tested
+rather than assumed:
+
+- no focus trap, because a non-modal surface must not trap - Tab runs through
+  the panel and ONWARD, out of the card entirely;
+- MANY MAY BE OPEN AT ONCE, which is legitimate for a disclosure and is how a
+  reader compares two pools' raw decimals side by side;
+- the rest of the board stays live to a pointer, including another card's
+  Spotlight.
+
+**The covered controls leave the TAB ORDER, and only the tab order.** The
+panel is opaque and covers its whole card, so while it is open the Spotlight
+button, the DexScreener link, Ask VEX and the trigger itself cannot be seen -
+and a Tab that reached one of them would put focus somewhere invisible, which
+rule 08 forbids. Each of them therefore carries `tabIndex="-1"` for exactly as
+long as the panel is open, so tabbing out of the panel leaves the card rather
+than landing behind it.
+
+`tabIndex="-1"` and NOT `inert`, deliberately. `inert` removes a subtree from
+the ACCESSIBILITY TREE, which would take the trigger's own
+`aria-expanded="true"` with it: the panel would be open with nothing able to
+report that it was, and the Escape restore could not focus the trigger either.
+`tabIndex="-1"` removes an element from the tab order alone - it keeps its
+accessible name and state, and it can still be focused programmatically. The
+attributes revert in the same commit that removes the panel, so a card nothing
+covers carries none of them. `TokenCardV3` owns the flag, which is why the
+disclosure's open state is controlled by the card rather than private to the
+disclosure: a component in the header cannot reach the footer's buttons.
+
+Focus still moves into the panel on open and returns to the trigger on close.
+That is not a modal obligation but this panel's own: it paints over the card
+it belongs to, so focus left behind it would be operating an invisible
+control. Escape closes it and is stopped from propagating, so closing a panel
+never closes the board `<dialog>` listening for the same key.
 
 Its cost to the floors is nothing: it sits in the identity row, whose
 flexible middle absorbs it, so no table above changes.
@@ -244,10 +282,10 @@ whole into a `whitespace-nowrap` cell inside an `overflow-hidden` card: the
 reader got a figure with its tail removed and nothing saying so.
 
 `boardCardValueBudget.ts` owns the fix. Each budget is the widest realistic
-string for that region measured in CHARACTERS - which is exactly the string
-the region's floor was derived from, so a value past it is by construction
-past what the layout was sized for, and it is the value that concedes rather
-than the layout.
+string for that region, measured in SLOTS - which is exactly the string the
+region's floor was derived from, so a value past it is by construction past
+what the layout was sized for, and it is the value that concedes rather than
+the layout.
 
 | Region | Budget | The string it is derived from |
 | --- | --- | --- |
@@ -257,19 +295,39 @@ than the layout.
 | Ticker | 10 | compact identity column, 88px |
 | Token name | none | keeps its CSS ellipsis by product decision |
 
-The ellipsis is charged TWO of those slots, which is measured rather than
-chosen. The regions render `tabular-nums`, where every digit is one width -
-but `…` is not a digit: in the display face at the hero's 28px it measures
-about 30px against a digit's 16.44. A value shortened to exactly the budget
-in characters therefore still overflowed by nine pixels, which the extreme
-case at the compact floor caught.
+**One slot is one narrow character of that region's own type**, and the unit
+matters because `String.length` is not it. Two corrections came out of that:
+
+- **The ellipsis costs TWO slots.** The financial regions render
+  `tabular-nums` where every digit is one width, but `…` is not a digit: in
+  the display face at the hero's 28px it measures about 30px against a
+  digit's 16.44. A value shortened to exactly the budget in characters still
+  overflowed by nine pixels, which the extreme case at the compact floor
+  caught.
+- **A wide code point costs TWO slots, and the cut is grapheme-safe.**
+  `baseTokenSymbol` is `z.string().min(1).max(512)`: 512 UTF-16 CODE UNITS of
+  any Unicode, and the ticker is not `tabular-nums`. A ten-character CJK
+  ticker was ten `String.length`, sat under a ten-character budget, and
+  rendered 130px into an 88px column with `shortened` reported as false -
+  silent loss from the module written to prevent it. And `String.slice` cuts
+  code units, so a cut between a surrogate pair emitted a LONE SURROGATE (an
+  ill-formed string on its way to the jsonb boundary) while a cut inside a ZWJ
+  sequence rendered a different token than the provider sent.
+
+  The model, owned in that module's head note: segment into grapheme clusters
+  with `Intl.Segmenter`, then charge a cluster ONE slot when every code point
+  in it is U+0000-U+00FF and TWO otherwise. It over-charges a Greek letter or
+  a combining mark, which is the right direction to be wrong in -
+  over-charging shortens early AND SAYS SO; under-charging overflows in
+  silence.
 
 A budget is a property of the DATA, decided before layout exists. It owns no
 threshold: it does not pick a column count, a mode or a floor, and no
 JavaScript reads a width back. The overflow assertions in
-`e2e/board-layout.spec.ts` run over the SCHEMA-EXTREME board at the compact
-floor and fail if any financial, stat, badge or action region scrolls, which
-is what proves the budgets hold.
+`e2e/board-layout.spec.ts` run over the SCHEMA-EXTREME board AND a WIDE-GLYPH
+board (CJK, emoji ZWJ sequences, combining marks) at the compact floor, and
+fail if any financial, stat, badge or action region scrolls. That is what
+proves the budgets hold.
 
 ## 5. What the matrix proves about the CURRENT card
 

--- a/vex-app/src/renderer/features/appShell/Board/board-layout-measurements.md
+++ b/vex-app/src/renderer/features/appShell/Board/board-layout-measurements.md
@@ -292,11 +292,34 @@ the layout.
 | Hero price | 12 | `$0.000001230`, 197.29px in a 198px slot |
 | Signed delta | 8 | `+661.00%`, 76px |
 | Stat value | 11 | wide mode's `(460 - 3 x 12) / 4 = 106px` column |
-| Ticker | 10 | compact identity column, 88px |
+| Ticker | 10 | compact identity column, 88px (one slot = 8.8px) |
 | Token name | none | keeps its CSS ellipsis by product decision |
 
+**TWO SURFACES, TWO WIDTH MODELS.** The price, delta and stat values render
+`tabular-nums`, where every digit advances the same width by definition of the
+feature, so a count of clusters IS a width. The TICKER does not: it renders in
+proportional uppercase Inter Tight, measured in the committed face at its own
+13px against a slot of 8.8px:
+
+| Advance | Glyphs |
+| --- | --- |
+| 11.82 | `W` |
+| 10.84 | `M` |
+| 9.85 | `%` |
+| 8.86 | `C D G H N O Q U` |
+| 7.88 | `A B K P R S T V X Y Z $ + 0 3 4` |
+| 6.90 | `E F L 2 5 6 7 8 9` |
+| 5.91 | `J` |
+| 4.93 | `1 -` |
+| 2.95 | `I . , :` |
+
+Anything past a slot is charged two, and the class is an ALLOWLIST of the
+glyphs measured inside one - so a character nobody measured, and the schema
+admits all of Latin-1, is charged the wide weight rather than assumed
+innocent. Classification uppercases first, because the element does.
+
 **One slot is one narrow character of that region's own type**, and the unit
-matters because `String.length` is not it. Two corrections came out of that:
+matters because `String.length` is not it. Three corrections came out of that:
 
 - **The ellipsis costs TWO slots.** The financial regions render
   `tabular-nums` where every digit is one width, but `…` is not a digit: in
@@ -313,6 +336,14 @@ matters because `String.length` is not it. Two corrections came out of that:
   code units, so a cut between a surrogate pair emitted a LONE SURROGATE (an
   ill-formed string on its way to the jsonb boundary) while a cut inside a ZWJ
   sequence rendered a different token than the provider sent.
+
+- **A wide LATIN glyph costs two slots on the proportional surface.** The
+  correction above was not enough, because it only caught non-Latin-1. Plain
+  ASCII `WWWWWWWW` is eight characters, cost eight of ten slots, and rendered
+  94.56px inside the 88px identity column - clipped, with `shortened` false
+  and a neutral affordance. Latin-1 and short, and it overflowed anyway. The
+  table above is what replaced the assumption; the browser case at the compact
+  floor is what would have caught it.
 
   The model, owned in that module's head note: segment into grapheme clusters
   with `Intl.Segmenter`, then charge a cluster ONE slot when every code point

--- a/vex-app/src/renderer/features/appShell/Board/board-layout-measurements.md
+++ b/vex-app/src/renderer/features/appShell/Board/board-layout-measurements.md
@@ -1,0 +1,320 @@
+# Board card measurement matrix
+
+Measured, not estimated. Every number below came out of a real Chromium at
+device pixel ratio 1 against the real production stylesheet, through the
+harness at `src/renderer/dev/board-layout/` (`e2e/board-layout.spec.ts` drives
+the same page). Regenerate by running that spec: it re-measures and asserts.
+
+Units are CSS pixels, `Math.ceil` of the natural (un-clamped, `white-space:
+nowrap`) border-box width of the element.
+
+Method: each element is cloned out of its card into an absolutely positioned
+off-flow copy with `width:auto; max-width:none; overflow:visible;
+text-overflow:clip; white-space:nowrap`, so the number is what the element
+WANTS, not what its parent currently allows.
+
+## 1. Realistic compact output
+
+Six pools whose figures are real DexScreener shapes: a five-figure price, a
+sub-cent price with eight leading zeros, hundreds-of-thousands and
+tens-of-millions liquidity, a billions volume, six-digit trade tallies, and
+ages from five minutes to three years. The fixtures live in
+`src/renderer/dev/board-layout/harness.tsx` (`REALISTIC_ROWS`).
+
+| Region | data-vex-area | Widest realistic | Producing row |
+| --- | --- | --- | --- |
+| Token name | `board-token-name` | 174 | Aerodrome Finance |
+| Ticker | `board-token-ticker` | 41 | DEGEN |
+| Hero price | `board-token-price` | 198 | `$0.000001230` (PEPE) |
+| Signed delta | `board-token-delta` | 76 | `+661.00%` |
+| Delta window | `board-token-delta-window` | 22 | `24h` |
+| Stat label `Liquidity` | `dt` | 45 | fixed copy |
+| Stat label `24h Volume` | `dt` | 66 | fixed copy (widest label) |
+| Stat label `Trades` | `dt` | 38 | fixed copy |
+| Stat label `Pair age` | `dt` | 45 | fixed copy |
+| Stat value, Liquidity | `dd` | 62 | `$495.6K` |
+| Stat value, 24h Volume | `dd` | 63 | `$998.8K` |
+| Stat value, Trades | `dd` | 54 | `900.0K` |
+| Stat value, Pair age | `dd` | 49 | `1095d` |
+| Token photo | `board-token-photo` | 64 | fixed |
+| Spotlight button | `board-card-spotlight` | 96 | fixed copy |
+| DexScreener link | `board-token-dexscreener-link` | 100 | fixed copy |
+| Ask VEX button | `board-card-ask` | 88 | fixed copy |
+
+## 2. Every safety chip label
+
+Measured in the chip's own type (`Pill` size `lg`, with its leading glyph and
+padding). The labels are the frozen table in
+`src/shared/board/safety-classifier.ts` plus `BOARD_NEW_PAIR_LABEL`. All of
+them are reachable in normal service, so none of them is an "extreme".
+
+| Label | Width |
+| --- | --- |
+| `Checks unavailable in this response` | 242 |
+| `Not indexed by the checks provider` | 239 |
+| `Checks describe another token` | 215 |
+| `Checks out of date` | 147 |
+| `Sources disagree` | 139 |
+| `Partial checks` | 120 |
+| `Clean checks` | 118 |
+| `Unverified` | 100 |
+| `Checking` | 95 |
+| `New pair` | 92 |
+| `High risk` | 90 |
+
+**242 is the number the footer has to survive.** It is not a schema extreme:
+a transport blip on the details channel produces it on every card at once.
+
+## 3. Schema-reachable extremes
+
+`BOARD_DECIMAL_MAX_CHARS = 40` and `BOARD_TOKEN_LABEL_MAX_CHARS = 512`
+(`src/lib/board/spec.ts`). A 40-character decimal renders as a 38-character
+hero price; a 512-character symbol renders as a 512-character ticker. Neither
+fits any card at any width the modal can reach, which is what the full-value
+disclosure exists for: the cut becomes recoverable rather than silent.
+
+## 4. Derived region floors
+
+Card padding is `px-5` (40 total). Inner width = card width - 40.
+
+| Region | Composition | Inner floor |
+| --- | --- | --- |
+| Stat block, 4 equal columns | `4 x max(label,value) + 3 x 12` gap, binding column is `24h Volume` at 66 | 300 |
+| Stat block, 2x2 | `2 x 66 + 12` | 144 |
+| Price row, no sparkline | `198 + 10 + 76 + 10 + 22` | 316 |
+| Price row, sparkline at `w-[30%]` | `316 + 12 <= 0.7 x inner` | 469 |
+| Footer, one row | `242 chip + 12 + (100 + 8 + 88)` | 450 |
+| Footer, stacked | `max(242, 196)` | 242 |
+
+## 4b. Per-mode floors, as built
+
+Two grid-wide modes. The mode is chosen by CARD width; the column count is
+chosen by CONTAINER width; both live in `global-css/board-layout.css` and
+nowhere else.
+
+**WIDE** keeps the anatomy the mockup fixes: the sparkline sits in the price
+row beside the figures, the stat `dl` is four equal columns, the footer is one
+row. The inline sparkline is a fixed `132px` rather than `w-[30%]`, so the
+price row's budget cannot shrink faster than the card does.
+
+| Wide constraint | Composition | Inner |
+| --- | --- | --- |
+| Price row | `316 + 12 gap + 132 sparkline` | **460** |
+| Footer, one row | `242 chip + 12 + (100 + 8 + 88)` | 450 |
+| Stat block, 4 columns | `4 x 66 + 3 x 12` | 300 |
+
+Binding: 460. Plus 40px of `px-5` padding AND the card border's 2px:
+**Wide floor = 460 + 42 = 502px card.**
+
+**COMPACT** adapts rather than deletes: the sparkline leaves the price row for
+its own fixed-height full-width slot below it, the footer stacks (chip row
+above actions row), the stat `dl` goes 2x2.
+
+| Compact constraint | Composition | Inner |
+| --- | --- | --- |
+| Price row, full width | `198 + 10 + 76 + 10 + 22` | **316** |
+| Footer, stacked | `max(242 chip, 100 + 8 + 88 actions)` | 242 |
+| Stat block, 2x2 | `2 x 66 + 12` | 144 |
+
+Binding: 316. Plus 40px of `px-5` padding AND the card border's 2px:
+**Compact floor = 316 + 42 = 358px card.**
+
+THE BORDER WAS MISSING FROM THE FIRST PASS OF THIS TABLE, and it is not a
+rounding detail. `CARD_CLASS` carries `border`, so a 356px card has 314px of
+inner width, not 316: the hero price got 196px for a string that measures
+197.29, and the one figure the entire ladder is derived from was cut by two
+pixels at every floor on it. The constrained 800px case in
+`e2e/board-layout.spec.ts` is what found it.
+
+Fixed heights per mode, so cards are equal within a mode:
+
+| Block | Wide | Compact |
+| --- | --- | --- |
+| Identity | 64 | 64 |
+| Price row | 44 | 44 |
+| Sparkline | inline, `132 x 44` | own slot, 36 high, 12 margin above |
+| Stat block | 46 | 92 (`2 x 40 + 12` row gap) |
+| Footer | one row | stacked |
+
+Measured card height, six realistic pools, every card in a grid identical:
+**293 wide, 423 compact.**
+
+The mode is declared on the GRID, not on the plate. `@container` styles apply
+to a container's DESCENDANTS and never to the container element itself, so
+mode variables written onto the plate would sit in a block that can never
+match - a defect this document's own verification pass caught after the CSS
+was first written. The grid is the correct owner in any case: it is the one
+element every card shares, which is what makes the mode grid-wide and
+therefore makes the cards equal.
+
+## 4c. The mode ladder
+
+`C` is the plate's content box, which is what `container-type: inline-size`
+measures. With `n` columns and a 16px gap, `card = (C - 16(n-1)) / n`.
+
+The rule, in one sentence: **take the most columns (max 3) whose card clears
+the compact floor, then use wide anatomy if that card also clears the wide
+floor.** Nothing else is consulted - not the viewport, not the drawer.
+
+| Threshold | Derivation | Result |
+| --- | --- | --- |
+| `C >= 1538` | `3 x 502 + 32` | 3 columns, WIDE |
+| `C >= 1106` | `3 x 358 + 32` | 3 columns, COMPACT |
+| `C >= 1020` | `2 x 502 + 16` | 2 columns, WIDE |
+| `C >= 732` | `2 x 358 + 16` | 2 columns, COMPACT |
+| `C >= 502` | `1 x 502` | 1 column, WIDE |
+| `C >= 358` | `1 x 358` | 1 column, COMPACT |
+| `C < 358` | UNDERSIZED | 1 column pinned at 358, the plate side-scrolls |
+
+The wide ranges are therefore `[502, 732)` or `[1020, 1106)` or
+`[1538, inf)` - the three windows where the chosen column count happens to
+leave a card 502px wide or better. That is ONE container-query block, not
+three: every mode-dependent value is a custom property set inside it.
+
+The UNDERSIZED regime KEEPS the sparkline slot. Hiding it there was
+permitted and is not needed: the pinned 358px card IS the compact floor, so
+every region still fits and the only thing that changes is that the plate
+scrolls horizontally instead of cutting a figure.
+
+### What the ladder produces at real widths
+
+`C = dialog - 80` with no drawer (body `px-6`, plate `p-4`), and
+`C = dialog - 440` with it. The dialog is `min(90vw, 1280)`, widened by the
+host to `min(94vw, 1640)` while the drawer is open.
+
+| Viewport | Drawer | Dialog | C | Columns | Mode | Card |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1920 | no | 1280 | 1200 | 3 | compact | 389 |
+| 1440 | no | 1280 | 1200 | 3 | compact | 389 |
+| 1366 | no | 1229 | 1149 | 3 | compact | 372 |
+| 1280 | no | 1152 | 1072 | 2 | WIDE | 528 |
+| 1000 | no | 900 | 820 | 2 | compact | 402 |
+| 1920 | yes | 1640 | 1200 | 3 | compact | 389 |
+| 1440 | yes | 1353 | 913 | 2 | compact | 448 |
+| 1366 | yes | 1284 | 844 | 2 | compact | 414 |
+| 1280 | yes | 1203 | 763 | 2 | compact | 373 |
+| 1000 | yes | 940 | 500 | 1 | WIDE | 500 |
+| 800 | no | 752 | 636 | 1 | WIDE | 636 |
+| 800 | yes | 752 | 312 | 1 | compact | 358, side-scrolls |
+
+Three columns hold at 1440 with no drawer, which was the requirement; the
+drawer costs a column rather than a figure. The 800px rows are the
+constrained case the Playwright suite runs: one of them is the only regime in
+which the plate side-scrolls, and it is what caught the missing border above.
+
+## 4d. The full-value disclosure
+
+A schema extreme cannot be made to fit and must not be cut in silence, so
+every card carries ONE always-present control in its header - a semantic
+`<button>` beside Spotlight - that opens the whole name, the whole ticker and
+the raw provider decimals for price, liquidity and volume.
+
+Its PRESENCE is **not** conditional on width, because a card always rounds
+something: `formatBoardPriceUsd` truncates every price by design, so the
+recovery path is owed to every card at every width.
+
+What IS conditional is what it SAYS. A control that reads "Show the full
+values" on a card whose price has had its tail removed tells the reader a
+panel exists and does not tell them the figure in front of them is not the
+figure. So when the card printed a shortened copy of a value, the button
+names the cut state in its accessible name, wears the accent treatment the
+card already uses for "this needs your attention", and repeats the statement
+visibly at the top of the panel. That is what turns a cut into a REPORTED
+bound.
+
+It also retires hover as a recovery path. `title` stays on the token name for
+the pointer, but the name's ellipsis now has a real, keyboard-reachable way
+back to the whole string.
+
+Its own tab sequence is CONTAINED (WAI modal-dialog pattern). The panel is a
+`role="dialog"` painted over the card's own buttons, which remain in the
+document after it; without the trap, Tab from its close button lands on a
+control the reader cannot see, and Escape from there reaches the board
+`<dialog>` and closes the whole board rather than the panel.
+
+Its cost to the floors is nothing: it sits in the identity row, whose
+flexible middle absorbs it, so no table above changes.
+
+## 4e. The content budgets
+
+The floors above are sized against the widest REALISTIC output. The schema
+permits far more (`BOARD_DECIMAL_MAX_CHARS = 40`,
+`BOARD_TOKEN_LABEL_MAX_CHARS = 512`), and such a value used to be rendered
+whole into a `whitespace-nowrap` cell inside an `overflow-hidden` card: the
+reader got a figure with its tail removed and nothing saying so.
+
+`boardCardValueBudget.ts` owns the fix. Each budget is the widest realistic
+string for that region measured in CHARACTERS - which is exactly the string
+the region's floor was derived from, so a value past it is by construction
+past what the layout was sized for, and it is the value that concedes rather
+than the layout.
+
+| Region | Budget | The string it is derived from |
+| --- | --- | --- |
+| Hero price | 12 | `$0.000001230`, 197.29px in a 198px slot |
+| Signed delta | 8 | `+661.00%`, 76px |
+| Stat value | 11 | wide mode's `(460 - 3 x 12) / 4 = 106px` column |
+| Ticker | 10 | compact identity column, 88px |
+| Token name | none | keeps its CSS ellipsis by product decision |
+
+The ellipsis is charged TWO of those slots, which is measured rather than
+chosen. The regions render `tabular-nums`, where every digit is one width -
+but `…` is not a digit: in the display face at the hero's 28px it measures
+about 30px against a digit's 16.44. A value shortened to exactly the budget
+in characters therefore still overflowed by nine pixels, which the extreme
+case at the compact floor caught.
+
+A budget is a property of the DATA, decided before layout exists. It owns no
+threshold: it does not pick a column count, a mode or a floor, and no
+JavaScript reads a width back. The overflow assertions in
+`e2e/board-layout.spec.ts` run over the SCHEMA-EXTREME board at the compact
+floor and fail if any financial, stat, badge or action region scrolls, which
+is what proves the budgets hold.
+
+## 5. What the matrix proves about the CURRENT card
+
+Three defects, all reproduced by `e2e/board-layout.spec.ts` before any fix:
+
+1. **The hero price row already wraps and is clipped, with no drawer and no
+   narrow window.** At a 1920px viewport the price row's inner flex box
+   measures `scrollHeight` 56 inside its `h-[44px]` parent on three of the six
+   realistic rows (WBTC, PEPE, TOSHI). The delta and its `24h` window wrap
+   onto a second line that the fixed height does not have room for. The
+   binding constraint is the `w-[30%]` sparkline: the row needs 469px of inner
+   width to hold realistic figures beside it, and a three-column grid at 1440
+   gives 349.
+
+2. **Cards in one grid are not the same width.** `<li className="flex
+   min-w-0">` wraps an `<article>` with no `w-full`, so each card shrinks to
+   its own content inside its column: 382 / 369 / 406 / 345 / 407 / 342 at a
+   1440px viewport where every grid track is 388.
+
+3. **Columns follow the viewport while the drawer shrinks the container.** At
+   1440 with the drawer open the grid still asks for three tracks and each one
+   measures 268px, below the 300 the stat block needs and far below the 316
+   the price row needs. `24h Volume` and every chip label ellipsize.
+
+## 6. The question this matrix raised, and how it was settled
+
+With the anatomy the mockup fixes and a `w-[30%]` sparkline, a card needed
+**509px** to render realistic figures with nothing cut. The modal's plate is
+1200px, which is two cards of 592 - never three. Three columns would have
+needed a window past 1820px.
+
+The owner's answer was that the board must be RESPONSIVE at every width, with
+no data loss and no empty-looking two-column board on a typical monitor. That
+is what sections 4b and 4c implement: the anatomy ADAPTS rather than the data
+being cut or a column being surrendered. The sparkline moves to its own slot,
+the footer stacks and the stat block goes 2x2, which drops the floor from 509
+to 358 and lets 1440 keep three columns.
+
+Rejected on the way there, and why:
+
+- **Two columns at 1440.** Wastes the owner's own screen for a constraint the
+  anatomy can absorb instead.
+- **Deleting the sparkline below a width.** Data loss, and the mockup fixes
+  that sparkline as part of the card.
+- **Shrinking the hero price type.** Financial display; rule 08 does not let
+  a layout constraint decide how legible a price is.
+- **Raising the dialog cap past 1280px.** Moves the problem to the next
+  window size instead of solving it, and widens a surface the owner sized.

--- a/vex-app/src/renderer/features/appShell/Board/boardCardValueBudget.ts
+++ b/vex-app/src/renderer/features/appShell/Board/boardCardValueBudget.ts
@@ -1,0 +1,104 @@
+/**
+ * WHAT A TOKEN CARD IS WILLING TO PRINT, and how it says when it printed less.
+ *
+ * WHY THIS EXISTS. `global-css/board-layout.css` sizes both card modes against
+ * the widest REALISTIC output (section 1 of `board-layout-measurements.md`).
+ * The schema, however, permits far more than realistic: a 40-character decimal
+ * (`BOARD_DECIMAL_MAX_CHARS`) and a 512-character symbol
+ * (`BOARD_TOKEN_LABEL_MAX_CHARS`) both parse, and no card at any width the
+ * modal can reach could show either. Until now such a value was rendered whole
+ * into a `whitespace-nowrap` cell inside an `overflow-hidden` card, so the
+ * reader was shown a figure with its tail cut off and NOTHING saying it had
+ * been - the silent loss `.claude/CLAUDE.md` forbids outright.
+ *
+ * WHY A CHARACTER BUDGET AND NOT A MEASUREMENT. The alternatives are worse.
+ * Reading layout back (a `ResizeObserver`, a `scrollWidth` probe) would make
+ * JavaScript a second owner of a threshold the stylesheet owns and would run
+ * on every card of every board. A CSS ellipsis would hide the cut without
+ * reporting it, which is the defect rather than the fix. A character count is
+ * a property of the DATA, decided before layout exists, and it takes no
+ * threshold away from the stylesheet: it does not decide a column count, a
+ * mode or a floor. It decides how much of a string is worth printing.
+ *
+ * WHERE EACH NUMBER COMES FROM. Each is the widest realistic string the
+ * measurement matrix records for that region, in characters - which is exactly
+ * the string the region's floor was derived from. A value longer than that is,
+ * by construction, past what the floor was sized for, so it is the value that
+ * concedes rather than the layout. Section 5 of
+ * `board-layout-measurements.md` carries the derivation, and the overflow
+ * assertions in `e2e/board-layout.spec.ts` are what prove the budgets hold:
+ * they run over the SCHEMA-EXTREME board at the compact floor and fail if any
+ * financial, stat, badge or action region scrolls.
+ *
+ * NOTHING IS LOST. A shortened value is marked `data-shortened` where it
+ * renders, the card's disclosure says in its accessible name that values were
+ * shortened, and the disclosure panel carries every whole string. The cut is
+ * a reported bound, never a silent one.
+ */
+
+/** The ellipsis a shortened value ends in. */
+const ELLIPSIS = "…";
+
+/**
+ * How many budget slots the ellipsis is charged.
+ *
+ * TWO, NOT ONE, and the number is measured rather than chosen. A budget is
+ * counted in characters because the regions it guards render `tabular-nums`,
+ * where every digit is the same width - but `…` is NOT one of those digits.
+ * In the display face at the hero's 28px it measures about 30px against a
+ * digit's 16.44, so a value shortened to exactly the budget in CHARACTERS
+ * still overflowed its region by nine pixels. Charging it two slots buys
+ * 1.84 digit-widths of room for a glyph that needs 1.84 of them.
+ */
+const ELLIPSIS_SLOTS = 2;
+
+/**
+ * Hero price. `$0.000001230` is 12 characters and 197.29px, which is the
+ * string the 316px compact price row was derived from.
+ */
+export const BOARD_CARD_PRICE_MAX_CHARS = 12;
+
+/** Signed 24h delta. `+661.00%` is 8 characters and 76px. */
+export const BOARD_CARD_DELTA_MAX_CHARS = 8;
+
+/**
+ * A stat value. The binding mode is WIDE, not compact: four equal columns of
+ * a 460px inner width leave `(460 - 3 x 12) / 4 = 106px` per column, and a
+ * stat value renders at roughly 9px per character.
+ */
+export const BOARD_CARD_STAT_MAX_CHARS = 11;
+
+/**
+ * The ticker under the name. The compact header spends its inner width on the
+ * 64px photo, two 16px gaps and the 132px action cluster, which leaves the
+ * identity column 88px; the ticker renders at roughly 8.2px per character.
+ */
+export const BOARD_CARD_TICKER_MAX_CHARS = 10;
+
+/** A value as the card will print it, and whether that is the whole of it. */
+export interface BoardCardValue {
+  readonly text: string;
+  readonly shortened: boolean;
+}
+
+/**
+ * The value the card prints for `text`, within `maxChars` slots INCLUDING the
+ * two the ellipsis is charged.
+ *
+ * A value at or under the budget is printed whole; a longer one keeps
+ * `maxChars - 2` characters and ends in the mark that says there was more. A
+ * tiny budget is clamped rather than emptied: the shortest honest output is
+ * one character and the ellipsis, because a bare `…` names no value at all.
+ */
+export function boardCardValue(text: string, maxChars: number): BoardCardValue {
+  if (text.length <= maxChars) return { text, shortened: false };
+  const kept = Math.max(1, maxChars - ELLIPSIS_SLOTS);
+  return { text: `${text.slice(0, kept)}${ELLIPSIS}`, shortened: true };
+}
+
+/** True when any of the values the card printed was not the whole value. */
+export function anyShortened(
+  values: readonly BoardCardValue[],
+): boolean {
+  return values.some((value) => value.shortened);
+}

--- a/vex-app/src/renderer/features/appShell/Board/boardCardValueBudget.ts
+++ b/vex-app/src/renderer/features/appShell/Board/boardCardValueBudget.ts
@@ -11,12 +11,12 @@
  * reader was shown a figure with its tail cut off and NOTHING saying it had
  * been - the silent loss `.claude/CLAUDE.md` forbids outright.
  *
- * WHY A CHARACTER BUDGET AND NOT A MEASUREMENT. The alternatives are worse.
+ * WHY A SLOT BUDGET AND NOT A MEASUREMENT. The alternatives are worse.
  * Reading layout back (a `ResizeObserver`, a `scrollWidth` probe) would make
  * JavaScript a second owner of a threshold the stylesheet owns and would run
  * on every card of every board. A CSS ellipsis would hide the cut without
- * reporting it, which is the defect rather than the fix. A character count is
- * a property of the DATA, decided before layout exists, and it takes no
+ * reporting it, which is the defect rather than the fix. A slot count is a
+ * property of the DATA, decided before layout exists, and it takes no
  * threshold away from the stylesheet: it does not decide a column count, a
  * mode or a floor. It decides how much of a string is worth printing.
  *
@@ -36,15 +36,58 @@
  * a reported bound, never a silent one.
  */
 
+/**
+ * WHY THE BUDGET IS SLOTS AND NOT CHARACTERS, and why it segments first.
+ *
+ * `baseTokenSymbol` is `z.string().min(1).max(512)` (`src/lib/board/spec.ts`):
+ * five hundred and twelve UTF-16 CODE UNITS of ANY Unicode, not 512 Latin
+ * letters. The ticker also does not render in `tabular-nums` - it is ordinary
+ * uppercase text - so counting `String.length` was wrong twice over:
+ *
+ *   - a CJK or full-width ticker is about twice as wide per character as the
+ *     Latin one the budget was measured against, so a five-character ticker
+ *     sat UNDER a ten-character budget, overflowed its column anyway, and -
+ *     because it was under budget - reported no cut at all. Silent loss, from
+ *     the module written to prevent it.
+ *   - `String.prototype.slice` cuts UTF-16 code units, so a cut landing
+ *     between a surrogate pair emitted a LONE SURROGATE: a broken preview,
+ *     and an ill-formed string headed for the jsonb persistence boundary. A
+ *     cut inside a ZWJ emoji or before a combining mark produced a preview
+ *     that meant something other than the value.
+ *
+ * So a value is segmented into GRAPHEME CLUSTERS before anything is measured
+ * or removed, and each cluster is charged in SLOTS, where one slot is the
+ * width every budget below was measured in: one Latin character of that
+ * region's own type.
+ *
+ * THE WIDTH MODEL, and it is deliberately conservative. A cluster costs ONE
+ * slot when every code point in it is U+0000-U+00FF - ASCII plus Latin-1,
+ * which covers every character `boardFormat.ts` can emit and every ticker a
+ * Latin market uses - and TWO otherwise. That over-charges a few genuinely
+ * narrow cases, such as a Greek letter or a base character carrying a
+ * combining mark, and that is the right direction to be wrong in:
+ * over-charging shortens a value slightly early AND SAYS SO, while
+ * under-charging overflows the card in silence. It is a model of the DATA,
+ * owned here. It is not a measurement, and it still takes no threshold away
+ * from `global-css/board-layout.css`.
+ */
+
+/** The last code point charged as one slot. */
+const NARROW_CODE_POINT_MAX = 0x00ff;
+
+/** What a cluster costs when it is not narrow. */
+const WIDE_SLOTS = 2;
+
 /** The ellipsis a shortened value ends in. */
 const ELLIPSIS = "…";
 
 /**
  * How many budget slots the ellipsis is charged.
  *
- * TWO, NOT ONE, and the number is measured rather than chosen. A budget is
- * counted in characters because the regions it guards render `tabular-nums`,
- * where every digit is the same width - but `…` is NOT one of those digits.
+ * TWO, NOT ONE, and the number is measured rather than chosen. One slot is one
+ * narrow character of the region's own type, and the regions this guards
+ * render `tabular-nums` where every digit is that width - but `…` is NOT one
+ * of those digits.
  * In the display face at the hero's 28px it measures about 30px against a
  * digit's 16.44, so a value shortened to exactly the budget in CHARACTERS
  * still overflowed its region by nine pixels. Charging it two slots buys
@@ -56,24 +99,24 @@ const ELLIPSIS_SLOTS = 2;
  * Hero price. `$0.000001230` is 12 characters and 197.29px, which is the
  * string the 316px compact price row was derived from.
  */
-export const BOARD_CARD_PRICE_MAX_CHARS = 12;
+export const BOARD_CARD_PRICE_MAX_SLOTS = 12;
 
 /** Signed 24h delta. `+661.00%` is 8 characters and 76px. */
-export const BOARD_CARD_DELTA_MAX_CHARS = 8;
+export const BOARD_CARD_DELTA_MAX_SLOTS = 8;
 
 /**
  * A stat value. The binding mode is WIDE, not compact: four equal columns of
  * a 460px inner width leave `(460 - 3 x 12) / 4 = 106px` per column, and a
  * stat value renders at roughly 9px per character.
  */
-export const BOARD_CARD_STAT_MAX_CHARS = 11;
+export const BOARD_CARD_STAT_MAX_SLOTS = 11;
 
 /**
  * The ticker under the name. The compact header spends its inner width on the
  * 64px photo, two 16px gaps and the 132px action cluster, which leaves the
  * identity column 88px; the ticker renders at roughly 8.2px per character.
  */
-export const BOARD_CARD_TICKER_MAX_CHARS = 10;
+export const BOARD_CARD_TICKER_MAX_SLOTS = 10;
 
 /** A value as the card will print it, and whether that is the whole of it. */
 export interface BoardCardValue {
@@ -82,18 +125,93 @@ export interface BoardCardValue {
 }
 
 /**
- * The value the card prints for `text`, within `maxChars` slots INCLUDING the
- * two the ellipsis is charged.
+ * `text` split into grapheme clusters.
  *
- * A value at or under the budget is printed whole; a longer one keeps
- * `maxChars - 2` characters and ends in the mark that says there was more. A
- * tiny budget is clamped rather than emptied: the shortest honest output is
- * one character and the ellipsis, because a bare `…` names no value at all.
+ * `Intl.Segmenter` is the only correct answer for a family emoji or a base
+ * character carrying two combining marks, and it is present in Electron 42's
+ * V8 and in the Node the tests run on. The fallback iterates CODE POINTS,
+ * which is weaker about clusters but still cannot produce a lone surrogate -
+ * so the persistence-boundary guarantee holds on either path.
  */
-export function boardCardValue(text: string, maxChars: number): BoardCardValue {
-  if (text.length <= maxChars) return { text, shortened: false };
-  const kept = Math.max(1, maxChars - ELLIPSIS_SLOTS);
-  return { text: `${text.slice(0, kept)}${ELLIPSIS}`, shortened: true };
+function graphemesOf(text: string): readonly string[] {
+  const segmenter = graphemeSegmenter();
+  if (segmenter === null) return [...text];
+  return [...segmenter.segment(text)].map((entry) => entry.segment);
+}
+
+/**
+ * ONE SEGMENTER FOR THE PROCESS, built on first use.
+ *
+ * `new Intl.Segmenter()` loads ICU locale data and is genuinely expensive.
+ * Constructing one PER VALUE - which is six values on each of eight cards,
+ * on every board render - was expensive enough to show up as a slower test
+ * suite, and it is the kind of per-row cost rule 05 exists to catch. The
+ * segmenter is a pure function of nothing, so process lifetime is the correct
+ * one; it is built lazily rather than at import so a runtime without
+ * `Intl.Segmenter` pays nothing and takes the fallback above.
+ */
+let segmenterCache: Intl.Segmenter | null | undefined;
+
+function graphemeSegmenter(): Intl.Segmenter | null {
+  if (segmenterCache === undefined) {
+    segmenterCache =
+      typeof Intl.Segmenter === "function"
+        ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+        : null;
+  }
+  return segmenterCache;
+}
+
+/** What one cluster costs, under the width model in this file's head note. */
+function slotsOf(grapheme: string): number {
+  for (const codePoint of grapheme) {
+    const value = codePoint.codePointAt(0);
+    if (value === undefined || value > NARROW_CODE_POINT_MAX) return WIDE_SLOTS;
+  }
+  return 1;
+}
+
+/** What `text` costs in slots, whole. Exported because the tests assert it. */
+export function boardCardValueSlots(text: string): number {
+  let slots = 0;
+  for (const grapheme of graphemesOf(text)) slots += slotsOf(grapheme);
+  return slots;
+}
+
+/**
+ * The value the card prints for `text`, within `maxSlots` INCLUDING the two
+ * the ellipsis is charged.
+ *
+ * A value at or under the budget is printed whole; a longer one keeps as many
+ * WHOLE clusters as fit in `maxSlots - 2` and ends in the mark that says
+ * there was more. A cut never lands inside a cluster, so no lone surrogate,
+ * no half of a ZWJ sequence and no orphaned combining mark can be emitted.
+ *
+ * One cluster always survives, even when it costs more than the whole budget:
+ * a bare `…` names no value at all, and the clamp is one cluster over rather
+ * than a preview that says nothing.
+ */
+export function boardCardValue(text: string, maxSlots: number): BoardCardValue {
+  // SEGMENTED ONCE. The whole-value cost and the kept prefix are two questions
+  // about the same clusters, and asking the segmenter twice is a per-row cost
+  // on every value of every card.
+  const graphemes = graphemesOf(text);
+  const costs = graphemes.map(slotsOf);
+  let total = 0;
+  for (const cost of costs) total += cost;
+  if (total <= maxSlots) return { text, shortened: false };
+
+  const budget = Math.max(1, maxSlots - ELLIPSIS_SLOTS);
+  let used = 0;
+  let kept = "";
+  for (const [index, grapheme] of graphemes.entries()) {
+    const cost = costs[index] ?? 1;
+    if (used + cost > budget) break;
+    used += cost;
+    kept += grapheme;
+  }
+  if (kept === "") kept = graphemes[0] ?? "";
+  return { text: `${kept}${ELLIPSIS}`, shortened: true };
 }
 
 /** True when any of the values the card printed was not the whole value. */

--- a/vex-app/src/renderer/features/appShell/Board/boardCardValueBudget.ts
+++ b/vex-app/src/renderer/features/appShell/Board/boardCardValueBudget.ts
@@ -60,23 +60,62 @@
  * width every budget below was measured in: one Latin character of that
  * region's own type.
  *
- * THE WIDTH MODEL, and it is deliberately conservative. A cluster costs ONE
- * slot when every code point in it is U+0000-U+00FF - ASCII plus Latin-1,
- * which covers every character `boardFormat.ts` can emit and every ticker a
- * Latin market uses - and TWO otherwise. That over-charges a few genuinely
- * narrow cases, such as a Greek letter or a base character carrying a
- * combining mark, and that is the right direction to be wrong in:
- * over-charging shortens a value slightly early AND SAYS SO, while
- * under-charging overflows the card in silence. It is a model of the DATA,
- * owned here. It is not a measurement, and it still takes no threshold away
- * from `global-css/board-layout.css`.
+ * TWO SURFACES, TWO WIDTH MODELS, because the card has two kinds of type and
+ * one model cannot describe both.
+ *
+ * TABULAR (`"tabular"`) is the price, the delta and the stat values. They
+ * render `tabular-nums`, where every digit advances by the same width by
+ * definition of the feature, so a count of clusters IS a width and one slot
+ * is one digit.
+ *
+ * PROPORTIONAL (`"proportional"`) is the ticker, which renders in ordinary
+ * uppercase Inter Tight (`TokenCardV3.tsx`) where glyph advances differ by
+ * more than a factor of four. Measured in the committed face at the ticker's
+ * own 13px, one slot is 8.8px - the 88px identity column divided by the
+ * budget of 10 - and the glyphs fall either side of it:
+ *
+ *   W 11.82   M 10.84   % 9.85   C D G H N O Q U 8.86
+ *   A B K P R S T V X Y Z $ + 0 3 4 7.88   E F L 2 5 6 7 8 9 6.90
+ *   J 5.91   1 - 4.93   I . , : 2.95
+ *
+ * So a count of characters is NOT a width here, and treating it as one was a
+ * defect: `WWWWWWWW` is eight characters, cost eight of ten slots, and
+ * rendered 94.56px into an 88px column - clipped, with nothing reporting it.
+ * Anything measuring wider than a slot is charged two.
+ *
+ * THE PROPORTIONAL CLASS IS AN ALLOWLIST OF NARROW GLYPHS, not a blocklist of
+ * wide ones, and that direction is the point: a character nobody measured -
+ * and the schema admits any of Latin-1 - is charged the wide weight rather
+ * than assumed innocent. The ticker also renders through `text-transform:
+ * uppercase`, so classification uppercases first: a lowercase `w` occupies a
+ * `W`.
+ *
+ * ABOVE LATIN-1, both surfaces charge two. That over-charges a Greek letter
+ * or a base character carrying a combining mark, and under-charges nothing.
+ *
+ * Over-charging shortens a value slightly early AND SAYS SO; under-charging
+ * overflows the card in silence. Every one of these numbers is a model of the
+ * DATA owned here, and none of them takes a threshold away from
+ * `global-css/board-layout.css`.
  */
+
+/** Which of the card's two type surfaces a value is printed on. */
+export type BoardCardSurface = "tabular" | "proportional";
 
 /** The last code point charged as one slot. */
 const NARROW_CODE_POINT_MAX = 0x00ff;
 
 /** What a cluster costs when it is not narrow. */
 const WIDE_SLOTS = 2;
+
+/**
+ * The glyphs measured at or under one slot (8.8px) in the ticker's own type,
+ * after its `uppercase` transform. Everything else on that surface - measured
+ * wider, or never measured - is charged {@link WIDE_SLOTS}.
+ */
+const PROPORTIONAL_NARROW = new Set(
+  [..."ABEFIJKLPRSTVXYZ0123456789.,:-$+ "],
+);
 
 /** The ellipsis a shortened value ends in. */
 const ELLIPSIS = "…";
@@ -112,9 +151,14 @@ export const BOARD_CARD_DELTA_MAX_SLOTS = 8;
 export const BOARD_CARD_STAT_MAX_SLOTS = 11;
 
 /**
- * The ticker under the name. The compact header spends its inner width on the
- * 64px photo, two 16px gaps and the 132px action cluster, which leaves the
- * identity column 88px; the ticker renders at roughly 8.2px per character.
+ * The ticker under the name, and the one PROPORTIONAL surface.
+ *
+ * The compact header spends its inner width on the 64px photo, two 16px gaps
+ * and the 132px action cluster, which leaves the identity column 88px. Ten
+ * slots of 8.8px each is that column exactly, which is what makes 8.8px the
+ * slot on this surface and what the glyph table in the head note is measured
+ * against. The widest a ten-slot string can render is ten narrow glyphs at
+ * 7.88px, or 78.8px, so the model keeps 9px in hand against its own column.
  */
 export const BOARD_CARD_TICKER_MAX_SLOTS = 10;
 
@@ -162,19 +206,28 @@ function graphemeSegmenter(): Intl.Segmenter | null {
   return segmenterCache;
 }
 
-/** What one cluster costs, under the width model in this file's head note. */
-function slotsOf(grapheme: string): number {
+/** What one cluster costs, under the width models in this file's head note. */
+function slotsOf(grapheme: string, surface: BoardCardSurface): number {
   for (const codePoint of grapheme) {
     const value = codePoint.codePointAt(0);
     if (value === undefined || value > NARROW_CODE_POINT_MAX) return WIDE_SLOTS;
+  }
+  if (surface === "tabular") return 1;
+  // Uppercased first: the ticker renders through `text-transform: uppercase`,
+  // so a lowercase `w` occupies a `W` and must be charged as one.
+  for (const character of grapheme.toUpperCase()) {
+    if (!PROPORTIONAL_NARROW.has(character)) return WIDE_SLOTS;
   }
   return 1;
 }
 
 /** What `text` costs in slots, whole. Exported because the tests assert it. */
-export function boardCardValueSlots(text: string): number {
+export function boardCardValueSlots(
+  text: string,
+  surface: BoardCardSurface = "tabular",
+): number {
   let slots = 0;
-  for (const grapheme of graphemesOf(text)) slots += slotsOf(grapheme);
+  for (const grapheme of graphemesOf(text)) slots += slotsOf(grapheme, surface);
   return slots;
 }
 
@@ -191,12 +244,16 @@ export function boardCardValueSlots(text: string): number {
  * a bare `…` names no value at all, and the clamp is one cluster over rather
  * than a preview that says nothing.
  */
-export function boardCardValue(text: string, maxSlots: number): BoardCardValue {
+export function boardCardValue(
+  text: string,
+  maxSlots: number,
+  surface: BoardCardSurface = "tabular",
+): BoardCardValue {
   // SEGMENTED ONCE. The whole-value cost and the kept prefix are two questions
   // about the same clusters, and asking the segmenter twice is a per-row cost
   // on every value of every card.
   const graphemes = graphemesOf(text);
-  const costs = graphemes.map(slotsOf);
+  const costs = graphemes.map((grapheme) => slotsOf(grapheme, surface));
   let total = 0;
   for (const cost of costs) total += cost;
   if (total <= maxSlots) return { text, shortened: false };

--- a/vex-app/src/renderer/styles/global-css/board-layout.css
+++ b/vex-app/src/renderer/styles/global-css/board-layout.css
@@ -1,0 +1,347 @@
+/* BOARD LAYOUT - the single owner of every board geometry threshold.
+ *
+ * THE CONTAINER, NOT THE VIEWPORT. The Ask VEX drawer removes 360px from the
+ * board plate without changing the window by a pixel, so a viewport media
+ * query decides columns from a number that is not the number the cards have
+ * to live in. That was the production defect: at a 1440px window with the
+ * drawer open the grid still asked for three tracks and each one measured
+ * 268px, below the 300 the stat block needs and the 316 the price row needs.
+ * Every rule below is a `@container` query on the plate's own inline size, so
+ * the drawer, a narrower window and a future side panel are all the same
+ * event to this file.
+ *
+ * THIS FILE IS THE ONLY PLACE A THRESHOLD LIVES. There is no TypeScript
+ * solver, no ResizeObserver, no mirrored table and no JavaScript that reads
+ * layout back. `--vex-board-mode` is published purely so a browser test can
+ * read the computed value and name which mode it measured; nothing in the
+ * application reads it.
+ *
+ * WHERE THE NUMBERS COME FROM. Every one of them is measured, and the
+ * derivation is a committed artifact:
+ * `features/appShell/Board/board-layout-measurements.md`. Sections 4b and 4c
+ * are the tables this file implements. In short, with realistic DexScreener
+ * figures and the widest label the frozen safety table can produce:
+ *
+ *   WIDE anatomy    (sparkline in the price row, 4 stat columns, one-row
+ *                    footer) needs 460px of inner width, so a 502px card.
+ *                    Binding constraint: 316 figures + 12 gap + 132 sparkline.
+ *   COMPACT anatomy (sparkline in its own slot, 2x2 stats, stacked footer)
+ *                    needs 316px of inner width, so a 358px card.
+ *                    Binding constraint: `$0.000001230 +661.00% 24h` = 316.
+ *
+ * A card's OUTER width is its inner floor plus 40px of `px-5` padding AND the
+ * 2px its own border occupies. That border was left out of the first pass of
+ * this table and it is not a rounding detail: at the old 356px floor the hero
+ * price had 196px for a string that wants 197.29, so the one figure the whole
+ * ladder is derived from was cut by two pixels at every floor on it. The
+ * constrained 800px case in `e2e/board-layout.spec.ts` is what says so.
+ *
+ * Card = (C - 16 x (n - 1)) / n for n columns in a container of C. The ladder
+ * takes the MOST columns whose card clears the compact floor, then uses wide
+ * anatomy if that card also clears the wide floor:
+ *
+ *   C >= 1538  3 columns WIDE       (3 x 502 + 32)
+ *   C >= 1106  3 columns compact    (3 x 358 + 32)
+ *   C >= 1020  2 columns WIDE       (2 x 502 + 16)
+ *   C >=  732  2 columns compact    (2 x 358 + 16)
+ *   C >=  502  1 column  WIDE
+ *   C >=  358  1 column  compact
+ *   C <   358  1 column  compact, pinned at 358, the plate side-scrolls
+ *
+ * NOTHING HERE TRANSITIONS. Geometry that animated would reflow the grid
+ * under a reader's pointer and, with the drawer, would put the cards through
+ * a squeezed interim layout on every open - which is the second half of the
+ * defect this file fixes. There is no `transition` on a layout property in
+ * this file at all, which is why the reduced-motion block at the bottom has
+ * nothing to still: it exists to say so, and to catch a future addition. */
+
+/* ------------------------------------------------------------------ */
+/* The container                                                       */
+/* ------------------------------------------------------------------ */
+
+/* `inline-size` and not `size`: the plate's height must stay content-driven
+ * (a board of eight cards is taller than a board of two), and only the inline
+ * axis is being queried. The query size is the plate's CONTENT box, which is
+ * the width the grid actually gets - the `p-4` is already subtracted. */
+.vex-board-plate {
+  container-type: inline-size;
+  container-name: vex-board-plate;
+}
+
+/* THE SIDE-SCROLL LIVES HERE, NOT ON THE PLATE. Giving the plate itself
+ * `overflow-x: auto` would make it a scroll container too, and the modal body
+ * already owns the board's vertical scrolling. So the horizontal escape hatch
+ * is a wrapper around the grid: below the compact floor the track stays 358px
+ * wide and this element scrolls, rather than a figure being cut.
+ *
+ * `overflow-y: visible` IS NOT AVAILABLE HERE, and asking for it was wrong.
+ * CSS overflow computes a `visible` on one axis to `auto` whenever the other
+ * axis is not `visible`, so this element is a scroll container on BOTH axes
+ * whatever is written for the block axis - and its block-axis padding box is
+ * exactly the grid, which clips the cards' hover shadow (`--shadow-lv2`
+ * reaches 16px below a card and 8px above).
+ *
+ * So the room is MADE rather than asked for: block padding wide enough for
+ * the shadow, cancelled by an equal negative margin so the plate's own
+ * spacing is unchanged. The inline axis deliberately gets none of this - an
+ * inline padding here would shrink the grid below the width the container
+ * query just decided the columns from, which is the whole defect this file
+ * exists to fix. A first card's leading shadow is reachable by the scroll
+ * that owns that axis. */
+.vex-board-grid-scroller {
+  overflow-x: auto;
+  padding-block: 16px;
+  margin-block: -16px;
+}
+
+/* ------------------------------------------------------------------ */
+/* Columns                                                             */
+/* ------------------------------------------------------------------ */
+
+/* One column is the floor case, so it is the unconditional rule. `minmax` and
+ * not `1fr`: below 358px the track REFUSES to shrink and the scroller above
+ * takes over, which is the uniswap-table policy the plan adopted - a reader
+ * scrolls to a figure rather than being shown a truncated one. */
+.vex-board-grid {
+  display: grid;
+  align-items: stretch;
+  gap: 16px;
+  grid-template-columns: minmax(358px, 1fr);
+}
+
+@container vex-board-plate (min-width: 732px) {
+  .vex-board-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@container vex-board-plate (min-width: 1106px) {
+  .vex-board-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Mode                                                                */
+/* ------------------------------------------------------------------ */
+
+/* THE MODE IS DECLARED ON THE GRID, NOT ON THE PLATE, and that is a rule of
+ * the mechanism rather than a preference: `@container` styles apply to a
+ * container's DESCENDANTS and never to the container element itself, so mode
+ * variables written onto `.vex-board-plate` would sit in a block that can
+ * never match. The grid is the right owner anyway - it is the one element
+ * every card shares, which is what makes the mode grid-wide and therefore
+ * makes the cards equal.
+ *
+ * COMPACT IS THE DEFAULT, and that is a deliberate direction. A card that is
+ * narrower than expected must degrade into the anatomy that fits rather than
+ * out of the anatomy that does not, so the failure mode of a query that never
+ * matches is a readable card, never a cut figure.
+ *
+ * Every mode difference is a VALUE, so the three wide windows are one block
+ * rather than three copies of the anatomy. */
+.vex-board-grid {
+  --vex-board-mode: compact;
+  --vex-board-sparkline-inline-display: none;
+  --vex-board-sparkline-slot-display: block;
+  --vex-board-stat-columns: repeat(2, minmax(0, 1fr));
+  --vex-board-stat-height: 92px;
+  --vex-board-footer-direction: column;
+  --vex-board-footer-align: flex-start;
+  --vex-board-footer-justify: flex-start;
+  --vex-board-footer-gap: 8px;
+}
+
+/* The three windows in which the chosen column count leaves a 500px card.
+ * They are ranges rather than a single `min-width` because the card width is
+ * a sawtooth in the container width: gaining a column makes every card
+ * narrower again. See section 4c of the measurements. */
+@container vex-board-plate ((min-width: 502px) and (max-width: 731.98px)) or
+  ((min-width: 1020px) and (max-width: 1105.98px)) or (min-width: 1538px) {
+  .vex-board-grid {
+    --vex-board-mode: wide;
+    --vex-board-sparkline-inline-display: block;
+    --vex-board-sparkline-slot-display: none;
+    --vex-board-stat-columns: repeat(4, minmax(0, 1fr));
+    --vex-board-stat-height: 46px;
+    --vex-board-footer-direction: row;
+    --vex-board-footer-align: center;
+    --vex-board-footer-justify: space-between;
+    --vex-board-footer-gap: 12px;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* The card's mode-dependent anatomy                                   */
+/* ------------------------------------------------------------------ */
+
+/* The sparkline ADAPTS, it is never deleted. In wide mode it sits in the
+ * price row beside the figures at a FIXED 132px - a percentage would shrink
+ * the figures' budget faster than the card shrinks, which is what made the
+ * delta and its `24h` window wrap out of a 44px row at 1920px with no drawer
+ * at all. In compact mode it takes its own full-width slot below the row, so
+ * the figures get the whole inner width and the reader still gets the line. */
+.vex-board-card-sparkline-inline {
+  display: var(--vex-board-sparkline-inline-display);
+  width: 132px;
+  height: 44px;
+  flex: none;
+}
+
+.vex-board-card-sparkline-slot {
+  display: var(--vex-board-sparkline-slot-display);
+  height: 36px;
+  margin-top: 12px;
+}
+
+.vex-board-card-stats {
+  display: grid;
+  grid-template-columns: var(--vex-board-stat-columns);
+  column-gap: 12px;
+  row-gap: 12px;
+  height: var(--vex-board-stat-height);
+}
+
+.vex-board-card-footer {
+  display: flex;
+  flex-direction: var(--vex-board-footer-direction);
+  align-items: var(--vex-board-footer-align);
+  justify-content: var(--vex-board-footer-justify);
+  gap: var(--vex-board-footer-gap);
+}
+
+/* ------------------------------------------------------------------ */
+/* Spotlight                                                           */
+/* ------------------------------------------------------------------ */
+
+/* THE SPOTLIGHT'S REGIONS DECIDE THEIR OWN THRESHOLDS. A card threshold must
+ * never decide a spotlight region: the two surfaces hold different content in
+ * the same shrinking container, and borrowing a number would be a second
+ * source of truth wearing a first source's clothes. Each rule below is named
+ * for the content that binds it.
+ *
+ * The spotlight plate is its own container because the drawer shrinks it the
+ * same way it shrinks the grid. */
+.vex-board-spotlight-plate {
+  container-type: inline-size;
+  container-name: vex-board-spotlight;
+}
+
+/* HERO. Four tracks: an 88px photo, the identity, the price block and the
+ * Spotlight button. The price block holds `$0.000001230 +661.00% 24h` at the
+ * hero's 40px type, which is 1.43x the card's 28px, so 316 x 1.43 = 452, plus
+ * 88 photo, 2 x 24 gaps, a 200 identity minimum and a 96 button = 884. Below
+ * that the hero stacks rather than crushing the price. */
+.vex-board-spotlight-hero {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  align-items: center;
+  column-gap: 24px;
+  row-gap: 12px;
+}
+
+/* THE STACKED ROWS ARE PLACED, NOT AUTO-PLACED, and that is the whole fix.
+ * The hero has FOUR children and, below the threshold, TWO tracks: grid
+ * auto-placement therefore put the price block into row 2 column 1 - the 88px
+ * photo track - and the Spotlight toggle beside it in column 2. The largest
+ * type on the surface was being asked to render `$0.000001230 +661.00% 24h`
+ * inside 88px. Spanning both of them across the hero is what "the hero stacks
+ * rather than crushing the price" actually requires. */
+.vex-board-spotlight-hero-price,
+.vex-board-spotlight-hero-action {
+  grid-column: 1 / -1;
+}
+
+.vex-board-spotlight-hero-action {
+  justify-self: start;
+}
+
+@container vex-board-spotlight (min-width: 884px) {
+  .vex-board-spotlight-hero {
+    grid-template-columns: 88px minmax(200px, 1fr) auto auto;
+  }
+
+  /* Four tracks, four children, one row: the placement above is RESET rather
+   * than overridden per-property, so the wide hero is exactly the layout
+   * auto-placement gives it. */
+  .vex-board-spotlight-hero-price,
+  .vex-board-spotlight-hero-action {
+    grid-column: auto;
+    justify-self: auto;
+  }
+}
+
+/* CHART BESIDE ITS METRICS COLUMN. The metrics track is a fixed 360px and the
+ * chart needs 480px to be a chart rather than a smear, so the pair needs
+ * 480 + 16 + 360 = 856. */
+.vex-board-spotlight-chart-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+}
+
+@container vex-board-spotlight (min-width: 856px) {
+  .vex-board-spotlight-chart-row {
+    grid-template-columns: minmax(0, 1fr) 360px;
+  }
+}
+
+/* THE THREE FACTUAL SECTIONS. A section's own binding content is the safety
+ * check rows, which need 280px to keep a check name beside its verdict:
+ * 3 x 280 + 2 x 16 = 872. Two of them fit at 2 x 280 + 16 = 576. */
+.vex-board-spotlight-row-3 {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+}
+
+@container vex-board-spotlight (min-width: 576px) {
+  .vex-board-spotlight-row-3 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@container vex-board-spotlight (min-width: 872px) {
+  .vex-board-spotlight-row-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/* THE SPOTLIGHT+ PAIRS. The binding content is the tape, whose row is a time,
+ * a side, a size and a price: 320px. Two of them need 656. */
+.vex-board-spotlight-row-2 {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+}
+
+@container vex-board-spotlight (min-width: 656px) {
+  .vex-board-spotlight-row-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Reduced motion                                                      */
+/* ------------------------------------------------------------------ */
+
+/* Nothing above transitions a geometric property, so there is nothing here to
+ * still. The block is the standing contract (`board.css` holds the same one
+ * for the two things that DO animate): a layout in this file changes in one
+ * paint, never over time. If a future edit adds a transition to a width, a
+ * height, a gap or a grid track, it belongs in this block first. */
+@media (prefers-reduced-motion: reduce) {
+  .vex-board-grid,
+  .vex-board-card-stats,
+  .vex-board-card-footer,
+  .vex-board-card-sparkline-inline,
+  .vex-board-card-sparkline-slot,
+  .vex-board-spotlight-hero,
+  .vex-board-spotlight-hero-price,
+  .vex-board-spotlight-hero-action,
+  .vex-board-spotlight-chart-row,
+  .vex-board-spotlight-row-2,
+  .vex-board-spotlight-row-3 {
+    transition: none;
+  }
+}

--- a/vex-app/src/renderer/styles/globals.css
+++ b/vex-app/src/renderer/styles/globals.css
@@ -15,6 +15,7 @@
 @import "./global-css/chronos-motion.css";
 @import "./global-css/chat-transcript.css";
 @import "./global-css/board.css";
+@import "./global-css/board-layout.css";
 @import "./global-css/scrollbars.css";
 @import "./global-css/ui-primitives.css";
 @import "./global-css/console.css";

--- a/vex-app/vite.board-layout.config.ts
+++ b/vex-app/vite.board-layout.config.ts
@@ -1,0 +1,64 @@
+/// <reference types="vite/client" />
+/**
+ * BOARD LAYOUT HARNESS - the dev server the board geometry spec drives.
+ *
+ * WHY A SECOND CONFIG AND NOT THE ELECTRON SMOKE APP. The board modal is
+ * unreachable from `e2e/smoke.spec.ts`: that fixture launches the built app
+ * against a throwaway config dir and, by its own head note, stops at
+ * SystemCheck because everything past it needs a real Docker daemon, a
+ * migrated Postgres and an unlocked vault. Geometry, however, is decided
+ * entirely by the renderer's own CSS - the container queries in
+ * `global-css/board-layout.css` - so it can be proven in a real Chromium at
+ * real widths with the real production stylesheet, and that is what this
+ * config serves.
+ *
+ * IT NEVER TOUCHES THE SHIPPED BUNDLE. `vite.renderer.config.ts` still has
+ * exactly one rollup input (`src/renderer/index.html`); the harness entry is
+ * a separate root that only this config and only `playwright.config.ts` know
+ * about, so no harness byte can reach a packaged build.
+ *
+ * The plugins, the aliases and the imported `styles/globals.css` are the
+ * renderer's own, because a harness that compiled a different stylesheet
+ * would prove a layout the product does not have.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const harnessRoot = path.resolve(dirname, "src/renderer/dev/board-layout");
+
+export default defineConfig({
+  root: harnessRoot,
+  appType: "spa",
+  base: "/",
+  envDir: dirname,
+  envPrefix: "VITE_",
+  // The renderer's OWN public dir: the display font is served from it, and a
+  // harness that fell back to a system font would measure text the product
+  // never renders.
+  publicDir: path.resolve(dirname, "src/renderer/public"),
+
+  define: {
+    __VEX_APP_VERSION__: JSON.stringify("board-layout-harness"),
+  },
+
+  plugins: [react(), tailwindcss()],
+
+  resolve: {
+    alias: {
+      "@": path.resolve(dirname, "src/renderer"),
+      "@shared": path.resolve(dirname, "src/shared"),
+      "@vex-lib": path.resolve(dirname, "../src/lib"),
+    },
+  },
+
+  server: {
+    host: "127.0.0.1",
+    port: 5273,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
The board modal squeezed token cards into data loss whenever the Ask VEX drawer opened: columns came from viewport media queries while the drawer shrank the container, money values and labels ellipsized silently, and shrink-0 members were overpainted by neighbour cards.

- native CSS container queries on the plate are now the single owner of every threshold; two fixed card anatomies (wide / compact) with floors derived from a committed measurement matrix; the drawer costs dialog width, not card width; sub-floor plates side-scroll
- nothing financial ever ellipsizes: schema-extreme values concede through a grapheme-safe, font-measured slot budget (tabular and proportional surfaces weighted separately) with a visible, keyboard-accessible named cut state; the full values live behind an honest disclosure (no false aria-modal, covered controls leave the tab order via tabindex=-1)
- fixes two pre-existing defects: the hero price row wrapped and clipped at 1920px, and cards rendered unequal widths inside equal tracks

Proven by a Playwright geometry harness over the real production stylesheet: 97 cases including a full threshold seam matrix asserting track counts and modes, focus containment, pointer independence, Unicode extremes (CJK, emoji ZWJ, combining marks, lone surrogates) and wide-glyph overflow. vex-app suite 7,725/0; renderer production build verified. External review: plan 3 turns to GREEN LIGHT; final review converged at the 3-turn cap with the last font-weighting defect fixed by the reviewer's own measurement and closed under the convergence decree (thread harness-board-render).