### PR TITLE
fix(sync): the bridge fill verifier tries every RPC the app trusts and names an endpoint's refusal

### DIFF
--- a/src/__tests__/vex-agent/sync/bridge-activity-repair-probe-reasons.test.ts
+++ b/src/__tests__/vex-agent/sync/bridge-activity-repair-probe-reasons.test.ts
@@ -72,6 +72,33 @@ function input() {
   };
 }
 
+/**
+ * The error viem 2.54.3 actually raises when an endpoint ANSWERS with a
+ * JSON-RPC `error` object, reproduced from a live probe of
+ * `https://arbitrum-one.publicnode.com` on 2026-09-04 (eth_chainId 42161, then
+ * `-32602` for a month-old receipt: "Archive requests require a personal
+ * token"). Shape, not text: `InvalidParamsRpcError` (numeric `code`) whose
+ * `cause` is `RpcRequestError` with the same numeric code.
+ */
+function refusedRequest(): Error {
+  const cause = new Error("Archive requests require a personal token. Get one at: https://www.allnodes.com/publicnode");
+  cause.name = "RpcRequestError";
+  Object.assign(cause, { code: -32602 });
+  const err = new Error("Invalid parameters were provided to the RPC method.", { cause });
+  err.name = "InvalidParamsRpcError";
+  Object.assign(err, { code: -32602 });
+  return err;
+}
+
+/** A transport failure as viem raises it: NO numeric code anywhere in the chain. */
+function transportFailure(): Error {
+  const socket = new Error("getaddrinfo ENOTFOUND rpc.example");
+  Object.assign(socket, { code: "ENOTFOUND" }); // a STRING code - not an answer.
+  const err = new Error("HTTP request failed.", { cause: socket });
+  err.name = "HttpRequestError";
+  return err;
+}
+
 function notFound(): Error {
   // viem carries the RPC URL in this message, which is why the code matches on
   // `name` and never on the text.
@@ -116,6 +143,36 @@ describe("verifyBridgeLegOnChain — one reason per real observation", () => {
     expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: false, reason: "rpc_unreachable" });
   });
 
+  it("an endpoint that ANSWERED and refused is not 'unreachable' - the loop moves on and a later URL verifies", async () => {
+    // The owner's row 132, replayed at the loop level: the first endpoint echoes
+    // 42161 and refuses the archive read, the second serves the receipt.
+    rpcUrls = ["https://refuses.example", "https://serves.example"];
+    clientScript.push({ chainId: 42161, throws: refusedRequest() }, { chainId: 42161, receiptStatus: "success" });
+    expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: true });
+  });
+
+  it("EVERY endpoint refused → rpc_refused_request, never rpc_unreachable", async () => {
+    rpcUrls = ["https://a", "https://b"];
+    clientScript.push({ chainId: 42161, throws: refusedRequest() }, { chainId: 42161, throws: refusedRequest() });
+    expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: false, reason: "rpc_refused_request" });
+  });
+
+  it("transport failure, then a refusal, then 'no receipt yet' → fill_not_mined wins by precedence", async () => {
+    rpcUrls = ["https://a", "https://b", "https://c"];
+    clientScript.push(
+      { chainId: 42161, throws: transportFailure() },
+      { chainId: 42161, throws: refusedRequest() },
+      { chainId: 42161, throws: notFound() },
+    );
+    expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: false, reason: "fill_not_mined" });
+  });
+
+  it("a refusal on the CHAIN-ID call also counts as an answer, not silence", async () => {
+    rpcUrls = ["https://a"];
+    clientScript.push({ chainId: undefined, throws: refusedRequest() });
+    expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: false, reason: "rpc_refused_request" });
+  });
+
   it("a receipt with status success verifies", async () => {
     clientScript.push({ chainId: 42161, receiptStatus: "success" });
     expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: true });
