### PR TITLE
test(pty-host): the curses witness is what every platform emits, and the deletion allowlist rests empty after the merge

### DIFF
--- a/scripts/deleted-test-allowlist.mjs
+++ b/scripts/deleted-test-allowlist.mjs
@@ -20,50 +20,7 @@
  * outlives its merge is stale by construction and the gate says so.
  */
 
-export const DELETED_TEST_ALLOWLIST = [
-  {
-    path: "vex-app/src/main/studio/__tests__/socket-test-adapter.ts",
-    reason:
-      "Its subject was the `net.Socket` weld itself. The helper monkey-patched "
-      + "a real `Socket` instance with `Object.defineProperties` so an "
-      + "EventEmitter double could be passed where the host demanded a socket. "
-      + "Stage B4.2b replaced that demand with the `StudioDuplexTransport` "
-      + "contract, so there is no socket left to impersonate and nothing for "
-      + "this adapter to do.",
-    coveredBy:
-      "src/vex-agent/mcp/duplex-transport-fake.ts (`FakeDuplexTransport`), the "
-      + "one honest double both test trees now drive: it implements the "
-      + "published contract instead of overriding a real stream. Its consumers "
-      + "are vex-app/src/main/studio/__tests__/outbound-queue-blocked.test.ts, "
-      + "vex-app/src/main/studio/__tests__/mcp-connection-refusal.test.ts and "
-      + "src/__tests__/vex-agent/mcp/socket-transport-framing.test.ts, all of "
-      + "which keep their cases unchanged.",
-  },
-  {
-    path: "vex-app/src/renderer/components/ui/__tests__/toast.test.tsx",
-    reason:
-      "Its subjects (components/ui/toast.tsx and the lib/toast.ts single-slot "
-      + "store) were deleted by the batch-2 transient-toast migration onto the "
-      + "notification model.",
-    coveredBy:
-      "vex-app/src/renderer/lib/notifications/__tests__/notification-model.test.ts "
-      + "(timing, stacking, purge pause, unmount leak gate) and "
-      + "vex-app/src/renderer/components/ui/__tests__/notification-toast.test.tsx "
-      + "(render, tones, announcement).",
-  },
-  {
-    path: "vex-app/src/renderer/features/appShell/__tests__/GlobalErrorBanner.test.tsx",
-    reason:
-      "Its subject (features/appShell/GlobalErrorBanner.tsx, the header pill "
-      + "and popover) was deleted by the batch-2 engine-error migration onto "
-      + "the notification model and center.",
-    coveredBy:
-      "vex-app/src/renderer/features/appShell/__tests__/engine-error-notifications.test.tsx "
-      + "(event projection, scoping, announcement, dismissal) and "
-      + "vex-app/src/renderer/features/appShell/__tests__/notification-center.test.tsx "
-      + "(the center chrome that replaced the popover).",
-  },
-];
+export const DELETED_TEST_ALLOWLIST = [];
 
 export const DELETED_TEST_ALLOWLIST_PATHS = new Set(
   DELETED_TEST_ALLOWLIST.map((entry) => entry.path),

--- a/vex-app/src/pty-host/__tests__/real-pty.test.ts
+++ b/vex-app/src/pty-host/__tests__/real-pty.test.ts
@@ -1007,16 +1007,24 @@ describe("a real curses program", () => {
       // without this the assertions below would also hold for a `cat`.
       //
       // MEASURED against this machine's `less` and `xterm-256color` terminfo
-      // rather than assumed: the complete set it emits is `?1049h` (alternate
-      // screen), `22;0;0t` (window title stack), `?1h` (application cursor
-      // keys), `7m`/`27m` (reverse video for the status line) and `K` (erase to
-      // end of line). It uses NO absolute cursor addressing - it repaints by
-      // writing newlines - so asserting on a `H` sequence here would be testing
-      // a convention this program does not follow. That assertion was written
-      // first, and the live stream is what corrected it.
+      // rather than assumed: on Linux the complete set it emits is `?1049h`
+      // (alternate screen), `22;0;0t` (window title stack), `?1h` (application
+      // cursor keys), `7m`/`27m` (reverse video for the status line) and `K`
+      // (erase to end of line). It uses NO absolute cursor addressing - it
+      // repaints by writing newlines - so asserting on a `H` sequence here
+      // would be testing a convention this program does not follow. That
+      // assertion was written first, and the live stream is what corrected it.
+      //
+      // The witnesses are the two sequences EVERY platform emits by the time
+      // the second page is on screen. Reverse video is not one of them: ConPTY
+      // re-encodes the stream on its own schedule (it also adds absolute
+      // addressing of its own), and the same commit's Windows lane saw `7m`
+      // in one vitest step and not in the next (CI run 33804547267, job
+      // 100811769277: the full run passed, the pty-host-alone run failed on
+      // exactly this line). A witness that depends on when the attribute
+      // repaint lands is a witness to timing, not to the mirror.
       const stream = dataOf(port);
       expect(stream).toContain("[?1049h");
-      expect(stream).toContain("[7m");
       expect(stream).toContain("[K");
 
       // The mirror's serialization must render back to the rows that are on


### PR DESCRIPTION
## What

The Windows lane on main (run 33804547267, job "Test (vitest, win32, pty host alone)") failed on one assertion in `real-pty.test.ts`: the curses test expected the reverse-video sequence `[7m` in the mirror's stream. The same job's full vitest step had passed the same test minutes earlier, and so had the PR run on the same commit. ConPTY re-encodes the stream on its own schedule, so the presence of that attribute repaint at serialization time is timing, not mirror behaviour.

- The witnesses that a TUI ran rather than a `cat` are now `[?1049h` (alternate screen) and `[K` (erase to end of line), which every platform emits before the page is painted. The rendered-screen text assertions are unchanged.
- `scripts/deleted-test-allowlist.mjs` returns to its documented resting state (empty): its three rows named tests whose subjects the studio-prod merge removed, and against the new base the gate reports them as stale, which would fail every pull request.

## Verification

- `pnpm --dir vex-app exec vitest run src/pty-host/__tests__/real-pty.test.ts` on Linux: 9 passed, 1 skipped.
- `node scripts/check-test-unsafe-escapes.mjs --base origin/main`: green.
- `node scripts/check-no-em-dash.mjs`: green.
- The Windows lane of this PR is the evidence for the flake fix.
