### PR TITLE
fix(boot): readiness commits after the drain, every registration path waits for the database, teardown never publishes readiness

### DIFF
--- a/vex-app/src/main/agent/__tests__/studio-settlement-bridge.test.ts
+++ b/vex-app/src/main/agent/__tests__/studio-settlement-bridge.test.ts
@@ -22,6 +22,18 @@ vi.mock("../../studio/approval-refusals.js", () => ({
   repairPendingStudioRefusal: vi.fn().mockResolvedValue(true),
 }));
 /**
+ * The project-cleanup repair, mocked because it is the WORK a teardown must
+ * not be able to start. It is launched after the barrier opens and never
+ * awaited into readiness, so counting its calls is the only way to see it.
+ */
+const repairUnfinishedProjectCleanups = vi.fn((_deps: unknown) =>
+  Promise.resolve(),
+);
+vi.mock("../../studio/project-delete.js", () => ({
+  repairUnfinishedProjectCleanups: (deps: unknown) =>
+    repairUnfinishedProjectCleanups(deps),
+}));
+/**
  * THE DATABASE, as the bridge actually sees it: the real
  * `database/engine-db-readiness.ts` owner over a faked compose boundary. Only
  * the two facts it reads are mocked - the connection config compose writes, and
@@ -232,6 +244,57 @@ describe("the readiness barrier", () => {
     teardown();
   });
 
+  /**
+   * TEARDOWN NEVER PUBLISHES READINESS.
+   *
+   * The reconciliation is awaited, so a teardown can land inside it. The write
+   * itself was already epoch-fenced, but everything the caller did AFTERWARDS
+   * was not: it logged a ready Studio the user reads as an open one, and it
+   * launched the project-cleanup repair - fresh database work - on a process
+   * that had just decided to go away. The transition now reports whether it
+   * committed, and both of those live strictly after that answer.
+   */
+  it("publishes NOTHING when a teardown lands during the reconciliation", async () => {
+    let releaseScan = (): void => {};
+    const scanning = new Promise<void>((resolve) => {
+      releaseScan = () => {
+        resolve();
+      };
+    });
+    reconcileAbandonedStudioDispatches.mockImplementation(async () => {
+      await scanning;
+      return [];
+    });
+
+    const teardown = setupStudioSettlementBridge();
+    await vi.waitFor(() => {
+      expect(trace).toEqual(["preflight", "reconcile"]);
+    });
+
+    teardown();
+    releaseScan();
+    // Well past every microtask the continuation could still be sitting on.
+    await vi.waitFor(() => {
+      expect(disposeStudioWriteRepair).toHaveBeenCalled();
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(isStudioRuntimeReady()).toBe(false);
+    const readiness = studioReadiness();
+    expect(readiness.ready).toBe(false);
+    if (readiness.ready) return;
+    expect(readiness.code).toBe("shutting_down");
+    // No ready log for a Studio that is not open ...
+    const { log } = await import("../../logger/index.js");
+    const readyLines = vi
+      .mocked(log.info)
+      .mock.calls.filter((call) => String(call[0]).includes("studio runtime ready"));
+    expect(readyLines).toEqual([]);
+    // ... and no new work started behind it.
+    expect(repairUnfinishedProjectCleanups).not.toHaveBeenCalled();
+  });
+
   it("DENIES after teardown instead of restoring the engine default", async () => {
     const teardown = setupStudioSettlementBridge();
     await awaitStudioRuntimeReady();
@@ -371,6 +434,58 @@ describe("the database is not up yet", () => {
       expect(isStudioRuntimeReady()).toBe(true);
       expect(trace).toEqual(["preflight", "reconcile", "reconcile_unstarted"]);
       expect(registered?.()).toBe(true);
+      teardown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * THE RETRY WAITS TOO, which is the other half of the owner's boot log.
+   *
+   * A registration that fails once and succeeds on the retry used to go
+   * STRAIGHT to the database work: the retry spent its bounded budget at 5, 10
+   * and 15 s against a database compose had not started, and Studio was
+   * declared unavailable for the session 265 ms before it came up. Every
+   * registration path now funnels through the same unbounded wait, so the
+   * bounded budget is only ever spent on failures that happen after the
+   * database is ready.
+   */
+  it("makes the RETRY path wait for the database too", async () => {
+    vi.useFakeTimers();
+    try {
+      poolConfig = null;
+      migrationsDone = false;
+      // The first registration fails, which is what arms the retry.
+      setStudioDispatchPreflight.mockImplementationOnce(() => {
+        throw new Error("engine import failed");
+      });
+      const teardown = setupStudioSettlementBridge();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(trace).toEqual(["preflight"]);
+
+      // The retry fires at 5 s and registers successfully, and then WAITS: the
+      // database is twenty seconds away.
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(trace).toEqual(["preflight", "preflight"]);
+      expect(repairPendingStudioRefusal).not.toHaveBeenCalled();
+      expect(reconcileAbandonedStudioDispatches).not.toHaveBeenCalled();
+      expect(isStudioRuntimeReady()).toBe(false);
+
+      databaseIsUp();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(isStudioRuntimeReady()).toBe(true);
+      // No unlock, no recovery pass: the wait itself finished the boot.
+      expect(repairPendingStudioRefusal).toHaveBeenCalledTimes(1);
+      // And the bounded budget is untouched by the wait, so it is still there
+      // for a genuinely transient post-database failure.
+      const { log: bridgeLog } = await import("../../logger/index.js");
+      expect(
+        vi
+          .mocked(bridgeLog.error)
+          .mock.calls.some((call) => String(call[0]).includes("bounded retries")),
+      ).toBe(false);
       teardown();
     } finally {
       vi.useRealTimers();

--- a/vex-app/src/main/agent/__tests__/studio-settlement-bridge.test.ts
+++ b/vex-app/src/main/agent/__tests__/studio-settlement-bridge.test.ts
@@ -382,6 +382,76 @@ describe("the registration retry is OWNED, and a teardown ends it", () => {
     }
   });
 
+  /**
+   * THE REGISTRATION THAT WAS ALREADY IN FLIGHT.
+   *
+   * Teardown clears the retry timer and then invalidates the epoch, but the
+   * registration it did not wait for answers afterwards. A `false` from that
+   * late answer used to arm a fresh timer at a call site the teardown had
+   * already passed, so the lifecycle ended owning a timer nobody could cancel.
+   * The arming itself now refuses a stale epoch and an aborted signal.
+   */
+  it("arms NOTHING when the teardown lands inside the first registration", async () => {
+    vi.useFakeTimers();
+    try {
+      let teardown: (() => void) | null = null;
+      setStudioDispatchPreflight.mockImplementationOnce(() => {
+        // The teardown lands while this registration is in flight.
+        teardown?.();
+        throw new Error("engine import failed");
+      });
+      teardown = setupStudioSettlementBridge();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // No timer survives the lifecycle that just ended.
+      expect(vi.getTimerCount()).toBe(0);
+      trace.length = 0;
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(trace).toEqual([]);
+      expect(isStudioRuntimeReady()).toBe(false);
+      const readiness = studioReadiness();
+      expect(readiness.ready).toBe(false);
+      if (readiness.ready) return;
+      expect(readiness.code).toBe("shutting_down");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("arms NOTHING when the teardown lands inside a RETRY registration", async () => {
+    vi.useFakeTimers();
+    try {
+      let teardown: (() => void) | null = null;
+      setStudioDispatchPreflight
+        .mockImplementationOnce(() => {
+          throw new Error("engine import failed");
+        })
+        .mockImplementationOnce(() => {
+          // The retry's own registration is the one the teardown interrupts.
+          teardown?.();
+          throw new Error("engine import failed again");
+        });
+      teardown = setupStudioSettlementBridge();
+      await vi.advanceTimersByTimeAsync(0);
+      // The first failure armed exactly one retry, which is the timer under
+      // test: it must not be replaced by another one.
+      expect(vi.getTimerCount()).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(vi.getTimerCount()).toBe(0);
+      expect(trace).toEqual(["preflight", "preflight"]);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(trace).toEqual(["preflight", "preflight"]);
+      expect(isStudioRuntimeReady()).toBe(false);
+      const readiness = studioReadiness();
+      expect(readiness.ready).toBe(false);
+      if (readiness.ready) return;
+      expect(readiness.code).toBe("shutting_down");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("disposes the engine write-repair owner on teardown", async () => {
     const teardown = setupStudioSettlementBridge();
     await awaitStudioRuntimeReady();

--- a/vex-app/src/main/agent/__tests__/studio-settlement-bridge.test.ts
+++ b/vex-app/src/main/agent/__tests__/studio-settlement-bridge.test.ts
@@ -252,7 +252,10 @@ describe("the readiness barrier", () => {
    * was not: it logged a ready Studio the user reads as an open one, and it
    * launched the project-cleanup repair - fresh database work - on a process
    * that had just decided to go away. The transition now reports whether it
-   * committed, and both of those live strictly after that answer.
+   * committed, and both of those live strictly after that answer. The same
+   * held INSIDE the helper: the announcement of the first scan's rows and the
+   * second reconciliation query both ran before anyone re-read the abort, so
+   * the checks are now between every await and every published effect.
    */
   it("publishes NOTHING when a teardown lands during the reconciliation", async () => {
     let releaseScan = (): void => {};
@@ -293,6 +296,14 @@ describe("the readiness barrier", () => {
     expect(readyLines).toEqual([]);
     // ... and no new work started behind it.
     expect(repairUnfinishedProjectCleanups).not.toHaveBeenCalled();
+    // Nor INSIDE the reconciliation itself: the scan that was in flight when
+    // the teardown landed neither announces its committed rows nor starts the
+    // second reconciliation query. Both used to run because the abort and the
+    // epoch were only consulted once the whole helper had returned.
+    expect(announceStudioReconciliations).not.toHaveBeenCalled();
+    expect(reconcileUnstartedStudioApprovals).not.toHaveBeenCalled();
+    expect(announceStudioUnstartedRefusals).not.toHaveBeenCalled();
+    expect(trace).toEqual(["preflight", "reconcile"]);
   });
 
   it("DENIES after teardown instead of restoring the engine default", async () => {

--- a/vex-app/src/main/agent/studio-settlement-bridge.ts
+++ b/vex-app/src/main/agent/studio-settlement-bridge.ts
@@ -38,7 +38,15 @@
  *      bridge WAITS for `whenEngineDbReady` instead of spending three bounded
  *      attempts against a database that has not been started yet and then
  *      declaring Studio unavailable for the session. The wait ends only when
- *      the database is ready or when this bridge's teardown aborts it.
+ *      the database is ready or when this bridge's teardown aborts it. EVERY
+ *      path that registers the preflight goes through it, the bounded retry
+ *      included: a retry that reached the database work directly spent the
+ *      whole budget on a database that had not started yet.
+ *   1c. AFTER EVERY AWAITED PHASE the abort signal and the epoch are checked
+ *      again, and the readiness write reports whether it COMMITTED. Only a
+ *      committed transition logs a ready Studio and starts the project-cleanup
+ *      repair, so a teardown landing inside the reconciliation cannot publish
+ *      readiness or begin new work.
  *   2. THE ABANDONED-DISPATCH RECONCILER runs, in bounded pages. A Studio row
  *      left `dispatching` belongs to a process that died holding it, and
  *      process start is the one moment at which that is provable - which is
@@ -245,22 +253,7 @@ async function initializeStudioRuntime(
       scheduleDispatchPreflightRetry(epoch, signal);
       return;
     }
-    try {
-      // UNBOUNDED on purpose, and cancellable: on a cold start the local
-      // Postgres appears when the renderer triggers compose, long after this
-      // point. Giving up here is what used to leave Studio unavailable for the
-      // whole session; the boot deadline lives in `awaitStudioRuntimeReady`,
-      // which opens the window without opening the fence.
-      await whenEngineDbReady({ signal });
-    } catch (cause) {
-      if (cause instanceof EngineDbWaitAbortedError) return;
-      log.warn(
-        "[agent:studio-settlement-bridge] database readiness wait failed",
-        cause,
-      );
-      return;
-    }
-    await completeStudioRuntime(epoch, signal, 0);
+    await awaitEngineDbThenComplete(epoch, signal, 0);
   } catch (cause) {
     // The barrier is awaited by boot (`awaitStudioRuntimeReady`), so a
     // rejection here would take the whole start-up down over a Studio step
@@ -272,6 +265,41 @@ async function initializeStudioRuntime(
   } finally {
     initializationInFlight = false;
   }
+}
+
+/**
+ * THE ONE CONTINUATION every successful registration takes: wait for the
+ * database, THEN do the work that needs it.
+ *
+ * It exists as a named seam because the retry path used to skip it. A
+ * registration that failed once and succeeded on the retry went straight to
+ * `completeStudioRuntime`, so on a cold start the retries spent the whole
+ * bounded budget querying a database that compose had not started yet - three
+ * attempts at 5, 10 and 15 s against a database that appeared at 15.6 s - and
+ * then declared Studio unavailable for the session. The bounded retry is for
+ * failures that happen AFTER the database is ready, and this is what keeps it
+ * that way, whichever attempt reaches it.
+ *
+ * UNBOUNDED on purpose, and cancellable: giving up here would decide, for the
+ * user, that a slow database is a dead one. The boot deadline lives in
+ * `awaitStudioRuntimeReady`, which opens the window without opening the fence.
+ */
+async function awaitEngineDbThenComplete(
+  epoch: number,
+  signal: AbortSignal,
+  retriesUsed: number,
+): Promise<void> {
+  try {
+    await whenEngineDbReady({ signal });
+  } catch (cause) {
+    if (cause instanceof EngineDbWaitAbortedError) return;
+    log.warn(
+      "[agent:studio-settlement-bridge] database readiness wait failed",
+      cause,
+    );
+    return;
+  }
+  await completeStudioRuntime(epoch, signal, retriesUsed);
 }
 
 /**
@@ -288,16 +316,25 @@ async function completeStudioRuntime(
   retriesUsed: number,
 ): Promise<void> {
   if (signal.aborted) return;
-  if (!(await repairPendingStudioRefusal())) {
+  const repaired = await repairPendingStudioRefusal();
+  // RE-CHECKED AFTER THE AWAIT, both facts. A teardown that landed during the
+  // repair has already cancelled the retry timer and invalidated the epoch, so
+  // arming another retry here would leave a live timer nobody owns.
+  if (signal.aborted || currentStudioReadinessEpoch() !== epoch) return;
+  if (!repaired) {
     markStudioFenceUninitialized(epoch);
     scheduleDispatchPreflightRetry(epoch, signal, retriesUsed);
     return;
   }
   await reconcileAbandonedDispatches();
-  // The epoch is checked INSIDE readiness, at the moment of the write, not
-  // here: a teardown can land during the awaits above, and a check performed
-  // before them would prove nothing about the state now.
-  markStudioRuntimeReady(epoch);
+  if (signal.aborted) return;
+  // THE COMMIT, and everything below it is strictly after it. The epoch is
+  // checked INSIDE readiness, at the moment of the write, not before the awaits
+  // above, which would prove nothing about the state now; what the caller needs
+  // back is whether that write actually happened, because a teardown during the
+  // reconciliation otherwise left this path announcing a ready Studio and
+  // starting fresh cleanup work on a process that is going away.
+  if (!markStudioRuntimeReady(epoch)) return;
   log.info("[agent:studio-settlement-bridge] studio runtime ready");
 
   // B0: finish any project cleanup a previous run did not. Deliberately AFTER
@@ -395,7 +432,9 @@ function scheduleDispatchPreflightRetry(
       initializationInFlight = true;
       try {
         if (await registerDispatchPreflight()) {
-          await completeStudioRuntime(epoch, signal, retriesUsed + 1);
+          // THE SAME continuation as the first attempt: the database wait comes
+          // before any work that needs the database, on every path.
+          await awaitEngineDbThenComplete(epoch, signal, retriesUsed + 1);
           return;
         }
         scheduleDispatchPreflightRetry(epoch, signal, retriesUsed + 1);

--- a/vex-app/src/main/agent/studio-settlement-bridge.ts
+++ b/vex-app/src/main/agent/studio-settlement-bridge.ts
@@ -416,6 +416,15 @@ function scheduleDispatchPreflightRetry(
   signal: AbortSignal,
   retriesUsed = 0,
 ): void {
+  // THE TEARDOWN CHECK BELONGS HERE, at the one owner of the arming, not at
+  // each caller. Every call site reaches this function AFTER an awaited
+  // registration, and a registration that was still in flight when teardown
+  // landed answers once the teardown has already cleared the timers: arming
+  // then leaves a live timer behind a lifecycle that is over, owned by
+  // nobody, on a process that is going away. Both facts teardown moves are
+  // checked, because they are moved by different owners: the controller here
+  // and the epoch in `readiness.ts`.
+  if (signal.aborted || currentStudioReadinessEpoch() !== epoch) return;
   if (retriesUsed >= PREFLIGHT_RETRY_ATTEMPTS) {
     log.error(
       "[agent:studio-settlement-bridge] studio runtime initialization did not "

--- a/vex-app/src/main/agent/studio-settlement-bridge.ts
+++ b/vex-app/src/main/agent/studio-settlement-bridge.ts
@@ -43,10 +43,11 @@
  *      included: a retry that reached the database work directly spent the
  *      whole budget on a database that had not started yet.
  *   1c. AFTER EVERY AWAITED PHASE the abort signal and the epoch are checked
- *      again, and the readiness write reports whether it COMMITTED. Only a
- *      committed transition logs a ready Studio and starts the project-cleanup
- *      repair, so a teardown landing inside the reconciliation cannot publish
- *      readiness or begin new work.
+ *      again, INSIDE the reconciliation as well as around it, and the readiness
+ *      write reports whether it COMMITTED. Only a committed transition logs a
+ *      ready Studio and starts the project-cleanup repair, so a teardown
+ *      landing inside the reconciliation can neither announce its rows, nor
+ *      start the second reconciliation query, nor publish readiness.
  *   2. THE ABANDONED-DISPATCH RECONCILER runs, in bounded pages. A Studio row
  *      left `dispatching` belongs to a process that died holding it, and
  *      process start is the one moment at which that is provable - which is
@@ -326,8 +327,8 @@ async function completeStudioRuntime(
     scheduleDispatchPreflightRetry(epoch, signal, retriesUsed);
     return;
   }
-  await reconcileAbandonedDispatches();
-  if (signal.aborted) return;
+  await reconcileAbandonedDispatches(epoch, signal);
+  if (!initializationIsCurrent(epoch, signal)) return;
   // THE COMMIT, and everything below it is strictly after it. The epoch is
   // checked INSIDE readiness, at the moment of the write, not before the awaits
   // above, which would prove nothing about the state now; what the caller needs
@@ -404,6 +405,19 @@ let preflightRetryTimer: NodeJS.Timeout | null = null;
  */
 let initializationAbort: AbortController | null = null;
 let initializationInFlight = false;
+
+/**
+ * Is THIS initialization still the one that may act?
+ *
+ * Both facts a teardown moves, checked together, because different owners move
+ * them: the abort controller lives in this module and the epoch in
+ * `readiness.ts`. A retry that outlived its teardown holds a stale epoch even
+ * though it also holds an aborted signal, and a re-entry that began a NEW epoch
+ * leaves the previous run's signal untouched.
+ */
+function initializationIsCurrent(epoch: number, signal: AbortSignal): boolean {
+  return !signal.aborted && currentStudioReadinessEpoch() === epoch;
+}
 
 function cancelDispatchPreflightRetry(): void {
   if (preflightRetryTimer === null) return;
@@ -515,7 +529,10 @@ export async function disposeStudioWriteRepairOwner(): Promise<void> {
  * have moved funds. A failed pass does not keep Studio closed - the scan is
  * over either way, so the race it exists to prevent is over too.
  */
-async function reconcileAbandonedDispatches(): Promise<void> {
+async function reconcileAbandonedDispatches(
+  epoch: number,
+  signal: AbortSignal,
+): Promise<void> {
   try {
     const {
       reconcileAbandonedStudioDispatches,
@@ -523,8 +540,14 @@ async function reconcileAbandonedDispatches(): Promise<void> {
       reconcileUnstartedStudioApprovals,
       announceStudioUnstartedRefusals,
     } = await import("@vex-agent/engine/core/approval-runtime.js");
+    if (!initializationIsCurrent(epoch, signal)) return;
     const reconciled = await reconcileAbandonedStudioDispatches();
-    // AFTER the writes have committed, never inside them.
+    // AFTER the writes have committed, never inside them - and only while this
+    // initialization is still the current one. The rows themselves are durable
+    // and the next process start reconciles them again, so a dropped
+    // announcement costs nothing; announcing from a process that is shutting
+    // down, or starting the SECOND scan behind it, is fresh work nobody owns.
+    if (!initializationIsCurrent(epoch, signal)) return;
     announceStudioReconciliations(reconciled);
     if (reconciled.length > 0) {
       log.warn(
@@ -534,7 +557,9 @@ async function reconcileAbandonedDispatches(): Promise<void> {
     }
     // The second half of the same premise: an APPROVED row that never started
     // has no owner either, and unlike a `dispatching` one it can still RUN.
+    if (!initializationIsCurrent(epoch, signal)) return;
     const unstarted = await reconcileUnstartedStudioApprovals();
+    if (!initializationIsCurrent(epoch, signal)) return;
     announceStudioUnstartedRefusals(unstarted);
     if (unstarted.length > 0) {
       log.warn(

--- a/vex-app/src/main/database/__tests__/engine-db-readiness.test.ts
+++ b/vex-app/src/main/database/__tests__/engine-db-readiness.test.ts
@@ -12,6 +12,8 @@
  *      share a single timer and a single in-flight probe.
  *   3. THE MIGRATIONS COUNT. A URL that resolves is not a schema that exists.
  *   4. NO TIMER SURVIVES. Resolve or abort, the interval is cleared.
+ *   5. THE RECYCLE COMMITS AT THE DRAIN. A `closePool()` that rejects leaves
+ *      readiness false and is retried; concurrent callers share one drain.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -82,6 +84,64 @@ describe("ensureEngineDbUrl", () => {
     const second = await ensureEngineDbUrl("corr-2");
     expect(second.ok).toBe(true);
     expect(closePool).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * THE COMMIT POINT. The applied URL used to be read back off
+   * `process.env.VEX_DB_URL`, which this function writes BEFORE the drain, so a
+   * `closePool()` that REJECTED left the next pass comparing its own
+   * half-applied variable, accepting the equality, and reporting a database
+   * that the pool it had failed to close was still serving.
+   */
+  it("stays UNREADY when the pool drain fails, and commits on the next one", async () => {
+    buildPoolConfig.mockResolvedValue(CONFIG);
+    migrationsDone = true;
+    closePool.mockRejectedValueOnce(new Error("pool would not drain"));
+
+    const failed = await ensureEngineDbUrl("corr-close-1");
+    expect(failed.ok).toBe(false);
+    expect(isEngineDbReady()).toBe(false);
+    // The variable IS written - the pool rebuilds itself from it - but it is
+    // not the fact readiness is derived from.
+    expect(process.env.VEX_DB_URL).toBe(
+      "postgresql://vex:test-password@127.0.0.1:5433/vex",
+    );
+
+    // The next call retries the recycle instead of trusting the environment.
+    const repaired = await ensureEngineDbUrl("corr-close-2");
+    expect(repaired.ok).toBe(true);
+    expect(closePool).toHaveBeenCalledTimes(2);
+    expect(isEngineDbReady()).toBe(true);
+  });
+
+  it("serializes concurrent callers into ONE drain", async () => {
+    buildPoolConfig.mockResolvedValue(CONFIG);
+    migrationsDone = true;
+    let releaseDrain = (): void => {};
+    closePool.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseDrain = () => {
+            resolve();
+          };
+        }),
+    );
+
+    const first = ensureEngineDbUrl("corr-concurrent-1");
+    const second = ensureEngineDbUrl("corr-concurrent-2");
+    // The second caller JOINED the pass already running, and nothing has been
+    // committed while the drain is still open.
+    await vi.waitFor(() => {
+      expect(closePool).toHaveBeenCalledTimes(1);
+    });
+    expect(isEngineDbReady()).toBe(false);
+
+    releaseDrain();
+    const [firstOutcome, secondOutcome] = await Promise.all([first, second]);
+    expect(firstOutcome.ok).toBe(true);
+    expect(secondOutcome.ok).toBe(true);
+    expect(closePool).toHaveBeenCalledTimes(1);
+    expect(isEngineDbReady()).toBe(true);
   });
 
   it("reports the database as unavailable while compose has written nothing", async () => {

--- a/vex-app/src/main/database/__tests__/engine-db-readiness.test.ts
+++ b/vex-app/src/main/database/__tests__/engine-db-readiness.test.ts
@@ -144,6 +144,44 @@ describe("ensureEngineDbUrl", () => {
     expect(isEngineDbReady()).toBe(true);
   });
 
+  /**
+   * THE JOIN IS MECHANICS, NOT IDENTITY.
+   *
+   * The single-flight used to share a whole `Result<void, VexError>`, so every
+   * caller that JOINED a failing pass was handed the FIRST caller's
+   * correlation id: two unrelated IPC requests reported the same id and any
+   * support trace built from it pointed at a request that was not theirs. The
+   * shared pass now answers only whether the recycle committed, and each
+   * caller builds its own error after joining.
+   */
+  it("gives each joined caller its OWN correlation id when the recycle fails", async () => {
+    buildPoolConfig.mockResolvedValue(CONFIG);
+    let failDrain = (): void => {};
+    closePool.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          failDrain = () => {
+            reject(new Error("pool would not drain"));
+          };
+        }),
+    );
+
+    const first = ensureEngineDbUrl("corr-own-1");
+    const second = ensureEngineDbUrl("corr-own-2");
+    await vi.waitFor(() => {
+      expect(closePool).toHaveBeenCalledTimes(1);
+    });
+
+    failDrain();
+    const [firstOutcome, secondOutcome] = await Promise.all([first, second]);
+    if (firstOutcome.ok || secondOutcome.ok) {
+      throw new Error("a failed drain must not report an applied URL");
+    }
+    expect(firstOutcome.error.correlationId).toBe("corr-own-1");
+    expect(secondOutcome.error.correlationId).toBe("corr-own-2");
+    expect(isEngineDbReady()).toBe(false);
+  });
+
   it("reports the database as unavailable while compose has written nothing", async () => {
     const outcome = await ensureEngineDbUrl("corr-3");
     expect(outcome.ok).toBe(false);

--- a/vex-app/src/main/database/engine-db-readiness.ts
+++ b/vex-app/src/main/database/engine-db-readiness.ts
@@ -32,6 +32,16 @@
  * The only way out of the wait is the caller's own `AbortSignal`, which its
  * lifecycle owner aborts at teardown.
  *
+ * ## The recycle COMMITS at the drain
+ *
+ * Pointing the pool at a new URL is two effects, not one: the environment
+ * variable the lazy pool reads, and the drain that makes the pool holding the
+ * old URL go away. Readiness is published only when the second one has
+ * completed, and one recycle runs at a time. A drain that rejects therefore
+ * leaves readiness FALSE and is retried by the next call, instead of being
+ * mistaken for a completed switch by a later pass that only compared the
+ * environment variable this one had already written.
+ *
  * ## Ownership of the poll
  *
  * ONE timer for the whole process, shared by every waiter (single-flight), held
@@ -51,10 +61,30 @@ import { migrationsApplied } from "./migrations-applied.js";
 const DEFAULT_POLL_MS = 1_000;
 
 /**
- * Whether `ensureEngineDbUrl` has successfully pointed the engine pool at the
- * app-managed Postgres in this process. Written only by a successful ensure.
+ * The URL this process has SUCCESSFULLY applied: written only once the pool
+ * that held the previous one has actually been drained.
+ *
+ * It is deliberately not `process.env.VEX_DB_URL`. The environment variable is
+ * what the lazy pool READS when it next builds itself, so it has to be written
+ * before the drain; the drain is what stops the old pool from serving the old
+ * URL, and only its completion proves the switch happened. Reading readiness
+ * off the environment made a REJECTED `closePool()` indistinguishable from a
+ * completed recycle: the next pass saw its own half-applied variable, accepted
+ * the equality, and reported ready while the pool it had failed to close was
+ * still serving.
  */
-let engineDbUrlApplied = false;
+let appliedDbUrl: string | null = null;
+
+/**
+ * SINGLE-FLIGHT for the recycle. `ensureEngineDbUrl` reads the config, writes
+ * the environment and drains the pool across three awaits; two callers
+ * interleaving inside that window would drain twice and could commit their
+ * URLs out of order. Concurrent callers therefore JOIN the pass already in
+ * flight and see its outcome - the shape VS Code's `Throttler` uses for the
+ * same problem (`base/common/async.ts`): one active promise, every other
+ * caller attached to it.
+ */
+let recycleInFlight: Promise<Result<void, VexError>> | null = null;
 
 /** Rejection handed to a waiter whose owner aborted the wait. */
 export class EngineDbWaitAbortedError extends Error {
@@ -93,8 +123,13 @@ function makePostgresUrl(args: {
  * Point the engine's lazy pool at the app-managed Postgres.
  *
  * Mutates `process.env.VEX_DB_URL` and recycles the pool when the resolved URL
- * differs from the one already in effect; `closePool` is idempotent, so
- * concurrent callers converge on the same URL and at most one drain.
+ * differs from the one this process has already applied. Callers that arrive
+ * while a recycle is running JOIN it rather than starting a second one.
+ *
+ * THE COMMIT POINT IS THE DRAIN, not the environment write. A `closePool()`
+ * that rejects leaves the applied URL untouched, so readiness stays false, the
+ * next call retries the recycle, and nothing reports a usable database while
+ * the pool holding the previous URL is still alive.
  *
  * The pool module is reached through a DYNAMIC import, and only on the path
  * that actually recycles it. This module is now read at BOOT - the settlement
@@ -102,21 +137,36 @@ function makePostgresUrl(args: {
  * `pg` into main's load path, which is exactly what the bridge's own dynamic
  * imports exist to avoid.
  */
-export async function ensureEngineDbUrl(
+export function ensureEngineDbUrl(
+  correlationId: string,
+): Promise<Result<void, VexError>> {
+  const joined = recycleInFlight;
+  if (joined !== null) return joined;
+  const pass: Promise<Result<void, VexError>> = applyEngineDbUrl(
+    correlationId,
+  ).finally(() => {
+    if (recycleInFlight === pass) recycleInFlight = null;
+  });
+  recycleInFlight = pass;
+  return pass;
+}
+
+async function applyEngineDbUrl(
   correlationId: string,
 ): Promise<Result<void, VexError>> {
   try {
     const cfg = await buildPoolConfig();
     if (cfg === null) return err(engineDbUnavailableError(correlationId));
     const nextUrl = makePostgresUrl(cfg);
-    if (process.env.VEX_DB_URL === nextUrl) {
-      engineDbUrlApplied = true;
-      return ok(undefined);
-    }
+    if (appliedDbUrl === nextUrl) return ok(undefined);
+    // The environment FIRST, because the pool the drain below destroys rebuilds
+    // itself from this variable at its next query. Writing it after the drain
+    // would let a query landing between the two rebuild the pool against the
+    // URL this call exists to replace.
     process.env.VEX_DB_URL = nextUrl;
     const { closePool } = await import("@vex-agent/db/client.js");
     await closePool();
-    engineDbUrlApplied = true;
+    appliedDbUrl = nextUrl;
     log.info(
       `[engine-db] engine database connection refreshed correlationId=${correlationId}`,
     );
@@ -131,7 +181,7 @@ export async function ensureEngineDbUrl(
  * least once in this process AND the migrate runner reported success.
  */
 export function isEngineDbReady(): boolean {
-  return engineDbUrlApplied && migrationsApplied();
+  return appliedDbUrl !== null && migrationsApplied();
 }
 
 interface EngineDbWaiter {
@@ -240,7 +290,10 @@ export function whenEngineDbReady(
   });
 }
 
-/** Test seam: forget the applied URL, the waiters, the timer and the logs. */
+/**
+ * Test seam: forget the applied URL, the in-flight recycle, the waiters, the
+ * timer and the logs.
+ */
 export function resetEngineDbReadinessForTests(): void {
   for (const waiter of [...waiters]) {
     waiters.delete(waiter);
@@ -251,7 +304,8 @@ export function resetEngineDbReadinessForTests(): void {
     clearInterval(pollTimer);
     pollTimer = null;
   }
-  engineDbUrlApplied = false;
+  appliedDbUrl = null;
+  recycleInFlight = null;
   pollInFlight = false;
   loggedWaiting = false;
   loggedReady = false;

--- a/vex-app/src/main/database/engine-db-readiness.ts
+++ b/vex-app/src/main/database/engine-db-readiness.ts
@@ -76,15 +76,28 @@ const DEFAULT_POLL_MS = 1_000;
 let appliedDbUrl: string | null = null;
 
 /**
- * SINGLE-FLIGHT for the recycle. `ensureEngineDbUrl` reads the config, writes
- * the environment and drains the pool across three awaits; two callers
+ * WHAT THE SHARED PASS ANSWERS: whether the recycle COMMITTED, and nothing
+ * about who asked for it.
+ *
+ * The single-flight below is joined by callers that have nothing to do with
+ * each other, so its result must not carry one caller's identity. It used to
+ * be a whole `Result<void, VexError>`, correlation id included, which meant
+ * every joiner was handed the FIRST caller's id and any support trace built
+ * from those ids pointed at a request that was not theirs.
+ */
+type EngineDbRecycleOutcome = "applied" | "unavailable";
+
+/**
+ * SINGLE-FLIGHT for the recycle MECHANICS. `applyEngineDbUrl` reads the config,
+ * writes the environment and drains the pool across three awaits; two callers
  * interleaving inside that window would drain twice and could commit their
  * URLs out of order. Concurrent callers therefore JOIN the pass already in
  * flight and see its outcome - the shape VS Code's `Throttler` uses for the
  * same problem (`base/common/async.ts`): one active promise, every other
- * caller attached to it.
+ * caller attached to it. The identity-bearing error is built AFTER the join,
+ * per caller, by `ensureEngineDbUrl`.
  */
-let recycleInFlight: Promise<Result<void, VexError>> | null = null;
+let recycleInFlight: Promise<EngineDbRecycleOutcome> | null = null;
 
 /** Rejection handed to a waiter whose owner aborted the wait. */
 export class EngineDbWaitAbortedError extends Error {
@@ -137,28 +150,37 @@ function makePostgresUrl(args: {
  * `pg` into main's load path, which is exactly what the bridge's own dynamic
  * imports exist to avoid.
  */
-export function ensureEngineDbUrl(
+export async function ensureEngineDbUrl(
   correlationId: string,
 ): Promise<Result<void, VexError>> {
+  const outcome = await recycleEngineDbUrl();
+  // THE ERROR IS THIS CALLER'S, built after the join: a joiner that inherited
+  // the pass's own error inherited the correlation id of whichever request
+  // happened to start it.
+  return outcome === "applied"
+    ? ok(undefined)
+    : err(engineDbUnavailableError(correlationId));
+}
+
+/** Join the recycle in flight, or start one. Identity-free by construction. */
+function recycleEngineDbUrl(): Promise<EngineDbRecycleOutcome> {
   const joined = recycleInFlight;
   if (joined !== null) return joined;
-  const pass: Promise<Result<void, VexError>> = applyEngineDbUrl(
-    correlationId,
-  ).finally(() => {
-    if (recycleInFlight === pass) recycleInFlight = null;
-  });
+  const pass: Promise<EngineDbRecycleOutcome> = applyEngineDbUrl().finally(
+    () => {
+      if (recycleInFlight === pass) recycleInFlight = null;
+    },
+  );
   recycleInFlight = pass;
   return pass;
 }
 
-async function applyEngineDbUrl(
-  correlationId: string,
-): Promise<Result<void, VexError>> {
+async function applyEngineDbUrl(): Promise<EngineDbRecycleOutcome> {
   try {
     const cfg = await buildPoolConfig();
-    if (cfg === null) return err(engineDbUnavailableError(correlationId));
+    if (cfg === null) return "unavailable";
     const nextUrl = makePostgresUrl(cfg);
-    if (appliedDbUrl === nextUrl) return ok(undefined);
+    if (appliedDbUrl === nextUrl) return "applied";
     // The environment FIRST, because the pool the drain below destroys rebuilds
     // itself from this variable at its next query. Writing it after the drain
     // would let a query landing between the two rebuild the pool against the
@@ -167,12 +189,12 @@ async function applyEngineDbUrl(
     const { closePool } = await import("@vex-agent/db/client.js");
     await closePool();
     appliedDbUrl = nextUrl;
-    log.info(
-      `[engine-db] engine database connection refreshed correlationId=${correlationId}`,
-    );
-    return ok(undefined);
+    // No correlation id: the recycle is shared by every joined caller, so
+    // stamping it with one of their ids would name the wrong request.
+    log.info("[engine-db] engine database connection refreshed");
+    return "applied";
   } catch {
-    return err(engineDbUnavailableError(correlationId));
+    return "unavailable";
   }
 }
 
@@ -223,7 +245,7 @@ async function pollOnce(): Promise<void> {
   try {
     if (waiters.size === 0) return;
     if (!isEngineDbReady()) {
-      await ensureEngineDbUrl("engine-db-readiness");
+      await recycleEngineDbUrl();
       if (waiters.size === 0) return;
       if (!isEngineDbReady()) return;
     }

--- a/vex-app/src/main/secrets/session.ts
+++ b/vex-app/src/main/secrets/session.ts
@@ -27,6 +27,38 @@ import {
 import { log } from "../logger/index.js";
 import { ensureEngineDbUrl } from "../database/engine-db-readiness.js";
 import { requestStudioRuntimeRetry } from "../studio/readiness.js";
+import {
+  beginStudioSessionTransition,
+  cancelStudioSessionTransition,
+  clearPendingRefusalCause,
+  clearStudioGenerationPoison,
+  ensureStudioRecoveryTimer,
+  isStudioDispatchPoisoned,
+  isStudioSessionTransitionInProgress,
+  needsStudioGenerationAdvance,
+  pendingStudioRefusalCause,
+  poisonStudioDispatch as poisonStudioDispatchFence,
+  retainPendingRefusalCause,
+  stopStudioRecoveryWhenClear,
+  type SecretSessionLockCause,
+} from "../studio/session-dispatch-fence.js";
+
+/**
+ * THE FENCE FACADE. The Studio dispatch poison, its recovery timer, the
+ * session-transition flag and the owed-refusal cause moved to
+ * `studio/session-dispatch-fence.ts` (one lifecycle, one owner, its own tests);
+ * this module stays the entry point every existing consumer already imports -
+ * the quit cleanup, the approval service, the settlement bridge's preflight -
+ * so the move changed no caller.
+ */
+export {
+  disposeStudioDispatchPoisonRetry,
+  hasPendingStudioRefusalRepair,
+  isStudioDispatchPoisoned,
+  isStudioSessionTransitionInProgress,
+  resetStudioDispatchPoisonForTests,
+  type SecretSessionLockCause,
+} from "../studio/session-dispatch-fence.js";
 
 let unlockedMasterPassword: string | null = null;
 
@@ -242,101 +274,13 @@ export async function unlockSecretSession(
   } catch (cause) {
     if (!unlockedRuntimeChanged) {
       cancelStudioSessionTransition();
-    } else if (studioSessionTransitionInProgress) {
+    } else if (isStudioSessionTransitionInProgress()) {
       // The runtime changed but the durable generation did not complete. Keep
       // the transition closed and let the recovery owner prove a fresh fence.
       poisonStudioDispatch();
     }
     return toPublicError(cause);
   }
-}
-
-/**
- * ## The POISON, and why a failed advance is not a shrug
- *
- * The durable dispatch generation is the fence: a queued Studio action may only
- * dispatch while the generation it recorded at enqueue is still current, so a
- * lock or an unlock ADVANCES it and every intent from before is refused. That
- * works exactly as long as the advance commits.
- *
- * When it does not - PostgreSQL is down while the user locks Vex - the old
- * generation stays current. The lock still scrubs and still revokes signing, so
- * nothing can be signed; but once the database comes back, a pre-lock intent's
- * recorded generation matches again and its slot claim would succeed. The fence
- * silently never moved.
- *
- * So a failed advance POISONS the runtime: no new Studio approval may be queued
- * (`isStudioRuntimeAvailable` in `studio/approval-service.ts`), and no approved
- * Studio intent may dispatch (the engine's dispatch preflight, registered in
- * `agent/studio-settlement-bridge.ts`). Only a SUCCESSFUL advance clears it,
- * and a bounded retry keeps trying so recovery does not wait for the user's
- * next lock or unlock.
- */
-let studioGenerationPoisoned = false;
-/**
- * Synchronous authority transition. Set before lock or unlock reaches its
- * first await and cleared only by a committed generation advance. It closes
- * the non-signing dispatch window that secret scrubbing alone cannot close.
- */
-let studioSessionTransitionInProgress = false;
-/**
- * A lock/quit refusal sweep that has not yet committed. The typed cause is
- * retained verbatim so a recovery pass writes the same durable audit fact.
- */
-let studioPendingRefusalCause: SecretSessionLockCause | null = null;
-let studioPoisonRetryTimer: NodeJS.Timeout | null = null;
-/**
- * SINGLE-FLIGHT for the retry. An advance is a database round trip that can
- * take longer than the retry interval when the database is the thing that is
- * unwell; without this, a slow database would accumulate one concurrent
- * advance per tick, each writing the same monotonic row.
- */
-let studioPoisonRetryInFlight = false;
-
-/** Bounded retry cadence while poisoned. Short: this blocks real work. */
-const STUDIO_POISON_RETRY_MS = 12_000;
-
-/**
- * Can Vex currently prove its Studio lock fence?
- *
- * Read by the enqueue predicate and by the engine's dispatch preflight. `true`
- * means an advance failed and no later advance has succeeded, so both refuse.
- */
-export function isStudioDispatchPoisoned(): boolean {
-  return (
-    studioGenerationPoisoned
-    || studioSessionTransitionInProgress
-    || studioPendingRefusalCause !== null
-  );
-}
-
-/** Main-side preflight fact, exported so dispatch checks it explicitly. */
-export function isStudioSessionTransitionInProgress(): boolean {
-  return studioSessionTransitionInProgress;
-}
-
-/** Test and readiness seam for the durable refusal-repair obligation. */
-export function hasPendingStudioRefusalRepair(): boolean {
-  return studioPendingRefusalCause !== null;
-}
-
-/**
- * Stop the retry timer. Owned by the ordered quit cleanup; idempotent, so a
- * second quit hook or a test teardown is safe.
- */
-export function disposeStudioDispatchPoisonRetry(): void {
-  if (studioPoisonRetryTimer === null) return;
-  clearInterval(studioPoisonRetryTimer);
-  studioPoisonRetryTimer = null;
-}
-
-/** Test seam: forget the poison and its timer between cases. */
-export function resetStudioDispatchPoisonForTests(): void {
-  disposeStudioDispatchPoisonRetry();
-  studioGenerationPoisoned = false;
-  studioSessionTransitionInProgress = false;
-  studioPendingRefusalCause = null;
-  studioPoisonRetryInFlight = false;
 }
 
 /**
@@ -374,7 +318,7 @@ async function advanceStudioDispatchGenerationSafely(
       "@vex-agent/engine/core/approval-runtime.js"
     );
     const pendingRefusalReason =
-      phase === "unlock" ? null : studioPendingRefusalCause;
+      phase === "unlock" ? null : pendingStudioRefusalCause();
     const advanced = await advanceStudioDispatchGeneration(
       pendingRefusalReason,
     );
@@ -384,6 +328,9 @@ async function advanceStudioDispatchGenerationSafely(
       return false;
     }
     clearStudioGenerationPoison();
+    // The all-clear is the fence's; whether admission may OPEN also depends on
+    // the vault session, which is this module's own state.
+    reopenStudioHostIfSafe();
     return true;
   } catch (err) {
     log.warn(`[secrets-session] studio dispatch advance failed on ${phase}`, err);
@@ -392,54 +339,17 @@ async function advanceStudioDispatchGenerationSafely(
   }
 }
 
+/**
+ * The session's own binding of the fence's two schedulers: the fence owns the
+ * timer and its single-flight, this module owns what the pass DOES, so the pass
+ * is handed in rather than imported back across the boundary.
+ */
 function poisonStudioDispatch(): void {
-  const wasPoisoned = studioGenerationPoisoned;
-  studioGenerationPoisoned = true;
-  if (!wasPoisoned) {
-    log.warn(
-      "[secrets-session] studio dispatch fence UNPROVEN: queueing and dispatch "
-        + "are refused until an advance succeeds",
-    );
-  }
-  ensureStudioRecoveryTimer();
+  poisonStudioDispatchFence(runStudioRecoveryPass);
 }
 
-function ensureStudioRecoveryTimer(): void {
-  if (studioPoisonRetryTimer !== null) return;
-  studioPoisonRetryTimer = setInterval(() => {
-    if (studioPoisonRetryInFlight) return;
-    studioPoisonRetryInFlight = true;
-    void runStudioRecoveryPass().finally(() => {
-      studioPoisonRetryInFlight = false;
-    });
-  }, STUDIO_POISON_RETRY_MS);
-  // The retry must never hold the process open by itself.
-  studioPoisonRetryTimer.unref?.();
-}
-
-function clearStudioGenerationPoison(): void {
-  if (studioGenerationPoisoned) {
-    log.info("[secrets-session] studio dispatch fence proven again");
-  }
-  studioGenerationPoisoned = false;
-  studioSessionTransitionInProgress = false;
-  stopStudioRecoveryWhenClear();
-  reopenStudioHostIfSafe();
-}
-
-function beginStudioSessionTransition(): void {
-  studioSessionTransitionInProgress = true;
-}
-
-function cancelStudioSessionTransition(): void {
-  studioSessionTransitionInProgress = false;
-  stopStudioRecoveryWhenClear();
-}
-
-function stopStudioRecoveryWhenClear(): void {
-  if (!isStudioDispatchPoisoned()) {
-    disposeStudioDispatchPoisonRetry();
-  }
+function ensureStudioRecoveryRetry(): void {
+  ensureStudioRecoveryTimer(runStudioRecoveryPass);
 }
 
 /**
@@ -465,10 +375,10 @@ export function reopenStudioHostIfSafe(): void {
  * never pretends a failed generation moved.
  */
 async function runStudioRecoveryPass(): Promise<void> {
-  if (studioGenerationPoisoned || studioSessionTransitionInProgress) {
+  if (needsStudioGenerationAdvance()) {
     await advanceStudioDispatchGenerationSafely("retry");
   }
-  const refusalCause = studioPendingRefusalCause;
+  const refusalCause = pendingStudioRefusalCause();
   if (refusalCause !== null) {
     await refuseStudioIntentsSafely(refusalCause);
   }
@@ -519,19 +429,6 @@ async function invalidateProviderCache(): Promise<void> {
     log.warn("[secrets-session] resetProvider after lock failed", err);
   }
 }
-
-/**
- * WHY the session is being locked, as a TRUSTED value.
- *
- * The two causes write DIFFERENT durable audit rows and must not be confused:
- * a user locking Vex is `lock`, and the application leaving is `vex_quit`. The
- * quit hooks used to call this with the default, so a quit stamped `lock` on
- * every pending Studio intent it happened to reach first, racing the ordered
- * quit cleanup's own `vex_quit` pass for the same rows. One caller, one cause,
- * threaded all the way to `approval_intents.refusal_reason` and to the cause
- * each blocked MCP call is told.
- */
-export type SecretSessionLockCause = "lock" | "vex_quit";
 
 /**
  * Relock the secret session. Scrubs the cached master password and every
@@ -616,32 +513,13 @@ async function refuseStudioIntentsSafely(
       ensureStudioRecoveryRetry();
       return;
     }
-    if (studioPendingRefusalCause === effectiveCause) {
-      studioPendingRefusalCause = null;
-    }
+    clearPendingRefusalCause(effectiveCause);
     stopStudioRecoveryWhenClear();
     reopenStudioHostIfSafe();
   } catch (err) {
     log.warn("[secrets-session] studio refusal on lock failed", err);
     ensureStudioRecoveryRetry();
   }
-}
-
-function retainPendingRefusalCause(
-  cause: SecretSessionLockCause,
-): SecretSessionLockCause {
-  // Quit is the terminal and more specific transition. A user-lock cleanup
-  // already in flight must never overwrite it with the weaker earlier cause.
-  if (studioPendingRefusalCause === "vex_quit" || cause === "vex_quit") {
-    studioPendingRefusalCause = "vex_quit";
-  } else {
-    studioPendingRefusalCause = "lock";
-  }
-  return studioPendingRefusalCause;
-}
-
-function ensureStudioRecoveryRetry(): void {
-  ensureStudioRecoveryTimer();
 }
 
 /**

--- a/vex-app/src/main/studio/readiness.ts
+++ b/vex-app/src/main/studio/readiness.ts
@@ -184,11 +184,18 @@ export function currentStudioReadinessEpoch(): number {
  * The barrier completed: preflight registered AND reconciliation finished.
  * Ignored, and LOGGED, when the caller's epoch is stale - which is what a
  * retry timer that outlived its teardown holds.
+ *
+ * RETURNS WHETHER IT COMMITTED, because the caller has work that belongs
+ * strictly after a successful transition: the ready log the user reads, and
+ * the project-cleanup repair it launches. A caller that could not tell a
+ * commit from a refusal announced a ready Studio, and started new database
+ * work, on a process whose teardown had already invalidated its epoch.
  */
-export function markStudioRuntimeReady(callerEpoch: number): void {
-  if (!ownsEpoch(callerEpoch, "ready")) return;
+export function markStudioRuntimeReady(callerEpoch: number): boolean {
+  if (!ownsEpoch(callerEpoch, "ready")) return false;
   readiness = { ready: true };
   announceReadiness();
+  return true;
 }
 
 /** The preflight could not be registered. Studio stays closed. */

--- a/vex-app/src/main/studio/session-dispatch-fence.ts
+++ b/vex-app/src/main/studio/session-dispatch-fence.ts
@@ -1,0 +1,231 @@
+/**
+ * THE STUDIO DISPATCH FENCE STATE, owned in one place.
+ *
+ * Three facts decide whether this process may let a Studio action be queued or
+ * dispatched, and all three are written by the secret session's lock and unlock
+ * paths: a durable generation advance that did NOT commit, a session transition
+ * that is still in flight, and a durable refusal sweep this process still owes.
+ * They used to live as five module bindings inside `secrets/session.ts`
+ * alongside the vault, the keystore-password provider and the env scrub, which
+ * put two unrelated lifecycles in one file: credentials, and a fence with a
+ * timer.
+ *
+ * This module owns the STATE and the TIMER; the secret session owns what the
+ * recovery pass actually DOES (the generation advance and the refusal write,
+ * both of which reach the engine and the vault session) and what an
+ * all-clear MEANS for MCP admission, which depends on the session being
+ * unlocked. That split is why the recovery pass is handed in as an argument
+ * rather than imported: an import in that direction would close a cycle back
+ * into the session this fence exists to serve.
+ *
+ * ## The POISON, and why a failed advance is not a shrug
+ *
+ * The durable dispatch generation is the fence: a queued Studio action may only
+ * dispatch while the generation it recorded at enqueue is still current, so a
+ * lock or an unlock ADVANCES it and every intent from before is refused. That
+ * works exactly as long as the advance commits.
+ *
+ * When it does not - PostgreSQL is down while the user locks Vex - the old
+ * generation stays current. The lock still scrubs and still revokes signing, so
+ * nothing can be signed; but once the database comes back, a pre-lock intent's
+ * recorded generation matches again and its slot claim would succeed. The fence
+ * silently never moved.
+ *
+ * So a failed advance POISONS the runtime: no new Studio approval may be queued
+ * (`isStudioRuntimeAvailable` in `studio/approval-service.ts`), and no approved
+ * Studio intent may dispatch (the engine's dispatch preflight, registered in
+ * `agent/studio-settlement-bridge.ts`). Only a SUCCESSFUL advance clears it,
+ * and a bounded retry keeps trying so recovery does not wait for the user's
+ * next lock or unlock.
+ */
+
+import { log } from "../logger/index.js";
+
+/**
+ * WHY the session is being locked, as a TRUSTED value.
+ *
+ * The two causes write DIFFERENT durable audit rows and must not be confused:
+ * a user locking Vex is `lock`, and the application leaving is `vex_quit`. The
+ * quit hooks used to call the lock with the default, so a quit stamped `lock`
+ * on every pending Studio intent it happened to reach first, racing the ordered
+ * quit cleanup's own `vex_quit` pass for the same rows. One caller, one cause,
+ * threaded all the way to `approval_intents.refusal_reason` and to the cause
+ * each blocked MCP call is told.
+ */
+export type SecretSessionLockCause = "lock" | "vex_quit";
+
+/** The recovery pass the session owns; this module only schedules it. */
+type StudioFenceRecoveryPass = () => Promise<void>;
+
+let studioGenerationPoisoned = false;
+/**
+ * Synchronous authority transition. Set before lock or unlock reaches its
+ * first await and cleared only by a committed generation advance. It closes
+ * the non-signing dispatch window that secret scrubbing alone cannot close.
+ */
+let studioSessionTransitionInProgress = false;
+/**
+ * A lock/quit refusal sweep that has not yet committed. The typed cause is
+ * retained verbatim so a recovery pass writes the same durable audit fact.
+ */
+let studioPendingRefusalCause: SecretSessionLockCause | null = null;
+let studioPoisonRetryTimer: NodeJS.Timeout | null = null;
+/**
+ * SINGLE-FLIGHT for the retry. An advance is a database round trip that can
+ * take longer than the retry interval when the database is the thing that is
+ * unwell; without this, a slow database would accumulate one concurrent
+ * advance per tick, each writing the same monotonic row.
+ */
+let studioPoisonRetryInFlight = false;
+
+/** Bounded retry cadence while poisoned. Short: this blocks real work. */
+const STUDIO_POISON_RETRY_MS = 12_000;
+
+/**
+ * Can Vex currently prove its Studio lock fence?
+ *
+ * Read by the enqueue predicate and by the engine's dispatch preflight. `true`
+ * means an advance failed and no later advance has succeeded, so both refuse.
+ */
+export function isStudioDispatchPoisoned(): boolean {
+  return (
+    studioGenerationPoisoned
+    || studioSessionTransitionInProgress
+    || studioPendingRefusalCause !== null
+  );
+}
+
+/** Main-side preflight fact, exported so dispatch checks it explicitly. */
+export function isStudioSessionTransitionInProgress(): boolean {
+  return studioSessionTransitionInProgress;
+}
+
+/** Test and readiness seam for the durable refusal-repair obligation. */
+export function hasPendingStudioRefusalRepair(): boolean {
+  return studioPendingRefusalCause !== null;
+}
+
+/** The exact typed cause a still-owed refusal sweep must write. */
+export function pendingStudioRefusalCause(): SecretSessionLockCause | null {
+  return studioPendingRefusalCause;
+}
+
+/**
+ * Whether the recovery pass still owes a GENERATION advance, as opposed to a
+ * refusal write. The two obligations are cleared independently: a successful
+ * advance never erases a pending refusal, and a successful refusal never
+ * pretends a failed generation moved.
+ */
+export function needsStudioGenerationAdvance(): boolean {
+  return studioGenerationPoisoned || studioSessionTransitionInProgress;
+}
+
+/**
+ * Stop the retry timer. Owned by the ordered quit cleanup; idempotent, so a
+ * second quit hook or a test teardown is safe.
+ */
+export function disposeStudioDispatchPoisonRetry(): void {
+  if (studioPoisonRetryTimer === null) return;
+  clearInterval(studioPoisonRetryTimer);
+  studioPoisonRetryTimer = null;
+}
+
+/** Test seam: forget the poison and its timer between cases. */
+export function resetStudioDispatchPoisonForTests(): void {
+  disposeStudioDispatchPoisonRetry();
+  studioGenerationPoisoned = false;
+  studioSessionTransitionInProgress = false;
+  studioPendingRefusalCause = null;
+  studioPoisonRetryInFlight = false;
+}
+
+/**
+ * The fence is UNPROVEN: refuse queueing and dispatch, and start the bounded
+ * recovery. Announced once per poisoned stretch rather than per failure.
+ */
+export function poisonStudioDispatch(recoveryPass: StudioFenceRecoveryPass): void {
+  const wasPoisoned = studioGenerationPoisoned;
+  studioGenerationPoisoned = true;
+  if (!wasPoisoned) {
+    log.warn(
+      "[secrets-session] studio dispatch fence UNPROVEN: queueing and dispatch "
+        + "are refused until an advance succeeds",
+    );
+  }
+  ensureStudioRecoveryTimer(recoveryPass);
+}
+
+export function ensureStudioRecoveryTimer(
+  recoveryPass: StudioFenceRecoveryPass,
+): void {
+  if (studioPoisonRetryTimer !== null) return;
+  studioPoisonRetryTimer = setInterval(() => {
+    if (studioPoisonRetryInFlight) return;
+    studioPoisonRetryInFlight = true;
+    void recoveryPass().finally(() => {
+      studioPoisonRetryInFlight = false;
+    });
+  }, STUDIO_POISON_RETRY_MS);
+  // The retry must never hold the process open by itself.
+  studioPoisonRetryTimer.unref?.();
+}
+
+/**
+ * A generation advance COMMITTED. Clears the poison and the transition, and
+ * stops the recovery when nothing else is outstanding. Reopening MCP admission
+ * belongs to the session, which owns the other half of that question.
+ */
+export function clearStudioGenerationPoison(): void {
+  if (studioGenerationPoisoned) {
+    log.info("[secrets-session] studio dispatch fence proven again");
+  }
+  studioGenerationPoisoned = false;
+  studioSessionTransitionInProgress = false;
+  stopStudioRecoveryWhenClear();
+}
+
+export function beginStudioSessionTransition(): void {
+  studioSessionTransitionInProgress = true;
+}
+
+export function cancelStudioSessionTransition(): void {
+  studioSessionTransitionInProgress = false;
+  stopStudioRecoveryWhenClear();
+}
+
+export function stopStudioRecoveryWhenClear(): void {
+  if (!isStudioDispatchPoisoned()) {
+    disposeStudioDispatchPoisonRetry();
+  }
+}
+
+/**
+ * Record the obligation to refuse pending intents durably, and answer with the
+ * cause that must actually be written.
+ *
+ * Quit is the terminal and more specific transition. A user-lock cleanup
+ * already in flight must never overwrite it with the weaker earlier cause.
+ */
+export function retainPendingRefusalCause(
+  cause: SecretSessionLockCause,
+): SecretSessionLockCause {
+  if (studioPendingRefusalCause === "vex_quit" || cause === "vex_quit") {
+    studioPendingRefusalCause = "vex_quit";
+  } else {
+    studioPendingRefusalCause = "lock";
+  }
+  return studioPendingRefusalCause;
+}
+
+/**
+ * A refusal sweep COMMITTED. Cleared only when the obligation is still the one
+ * that was written: a quit that escalated the cause while the sweep ran leaves
+ * its own stronger obligation standing.
+ */
+export function clearPendingRefusalCause(
+  written: SecretSessionLockCause,
+): void {
+  if (studioPendingRefusalCause === written) {
+    studioPendingRefusalCause = null;
+  }
+}


### PR DESCRIPTION
## What changes

- **Readiness commits after the drain.** `ensureEngineDbUrl` tracked nothing but `process.env`; when `closePool()` rejected, the next pass saw the new URL already in the environment and reported ready over a pool bound to the old one. The applied URL is now its own fact, committed only after the drain resolves; concurrent refreshes join one in-flight drain; a failed drain is retried by the next call.
- **Every registration path waits for the database.** The preflight retry timer called completion directly after registering, so a database twenty seconds late could exhaust the bounded retry with database work. Every successful registration now funnels through one `awaitEngineDbThenComplete` continuation.
- **Teardown never publishes readiness.** `markStudioRuntimeReady` answers whether it committed under the current epoch; the bridge re-checks the signal and the epoch after every awaited phase, and the ready log and the project-cleanup repair run only after a committed transition.
- **`session.ts` facade extraction** (761 to 639 lines): the dispatch poison, transition flag, owed refusal cause and recovery timer move to `studio/session-dispatch-fence.ts`; `session.ts` re-exports every previous symbol, so no importer changes. Admission reopening stays with the session (it depends on the vault state), passed into the fence's schedulers as an argument to avoid an import cycle.

## Verification

- `vex-app` vitest on `src/main/database`, `src/main/agent`, `src/main/secrets`: 88 files, 928 tests passed. Red-on-revert proven for all three fixes (the four new cases fail with the corresponding fix reverted).
- `lint:tsc` and `lint:tsc:ratchet` green (the ratchet caught two dangling references in `session.ts` during the extraction; fixed); process-boundaries, em-dash and unsafe-escapes gates green.
- `src/main/studio`: 56 of 59 files green; the three failing socket tests (`host-status-transitions`, `mcp-host-lifecycle`, `mcp-wire-error-redaction`) fail identically on a clean `main` checkout under the same machine load and passed in the low-load combined-tree ladder earlier today; they are load-sensitive socket-close waits, not this diff, and are recorded for the MCP host lane.

Reference reading: VS Code `async.ts` (`Throttler` single flight adopted for the recycle, `Sequencer` and `Barrier` rejected with reasons), `async.test.ts` (count-the-factory assertion form), `ptyHostService.ts` and `electronPtyHostStarter.ts` (nothing published until the new host answers).