@@ -150,6 +207,10 @@ describe("multi-endpoint precedence is fixed, not URL-order dependent", () => {
     [["fill_not_mined", "rpc_unreachable"], "fill_not_mined"],
     [["chain_echo_mismatch", "rpc_unreachable"], "chain_echo_mismatch"],
     [["fill_not_mined", "unreadable_receipt_status"], "unreadable_receipt_status"],
+    [["rpc_unreachable", "rpc_refused_request"], "rpc_refused_request"],
+    [["rpc_refused_request", "rpc_unreachable"], "rpc_refused_request"],
+    [["rpc_refused_request", "chain_echo_mismatch"], "chain_echo_mismatch"],
+    [["rpc_refused_request"], "rpc_refused_request"],
     [["rpc_unreachable"], "rpc_unreachable"],
     [[], "no_safe_rpc"],
   ] as const)("%j → %s", (observations, expected) => {

--- a/src/__tests__/vex-agent/sync/bridge-activity-repair-rpc-candidates.test.ts
+++ b/src/__tests__/vex-agent/sync/bridge-activity-repair-rpc-candidates.test.ts
@@ -1,0 +1,182 @@
+/**
+ * WHICH ENDPOINTS the bridge fill verifier is allowed to ask about a destination
+ * chain, and in what order.
+ *
+ * THE DEFECT THIS PINS (owner's install, measured 2026-09-04). A Relay row
+ * expecting a fill on Arbitrum One (42161) had exactly ONE candidate URL for 31
+ * days: Relay's own registry entry, `arbitrum-one.publicnode.com`, which echoes
+ * `eth_chainId` 42161 and then answers a month-old receipt with JSON-RPC -32602
+ * ("Archive requests require a personal token"). The local chain registry does
+ * not know 42161, and the verifier consulted only the row's OWN protocol
+ * registry, so nothing else was ever tried through 1227 attempts and the row
+ * could not conclude - which withheld every wallet snapshot behind the
+ * publication gate. Khalani's registry and viem's bundled definition both serve
+ * 42161 as `https://arb1.arbitrum.io/rpc`, which returns the receipt
+ * (`status: success`, block 490770285) on the same live probe.
+ *
+ * The real `selectVerificationRpcUrls` runs here (it is the one ordering and
+ * SSRF owner); only the registries and the RPC client are scripted, so what is
+ * asserted is the candidate SET, its ORDER, and that a refusing endpoint no
+ * longer ends the search.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/** Every URL the verifier actually opened a client for, in order. */
+const probed: string[] = [];
+
+type ScriptedEndpoint = { chainId?: number; receiptStatus?: unknown; throws?: Error };
+const byUrl = new Map<string, ScriptedEndpoint>();
+
+vi.mock("viem", () => ({
+  http: (url: string) => url,
+  createPublicClient: ({ transport }: { transport: string }) => {
+    probed.push(transport);
+    const step = byUrl.get(transport) ?? {};
+    return {
+      getChainId: async () => {
+        if (step.throws && step.chainId === undefined) throw step.throws;
+        return step.chainId ?? 42161;
+      },
+      getTransactionReceipt: async () => {
+        if (step.throws) throw step.throws;
+        return { status: step.receiptStatus };
+      },
+    };
+  },
+}));
+
+let userOverrides: string[] = [];
+let localChainUrl: string | null = null;
+let khalaniUrl: string | null = null;
+let relayUrl: string | null = null;
+
+vi.mock("@config/chain-rpc-overrides.js", () => ({
+  getUserRpcOverridesForChain: () => userOverrides,
+}));
+vi.mock("@tools/evm-chains/registry.js", () => ({
+  getLocalChain: () => (localChainUrl === null ? null : { id: 4663 }),
+  getLocalChainRpcUrl: () => localChainUrl ?? "",
+}));
+vi.mock("@tools/khalani/chains.js", () => ({
+  getCachedKhalaniChains: async () =>
+    khalaniUrl === null ? [] : [{ id: 42161, rpcUrls: { default: { http: [khalaniUrl] } } }],
+}));
+vi.mock("@tools/relay/client.js", () => ({
+  getCachedRelayChains: async () => (relayUrl === null ? [] : [{ id: 42161, httpRpcUrl: relayUrl }]),
+}));
+
+const { verifyBridgeLegOnChain } = await import("@vex-agent/sync/bridge-activity-repair-verification.js");
+
+/** viem's bundled canonical default for 42161, the last candidate source. */
+const VIEM_ARBITRUM_DEFAULT = "https://arb1.arbitrum.io/rpc";
+const PUBLICNODE = "https://arbitrum-one.publicnode.com";
+const HASH = "0xd6cc8dce232ab4893d79c0b9a339306cb15c56e099828ab146299885a3615201";
+
+/** The live-observed refusal shape: a numeric JSON-RPC code, never matched by message text. */
+function refusedRequest(): Error {
+  const cause = new Error("Archive requests require a personal token.");
+  cause.name = "RpcRequestError";
+  Object.assign(cause, { code: -32602 });
+  const err = new Error("Invalid parameters were provided to the RPC method.", { cause });
+  err.name = "InvalidParamsRpcError";
+  Object.assign(err, { code: -32602 });
+  return err;
+}
+
+function input(overrides: Partial<{ expectedChainId: number; protocol: string }> = {}) {
+  return {
+    txHash: HASH,
+    expectedChainId: 42161,
+    chainFamily: "eip155" as const,
+    protocol: "relay",
+    tokenOutAddress: null,
+    recipient: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  probed.length = 0;
+  byUrl.clear();
+  userOverrides = [];
+  localChainUrl = null;
+  khalaniUrl = null;
+  relayUrl = null;
+});
+
+describe("the destination chain is looked up in EVERY registry the app trusts", () => {
+  it("replays row 132: Relay's endpoint refuses the archive read, viem's bundled default verifies the fill", async () => {
+    relayUrl = PUBLICNODE;
+    byUrl.set(PUBLICNODE, { chainId: 42161, throws: refusedRequest() });
+    byUrl.set(VIEM_ARBITRUM_DEFAULT, { chainId: 42161, receiptStatus: "success" });
+
+    expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: true });
+    expect(probed).toEqual([PUBLICNODE, VIEM_ARBITRUM_DEFAULT]);
+  });
+
+  it("a RELAY row still consults the Khalani registry - the chain id is the key, not the venue", async () => {
+    relayUrl = PUBLICNODE;
+    khalaniUrl = "https://khalani.example/arb";
+    byUrl.set(PUBLICNODE, { chainId: 42161, throws: refusedRequest() });
+    byUrl.set("https://khalani.example/arb", { chainId: 42161, receiptStatus: "success" });
+
+    expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: true });
+    // Khalani precedes Relay in the fixed candidate order.
+    expect(probed).toEqual(["https://khalani.example/arb"]);
+  });
+
+  it("the full order is user override, local registry, Khalani, Relay, viem - deduplicated", async () => {
+    userOverrides = ["https://mine.example"];
+    localChainUrl = "https://local.example";
+    khalaniUrl = VIEM_ARBITRUM_DEFAULT; // the same endpoint viem ships; probed once, not twice.
+    relayUrl = PUBLICNODE;
+    for (const url of ["https://mine.example", "https://local.example", VIEM_ARBITRUM_DEFAULT, PUBLICNODE]) {
+      byUrl.set(url, { chainId: 42161, throws: refusedRequest() });
+    }
+
+    expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: false, reason: "rpc_refused_request" });
+    expect(probed).toEqual([
+      "https://mine.example",
+      "https://local.example",
+      VIEM_ARBITRUM_DEFAULT,
+      PUBLICNODE,
+    ]);
+  });
+
+  it("a user override is used AS CONFIGURED - a private local archive node is a supported setup", async () => {
+    userOverrides = ["http://127.0.0.1:8545"]; // would fail the SSRF filter; it is the app's own config.
+    byUrl.set("http://127.0.0.1:8545", { chainId: 42161, receiptStatus: "success" });
+
+    expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: true });
+    expect(probed).toEqual(["http://127.0.0.1:8545"]);
+  });
+
+  it("a PROVIDER registry URL that is private or non-HTTPS is dropped before any request", async () => {
+    khalaniUrl = "http://10.0.0.5:8545"; // untrusted input: SSRF-refused.
+    relayUrl = "https://relay.example/arb";
+    byUrl.set("https://relay.example/arb", { chainId: 42161, receiptStatus: "success" });
+
+    expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: true });
+    expect(probed).toEqual(["https://relay.example/arb"]);
+  });
+
+  it("viem's bundled list is looked up BY ID: 4663 is not in it, so that source contributes nothing", async () => {
+    // The local registry owns 4663 (Robinhood Chain) and viem has never heard of
+    // it - the bundled source is a bonus for public chains, never a requirement.
+    expect(await verifyBridgeLegOnChain(input({ expectedChainId: 4663 }))).toEqual({
+      verified: false,
+      reason: "no_safe_rpc",
+    });
+    expect(probed).toEqual([]);
+  });
+
+  it("an endpoint echoing the WRONG chain is skipped, and the next candidate still verifies", async () => {
+    relayUrl = PUBLICNODE;
+    byUrl.set(PUBLICNODE, { chainId: 8453 });
+    byUrl.set(VIEM_ARBITRUM_DEFAULT, { chainId: 42161, receiptStatus: "success" });
+
+    expect(await verifyBridgeLegOnChain(input())).toEqual({ verified: true });
+    expect(probed).toEqual([PUBLICNODE, VIEM_ARBITRUM_DEFAULT]);
+  });
+});

--- a/src/__tests__/vex-agent/sync/bridge-activity-repair-verification.test.ts
+++ b/src/__tests__/vex-agent/sync/bridge-activity-repair-verification.test.ts
@@ -446,6 +446,23 @@ describe("selectVerificationRpcUrls — curated first, SSRF-filtered fallback", 
     expect(result).toEqual(["https://shared.example", "https://other.example"]);
   });
 
+  it("keeps the five candidate sources in their fixed order and probes a shared endpoint once", () => {
+    // The buckets the bridge verifier fills: `curated` = the user's own override
+    // then the local registry (the app's own config, used as configured);
+    // `providerRegistry` = Khalani, Relay, then viem's bundled default (untrusted,
+    // SSRF-filtered). Khalani and viem naming the same endpoint costs one probe.
+    const result = selectVerificationRpcUrls({
+      curated: ["https://mine.example", "https://local.example"],
+      providerRegistry: ["https://arb1.arbitrum.io/rpc", "https://arbitrum-one.publicnode.com", "https://arb1.arbitrum.io/rpc"],
+    });
+    expect(result).toEqual([
+      "https://mine.example",
+      "https://local.example",
+      "https://arb1.arbitrum.io/rpc",
+      "https://arbitrum-one.publicnode.com",
+    ]);
+  });
+
   it("returns [] when nothing is safe (fail-closed → verifier reports unverifiable)", () => {
     expect(selectVerificationRpcUrls({ curated: [], providerRegistry: ["http://x.local", "https://10.0.0.1"] })).toEqual([]);
   });

--- a/src/__tests__/vex-agent/sync/verification-reason-lockstep.test.ts
+++ b/src/__tests__/vex-agent/sync/verification-reason-lockstep.test.ts
@@ -23,6 +23,10 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { getPackageRoot } from "@utils/package-assets.js";
 import { VERIFICATION_REASONS } from "@vex-agent/db/repos/agent-activity.js";
+import type {
+  EvmProbeObservation,
+  SolanaProbeObservation,
+} from "@vex-agent/sync/bridge-activity-repair-verification.js";
 
 const SYNC_DIR = join(getPackageRoot(), "src", "vex-agent", "sync");
 
@@ -87,6 +91,40 @@ describe("the 065 reason vocabulary has ONE owner and no drifting writers", () =
     for (const foreign of ["in_mempool", "nonce_superseded", "amounts_incomplete", "amounts_undecodable"]) {
       expect(VERIFICATION_REASONS).not.toContain(foreign);
     }
+  });
+
+  it("admits EVERY bridge probe observation the verifier can report", () => {
+    // The `Record<Union, true>` is the enforcement: adding a member to either
+    // observation union without listing it here fails to COMPILE, and listing
+    // one the 065 vocabulary has never heard of fails this assertion. The
+    // observation strings are stored verbatim in `last_verification_reason` and
+    // rendered verbatim to the user and the agent, so the two sets must not
+    // drift.
+    const evm: Record<EvmProbeObservation, true> = {
+      chain_echo_mismatch: true,
+      fill_not_mined: true,
+      unreadable_receipt_status: true,
+      rpc_refused_request: true,
+      rpc_unreachable: true,
+    };
+    const solana: Record<SolanaProbeObservation, true> = {
+      chain_echo_mismatch: true,
+      signature_status_unavailable: true,
+      rpc_unreachable: true,
+    };
+    for (const observation of [...Object.keys(evm), ...Object.keys(solana)]) {
+      expect(VERIFICATION_REASONS).toContain(observation);
+    }
+  });
+
+  it("names an endpoint that ANSWERED and refused apart from one that never answered", () => {
+    // Live-measured distinction (2026-09-04): `arbitrum-one.publicnode.com`
+    // served `eth_chainId` for 42161 and returned JSON-RPC -32602 for a
+    // month-old receipt. Reporting that as `rpc_unreachable` claims we cannot
+    // see the chain, which is false and is what kept one row re-probing the
+    // same URL for 31 days.
+    expect(VERIFICATION_REASONS).toContain("rpc_refused_request");
+    expect(VERIFICATION_REASONS).toContain("rpc_unreachable");
   });
 
   it("keeps `receipt_unavailable` readable for pre-existing rows but produces it nowhere", () => {

--- a/src/config/chain-rpc-overrides.ts
+++ b/src/config/chain-rpc-overrides.ts
@@ -1,0 +1,44 @@
+/**
+ * The user's own EVM RPC endpoints for one chain id, read from the two config
+ * override maps (`localChainRpcUrls`, `pendleRpcUrls` in `./store.ts`).
+ *
+ * WHY THIS EXISTS AS A NAMED READER. Both maps are keyed by chain-id string and
+ * both mean the same thing to a consumer that only needs an endpoint for a
+ * chain: "the endpoint the OWNER of this install told us to use". Each map had
+ * exactly one reader that knew about it (`tools/evm-chains/registry.ts`
+ * `getLocalChainRpcUrl`, `tools/pendle/evm-client.ts` `rpcUrlFor`), and both of
+ * those resolve a URL for a chain they already have a registry entry for. The
+ * bridge fill verifier needs the opposite question - "does the user have ANY
+ * endpoint for chain 42161?" - for a chain no local registry knows, so the
+ * question gets an owner here rather than a third private copy of the lookup.
+ *
+ * TRUST. These are the app's own configuration, written by the user, not
+ * provider-supplied input: callers use them WITHOUT the SSRF filter that guards
+ * a provider registry (a user pointing Vex at their own `http://localhost:8545`
+ * archive node is a supported setup, and `isSsrfSafeRpcUrl` would refuse it).
+ * The shape check below is therefore the only bound: an http(s) URL, same rule
+ * `getLocalChainRpcUrl` already applies to the same map.
+ */
+
+import { loadConfig } from "./store.js";
+
+/** Same shape rule the local-chain registry applies to `localChainRpcUrls`. */
+const HTTP_URL = /^https?:\/\/\S+$/i;
+
+/**
+ * Every user-configured RPC endpoint for `chainId`, `localChainRpcUrls` first,
+ * de-duplicated, order preserved. Empty when the user configured none.
+ */
+export function getUserRpcOverridesForChain(chainId: number): string[] {
+  const config = loadConfig();
+  const key = String(chainId);
+  const out: string[] = [];
+  for (const map of [config.localChainRpcUrls, config.pendleRpcUrls]) {
+    const raw = map?.[key];
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (!HTTP_URL.test(trimmed) || out.includes(trimmed)) continue;
+    out.push(trimmed);
+  }
+  return out;
+}

--- a/src/vex-agent/db/repos/agent-activity/types/verification.ts
+++ b/src/vex-agent/db/repos/agent-activity/types/verification.ts
@@ -100,11 +100,21 @@ export const VERIFICATION_REASONS = [
   "unreadable_transaction_meta",
   "no_blockhash_evidence",
   "block_height_unavailable",
-  // ── The bridge verifier's four-way split of the old `receipt_unavailable` ──
+  // ── The bridge verifier's five-way split of the old `receipt_unavailable` ──
   /** An endpoint echoed the right chain and answered "no receipt yet" — WAIT. */
   "fill_not_mined",
   /** No endpoint ever answered — we cannot see this chain at all. */
   "rpc_unreachable",
+  /**
+   * An endpoint ANSWERED and REFUSED the request: a JSON-RPC error response,
+   * not a transport failure. Measured origin (owner's install, 2026-09-04): a
+   * public endpoint served `eth_chainId` for Arbitrum One and returned
+   * `-32602 archive request` for a month-old receipt. That is a statement about
+   * THIS ENDPOINT, not about the chain, and calling it `rpc_unreachable` is what
+   * let a row re-probe the same refusing URL 1227 times. Surfaces must say "an
+   * endpoint refused the request", never "chain unreachable".
+   */
+  "rpc_refused_request",
   /** Every endpoint answered `eth_chainId` with a different chain than the one we need. */
   "chain_echo_mismatch",
   /**

--- a/src/vex-agent/sync/bridge-activity-repair-contracts.ts
+++ b/src/vex-agent/sync/bridge-activity-repair-contracts.ts
@@ -173,7 +173,13 @@ export interface FillVerificationInput {
   /** The chain the leg MUST have executed on (fill → stored destination; refund → stored origin). */
   readonly expectedChainId: number;
   readonly chainFamily: BridgeChainFamily;
-  /** The owning protocol — selects the RIGHT provider registry for RPC selection (relay `/chains` vs khalani `/v1/chains`). */
+  /**
+   * The owning protocol. It selects the provider registry for a NON-EVM
+   * destination (relay `/chains` vs khalani `/v1/chains`); an EVM destination
+   * consults every registry the app trusts for that chain id, because whose
+   * registry lists an endpoint says nothing about whether it can answer for the
+   * chain (see `resolveVerificationRpcs`).
+   */
   readonly protocol: string;
   /** Stored destination token — executed amounts are trusted ONLY if transfer evidence decodes against it. */
   readonly tokenOutAddress: string | null;

--- a/src/vex-agent/sync/bridge-activity-repair-verification.ts
+++ b/src/vex-agent/sync/bridge-activity-repair-verification.ts
@@ -18,8 +18,10 @@ import type { FillVerification, FillVerificationInput } from "./bridge-activity-
 
 /**
  * Production B4 leg verifier (fills AND refunds). EVM: SSRF-controlled RPC
- * selection (curated/local first, provider-registry fallback validated
- * public-HTTPS + non-private) → `eth_chainId` echo (must match the expected
+ * selection over EVERY endpoint source the app trusts for the destination chain
+ * (`resolveVerificationRpcs`: user overrides and the local registry first, then
+ * the Khalani, Relay and viem-bundled registries, each validated public-HTTPS +
+ * non-private) → `eth_chainId` echo (must match the expected
  * chain) → `getTransactionReceipt` (must exist and succeed). Solana:
  * `getGenesisHash` cluster echo → `getSignatureStatuses` (`err == null` + a
  * `confirmed`/`finalized` status).
@@ -74,11 +76,18 @@ export async function verifyBridgeLegOnChain(input: FillVerificationInput): Prom
       observations.push("unreadable_receipt_status");
       continue;
     } catch (err) {
-      // Not mined yet, or a transport failure. The two are different facts for
-      // the user — "wait" versus "we cannot see this chain" — and this loop is
-      // the only place that can still tell them apart.
-      observations.push(isReceiptNotFound(err) ? "fill_not_mined" : "rpc_unreachable");
-      logger.debug("bridge.repair.rpc_probe_miss", { chainId: input.expectedChainId, error: summarizeProtocolError(err).message });
+      // Not mined yet, an endpoint that ANSWERED and refused, or a transport
+      // failure. Three different facts for the user - "wait", "this endpoint
+      // will not serve us", "we cannot see this chain" - and this loop is the
+      // only place that can still tell them apart. A refusal continues to the
+      // next URL exactly as a chain mismatch does.
+      const observation = classifyEvmProbeError(err);
+      observations.push(observation);
+      logger.debug("bridge.repair.rpc_probe_miss", {
+        chainId: input.expectedChainId,
+        observation,
+        error: summarizeProtocolError(err).message,
+      });
       continue;
     }
   }
@@ -90,6 +99,7 @@ export type EvmProbeObservation =
   | "chain_echo_mismatch"
   | "fill_not_mined"
   | "unreadable_receipt_status"
+  | "rpc_refused_request"
   | "rpc_unreachable";
 
 /**
@@ -104,12 +114,26 @@ export type EvmProbeObservation =
  *
  * PRECEDENCE IS FIXED, most-specific-wins, so the answer does not depend on the
  * order the URLs happened to be tried: a receipt we could not READ beats
- * "no receipt yet" beats "no endpoint served this chain" beats "no endpoint
- * answered at all". (A receipt we COULD read never reaches here — the loop
- * returns on it.)
+ * "no receipt yet" beats "no endpoint served this chain" beats "an endpoint
+ * refused the request" beats "no endpoint answered at all". (A receipt we COULD
+ * read never reaches here: the loop returns on it.)
+ *
+ * `rpc_refused_request` outranks `rpc_unreachable` because it is the strictly
+ * stronger statement: an endpoint was reached, understood us, and declined -
+ * measured live on 2026-09-04, where `arbitrum-one.publicnode.com` answered
+ * `eth_chainId` for chain 42161 and then returned JSON-RPC `-32602` for a
+ * month-old receipt (an "archive" request there). Reporting that as "we cannot
+ * see this chain" is what let one row re-probe the same refusing endpoint 1227
+ * times over 31 days.
  */
 export function resolveEvmProbeReason(observations: readonly EvmProbeObservation[]): EvmProbeObservation | "no_safe_rpc" {
-  for (const candidate of ["unreadable_receipt_status", "fill_not_mined", "chain_echo_mismatch", "rpc_unreachable"] as const) {
+  for (const candidate of [
+    "unreadable_receipt_status",
+    "fill_not_mined",
+    "chain_echo_mismatch",
+    "rpc_refused_request",
+    "rpc_unreachable",
+  ] as const) {
     if (observations.includes(candidate)) return candidate;
   }
   // Unreachable while `urls.length > 0` — every path above records exactly one
@@ -124,6 +148,54 @@ export function resolveEvmProbeReason(observations: readonly EvmProbeObservation
  */
 function isReceiptNotFound(err: unknown): boolean {
   return err instanceof Error && err.name === "TransactionReceiptNotFoundError";
+}
+
+/** How far down an error's `cause` chain the classifier looks. viem nests two levels; five is slack. */
+const ERROR_CAUSE_MAX_DEPTH = 5;
+
+/**
+ * viem's placeholder code for "an error with no JSON-RPC code of its own"
+ * (`UnknownRpcError`, `errors/rpc.js` `unknownErrorCode`). It is NOT evidence
+ * that an endpoint answered, so it never counts as a refusal.
+ */
+const VIEM_UNKNOWN_RPC_CODE = -1;
+
+/** What ONE failed probe of a single endpoint established. */
+function classifyEvmProbeError(err: unknown): EvmProbeObservation {
+  if (isReceiptNotFound(err)) return "fill_not_mined";
+  return isJsonRpcErrorResponse(err) ? "rpc_refused_request" : "rpc_unreachable";
+}
+
+/**
+ * Did the endpoint ANSWER with a JSON-RPC `error` object, as opposed to never
+ * answering at all?
+ *
+ * MATCHED BY CLASS AND CODE, NEVER BY MESSAGE TEXT. The message is the
+ * provider's own prose (`arbitrum-one.publicnode.com` says "Archive requests
+ * require a personal token"), it changes without notice, and it embeds the RPC
+ * URL - none of which belongs in a comparison that decides what we tell the
+ * user.
+ *
+ * MEASURED against viem 2.54.3 on 2026-09-04, both branches, one call each:
+ *
+ * - JSON-RPC error response: `InvalidParamsRpcError` (`code` -32602, a NUMBER)
+ *   whose `cause` is `RpcRequestError` (`code` -32602). Every `RpcError`
+ *   subclass carries the numeric code from its `RpcRequestError` cause
+ *   (`errors/rpc.js`), and `buildRequest` mints them from the response body's
+ *   `error.code`, so the pair (name, numeric code) is the stable artifact.
+ * - Transport failure: `HttpRequestError` (no `code`) -> `TypeError` (no
+ *   `code`) -> a Node error whose `code` is the STRING "ENOTFOUND". Requiring
+ *   a NUMBER is what keeps a socket error out of this branch.
+ */
+function isJsonRpcErrorResponse(err: unknown): boolean {
+  let node: unknown = err;
+  for (let depth = 0; depth < ERROR_CAUSE_MAX_DEPTH && node instanceof Error; depth += 1) {
+    if (node.name === "RpcRequestError") return true;
+    const code = (node as Error & { code?: unknown }).code;
+    if (typeof code === "number" && code !== VIEM_UNKNOWN_RPC_CODE) return true;
+    node = node.cause;
+  }
+  return false;
 }
 
 /**
@@ -203,53 +275,150 @@ export function resolveSolanaProbeReason(
 }
 
 /**
- * Curated/local RPCs (EVM only, trusted) + PROVIDER-registry RPCs from the RIGHT
- * registry for the owning protocol (Blocker 10): Relay `/chains` (`httpRpcUrl`)
- * for relay bridges, Khalani `/v1/chains` (`rpcUrls.default.http[0]`) for khalani
- * — never always Khalani. All provider-registry URLs are SSRF-validated downstream.
+ * EVERY endpoint this app already trusts for a destination chain, in one fixed
+ * order, split by whether the URL is OURS (curated, used as configured) or a
+ * provider's (SSRF-validated by `selectVerificationRpcUrls`).
+ *
+ * WHY EVERY SOURCE, NOT THE ROW'S OWN PROTOCOL. This used to consult exactly one
+ * provider registry - Relay's for a Relay row, Khalani's for everything else -
+ * on the reasoning that a bridge's own registry is the authority for its chains.
+ * Measured consequence, owner's install, 2026-09-04: a Relay row expecting a
+ * fill on Arbitrum One (42161) had ONE candidate URL for 31 days, Relay's
+ * `arbitrum-one.publicnode.com`, which answers `eth_chainId` and then refuses a
+ * month-old receipt as an archive request. The local registry does not know
+ * 42161, so nothing else was ever tried and the row could not conclude through
+ * 1227 attempts. WHOSE registry lists an endpoint says nothing about whether the
+ * endpoint can answer for the chain: the chain id is the key, and the
+ * `eth_chainId` echo below is what makes consulting a wider set safe. Khalani's
+ * registry and viem's bundled definition both serve 42161 as
+ * `https://arb1.arbitrum.io/rpc`, which returns the receipt (live-probed, same
+ * date).
+ *
+ * ORDER (deduplicated downstream, first occurrence wins the slot):
+ *   (a) the user's own overrides for this chain id (`@config/chain-rpc-overrides.js`);
+ *   (b) the local chain registry (`@tools/evm-chains/registry.js`);
+ *   (c) the Khalani chain registry, whatever this row's protocol is;
+ *   (d) the Relay chain registry, whatever this row's protocol is;
+ *   (e) viem's bundled canonical default for the chain - shipped data from a
+ *       pinned dependency, no network call and no key, skipped when viem has
+ *       never heard of the chain.
+ *
+ * (a) and (b) are the app's own configuration and are NOT SSRF-filtered (a user
+ * pointing Vex at their own local archive node is a supported setup). (c), (d)
+ * and (e) go through `isSsrfSafeRpcUrl`.
+ *
+ * SOLANA IS UNCHANGED: its destination lookup stays protocol-scoped, since the
+ * defect and the widening above are about EVM chain registries.
  */
 async function resolveVerificationRpcs(
   chainId: number,
   protocol: string,
   family: BridgeChainFamily,
 ): Promise<{ curated: string[]; providerRegistry: string[] }> {
+  if (family !== "eip155") {
+    return { curated: [], providerRegistry: await readProtocolRegistryRpcs(chainId, protocol) };
+  }
+
   const curated: string[] = [];
+  try {
+    const { getUserRpcOverridesForChain } = await import("@config/chain-rpc-overrides.js");
+    curated.push(...getUserRpcOverridesForChain(chainId));
+  } catch (err) {
+    logger.debug("bridge.repair.user_rpc_lookup_failed", { chainId, error: summarizeProtocolError(err).message });
+  }
+  try {
+    const { getLocalChain, getLocalChainRpcUrl } = await import("@tools/evm-chains/registry.js");
+    const local = getLocalChain(chainId);
+    if (local) curated.push(getLocalChainRpcUrl(local));
+  } catch (err) {
+    logger.debug("bridge.repair.local_rpc_lookup_failed", { chainId, error: summarizeProtocolError(err).message });
+  }
+
   const providerRegistry: string[] = [];
-
-  if (family === "eip155") {
-    try {
-      const { getLocalChain, getLocalChainRpcUrl } = await import("@tools/evm-chains/registry.js");
-      const local = getLocalChain(chainId);
-      if (local) curated.push(getLocalChainRpcUrl(local));
-    } catch (err) {
-      logger.debug("bridge.repair.local_rpc_lookup_failed", { chainId, error: summarizeProtocolError(err).message });
-    }
-  }
-
-  if (protocol === "relay") {
-    try {
-      const { getCachedRelayChains } = await import("@tools/relay/client.js");
-      const chains = await getCachedRelayChains();
-      const match = chains.find((c) => c.id === chainId);
-      // Relay `/chains` exposes the RPC as `httpRpcUrl` (passthrough on RelayChain).
-      const url = match ? readHttpRpcUrl(match) : null;
-      if (url) providerRegistry.push(url);
-    } catch (err) {
-      logger.debug("bridge.repair.provider_rpc_lookup_failed", { chainId, protocol, error: summarizeProtocolError(err).message });
-    }
-  } else {
-    try {
-      const { getCachedKhalaniChains } = await import("@tools/khalani/chains.js");
-      const chains = await getCachedKhalaniChains();
-      const match = chains.find((c) => c.id === chainId);
-      const url = match?.rpcUrls?.default?.http?.[0];
-      if (url) providerRegistry.push(url);
-    } catch (err) {
-      logger.debug("bridge.repair.provider_rpc_lookup_failed", { chainId, protocol, error: summarizeProtocolError(err).message });
-    }
-  }
+  const khalani = await readKhalaniRegistryRpc(chainId);
+  if (khalani) providerRegistry.push(khalani);
+  const relay = await readRelayRegistryRpc(chainId);
+  if (relay) providerRegistry.push(relay);
+  const bundled = await readViemBundledRpc(chainId);
+  if (bundled) providerRegistry.push(bundled);
 
   return { curated, providerRegistry };
+}
+
+/** The non-EVM path's registry lookup: the owning protocol's registry only (unchanged behavior). */
+async function readProtocolRegistryRpcs(chainId: number, protocol: string): Promise<string[]> {
+  const url = protocol === "relay" ? await readRelayRegistryRpc(chainId) : await readKhalaniRegistryRpc(chainId);
+  return url ? [url] : [];
+}
+
+/** Khalani `/v1/chains` (`rpcUrls.default.http[0]`), cached 24h by its own client. */
+async function readKhalaniRegistryRpc(chainId: number): Promise<string | null> {
+  try {
+    const { getCachedKhalaniChains } = await import("@tools/khalani/chains.js");
+    const chains = await getCachedKhalaniChains();
+    return chains.find((c) => c.id === chainId)?.rpcUrls?.default?.http?.[0] ?? null;
+  } catch (err) {
+    logger.debug("bridge.repair.provider_rpc_lookup_failed", {
+      chainId,
+      registry: "khalani",
+      error: summarizeProtocolError(err).message,
+    });
+    return null;
+  }
+}
+
+/** Relay `/chains`, which exposes the RPC as `httpRpcUrl` (passthrough on RelayChain), cached 1h. */
+async function readRelayRegistryRpc(chainId: number): Promise<string | null> {
+  try {
+    const { getCachedRelayChains } = await import("@tools/relay/client.js");
+    const chains = await getCachedRelayChains();
+    const match = chains.find((c) => c.id === chainId);
+    return match ? readHttpRpcUrl(match) : null;
+  } catch (err) {
+    logger.debug("bridge.repair.provider_rpc_lookup_failed", {
+      chainId,
+      registry: "relay",
+      error: summarizeProtocolError(err).message,
+    });
+    return null;
+  }
+}
+
+/**
+ * viem's own chain definition for this id, by scanning the bundled `viem/chains`
+ * export map. Shipped data from a dependency we already pin: no network call, no
+ * API key, no provider trust. `null` when viem has no definition for the chain,
+ * which is the normal answer for an app-local chain like 4663.
+ */
+async function readViemBundledRpc(chainId: number): Promise<string | null> {
+  try {
+    // The namespace is walked as plain data: every export is checked for the
+    // chain shape before a field is read, so no cast stands in for the check.
+    const chains: Record<string, unknown> = await import("viem/chains");
+    for (const value of Object.values(chains)) {
+      if (!isBundledChainRecord(value) || value.id !== chainId) continue;
+      const url = value.rpcUrls.default.http[0];
+      if (typeof url === "string" && url.length > 0) return url;
+    }
+    return null;
+  } catch (err) {
+    logger.debug("bridge.repair.bundled_rpc_lookup_failed", { chainId, error: summarizeProtocolError(err).message });
+    return null;
+  }
+}
+
+/** The two fields the bundled lookup reads, established by inspection rather than assumed. */
+function isBundledChainRecord(
+  value: unknown,
+): value is { readonly id: number; readonly rpcUrls: { readonly default: { readonly http: readonly unknown[] } } } {
+  if (typeof value !== "object" || value === null) return false;
+  const record: { id?: unknown; rpcUrls?: unknown } = value;
+  if (typeof record.id !== "number") return false;
+  if (typeof record.rpcUrls !== "object" || record.rpcUrls === null) return false;
+  const rpc: { default?: unknown } = record.rpcUrls;
+  if (typeof rpc.default !== "object" || rpc.default === null) return false;
+  const dflt: { http?: unknown } = rpc.default;
+  return Array.isArray(dflt.http);
 }
 
 /** Read the passthrough `httpRpcUrl` string from a Relay chain record (not in the typed schema). */

--- a/src/vex-agent/sync/solana-rpc-safety.ts
+++ b/src/vex-agent/sync/solana-rpc-safety.ts
@@ -149,6 +149,14 @@ function isPrivateIpv6(host: string): boolean {
  * that pass {@link isSsrfSafeRpcUrl}. De-duplicated, order preserved. An empty
  * result means "no safe RPC" — the caller reports unverifiable and the row
  * stays pending (fail-closed).
+ *
+ * THE ONE ORDERING OWNER. Callers grow the CANDIDATE SET, never add a second
+ * selector: the bridge verifier's `resolveVerificationRpcs` puts the user's own
+ * RPC overrides and the local chain registry in `curated` (the app's own
+ * configuration, used as configured) and the Khalani, Relay and viem-bundled
+ * chain registries in `providerRegistry` (untrusted, SSRF-filtered here), and
+ * each bucket keeps its internal order. Two registries naming the same endpoint
+ * cost one probe, not two.
  */
 export function selectVerificationRpcUrls(input: {
   readonly curated: readonly string[];


### PR DESCRIPTION
## What this fixes

A bridge fill that the provider confirmed a month ago (Relay request 0x0648…95fb, 0.0009975 ETH from chain 4663 to Arbitrum, filled in block 490770285 to the owner's wallet) stayed `pending` in `agent_activity` for 31 days with `last_verification_reason = rpc_unreachable` after 1227 attempts. Because a pending money-path row withholds every wallet snapshot, the Position card showed a 31-day-old baseline next to the live total.

Measured live (read-only): the only RPC the fill verifier tried for chain 42161 was the one in Relay's own chain registry (`arbitrum-one.publicnode.com`), which answers `eth_chainId` but refuses a month-old `eth_getTransactionReceipt` with JSON-RPC `-32602` "Archive requests require a personal token". The verifier mapped every non-not-found error to `rpc_unreachable` and never tried another endpoint. `arb1.arbitrum.io/rpc` returns the receipt with `status 0x1`.

## The change

- The verifier builds its candidate RPC set for an EVM destination chain from every source the app already trusts, in order: the user's RPC overrides for that chain id, the local chain registry, the Khalani registry, the Relay registry (both regardless of the row's own protocol), and viem's bundled default for the chain. Provider-supplied URLs still pass the SSRF filter; the `eth_chainId` echo is still required before a receipt is believed.
- An endpoint that ANSWERED with a JSON-RPC error is recorded as `rpc_refused_request` (matched on viem's error class and numeric code, never on message text), distinct from a transport failure, and the loop continues to the next URL. Precedence stays fixed, most specific wins.
- Nothing terminalizes on a refusal; the sweep cadence, the snapshot gate and the age policy are untouched. Nothing in vex-app changed: both surfaces that show the reason render it verbatim inside neutral copy.

Reference read first: MetaMask `PendingTransactionTracker` (three outcomes kept apart; a lookup that throws attaches a warning and concludes nothing; no age-only conclusions).

## After deploy

On the next sweep tick the first candidate for 42161 is `arb1.arbitrum.io/rpc`; the receipt verifies on the first probe, the row becomes `confirmed` with its fill hash, and the next full balance sync publishes the snapshot (provided no other pending row exists for the wallet).

## Verification

Live probe table archived with provenance (publicnode refusal class `InvalidParamsRpcError -32602`; `arb1` receipt `success`; a DNS control proving the transport branch carries no numeric code). Scoped suites: sync, agent-activity repos, inspect views (93 files, 1215 tests); root tsc; em-dash and unsafe-escapes gates; the coordinator's ladder on the tree (root tsc, ratchet, boundaries, gates, full root suite). The row-132 replay is a test that fails with the change reverted.

## Named follow-ups

- A row whose provider never answers still has no terminal state (owner decision on a bounded "unresolved" reconciliation outcome).
- HTTP-level refusals (401, 403, 429 without a JSON-RPC body) still read as `rpc_unreachable`.
- Two other readers of the same user RPC override maps (`evm-chains/registry.ts`, `pendle/evm-client.ts`) could consolidate behind the new accessor.
