### PR TITLE
fix(terminal): the terminal answers OSC 11 with the surface it paints

### DIFF
--- a/vex-app/e2e/fixtures/terminal-glass-probes.ts
+++ b/vex-app/e2e/fixtures/terminal-glass-probes.ts
@@ -1,0 +1,667 @@
+/**
+ * THE MEASUREMENT OWNERS behind `studio-terminal-glass.spec.ts`.
+ *
+ * The spec makes claims about the Studio terminal as PAINTED in the built app:
+ * the gutter, the pane's renderer and filters, scroll throughput, the
+ * scrollbar's geometry and reveal states, foreground contrast over the glass,
+ * what the terminal answers an OSC 11 query, and how reverse video reads. Each
+ * of those is a measurement with its own apparatus, and none of it is an
+ * assertion. This module owns the apparatus; the spec keeps the walk and every
+ * claim it makes about the numbers.
+ *
+ * Two things deliberately stay OUT of here:
+ *
+ *  - the tour navigator is QA scaffolding the spec owns, so the two probes
+ *    that need a screenshot take a `CaptureClip` from the caller rather than
+ *    reaching for the tour themselves;
+ *  - the theme walk (`pickTheme`) and the output directory are the spec's own
+ *    route through the product, not a measurement.
+ *
+ * `expect` appears here only where a probe cannot continue without the thing
+ * it is measuring (no layout, no grid, no reply), the same way
+ * `studio-shell.ts` uses it inside `focusTerminalGrid`.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { expect, type Page } from "@playwright/test";
+import sharp from "sharp";
+import { focusTerminalGrid } from "./studio-shell.js";
+
+/** Lines the burst writes. Thirty times the 1000-row scrollback, so the buffer wraps. */
+export const BURST_LINES = 30_000;
+/** How long the burst may take on a cold, loaded box before the run counts as wedged. */
+export const BURST_TIMEOUT_MS = 90_000;
+/** Wheel ticks and their spacing while measuring scroll frames. */
+export const WHEEL_TICKS = 60;
+export const WHEEL_TICK_DELTA = -120;
+export const WHEEL_TICK_GAP_MS = 16;
+
+/**
+ * A clipped screenshot of the page. The caller supplies it, because what has
+ * to be hidden for a capture (the tour navigator) belongs to the caller.
+ */
+export type CaptureClip = (clip: {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}) => Promise<Buffer>;
+
+export interface GutterMeasurement {
+  readonly viewportWidth: number;
+  readonly sidebarRight: number;
+  readonly centerLeft: number;
+  readonly paneLeft: number;
+  readonly gridLeft: number;
+  /** Sidebar right edge to the first terminal column, in CSS px. */
+  readonly gutter: number;
+  /** Column edge to pane edge (the workspace padding). */
+  readonly columnPadding: number;
+  /** Pane edge to the first column (the pane's own inset). */
+  readonly paneInset: number;
+}
+
+export interface PaneFacts {
+  readonly renderer: "webgl" | "dom";
+  /** Whether this environment can hand out a WebGL2 context at all. */
+  readonly webgl2Available: boolean;
+  readonly paneBackdropFilter: string;
+  readonly paneBackground: string;
+  readonly hostBackground: string;
+  readonly foreground: string;
+}
+
+export interface Throughput {
+  readonly burstLines: number;
+  readonly burstMs: number;
+  readonly burstFrames: number;
+  readonly burstFps: number;
+  /** Frames painted in the second after the cwd marker landed. */
+  readonly settleFrames: number;
+  readonly wheelTicks: number;
+  readonly wheelMs: number;
+  readonly wheelFrames: number;
+  readonly wheelFps: number;
+  readonly scrolledPx: number;
+}
+
+/**
+ * The terminal's scrollbar as PAINTED. xterm 6 mounts VS Code's
+ * ScrollableElement, so the bar is a real `.slider` element sized inline and
+ * coloured by scrollbars.css; none of that is readable in jsdom.
+ */
+export interface ScrollbarFacts {
+  /** The vestigial `.xterm-viewport`'s own native gutter, in CSS px. 0 means gone. */
+  readonly viewportGutter: number;
+  readonly trackWidth: number;
+  readonly sliderWidth: number;
+  /** The transparent inset each side of the thumb (the slider's padding). */
+  readonly sliderInset: number;
+  readonly sliderRadius: string;
+  readonly sliderBackground: string;
+  /** `--vex-scrollbar-thumb` resolved in the track's own scope, for comparison. */
+  readonly tokenBackground: string;
+  /**
+   * xterm's injected `<style>` elements inside the terminal, and how many of
+   * them the document actually applied. The renderer's CSP (`style-src
+   * 'self'`) refuses inline sheets, which is why the slider's colour cannot
+   * come from the palette bridge and lives in scrollbars.css instead.
+   */
+  readonly injectedSheets: { readonly count: number; readonly applied: number };
+  /** The track's class list right after the wheel, with the pointer still over the grid. */
+  readonly classesAfterWheel: string;
+  /** The track's class list once the pointer left and the idle hide ran. */
+  readonly classesAfterLeave: string;
+  /** The track's class list once the pointer came back over the grid. */
+  readonly classesOnHover: string;
+  /** The show/fade transition duration under `prefers-reduced-motion: reduce`. */
+  readonly reducedMotionTransition: string;
+}
+
+export interface Contrast {
+  readonly theme: string;
+  readonly sample: { readonly mean: [number, number, number]; readonly extreme: [number, number, number] };
+  readonly foreground: [number, number, number];
+  readonly contrastMean: number;
+  readonly contrastWorst: number;
+}
+
+/**
+ * What the terminal ANSWERED when the shell asked for its background colour
+ * (OSC 11), read back from the file the shell wrote, not from the DOM.
+ */
+export interface Osc11Reply {
+  readonly theme: string;
+  /** The reply as `printf %q` escaped it, verbatim from the file. */
+  readonly raw: string;
+  /** The reply's RGB scaled to 8 bits, the way xterm's own `parseColor` does. */
+  readonly rgb: [number, number, number];
+  /** Claude Code's `auto` rule over that RGB: what it would pick in this pane. */
+  readonly claudeCodeTheme: "light" | "dark";
+}
+
+/**
+ * An SGR 7 (reverse video) sample as PAINTED: the box takes the palette
+ * foreground and the glyphs inside it take the theme background, which is
+ * alpha 0 in the token and made opaque by the WebGL renderer's `color.opaque`
+ * under `allowTransparency`. So the glyph colour a user sees is the token's
+ * RGB, and the legibility of reverse video is a consequence of that RGB.
+ */
+export interface ReverseVideoSample {
+  readonly measured: true;
+  readonly theme: string;
+  readonly foreground: [number, number, number];
+  /** The solid box found in the capture, in clip-relative px. */
+  readonly box: { readonly left: number; readonly top: number; readonly width: number; readonly height: number };
+  readonly boxMean: [number, number, number];
+  /** The pixel inside the box furthest from the box colour: a glyph stroke. */
+  readonly glyphExtreme: [number, number, number];
+  /** Pixels inside the box that are clearly not the box colour. 0 means no visible glyphs. */
+  readonly glyphPixels: number;
+  /** Contrast of that stroke against the box. */
+  readonly contrast: number;
+}
+
+/**
+ * The DOM renderer cannot be measured this way: it paints every colour,
+ * reverse video included, through a `<style>` it injects, and the renderer's
+ * CSP (`style-src 'self'`) refuses it, so the sample shows no box at all
+ * (measured under xvfb, where WebGL2 is unavailable, 2026-09-04). A WebGL run
+ * that finds no box is a defect; a DOM run is recorded as unmeasured.
+ */
+export interface ReverseVideoUnmeasured {
+  readonly measured: false;
+  readonly theme: string;
+  readonly renderer: "dom";
+  readonly reason: string;
+}
+
+export type ReverseVideoResult = ReverseVideoSample | ReverseVideoUnmeasured;
+
+export async function measureGutter(page: Page, width: number, height: number): Promise<GutterMeasurement> {
+  await page.setViewportSize({ width, height });
+  // The grid refits on resize through a ResizeObserver; give it two frames.
+  await page.evaluate(
+    () => new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    }),
+  );
+  const measured = await page.evaluate(() => {
+    const sidebar = document.querySelector('[data-vex-area="studio-sidebar"]');
+    const center = document.querySelector('[data-vex-area="studio-center"]');
+    const pane = document.querySelector("[data-vex-workspace-card] > div");
+    const grid = document.querySelector(".vex-terminal-surface--active .xterm-screen");
+    if (!sidebar || !center || !pane || !grid) return null;
+    return {
+      sidebarRight: sidebar.getBoundingClientRect().right,
+      centerLeft: center.getBoundingClientRect().left,
+      paneLeft: pane.getBoundingClientRect().left,
+      gridLeft: grid.getBoundingClientRect().left,
+    };
+  });
+  expect(measured, `no measurable studio layout at ${String(width)}px`).not.toBeNull();
+  if (measured === null) throw new Error("unreachable");
+  return {
+    viewportWidth: width,
+    ...measured,
+    gutter: measured.gridLeft - measured.sidebarRight,
+    columnPadding: measured.paneLeft - measured.centerLeft,
+    paneInset: measured.gridLeft - measured.paneLeft,
+  };
+}
+
+export async function readPaneFacts(page: Page): Promise<PaneFacts> {
+  return page.evaluate(() => {
+    const surface = document.querySelector<HTMLElement>(".vex-terminal-surface--active");
+    const pane = document.querySelector<HTMLElement>("[data-vex-workspace-card] > div");
+    const host = surface?.parentElement?.parentElement ?? null;
+    const probe = document.createElement("span");
+    probe.style.color = "var(--vex-alias-term-foreground)";
+    document.body.appendChild(probe);
+    const foreground = getComputedStyle(probe).color;
+    probe.remove();
+    const paneStyle = pane === null ? null : getComputedStyle(pane);
+    const gl = document.createElement("canvas").getContext("webgl2");
+    return {
+      renderer: surface?.querySelector("canvas") ? "webgl" : "dom",
+      webgl2Available: gl !== null,
+      paneBackdropFilter: paneStyle?.backdropFilter ?? "",
+      paneBackground: paneStyle?.backgroundColor ?? "",
+      hostBackground: host === null ? "" : getComputedStyle(host).backgroundColor,
+      foreground,
+    } as const;
+  });
+}
+
+/** Count animation frames on the page until `stop` is called. */
+export async function startFrameCounter(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const w = window as unknown as { __vexFrames?: { count: number; running: boolean; start: number } };
+    const state = { count: 0, running: true, start: performance.now() };
+    w.__vexFrames = state;
+    const tick = (): void => {
+      if (!state.running) return;
+      state.count += 1;
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  });
+}
+
+export async function readFrameCounter(page: Page): Promise<{ frames: number; ms: number }> {
+  return page.evaluate(() => {
+    const w = window as unknown as { __vexFrames?: { count: number; running: boolean; start: number } };
+    const state = w.__vexFrames;
+    if (state === undefined) return { frames: 0, ms: 0 };
+    return { frames: state.count, ms: performance.now() - state.start };
+  });
+}
+
+export async function stopFrameCounter(page: Page): Promise<{ frames: number; ms: number }> {
+  return page.evaluate(() => {
+    const w = window as unknown as { __vexFrames?: { count: number; running: boolean; start: number } };
+    const state = w.__vexFrames;
+    if (state === undefined) return { frames: 0, ms: 0 };
+    state.running = false;
+    return { frames: state.count, ms: performance.now() - state.start };
+  });
+}
+
+export async function measureThroughput(page: Page): Promise<Throughput> {
+  await focusTerminalGrid(page);
+  const marker = `glassdone${Date.now().toString(36)}`;
+  // The HEADER's location line, not the whole center: under the DOM renderer
+  // `.xterm-rows` carries the typed command, marker included, so a poll on
+  // the center's text matched before Enter had even landed (measured:
+  // burstMs 17, burstFrames 0).
+  const location = page
+    .locator('[data-vex-area="studio-center"]')
+    .locator("p:has([data-vex-terminal-shell])");
+
+  await page.keyboard.type(
+    `seq 1 ${String(BURST_LINES)}; mkdir -p ${marker}; cd ${marker}`,
+  );
+  await startFrameCounter(page);
+  const t0 = Date.now();
+  await page.keyboard.press("Enter");
+  await expect
+    .poll(async () => await location.textContent(), { timeout: BURST_TIMEOUT_MS })
+    .toContain(marker);
+  const burstMs = Date.now() - t0;
+  const burst = await readFrameCounter(page);
+
+  // The burst's tail is still being parsed and painted when the cwd lands
+  // (the shell moved on the moment `seq` finished writing); count the frames
+  // of the second after it as well, so a renderer that stalls on the tail
+  // shows up as a low settle count.
+  await page.waitForTimeout(1_000);
+  const settled = await stopFrameCounter(page);
+
+  // Wheel the scrollback from the bottom upwards and count the frames painted.
+  // xterm 6 scrolls through a ScrollableElement (VS Code's), so the viewport's
+  // own scrollTop never moves; the vertical slider's offset is what does.
+  const grid = page.locator(".vex-terminal-surface--active .xterm-screen");
+  const box = await grid.boundingBox();
+  expect(box, "no terminal grid to wheel").not.toBeNull();
+  if (box === null) throw new Error("unreachable");
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  const sliderTop = async (): Promise<number> =>
+    page.evaluate(() => {
+      const slider = document.querySelector<HTMLElement>(
+        ".vex-terminal-surface--active .xterm-scrollable-element > .scrollbar.vertical > .slider",
+      );
+      return slider === null ? Number.NaN : Number.parseFloat(slider.style.top || "0");
+    });
+  const scrollBefore = await sliderTop();
+  await startFrameCounter(page);
+  const w0 = Date.now();
+  for (let tick = 0; tick < WHEEL_TICKS; tick += 1) {
+    await page.mouse.wheel(0, WHEEL_TICK_DELTA);
+    await page.waitForTimeout(WHEEL_TICK_GAP_MS);
+  }
+  const wheelMs = Date.now() - w0;
+  const wheel = await stopFrameCounter(page);
+  const scrollAfter = await sliderTop();
+
+  return {
+    burstLines: BURST_LINES,
+    burstMs,
+    burstFrames: burst.frames,
+    burstFps: Math.round((burst.frames / burst.ms) * 1000),
+    settleFrames: settled.frames - burst.frames,
+    wheelTicks: WHEEL_TICKS,
+    wheelMs,
+    wheelFrames: wheel.frames,
+    wheelFps: Math.round((wheel.frames / wheel.ms) * 1000),
+    scrolledPx: Math.round(scrollBefore - scrollAfter),
+  };
+}
+
+export const TRACK_SELECTOR =
+  ".vex-terminal-surface--active .xterm-scrollable-element > .scrollbar.vertical";
+
+export async function trackClasses(page: Page): Promise<string> {
+  return page.evaluate(
+    (selector) => document.querySelector(selector)?.className ?? "",
+    TRACK_SELECTOR,
+  );
+}
+
+/**
+ * Read the bar with the pointer still over the grid (the wheel just ran, so
+ * VS Code's state machine holds it `visible`), then prove the auto-hide: the
+ * pointer leaves, the 500ms idle hide runs and the track turns `invisible`;
+ * the pointer returns and it is `visible` again. Reduced motion is emulated
+ * last and undone before returning, so the capture that follows is unaffected.
+ */
+export async function measureScrollbar(page: Page, gridBox: { x: number; y: number; width: number; height: number }): Promise<ScrollbarFacts> {
+  const geometry = await page.evaluate((selector) => {
+    const viewport = document.querySelector<HTMLElement>(".vex-terminal-surface--active .xterm-viewport");
+    const track = document.querySelector<HTMLElement>(selector);
+    const slider = track?.querySelector<HTMLElement>(".slider") ?? null;
+    const probe = document.createElement("span");
+    probe.style.backgroundColor = "var(--vex-scrollbar-thumb)";
+    (track ?? document.body).appendChild(probe);
+    const tokenBackground = getComputedStyle(probe).backgroundColor;
+    probe.remove();
+    const sliderStyle = slider === null ? null : getComputedStyle(slider);
+    const sheets = [...document.querySelectorAll<HTMLStyleElement>(".vex-terminal-surface--active style")];
+    const injectedSheets = {
+      count: sheets.length,
+      applied: sheets.filter((sheet) => (sheet.sheet?.cssRules.length ?? 0) > 0).length,
+    };
+    return {
+      injectedSheets,
+      viewportGutter: viewport === null ? Number.NaN : viewport.offsetWidth - viewport.clientWidth,
+      trackWidth: track?.offsetWidth ?? Number.NaN,
+      sliderWidth: slider?.offsetWidth ?? Number.NaN,
+      sliderInset: sliderStyle === null ? Number.NaN : Number.parseFloat(sliderStyle.paddingLeft),
+      sliderRadius: sliderStyle?.borderRadius ?? "",
+      sliderBackground: sliderStyle?.backgroundColor ?? "",
+      tokenBackground,
+      classesAfterWheel: track?.className ?? "",
+    };
+  }, TRACK_SELECTOR);
+
+  // Leave the terminal: the hide is scheduled 500ms after the pointer goes
+  // and the fade takes 800ms; the class flips at the schedule, not the fade.
+  // `invisible` contains `visible`, so the states are matched on word
+  // boundaries, never by substring.
+  await page.mouse.move(2, 2);
+  await expect.poll(() => trackClasses(page), { timeout: 5_000 }).toMatch(/\binvisible\b/);
+  const classesAfterLeave = await trackClasses(page);
+
+  await page.mouse.move(gridBox.x + gridBox.width / 2, gridBox.y + gridBox.height / 2);
+  await expect
+    .poll(async () => /\bvisible\b/.test(await trackClasses(page)), { timeout: 5_000 })
+    .toBe(true);
+  const classesOnHover = await trackClasses(page);
+
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  const reducedMotionTransition = await page.evaluate(
+    (selector) => {
+      const track = document.querySelector<HTMLElement>(selector);
+      return track === null ? "" : getComputedStyle(track).transitionDuration;
+    },
+    TRACK_SELECTOR,
+  );
+  await page.emulateMedia({ reducedMotion: null });
+
+  return { ...geometry, classesAfterLeave, classesOnHover, reducedMotionTransition };
+}
+
+/** A computed `transition-duration` ("0.01ms", "1e-05s", "0.8s") in milliseconds. */
+export function durationMs(value: string): number {
+  const match = /^([0-9.e+-]+)(ms|s)$/.exec(value.trim());
+  if (match === null) throw new Error(`not a duration: ${value}`);
+  const amount = Number(match[1]);
+  return match[2] === "s" ? amount * 1000 : amount;
+}
+
+export function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const channel = (value: number): number => {
+    const s = value / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+export function contrastRatio(a: [number, number, number], b: [number, number, number]): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return Math.round(((hi + 0.05) / (lo + 0.05)) * 100) / 100;
+}
+
+export function parseRgb(css: string): [number, number, number] {
+  const match = /rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/.exec(css);
+  if (match === null) throw new Error(`not an rgb() colour: ${css}`);
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/**
+ * Contrast of the terminal foreground over the pane as PAINTED: the mean of
+ * the blank region's pixels and the extreme one (brightest on a dark theme,
+ * darkest on a light one), since the wallpaper under glass is not uniform.
+ */
+export async function measureContrast(
+  page: Page,
+  theme: string,
+  foregroundCss: string,
+  capture: CaptureClip,
+): Promise<Contrast> {
+  const grid = page.locator(".vex-terminal-surface--active .xterm-screen");
+  const box = await grid.boundingBox();
+  expect(box).not.toBeNull();
+  if (box === null) throw new Error("unreachable");
+  // The lower half of the grid is blank right after a `clear`.
+  const clip = {
+    x: Math.round(box.x + box.width * 0.1),
+    y: Math.round(box.y + box.height * 0.55),
+    width: Math.round(box.width * 0.8),
+    height: Math.round(box.height * 0.4),
+  };
+  const png = await capture(clip);
+  const { data, info } = await sharp(png).raw().toBuffer({ resolveWithObject: true });
+  const foreground = parseRgb(foregroundCss);
+  const fgLum = relativeLuminance(foreground);
+  let sumR = 0;
+  let sumG = 0;
+  let sumB = 0;
+  let extreme: [number, number, number] = [0, 0, 0];
+  let extremeLum = fgLum > 0.5 ? -1 : 2;
+  const pixels = info.width * info.height;
+  for (let i = 0; i < pixels; i += 1) {
+    const px: [number, number, number] = [
+      data[i * info.channels] ?? 0,
+      data[i * info.channels + 1] ?? 0,
+      data[i * info.channels + 2] ?? 0,
+    ];
+    sumR += px[0];
+    sumG += px[1];
+    sumB += px[2];
+    const lum = relativeLuminance(px);
+    // Worst case is the pixel closest in luminance to the foreground.
+    if (fgLum > 0.5 ? lum > extremeLum : lum < extremeLum) {
+      extremeLum = lum;
+      extreme = px;
+    }
+  }
+  const mean: [number, number, number] = [
+    Math.round(sumR / pixels),
+    Math.round(sumG / pixels),
+    Math.round(sumB / pixels),
+  ];
+  return {
+    theme,
+    sample: { mean, extreme },
+    foreground,
+    contrastMean: contrastRatio(foreground, mean),
+    contrastWorst: contrastRatio(foreground, extreme),
+  };
+}
+
+/** How long the shell gets to write the OSC 11 reply file before the probe counts as unanswered. */
+const OSC11_REPLY_TIMEOUT_MS = 10_000;
+
+/**
+ * Ask the terminal for its background colour THE WAY A PROGRAM DOES.
+ *
+ * The shell writes the OSC 11 query, reads the answer xterm types back into
+ * the pty (up to the `ESC \` terminator) and writes it, `printf %q`-escaped so
+ * it is both legible on screen and parseable, to a file the test then reads.
+ * The file is the evidence: it proves the bytes travelled renderer -> bridge
+ * -> pty -> shell, which is exactly the path Claude Code's theme detection
+ * takes, and it is readable under the WebGL renderer where the rows are not.
+ */
+export async function probeOsc11(page: Page, theme: string, dir: string): Promise<Osc11Reply> {
+  const file = path.join(dir, `osc11-${theme}.txt`);
+  fs.rmSync(file, { force: true });
+  await focusTerminalGrid(page);
+  await page.keyboard.type(
+    `printf '\\e]11;?\\a'; IFS= read -rs -d '\\' -t 3 vex_osc11; printf '%q\\n' "$vex_osc11" | tee '${file}'`,
+  );
+  await page.keyboard.press("Enter");
+  await expect
+    .poll(() => (fs.existsSync(file) ? fs.readFileSync(file, "utf8").trim() : ""), {
+      timeout: OSC11_REPLY_TIMEOUT_MS,
+    })
+    .not.toBe("");
+  const raw = fs.readFileSync(file, "utf8").trim();
+  // xterm answers `rgb:RRRR/GGGG/BBBB`; each channel is scaled by its own
+  // digit count, as xterm's `parseColor` scales an incoming one.
+  const match = /rgb:([0-9a-f]+)\/([0-9a-f]+)\/([0-9a-f]+)/i.exec(raw);
+  if (match === null) throw new Error(`no rgb: in the OSC 11 reply for ${theme}: ${raw}`);
+  const channel = (hex: string | undefined): number => {
+    const digits = hex ?? "";
+    return Math.round((parseInt(digits, 16) / (16 ** digits.length - 1)) * 255);
+  };
+  const rgb: [number, number, number] = [channel(match[1]), channel(match[2]), channel(match[3])];
+  // Claude Code 2.1.260's detector, verbatim: linear channel weights over 0..1.
+  const weighted = (0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]) / 255;
+  return { theme, raw, rgb, claudeCodeTheme: weighted > 0.5 ? "light" : "dark" };
+}
+
+/** How far (Euclidean, 0..441) a pixel may sit from a colour and still count as it. */
+export const SAME_COLOUR_DISTANCE = 40;
+/** A horizontal run of foreground-coloured pixels this long is a reverse-video box, never a glyph stroke. */
+export const BOX_RUN_MIN_PX = 30;
+
+export function colourDistance(a: [number, number, number], b: [number, number, number]): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+/**
+ * Print an SGR 7 sample and measure it as painted. The box is found by
+ * colour: reverse video paints its cells solid in the palette foreground, so
+ * the leading and trailing blank cells are the only place in the grid where
+ * foreground-coloured pixels run unbroken for whole cells. Rows carrying such
+ * a run are the box; the glyphs are whatever inside it is not the box colour.
+ */
+export async function measureReverseVideo(
+  page: Page,
+  theme: string,
+  facts: PaneFacts,
+  capture: CaptureClip,
+): Promise<ReverseVideoResult> {
+  const foregroundCss = facts.foreground;
+  await focusTerminalGrid(page);
+  await page.keyboard.type("printf '\\e[7m      REVERSE VIDEO      \\e[0m plain\\n'");
+  await page.keyboard.press("Enter");
+  await page.waitForTimeout(600);
+  const grid = page.locator(".vex-terminal-surface--active .xterm-screen");
+  const gridBox = await grid.boundingBox();
+  expect(gridBox, "no terminal grid to sample").not.toBeNull();
+  if (gridBox === null) throw new Error("unreachable");
+  // The sample sits in the first rows after a `clear`; the upper half is enough.
+  const clip = {
+    x: Math.round(gridBox.x),
+    y: Math.round(gridBox.y),
+    width: Math.round(gridBox.width),
+    height: Math.round(gridBox.height * 0.5),
+  };
+  const png = await capture(clip);
+  const { data, info } = await sharp(png).raw().toBuffer({ resolveWithObject: true });
+  const foreground = parseRgb(foregroundCss);
+  const at = (x: number, y: number): [number, number, number] => {
+    const i = (y * info.width + x) * info.channels;
+    return [data[i] ?? 0, data[i + 1] ?? 0, data[i + 2] ?? 0];
+  };
+  const isForeground = (x: number, y: number): boolean =>
+    colourDistance(at(x, y), foreground) <= SAME_COLOUR_DISTANCE;
+
+  // Rows that carry a box run, and the run extents across them.
+  let top = -1;
+  let bottom = -1;
+  let left = info.width;
+  let right = -1;
+  for (let y = 0; y < info.height; y += 1) {
+    let run = 0;
+    let rowHasBox = false;
+    for (let x = 0; x <= info.width; x += 1) {
+      if (x < info.width && isForeground(x, y)) {
+        run += 1;
+        continue;
+      }
+      if (run >= BOX_RUN_MIN_PX) {
+        rowHasBox = true;
+        left = Math.min(left, x - run);
+        right = Math.max(right, x - 1);
+      }
+      run = 0;
+    }
+    if (rowHasBox) {
+      if (top === -1) top = y;
+      bottom = y;
+    }
+  }
+  if (top === -1 && facts.renderer === "dom") {
+    return {
+      measured: false,
+      theme,
+      renderer: "dom",
+      reason: "the DOM renderer's injected colour sheet is refused by the renderer CSP; no box is painted",
+    };
+  }
+  expect(top, `${theme}: no reverse-video box found in the capture`).toBeGreaterThanOrEqual(0);
+
+  let boxCount = 0;
+  const boxSum = [0, 0, 0];
+  let glyphPixels = 0;
+  let glyphExtreme: [number, number, number] = foreground;
+  let glyphDistance = -1;
+  for (let y = top; y <= bottom; y += 1) {
+    for (let x = left; x <= right; x += 1) {
+      const px = at(x, y);
+      const distance = colourDistance(px, foreground);
+      if (distance <= SAME_COLOUR_DISTANCE) {
+        boxCount += 1;
+        boxSum[0] = (boxSum[0] ?? 0) + px[0];
+        boxSum[1] = (boxSum[1] ?? 0) + px[1];
+        boxSum[2] = (boxSum[2] ?? 0) + px[2];
+        continue;
+      }
+      glyphPixels += 1;
+      if (distance > glyphDistance) {
+        glyphDistance = distance;
+        glyphExtreme = px;
+      }
+    }
+  }
+  const boxMean: [number, number, number] = [
+    Math.round((boxSum[0] ?? 0) / Math.max(1, boxCount)),
+    Math.round((boxSum[1] ?? 0) / Math.max(1, boxCount)),
+    Math.round((boxSum[2] ?? 0) / Math.max(1, boxCount)),
+  ];
+  return {
+    measured: true,
+    theme,
+    foreground,
+    box: { left, top, width: right - left + 1, height: bottom - top + 1 },
+    boxMean,
+    glyphExtreme,
+    glyphPixels,
+    contrast: contrastRatio(boxMean, glyphExtreme),
+  };
+}

--- a/vex-app/e2e/fixtures/terminal-glass-probes.ts
+++ b/vex-app/e2e/fixtures/terminal-glass-probes.ts
@@ -132,6 +132,7 @@ export interface Contrast {
  * (OSC 11), read back from the file the shell wrote, not from the DOM.
  */
 export interface Osc11Reply {
+  readonly measured: true;
   readonly theme: string;
   /** The reply as `printf %q` escaped it, verbatim from the file. */
   readonly raw: string;
@@ -139,6 +140,42 @@ export interface Osc11Reply {
   readonly rgb: [number, number, number];
   /** Claude Code's `auto` rule over that RGB: what it would pick in this pane. */
   readonly claudeCodeTheme: "light" | "dark";
+}
+
+/**
+ * A probe that types a POSIX shell line (`printf`, `read -d`, `%q`, `tee`)
+ * cannot run where the Studio launches `ComSpec`: cmd.exe has none of those,
+ * and a PowerShell reader would have to take the reply back through ConPTY's
+ * input translation, which is a measurement of its own, not a one-liner. So
+ * on Windows the probe records that it did not run rather than typing bash
+ * into cmd.exe and failing on the echo. The contract the pty probe proves
+ * elsewhere (the reply bytes classify by theme) is proven without a pty by
+ * `terminal-theme-resolution.test.ts`, which computes the bytes xterm sends
+ * from the resolved theme.
+ */
+export interface ProbeUnmeasured {
+  readonly measured: false;
+  readonly theme: string;
+  readonly reason: "posix_probe";
+  readonly platform: NodeJS.Platform;
+  readonly detail: string;
+}
+
+export type Osc11Result = Osc11Reply | ProbeUnmeasured;
+
+/** Whether the shell the Studio launches on this platform can run the POSIX probes. */
+export function posixProbesAvailable(): boolean {
+  return process.platform !== "win32";
+}
+
+function unmeasuredPosixProbe(theme: string, probe: string): ProbeUnmeasured {
+  return {
+    measured: false,
+    theme,
+    reason: "posix_probe",
+    platform: process.platform,
+    detail: `${probe} types a POSIX shell line; the Studio launches ComSpec on ${process.platform}`,
+  };
 }
 
 /**
@@ -173,11 +210,12 @@ export interface ReverseVideoSample {
 export interface ReverseVideoUnmeasured {
   readonly measured: false;
   readonly theme: string;
+  readonly reason: "dom_renderer";
   readonly renderer: "dom";
-  readonly reason: string;
+  readonly detail: string;
 }
 
-export type ReverseVideoResult = ReverseVideoSample | ReverseVideoUnmeasured;
+export type ReverseVideoResult = ReverseVideoSample | ReverseVideoUnmeasured | ProbeUnmeasured;
 
 export async function measureGutter(page: Page, width: number, height: number): Promise<GutterMeasurement> {
   await page.setViewportSize({ width, height });
@@ -515,7 +553,8 @@ const OSC11_REPLY_TIMEOUT_MS = 10_000;
  * -> pty -> shell, which is exactly the path Claude Code's theme detection
  * takes, and it is readable under the WebGL renderer where the rows are not.
  */
-export async function probeOsc11(page: Page, theme: string, dir: string): Promise<Osc11Reply> {
+export async function probeOsc11(page: Page, theme: string, dir: string): Promise<Osc11Result> {
+  if (!posixProbesAvailable()) return unmeasuredPosixProbe(theme, "probeOsc11");
   const file = path.join(dir, `osc11-${theme}.txt`);
   fs.rmSync(file, { force: true });
   await focusTerminalGrid(page);
@@ -540,7 +579,7 @@ export async function probeOsc11(page: Page, theme: string, dir: string): Promis
   const rgb: [number, number, number] = [channel(match[1]), channel(match[2]), channel(match[3])];
   // Claude Code 2.1.260's detector, verbatim: linear channel weights over 0..1.
   const weighted = (0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]) / 255;
-  return { theme, raw, rgb, claudeCodeTheme: weighted > 0.5 ? "light" : "dark" };
+  return { measured: true, theme, raw, rgb, claudeCodeTheme: weighted > 0.5 ? "light" : "dark" };
 }
 
 /** How far (Euclidean, 0..441) a pixel may sit from a colour and still count as it. */
@@ -565,6 +604,7 @@ export async function measureReverseVideo(
   facts: PaneFacts,
   capture: CaptureClip,
 ): Promise<ReverseVideoResult> {
+  if (!posixProbesAvailable()) return unmeasuredPosixProbe(theme, "measureReverseVideo");
   const foregroundCss = facts.foreground;
   await focusTerminalGrid(page);
   await page.keyboard.type("printf '\\e[7m      REVERSE VIDEO      \\e[0m plain\\n'");
@@ -620,8 +660,9 @@ export async function measureReverseVideo(
     return {
       measured: false,
       theme,
+      reason: "dom_renderer",
       renderer: "dom",
-      reason: "the DOM renderer's injected colour sheet is refused by the renderer CSP; no box is painted",
+      detail: "the DOM renderer's injected colour sheet is refused by the renderer CSP; no box is painted",
     };
   }
   expect(top, `${theme}: no reverse-video box found in the capture`).toBeGreaterThanOrEqual(0);

--- a/vex-app/e2e/studio-terminal-glass.spec.ts
+++ b/vex-app/e2e/studio-terminal-glass.spec.ts
@@ -22,6 +22,13 @@
  *    pass per frame; whether that is visible is measured as frames per second
  *    while a 30 000-line burst lands and while the scrollback is wheeled, and
  *    written next to the gutter numbers for the same before/after comparison.
+ *  - THE ANSWER TO OSC 11. xterm tells a program that asks for the background
+ *    colour whatever `theme.background` says, alpha dropped, and Claude Code
+ *    (in `auto`), bat, delta and nvim pick light or dark from that answer. The
+ *    shell asks, the reply travels the real pty round trip, and the file the
+ *    shell writes is asserted to classify light in celeris and dark in
+ *    chronos. A reverse-video sample is measured alongside, since its glyphs
+ *    take the same token's RGB.
  *
  * ## The completion signal for the burst
  *
@@ -46,7 +53,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { Page, TestInfo } from "@playwright/test";
-import sharp from "sharp";
 import {
   test,
   expect,
@@ -59,96 +65,23 @@ import {
   tourTo,
   TOUR_SKIP_REASON,
 } from "./fixtures/studio-shell.js";
-
-/** Lines the burst writes. Thirty times the 1000-row scrollback, so the buffer wraps. */
-const BURST_LINES = 30_000;
-/** How long the burst may take on a cold, loaded box before the run counts as wedged. */
-const BURST_TIMEOUT_MS = 90_000;
-/** Wheel ticks and their spacing while measuring scroll frames. */
-const WHEEL_TICKS = 60;
-const WHEEL_TICK_DELTA = -120;
-const WHEEL_TICK_GAP_MS = 16;
+import {
+  measureContrast,
+  measureGutter,
+  measureReverseVideo,
+  measureScrollbar,
+  measureThroughput,
+  probeOsc11,
+  readPaneFacts,
+  durationMs,
+  type CaptureClip,
+  type Contrast,
+  type GutterMeasurement,
+  type Osc11Reply,
+  type ReverseVideoResult,
+} from "./fixtures/terminal-glass-probes.js";
 
 const OUT_DIR = process.env["VEX_GLASS_OUT"] ?? "";
-
-interface GutterMeasurement {
-  readonly viewportWidth: number;
-  readonly sidebarRight: number;
-  readonly centerLeft: number;
-  readonly paneLeft: number;
-  readonly gridLeft: number;
-  /** Sidebar right edge to the first terminal column, in CSS px. */
-  readonly gutter: number;
-  /** Column edge to pane edge (the workspace padding). */
-  readonly columnPadding: number;
-  /** Pane edge to the first column (the pane's own inset). */
-  readonly paneInset: number;
-}
-
-interface PaneFacts {
-  readonly renderer: "webgl" | "dom";
-  /** Whether this environment can hand out a WebGL2 context at all. */
-  readonly webgl2Available: boolean;
-  readonly paneBackdropFilter: string;
-  readonly paneBackground: string;
-  readonly hostBackground: string;
-  readonly foreground: string;
-}
-
-interface Throughput {
-  readonly burstLines: number;
-  readonly burstMs: number;
-  readonly burstFrames: number;
-  readonly burstFps: number;
-  /** Frames painted in the second after the cwd marker landed. */
-  readonly settleFrames: number;
-  readonly wheelTicks: number;
-  readonly wheelMs: number;
-  readonly wheelFrames: number;
-  readonly wheelFps: number;
-  readonly scrolledPx: number;
-}
-
-/**
- * The terminal's scrollbar as PAINTED. xterm 6 mounts VS Code's
- * ScrollableElement, so the bar is a real `.slider` element sized inline and
- * coloured by scrollbars.css; none of that is readable in jsdom.
- */
-interface ScrollbarFacts {
-  /** The vestigial `.xterm-viewport`'s own native gutter, in CSS px. 0 means gone. */
-  readonly viewportGutter: number;
-  readonly trackWidth: number;
-  readonly sliderWidth: number;
-  /** The transparent inset each side of the thumb (the slider's padding). */
-  readonly sliderInset: number;
-  readonly sliderRadius: string;
-  readonly sliderBackground: string;
-  /** `--vex-scrollbar-thumb` resolved in the track's own scope, for comparison. */
-  readonly tokenBackground: string;
-  /**
-   * xterm's injected `<style>` elements inside the terminal, and how many of
-   * them the document actually applied. The renderer's CSP (`style-src
-   * 'self'`) refuses inline sheets, which is why the slider's colour cannot
-   * come from the palette bridge and lives in scrollbars.css instead.
-   */
-  readonly injectedSheets: { readonly count: number; readonly applied: number };
-  /** The track's class list right after the wheel, with the pointer still over the grid. */
-  readonly classesAfterWheel: string;
-  /** The track's class list once the pointer left and the idle hide ran. */
-  readonly classesAfterLeave: string;
-  /** The track's class list once the pointer came back over the grid. */
-  readonly classesOnHover: string;
-  /** The show/fade transition duration under `prefers-reduced-motion: reduce`. */
-  readonly reducedMotionTransition: string;
-}
-
-interface Contrast {
-  readonly theme: string;
-  readonly sample: { readonly mean: [number, number, number]; readonly extreme: [number, number, number] };
-  readonly foreground: [number, number, number];
-  readonly contrastMean: number;
-  readonly contrastWorst: number;
-}
 
 /** Hide the tour navigator (QA scaffolding, never a shipped surface) for a capture. */
 async function withTourHidden<T>(page: Page, run: () => Promise<T>): Promise<T> {
@@ -164,328 +97,6 @@ async function withTourHidden<T>(page: Page, run: () => Promise<T>): Promise<T> 
       if (tour instanceof HTMLElement) tour.style.visibility = "";
     });
   }
-}
-
-async function measureGutter(page: Page, width: number, height: number): Promise<GutterMeasurement> {
-  await page.setViewportSize({ width, height });
-  // The grid refits on resize through a ResizeObserver; give it two frames.
-  await page.evaluate(
-    () => new Promise<void>((resolve) => {
-      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-    }),
-  );
-  const measured = await page.evaluate(() => {
-    const sidebar = document.querySelector('[data-vex-area="studio-sidebar"]');
-    const center = document.querySelector('[data-vex-area="studio-center"]');
-    const pane = document.querySelector("[data-vex-workspace-card] > div");
-    const grid = document.querySelector(".vex-terminal-surface--active .xterm-screen");
-    if (!sidebar || !center || !pane || !grid) return null;
-    return {
-      sidebarRight: sidebar.getBoundingClientRect().right,
-      centerLeft: center.getBoundingClientRect().left,
-      paneLeft: pane.getBoundingClientRect().left,
-      gridLeft: grid.getBoundingClientRect().left,
-    };
-  });
-  expect(measured, `no measurable studio layout at ${String(width)}px`).not.toBeNull();
-  if (measured === null) throw new Error("unreachable");
-  return {
-    viewportWidth: width,
-    ...measured,
-    gutter: measured.gridLeft - measured.sidebarRight,
-    columnPadding: measured.paneLeft - measured.centerLeft,
-    paneInset: measured.gridLeft - measured.paneLeft,
-  };
-}
-
-async function readPaneFacts(page: Page): Promise<PaneFacts> {
-  return page.evaluate(() => {
-    const surface = document.querySelector<HTMLElement>(".vex-terminal-surface--active");
-    const pane = document.querySelector<HTMLElement>("[data-vex-workspace-card] > div");
-    const host = surface?.parentElement?.parentElement ?? null;
-    const probe = document.createElement("span");
-    probe.style.color = "var(--vex-alias-term-foreground)";
-    document.body.appendChild(probe);
-    const foreground = getComputedStyle(probe).color;
-    probe.remove();
-    const paneStyle = pane === null ? null : getComputedStyle(pane);
-    const gl = document.createElement("canvas").getContext("webgl2");
-    return {
-      renderer: surface?.querySelector("canvas") ? "webgl" : "dom",
-      webgl2Available: gl !== null,
-      paneBackdropFilter: paneStyle?.backdropFilter ?? "",
-      paneBackground: paneStyle?.backgroundColor ?? "",
-      hostBackground: host === null ? "" : getComputedStyle(host).backgroundColor,
-      foreground,
-    } as const;
-  });
-}
-
-/** Count animation frames on the page until `stop` is called. */
-async function startFrameCounter(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const w = window as unknown as { __vexFrames?: { count: number; running: boolean; start: number } };
-    const state = { count: 0, running: true, start: performance.now() };
-    w.__vexFrames = state;
-    const tick = (): void => {
-      if (!state.running) return;
-      state.count += 1;
-      requestAnimationFrame(tick);
-    };
-    requestAnimationFrame(tick);
-  });
-}
-
-async function readFrameCounter(page: Page): Promise<{ frames: number; ms: number }> {
-  return page.evaluate(() => {
-    const w = window as unknown as { __vexFrames?: { count: number; running: boolean; start: number } };
-    const state = w.__vexFrames;
-    if (state === undefined) return { frames: 0, ms: 0 };
-    return { frames: state.count, ms: performance.now() - state.start };
-  });
-}
-
-async function stopFrameCounter(page: Page): Promise<{ frames: number; ms: number }> {
-  return page.evaluate(() => {
-    const w = window as unknown as { __vexFrames?: { count: number; running: boolean; start: number } };
-    const state = w.__vexFrames;
-    if (state === undefined) return { frames: 0, ms: 0 };
-    state.running = false;
-    return { frames: state.count, ms: performance.now() - state.start };
-  });
-}
-
-async function measureThroughput(page: Page): Promise<Throughput> {
-  await focusTerminalGrid(page);
-  const marker = `glassdone${Date.now().toString(36)}`;
-  // The HEADER's location line, not the whole center: under the DOM renderer
-  // `.xterm-rows` carries the typed command, marker included, so a poll on
-  // the center's text matched before Enter had even landed (measured:
-  // burstMs 17, burstFrames 0).
-  const location = page
-    .locator('[data-vex-area="studio-center"]')
-    .locator("p:has([data-vex-terminal-shell])");
-
-  await page.keyboard.type(
-    `seq 1 ${String(BURST_LINES)}; mkdir -p ${marker}; cd ${marker}`,
-  );
-  await startFrameCounter(page);
-  const t0 = Date.now();
-  await page.keyboard.press("Enter");
-  await expect
-    .poll(async () => await location.textContent(), { timeout: BURST_TIMEOUT_MS })
-    .toContain(marker);
-  const burstMs = Date.now() - t0;
-  const burst = await readFrameCounter(page);
-
-  // The burst's tail is still being parsed and painted when the cwd lands
-  // (the shell moved on the moment `seq` finished writing); count the frames
-  // of the second after it as well, so a renderer that stalls on the tail
-  // shows up as a low settle count.
-  await page.waitForTimeout(1_000);
-  const settled = await stopFrameCounter(page);
-
-  // Wheel the scrollback from the bottom upwards and count the frames painted.
-  // xterm 6 scrolls through a ScrollableElement (VS Code's), so the viewport's
-  // own scrollTop never moves; the vertical slider's offset is what does.
-  const grid = page.locator(".vex-terminal-surface--active .xterm-screen");
-  const box = await grid.boundingBox();
-  expect(box, "no terminal grid to wheel").not.toBeNull();
-  if (box === null) throw new Error("unreachable");
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-  const sliderTop = async (): Promise<number> =>
-    page.evaluate(() => {
-      const slider = document.querySelector<HTMLElement>(
-        ".vex-terminal-surface--active .xterm-scrollable-element > .scrollbar.vertical > .slider",
-      );
-      return slider === null ? Number.NaN : Number.parseFloat(slider.style.top || "0");
-    });
-  const scrollBefore = await sliderTop();
-  await startFrameCounter(page);
-  const w0 = Date.now();
-  for (let tick = 0; tick < WHEEL_TICKS; tick += 1) {
-    await page.mouse.wheel(0, WHEEL_TICK_DELTA);
-    await page.waitForTimeout(WHEEL_TICK_GAP_MS);
-  }
-  const wheelMs = Date.now() - w0;
-  const wheel = await stopFrameCounter(page);
-  const scrollAfter = await sliderTop();
-
-  return {
-    burstLines: BURST_LINES,
-    burstMs,
-    burstFrames: burst.frames,
-    burstFps: Math.round((burst.frames / burst.ms) * 1000),
-    settleFrames: settled.frames - burst.frames,
-    wheelTicks: WHEEL_TICKS,
-    wheelMs,
-    wheelFrames: wheel.frames,
-    wheelFps: Math.round((wheel.frames / wheel.ms) * 1000),
-    scrolledPx: Math.round(scrollBefore - scrollAfter),
-  };
-}
-
-const TRACK_SELECTOR =
-  ".vex-terminal-surface--active .xterm-scrollable-element > .scrollbar.vertical";
-
-async function trackClasses(page: Page): Promise<string> {
-  return page.evaluate(
-    (selector) => document.querySelector(selector)?.className ?? "",
-    TRACK_SELECTOR,
-  );
-}
-
-/**
- * Read the bar with the pointer still over the grid (the wheel just ran, so
- * VS Code's state machine holds it `visible`), then prove the auto-hide: the
- * pointer leaves, the 500ms idle hide runs and the track turns `invisible`;
- * the pointer returns and it is `visible` again. Reduced motion is emulated
- * last and undone before returning, so the capture that follows is unaffected.
- */
-async function measureScrollbar(page: Page, gridBox: { x: number; y: number; width: number; height: number }): Promise<ScrollbarFacts> {
-  const geometry = await page.evaluate((selector) => {
-    const viewport = document.querySelector<HTMLElement>(".vex-terminal-surface--active .xterm-viewport");
-    const track = document.querySelector<HTMLElement>(selector);
-    const slider = track?.querySelector<HTMLElement>(".slider") ?? null;
-    const probe = document.createElement("span");
-    probe.style.backgroundColor = "var(--vex-scrollbar-thumb)";
-    (track ?? document.body).appendChild(probe);
-    const tokenBackground = getComputedStyle(probe).backgroundColor;
-    probe.remove();
-    const sliderStyle = slider === null ? null : getComputedStyle(slider);
-    const sheets = [...document.querySelectorAll<HTMLStyleElement>(".vex-terminal-surface--active style")];
-    const injectedSheets = {
-      count: sheets.length,
-      applied: sheets.filter((sheet) => (sheet.sheet?.cssRules.length ?? 0) > 0).length,
-    };
-    return {
-      injectedSheets,
-      viewportGutter: viewport === null ? Number.NaN : viewport.offsetWidth - viewport.clientWidth,
-      trackWidth: track?.offsetWidth ?? Number.NaN,
-      sliderWidth: slider?.offsetWidth ?? Number.NaN,
-      sliderInset: sliderStyle === null ? Number.NaN : Number.parseFloat(sliderStyle.paddingLeft),
-      sliderRadius: sliderStyle?.borderRadius ?? "",
-      sliderBackground: sliderStyle?.backgroundColor ?? "",
-      tokenBackground,
-      classesAfterWheel: track?.className ?? "",
-    };
-  }, TRACK_SELECTOR);
-
-  // Leave the terminal: the hide is scheduled 500ms after the pointer goes
-  // and the fade takes 800ms; the class flips at the schedule, not the fade.
-  // `invisible` contains `visible`, so the states are matched on word
-  // boundaries, never by substring.
-  await page.mouse.move(2, 2);
-  await expect.poll(() => trackClasses(page), { timeout: 5_000 }).toMatch(/\binvisible\b/);
-  const classesAfterLeave = await trackClasses(page);
-
-  await page.mouse.move(gridBox.x + gridBox.width / 2, gridBox.y + gridBox.height / 2);
-  await expect
-    .poll(async () => /\bvisible\b/.test(await trackClasses(page)), { timeout: 5_000 })
-    .toBe(true);
-  const classesOnHover = await trackClasses(page);
-
-  await page.emulateMedia({ reducedMotion: "reduce" });
-  const reducedMotionTransition = await page.evaluate(
-    (selector) => {
-      const track = document.querySelector<HTMLElement>(selector);
-      return track === null ? "" : getComputedStyle(track).transitionDuration;
-    },
-    TRACK_SELECTOR,
-  );
-  await page.emulateMedia({ reducedMotion: null });
-
-  return { ...geometry, classesAfterLeave, classesOnHover, reducedMotionTransition };
-}
-
-/** A computed `transition-duration` ("0.01ms", "1e-05s", "0.8s") in milliseconds. */
-function durationMs(value: string): number {
-  const match = /^([0-9.e+-]+)(ms|s)$/.exec(value.trim());
-  if (match === null) throw new Error(`not a duration: ${value}`);
-  const amount = Number(match[1]);
-  return match[2] === "s" ? amount * 1000 : amount;
-}
-
-function relativeLuminance([r, g, b]: [number, number, number]): number {
-  const channel = (value: number): number => {
-    const s = value / 255;
-    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
-  };
-  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
-}
-
-function contrastRatio(a: [number, number, number], b: [number, number, number]): number {
-  const la = relativeLuminance(a);
-  const lb = relativeLuminance(b);
-  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
-  return Math.round(((hi + 0.05) / (lo + 0.05)) * 100) / 100;
-}
-
-function parseRgb(css: string): [number, number, number] {
-  const match = /rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/.exec(css);
-  if (match === null) throw new Error(`not an rgb() colour: ${css}`);
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-/**
- * Contrast of the terminal foreground over the pane as PAINTED: the mean of
- * the blank region's pixels and the extreme one (brightest on a dark theme,
- * darkest on a light one), since the wallpaper under glass is not uniform.
- */
-async function measureContrast(
-  page: Page,
-  theme: string,
-  foregroundCss: string,
-): Promise<Contrast> {
-  const grid = page.locator(".vex-terminal-surface--active .xterm-screen");
-  const box = await grid.boundingBox();
-  expect(box).not.toBeNull();
-  if (box === null) throw new Error("unreachable");
-  // The lower half of the grid is blank right after a `clear`.
-  const clip = {
-    x: Math.round(box.x + box.width * 0.1),
-    y: Math.round(box.y + box.height * 0.55),
-    width: Math.round(box.width * 0.8),
-    height: Math.round(box.height * 0.4),
-  };
-  const png = await withTourHidden(page, () => page.screenshot({ clip }));
-  const { data, info } = await sharp(png).raw().toBuffer({ resolveWithObject: true });
-  const foreground = parseRgb(foregroundCss);
-  const fgLum = relativeLuminance(foreground);
-  let sumR = 0;
-  let sumG = 0;
-  let sumB = 0;
-  let extreme: [number, number, number] = [0, 0, 0];
-  let extremeLum = fgLum > 0.5 ? -1 : 2;
-  const pixels = info.width * info.height;
-  for (let i = 0; i < pixels; i += 1) {
-    const px: [number, number, number] = [
-      data[i * info.channels] ?? 0,
-      data[i * info.channels + 1] ?? 0,
-      data[i * info.channels + 2] ?? 0,
-    ];
-    sumR += px[0];
-    sumG += px[1];
-    sumB += px[2];
-    const lum = relativeLuminance(px);
-    // Worst case is the pixel closest in luminance to the foreground.
-    if (fgLum > 0.5 ? lum > extremeLum : lum < extremeLum) {
-      extremeLum = lum;
-      extreme = px;
-    }
-  }
-  const mean: [number, number, number] = [
-    Math.round(sumR / pixels),
-    Math.round(sumG / pixels),
-    Math.round(sumB / pixels),
-  ];
-  return {
-    theme,
-    sample: { mean, extreme },
-    foreground,
-    contrastMean: contrastRatio(foreground, mean),
-    contrastWorst: contrastRatio(foreground, extreme),
-  };
 }
 
 /**
@@ -555,6 +166,9 @@ test("Studio terminal on glass: backdrop shows through, gutter and scroll throug
   test.skip(!(await tourIsPresent(page)), TOUR_SKIP_REASON);
 
   const dir = outDir(testInfo);
+  // The probes take their screenshots through here, so the tour navigator is
+  // hidden by the surface that owns it rather than by the measurement.
+  const capture: CaptureClip = (clip) => withTourHidden(page, () => page.screenshot({ clip }));
   const report: Record<string, unknown> = {};
   const save = (): void => {
     fs.writeFileSync(path.join(dir, "glass-measurements.json"), JSON.stringify(report, null, 2));
@@ -599,8 +213,18 @@ test("Studio terminal on glass: backdrop shows through, gutter and scroll throug
   await page.keyboard.type("clear");
   await page.keyboard.press("Enter");
   await page.waitForTimeout(400);
-  const contrasts: Contrast[] = [await measureContrast(page, theme, facts.foreground)];
+  const contrasts: Contrast[] = [await measureContrast(page, theme, facts.foreground, capture)];
   report["contrasts"] = contrasts;
+  save();
+
+  /* ---- 3b. WHAT THE TERMINAL TELLS A PROGRAM, and reverse video --------- */
+  const osc11: Osc11Reply[] = [await probeOsc11(page, theme, dir)];
+  const reverseVideo: ReverseVideoResult[] = [await measureReverseVideo(page, theme, facts, capture)];
+  report["osc11"] = osc11;
+  report["reverseVideo"] = reverseVideo;
+  await withTourHidden(page, () =>
+    page.screenshot({ path: path.join(dir, `terminal-osc11-${theme}.png`) }),
+  );
   save();
 
   /* ---- 4. THROUGHPUT: a 30 000-line burst, then the wheel -------------- */
@@ -625,7 +249,9 @@ test("Studio terminal on glass: backdrop shows through, gutter and scroll throug
     await page.keyboard.press("Enter");
     await page.waitForTimeout(400);
     const celerisFacts = await readPaneFacts(page);
-    contrasts.push(await measureContrast(page, "celeris", celerisFacts.foreground));
+    contrasts.push(await measureContrast(page, "celeris", celerisFacts.foreground, capture));
+    osc11.push(await probeOsc11(page, "celeris", dir));
+    reverseVideo.push(await measureReverseVideo(page, "celeris", celerisFacts, capture));
     const celerisShot = path.join(dir, "terminal-glass-celeris.png");
     await withTourHidden(page, () => page.screenshot({ path: celerisShot }));
     (report["screenshots"] as Record<string, string>)["celeris"] = celerisShot;
@@ -666,5 +292,32 @@ test("Studio terminal on glass: backdrop shows through, gutter and scroll throug
   // the pane as painted, at its worst sampled pixel, never below 7:1.
   for (const contrast of contrasts) {
     expect(contrast.contrastWorst, `${contrast.theme} contrastWorst`).toBeGreaterThanOrEqual(7);
+  }
+
+  // THE OSC 11 ANSWER (both themes; the light one is the claim, so a skipped
+  // celeris is a failure here rather than a note). xterm answers from
+  // `theme.background` with the alpha dropped, and Claude Code in `auto` mode
+  // picks its theme from that answer by the rule `probeOsc11` applies. A
+  // pane that answered black in light mode got dark chrome painted over it.
+  expect(
+    osc11.map((reply) => reply.theme).sort(),
+    `celerisSkipped: ${String(report["celerisSkipped"] ?? "no")}`,
+  ).toEqual(["celeris", "chronos"]);
+  for (const reply of osc11) {
+    expect(reply.claudeCodeTheme, `${reply.theme} OSC 11 answered ${reply.raw}`).toBe(
+      reply.theme === "celeris" ? "light" : "dark",
+    );
+  }
+
+  // REVERSE VIDEO: the glyphs take the background token's RGB, made opaque by
+  // the WebGL renderer, so with the token carrying the pane's surface they
+  // read against the foreground-coloured box. Before the token carried an
+  // RGB the light theme painted black glyphs on a near-black box (1.6:1).
+  // Under the DOM renderer (xvfb: no WebGL2) the sample is unmeasurable and
+  // is recorded as such; the floor holds wherever the WebGL renderer paints.
+  for (const sample of reverseVideo) {
+    if (!sample.measured) continue;
+    expect(sample.glyphPixels, `${sample.theme} reverse video shows no glyphs`).toBeGreaterThan(0);
+    expect(sample.contrast, `${sample.theme} reverse video contrast`).toBeGreaterThanOrEqual(4.5);
   }
 });

--- a/vex-app/e2e/studio-terminal-glass.spec.ts
+++ b/vex-app/e2e/studio-terminal-glass.spec.ts
@@ -28,7 +28,11 @@
  *    shell asks, the reply travels the real pty round trip, and the file the
  *    shell writes is asserted to classify light in celeris and dark in
  *    chronos. A reverse-video sample is measured alongside, since its glyphs
- *    take the same token's RGB.
+ *    take the same token's RGB. Both probes type a POSIX shell line, so where
+ *    the Studio launches `ComSpec` (Windows) they record an unmeasured
+ *    `posix_probe` outcome instead of running, and the classification is
+ *    asserted only where it was measured; the reply bytes themselves are
+ *    proven without a pty in `terminal-theme-resolution.test.ts`.
  *
  * ## The completion signal for the burst
  *
@@ -77,7 +81,8 @@ import {
   type CaptureClip,
   type Contrast,
   type GutterMeasurement,
-  type Osc11Reply,
+  posixProbesAvailable,
+  type Osc11Result,
   type ReverseVideoResult,
 } from "./fixtures/terminal-glass-probes.js";
 
@@ -218,7 +223,7 @@ test("Studio terminal on glass: backdrop shows through, gutter and scroll throug
   save();
 
   /* ---- 3b. WHAT THE TERMINAL TELLS A PROGRAM, and reverse video --------- */
-  const osc11: Osc11Reply[] = [await probeOsc11(page, theme, dir)];
+  const osc11: Osc11Result[] = [await probeOsc11(page, theme, dir)];
   const reverseVideo: ReverseVideoResult[] = [await measureReverseVideo(page, theme, facts, capture)];
   report["osc11"] = osc11;
   report["reverseVideo"] = reverseVideo;
@@ -299,11 +304,20 @@ test("Studio terminal on glass: backdrop shows through, gutter and scroll throug
   // `theme.background` with the alpha dropped, and Claude Code in `auto` mode
   // picks its theme from that answer by the rule `probeOsc11` applies. A
   // pane that answered black in light mode got dark chrome painted over it.
+  // The probe is a POSIX shell line: where the Studio launches ComSpec it does
+  // not run, and what it records instead is the gate's own outcome, so a
+  // probe that silently did nothing cannot pass as measured.
   expect(
     osc11.map((reply) => reply.theme).sort(),
     `celerisSkipped: ${String(report["celerisSkipped"] ?? "no")}`,
   ).toEqual(["celeris", "chronos"]);
   for (const reply of osc11) {
+    if (!reply.measured) {
+      expect(posixProbesAvailable(), `${reply.theme} OSC 11 unmeasured on a POSIX host`).toBe(false);
+      expect(reply.reason).toBe("posix_probe");
+      continue;
+    }
+    expect(posixProbesAvailable(), `${reply.theme} OSC 11 measured where the probe cannot run`).toBe(true);
     expect(reply.claudeCodeTheme, `${reply.theme} OSC 11 answered ${reply.raw}`).toBe(
       reply.theme === "celeris" ? "light" : "dark",
     );
@@ -314,9 +328,13 @@ test("Studio terminal on glass: backdrop shows through, gutter and scroll throug
   // read against the foreground-coloured box. Before the token carried an
   // RGB the light theme painted black glyphs on a near-black box (1.6:1).
   // Under the DOM renderer (xvfb: no WebGL2) the sample is unmeasurable and
-  // is recorded as such; the floor holds wherever the WebGL renderer paints.
+  // is recorded as such, as it is where the POSIX probe cannot run; the floor
+  // holds wherever the WebGL renderer paints and the probe ran.
   for (const sample of reverseVideo) {
-    if (!sample.measured) continue;
+    if (!sample.measured) {
+      if (sample.reason === "posix_probe") expect(posixProbesAvailable()).toBe(false);
+      continue;
+    }
     expect(sample.glyphPixels, `${sample.theme} reverse video shows no glyphs`).toBeGreaterThan(0);
     expect(sample.contrast, `${sample.theme} reverse video contrast`).toBeGreaterThanOrEqual(4.5);
   }

--- a/vex-app/src/renderer/features/appShell/studio/terminal/__tests__/terminal-theme-resolution.test.ts
+++ b/vex-app/src/renderer/features/appShell/studio/terminal/__tests__/terminal-theme-resolution.test.ts
@@ -1,0 +1,177 @@
+/**
+ * THE RESOLVED THEME, per theme attribute, against the REAL stylesheet.
+ *
+ * `terminal-palette-tokens.test.ts` pins the token contract as CSS text. This
+ * suite is the other half, in the shape VS Code's `xtermTerminal.test.ts`
+ * `suite('theme')` uses: mount the stylesheet, resolve the theme against a root
+ * carrying each theme attribute, assert the whole resolved `ITheme`, flip, and
+ * assert again. The reader is the real `readTerminalTheme`, the cascade is
+ * jsdom's own (it resolves a custom property by selector; it does NOT resolve a
+ * `var()` chain, which is why the ANSI slots and the background, the literal
+ * ones, are the slots asserted by value).
+ *
+ * WHY THE BACKGROUND GETS ITS OWN INVARIANT. `options.theme.background` is not
+ * only a paint instruction: xterm 6.0.0 answers a program's OSC 11 query
+ * ("what is your background colour?") from it and DROPS THE ALPHA
+ * (`color.toColorRGB` keeps r, g, b). Claude Code in its `auto` theme mode
+ * sends that query and applies `0.2126 r + 0.7152 g + 0.0722 b > 0.5` to pick
+ * light or dark, and so do bat, delta, nvim and starship in their own words.
+ * A background of `#00000000` therefore told every one of them the pane was
+ * pure black, in light mode too (measured on the owner's machine 2026-09-04:
+ * Claude Code's dark-theme grey `rgb(153,153,153)` on the light pane, 2.5:1).
+ * The token keeps alpha 0 so the watermark survives and carries the RGB of the
+ * surface the pane paints, so the answer classifies by theme.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { readTerminalTheme } from "../terminal-palette.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const tokensCss = readFileSync(
+  path.join(here, "..", "..", "..", "..", "..", "styles", "global-css", "tokens.css"),
+  "utf8",
+);
+
+/**
+ * The stylesheet minus its Tailwind `@theme` at-rules, which jsdom's CSS
+ * parser refuses (and reports on the virtual console) while parsing the rest.
+ * Nothing the terminal reads lives in those blocks: the alias tier is plain
+ * `:root` and `[data-vex-theme="celeris"]` rules, mounted intact. Anchored to
+ * column 0 because the theme blocks MENTION `@theme` in their comments, and
+ * an unanchored match would eat the block from that mention to its brace.
+ */
+const themeableCss = tokensCss.replace(/^@theme[^{]*\{[\s\S]*?\n\}/gm, "");
+
+/** Every slot the bridge hands xterm, sorted, so an added or lost key shows. */
+const THEME_SLOTS = [
+  "background",
+  "foreground",
+  "cursor",
+  "cursorAccent",
+  "selectionBackground",
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+  "brightBlack",
+  "brightRed",
+  "brightGreen",
+  "brightYellow",
+  "brightBlue",
+  "brightMagenta",
+  "brightCyan",
+  "brightWhite",
+].sort();
+
+const ANSI_KEYS = THEME_SLOTS.filter(
+  (slot) => !["background", "foreground", "cursor", "cursorAccent", "selectionBackground"].includes(slot),
+);
+
+/** The reader's fallbacks: what an unthemed environment shows. */
+const NEUTRAL = "rgba(128, 136, 152, 1)";
+const NEUTRAL_SELECTION = "rgba(128, 136, 152, 0.24)";
+const COLOURLESS = "#00000000";
+
+/** `#rrggbbaa` to its channels, the way xterm's `css.toColor` case 9 reads it. */
+function channels(hex8: string): { r: number; g: number; b: number; a: number } {
+  const packed = parseInt(hex8.slice(1), 16) >>> 0;
+  return {
+    r: (packed >>> 24) & 0xff,
+    g: (packed >>> 16) & 0xff,
+    b: (packed >>> 8) & 0xff,
+    a: packed & 0xff,
+  };
+}
+
+/**
+ * Claude Code 2.1.260's `auto` rule over an OSC 11 answer: xterm reports the
+ * RGB with the alpha gone, and the detector weighs the channels linearly.
+ */
+function claudeCodeClassifies(hex8: string): "light" | "dark" {
+  const { r, g, b } = channels(hex8);
+  const weighted = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return weighted > 0.5 ? "light" : "dark";
+}
+
+function setTheme(theme: "chronos" | "celeris"): void {
+  if (theme === "chronos") {
+    document.documentElement.removeAttribute("data-vex-theme");
+  } else {
+    document.documentElement.setAttribute("data-vex-theme", theme);
+  }
+}
+
+beforeAll(() => {
+  const sheet = document.createElement("style");
+  sheet.dataset["terminalThemeSuite"] = "tokens";
+  sheet.textContent = themeableCss;
+  document.head.appendChild(sheet);
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute("data-vex-theme");
+});
+
+describe("readTerminalTheme against the real stylesheet", () => {
+  it.each([
+    ["chronos", "dark"],
+    ["celeris", "light"],
+  ] as const)("resolves the whole theme in %s and answers OSC 11 as %s", (theme, expected) => {
+    setTheme(theme);
+    const typed = readTerminalTheme(document.documentElement);
+    const resolved: Record<string, unknown> = { ...typed };
+
+    // The complete slot set, and none of it left to the fallbacks: a slot
+    // that fell back would mean the stylesheet stopped declaring it.
+    expect(Object.keys(resolved).sort()).toEqual(THEME_SLOTS);
+    for (const slot of THEME_SLOTS) {
+      expect(resolved[slot], `${theme}/${slot} fell back`).not.toBe(NEUTRAL);
+      expect(resolved[slot], `${theme}/${slot} fell back`).not.toBe(NEUTRAL_SELECTION);
+      expect(resolved[slot], `${theme}/${slot} is empty`).not.toBe("");
+    }
+    for (const key of ANSI_KEYS) {
+      expect(resolved[key], `${theme}/${key} is not a wire-contract hex`).toMatch(/^#[0-9a-f]{6}$/);
+    }
+
+    // THE BACKGROUND: 8-digit hex (xterm's fast path), alpha 0 (the watermark
+    // shows through), and the RGB of the pane's surface, so a program that asks
+    // is told the truth about the theme it is running in.
+    const background = typed.background ?? "";
+    expect(background).toMatch(/^#[0-9a-f]{8}$/);
+    expect(channels(background).a).toBe(0);
+    expect(background, `${theme} background is colourless`).not.toBe(COLOURLESS);
+    expect(claudeCodeClassifies(background)).toBe(expected);
+    // The glyph colour under a block cursor reuses the background token.
+    expect(resolved["cursorAccent"]).toBe(background);
+  });
+
+  it("re-resolves to the other theme's surface when the root attribute flips", () => {
+    setTheme("chronos");
+    const dark = readTerminalTheme(document.documentElement);
+    setTheme("celeris");
+    const light = readTerminalTheme(document.documentElement);
+
+    expect(dark.background).not.toBe(light.background);
+    expect(dark.foreground).not.toBe(light.foreground);
+    expect(claudeCodeClassifies(dark.background ?? "")).toBe("dark");
+    expect(claudeCodeClassifies(light.background ?? "")).toBe("light");
+  });
+
+  it("stays neutral and colourless with no element to resolve against", () => {
+    // An unthemed environment should look unthemed: neutral chrome, and a
+    // background that paints nothing rather than one theme's surface.
+    const fallback: Record<string, unknown> = { ...readTerminalTheme(null) };
+    expect(fallback["background"]).toBe(COLOURLESS);
+    expect(fallback["cursorAccent"]).toBe(COLOURLESS);
+    expect(fallback["foreground"]).toBe(NEUTRAL);
+    expect(fallback["selectionBackground"]).toBe(NEUTRAL_SELECTION);
+    for (const key of ANSI_KEYS) expect(fallback[key]).toBe(NEUTRAL);
+  });
+});

--- a/vex-app/src/renderer/features/appShell/studio/terminal/__tests__/terminal-theme-resolution.test.ts
+++ b/vex-app/src/renderer/features/appShell/studio/terminal/__tests__/terminal-theme-resolution.test.ts
@@ -21,6 +21,12 @@
  * Claude Code's dark-theme grey `rgb(153,153,153)` on the light pane, 2.5:1).
  * The token keeps alpha 0 so the watermark survives and carries the RGB of the
  * surface the pane paints, so the answer classifies by theme.
+ *
+ * The last suite computes the reply BYTES xterm sends for each resolved
+ * background and classifies them, so the wire contract is proven on every
+ * platform without a pty: the e2e probe in `terminal-glass-probes.ts` types
+ * a POSIX shell line and records itself unmeasured where the Studio launches
+ * `ComSpec`.
  */
 
 import { readFileSync } from "node:fs";
@@ -100,6 +106,40 @@ function claudeCodeClassifies(hex8: string): "light" | "dark" {
   return weighted > 0.5 ? "light" : "dark";
 }
 
+/**
+ * The OSC 11 reply xterm 6.0.0 sends for a theme background, byte for byte:
+ * `CoreBrowserTerminal` answers a REPORT with `ESC ] 11 ; <rgb> ESC \`, the
+ * colour going through `color.toColorRGB` (alpha dropped) and
+ * `toRgbString(rgb, 16)`, which writes each 8-bit channel as the 16-bit form
+ * `hh` + `hh` (`XParseColor.pad`, default branch). So `#ffffff00` is answered
+ * `rgb:ffff/ffff/ffff`, never black.
+ */
+function osc11ReplyBytes(hex8: string): string {
+  const { r, g, b } = channels(hex8);
+  const channel16 = (value: number): string => {
+    const hh = value.toString(16).padStart(2, "0");
+    return hh + hh;
+  };
+  return `\x1b]11;rgb:${channel16(r)}/${channel16(g)}/${channel16(b)}\x1b\\`;
+}
+
+/**
+ * Read a reply the way the asking program does: the `rgb:` triple, each
+ * channel scaled by its own digit count back to 8 bits (xterm's `parseColor`
+ * and the e2e probe read it the same way), then Claude Code's linear rule.
+ */
+function classifyOsc11Reply(reply: string): { rgb: [number, number, number]; theme: "light" | "dark" } {
+  const match = /^\x1b\]11;rgb:([0-9a-f]+)\/([0-9a-f]+)\/([0-9a-f]+)\x1b\\$/.exec(reply);
+  if (match === null) throw new Error(`not an OSC 11 reply: ${JSON.stringify(reply)}`);
+  const channel = (hex: string | undefined): number => {
+    const digits = hex ?? "";
+    return Math.round((parseInt(digits, 16) / (16 ** digits.length - 1)) * 255);
+  };
+  const rgb: [number, number, number] = [channel(match[1]), channel(match[2]), channel(match[3])];
+  const weighted = (0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]) / 255;
+  return { rgb, theme: weighted > 0.5 ? "light" : "dark" };
+}
+
 function setTheme(theme: "chronos" | "celeris"): void {
   if (theme === "chronos") {
     document.documentElement.removeAttribute("data-vex-theme");
@@ -162,6 +202,33 @@ describe("readTerminalTheme against the real stylesheet", () => {
     expect(dark.foreground).not.toBe(light.foreground);
     expect(claudeCodeClassifies(dark.background ?? "")).toBe("dark");
     expect(claudeCodeClassifies(light.background ?? "")).toBe("light");
+  });
+
+  it.each([
+    ["chronos", "dark"],
+    ["celeris", "light"],
+  ] as const)("the OSC 11 reply bytes for %s classify as %s without a pty", (theme, expected) => {
+    setTheme(theme);
+    const background = readTerminalTheme(document.documentElement).background ?? "";
+    const reply = osc11ReplyBytes(background);
+    const { r, g, b } = channels(background);
+    const hh = (value: number): string => value.toString(16).padStart(2, "0");
+
+    // The bytes carry the token's RGB in the 16-bit form and no alpha at all,
+    // so a program that asks reads the surface colour, not the transparency.
+    expect(reply).toBe(`\x1b]11;rgb:${hh(r)}${hh(r)}/${hh(g)}${hh(g)}/${hh(b)}${hh(b)}\x1b\\`);
+    expect(reply).not.toContain("rgb:0000/0000/0000");
+    const read = classifyOsc11Reply(reply);
+    expect(read.rgb).toEqual([r, g, b]);
+    expect(read.theme).toBe(expected);
+  });
+
+  it("the colourless fallback would be answered as black, which is why the tokens carry an RGB", () => {
+    // The pre-fix defect, pinned as arithmetic: an alpha-0 black token answers
+    // `rgb:0000/0000/0000` and every asking program picks dark, in light mode too.
+    const reply = osc11ReplyBytes(COLOURLESS);
+    expect(reply).toBe("\x1b]11;rgb:0000/0000/0000\x1b\\");
+    expect(classifyOsc11Reply(reply).theme).toBe("dark");
   });
 
   it("stays neutral and colourless with no element to resolve against", () => {

--- a/vex-app/src/renderer/features/appShell/studio/terminal/terminal-palette.ts
+++ b/vex-app/src/renderer/features/appShell/studio/terminal/terminal-palette.ts
@@ -58,6 +58,18 @@ const NEUTRAL = "rgba(128, 136, 152, 1)";
  * light theme shipped near-black ink on black. The 8-digit hex takes the fast
  * path with alpha 0. Terminals are created with `allowTransparency: true` so
  * that alpha reaches the renderer instead of being composited away.
+ *
+ * THIS IS THE FALLBACK ONLY, and it is colourless on purpose. The stylesheet's
+ * own background tokens keep the alpha at 0 but carry the RGB of the surface
+ * the pane paints in each theme (`--vex-alias-bg-base`: `#0a0d1800` in
+ * chronos, `#ffffff00` in celeris), because `options.theme.background` is also
+ * the terminal's ANSWER to a program's OSC 11 query: xterm reports it with the
+ * alpha dropped (`color.toColorRGB` keeps r, g, b), and Claude Code in `auto`
+ * mode, bat, delta and nvim pick light or dark from that answer. A colourless
+ * token answered "black" in light mode and got Claude Code's dark chrome
+ * painted over the light pane (measured 2026-09-04). The fallback stays
+ * colourless because an environment without computed styles should look
+ * unthemed, not plausibly light or dark.
  */
 const TRANSPARENT = "#00000000";
 
@@ -78,12 +90,15 @@ function readVar(
 /**
  * Resolve the whole xterm theme against `element`.
  *
- * The BACKGROUND stays transparent by contract: the pane paints its own surface
- * and layers the brand watermark UNDER the terminal, so an opaque background
- * here would hide it. The stylesheet declares `#00000000` in both themes and
- * the fallback repeats it, because a fallback that painted a colour would break
- * the watermark exactly when the token lookup failed - and because the keyword
+ * The BACKGROUND keeps alpha 0 by contract: the pane paints its own surface and
+ * layers the brand watermark UNDER the terminal, so an opaque background here
+ * would hide it. Its RGB is NOT free, though: it is what xterm reports to a
+ * program asking with OSC 11, so the stylesheet carries the pane's surface RGB
+ * per theme and this reader hands it over untouched. The fallback is colourless
+ * (`#00000000`) because a fallback that painted a colour would break the
+ * watermark exactly when the token lookup failed, and because the keyword
  * `transparent` is not transparent to xterm at all (see {@link TRANSPARENT}).
+ * `cursorAccent` (the glyph colour under a block cursor) reuses the same token.
  */
 export function readTerminalTheme(element: HTMLElement | null): ITheme {
   const styles =

--- a/vex-app/src/renderer/styles/global-css/__tests__/terminal-palette-tokens.test.ts
+++ b/vex-app/src/renderer/styles/global-css/__tests__/terminal-palette-tokens.test.ts
@@ -165,19 +165,33 @@ describe("terminal palette tokens", () => {
     expect(declaredIn(celeris)).toEqual(declaredIn(chronos));
   });
 
-  it("keeps the terminal background transparent IN A SYNTAX XTERM PARSES", () => {
+  it.each([
+    ["chronos", chronos],
+    ["celeris", celeris],
+  ])("keeps the background alpha 0 AND carries the pane's surface RGB (%s)", (name, body) => {
     // The pane paints its own surface and the watermark sits UNDER the
     // terminal. An opaque background would hide it, in one theme or both.
     //
     // The keyword `transparent` looks like it says this and does the opposite:
     // xterm's parser rejects it, ThemeService keeps its `#000000` default, and
     // the canvas paints opaque black. Only the 8-digit hex form survives.
-    for (const [name, body] of [["chronos", chronos], ["celeris", celeris]] as const) {
-      expect(body, `${name} background`).toContain("--vex-alias-term-background: #00000000;");
-      expect(body, `${name} must not use the keyword xterm rejects`).not.toContain(
-        "--vex-alias-term-background: transparent;",
-      );
-    }
+    //
+    // AND THE RGB IS NOT FREE. xterm answers a program's OSC 11 query from this
+    // token with the alpha dropped, so `#00000000` told Claude Code, bat, delta
+    // and nvim that a light pane was pure black (measured 2026-09-04: Claude
+    // Code's dark chrome over the light pane at 2.5:1). The RGB is the surface
+    // the glass pane veils with (`--vex-alias-bg-base`: the tint in shell.css
+    // is that ramp step at partial alpha), resolved through the var chain so a
+    // moved surface re-measures the token rather than silently outdating it.
+    const value = declarationValue(body, "--vex-alias-term-background");
+    expect(value, `${name} must not use the keyword xterm rejects`).not.toBe("transparent");
+    const match = /^#([0-9a-f]{6})([0-9a-f]{2})$/.exec(value ?? "");
+    expect(match, `${name} background "${String(value)}" is not an 8-digit hex`).not.toBeNull();
+    if (match === null) return;
+    expect(match[2], `${name} background alpha`).toBe("00");
+    expect(`#${match[1] ?? ""}`, `${name} background RGB`).toBe(
+      resolveHex(body, "--vex-alias-bg-base"),
+    );
   });
 
   it("gives every ANSI slot a concrete colour rather than a brand alias", () => {

--- a/vex-app/src/renderer/styles/global-css/tokens.css
+++ b/vex-app/src/renderer/styles/global-css/tokens.css
@@ -305,13 +305,12 @@
    * written into a component would be invisible to the theme flip and banned
    * by the design guard.
    *
-   * `background` is TRANSPARENT on purpose - the pane paints its own surface
-   * (`--vex-alias-bg-layer-1`, the card `XtermHost` draws) and the watermark
-   * sits under the terminal.
+   * `background` has ALPHA 0 on purpose - the glass pane paints its own
+   * surface and the watermark sits under the terminal.
    *
-   * IT IS SPELLED `#00000000`, NOT `transparent`, AND THAT IS THE WHOLE POINT.
-   * xterm 6.0.0 parses a theme colour with `css.toColor`, which accepts hex
-   * (3-8 digits) and `rgb()/rgba()` and otherwise falls through to a 1x1
+   * IT IS SPELLED AS 8-DIGIT HEX, NOT `transparent`, AND THAT IS THE WHOLE
+   * POINT. xterm 6.0.0 parses a theme colour with `css.toColor`, which accepts
+   * hex (3-8 digits) and `rgb()/rgba()` and otherwise falls through to a 1x1
    * canvas probe that THROWS when the resulting alpha is not 255
    * (`node_modules/@xterm/xterm/lib/xterm.js`: "css.toColor: Unsupported css
    * format"). ThemeService swallows that throw and keeps its own default,
@@ -322,6 +321,23 @@
    * `allowTransparency: true` on the Terminal (see `terminal-registry.ts`) is
    * what lets that alpha survive to the renderer.
    *
+   * AND THE RGB UNDER THAT ALPHA IS A WIRE CONTRACT, NOT A PAINT DETAIL. xterm
+   * answers a program's OSC 11 query ("what is your background colour?") from
+   * this same token with the alpha DROPPED (`color.toColorRGB` keeps r, g, b),
+   * so `#00000000` told every program that asked - Claude Code in its `auto`
+   * theme mode, bat, delta, nvim, starship - that the pane was pure black, in
+   * light mode too (measured on the owner's machine 2026-09-04: Claude Code's
+   * dark-theme grey `rgb(153,153,153)` over the light pane, 2.5:1, and its
+   * truecolor black placeholder box). The RGB is therefore the surface the
+   * pane paints in each theme, taken from that theme's `--vex-alias-bg-base`
+   * (the glass tint in shell.css is that ramp step at partial alpha; measured
+   * pane pixels 2026-09-04: chronos (12,17,31) against #0a0d18, celeris
+   * (245,249,251) against #ffffff). It has to be a literal: CSS cannot append
+   * an alpha byte to an alias, so `__tests__/terminal-palette-tokens.test.ts`
+   * pins the RGB to the alias instead. The same RGB, made opaque by the WebGL
+   * renderer, is the glyph colour of SGR 7 reverse video, which is why that
+   * was black-on-near-black in celeris before this carried a colour.
+   *
    * The ANSI slots are the only place in this file where raw hex is right:
    * they are a WIRE CONTRACT with programs that emit SGR 30-37 and 90-97, not
    * brand decisions, and bending them to the brand ramp would misrender every
@@ -329,7 +345,7 @@
    * to clear the rule-08 contrast floor against the surface the canvas sits
    * on; `__tests__/terminal-palette-tokens.test.ts` measures every one of them
    * and names the single documented exception. */
-  --vex-alias-term-background: #00000000;
+  --vex-alias-term-background: #0a0d1800;
   --vex-alias-term-foreground: var(--color-gray-200);
   --vex-alias-term-cursor: var(--vex-alias-accent-primary);
   --vex-alias-term-selection: rgba(255, 255, 255, 0.18);
@@ -601,11 +617,13 @@
    * written into a component would be invisible to the theme flip and banned
    * by the design guard.
    *
-   * `background` is TRANSPARENT on purpose - the pane paints its own surface
-   * and the watermark sits under the terminal. It is spelled `#00000000`
-   * rather than `transparent` because xterm's own colour parser rejects the
-   * keyword and falls back to opaque black; the chronos block above carries
-   * the measurement and the reference.
+   * `background` has ALPHA 0 on purpose - the pane paints its own surface and
+   * the watermark sits under the terminal. It is spelled as 8-digit hex rather
+   * than `transparent` because xterm's own colour parser rejects the keyword
+   * and falls back to opaque black, and its RGB is this theme's
+   * `--vex-alias-bg-base` (white) because xterm reports that RGB, alpha
+   * dropped, to any program that asks with OSC 11; the chronos block above
+   * carries the measurement and the reference.
    *
    * The ANSI slots are the only place in this file where raw hex is right:
    * they are a WIRE CONTRACT with programs that emit SGR 30-37 and 90-97, not
@@ -615,7 +633,7 @@
    * so `git diff`'s bright red still reads as the lighter red while clearing
    * 4.5:1. The previous ramp put the brights at 3.5-4.1:1, which is the same
    * "bright means invisible" defect the light theme had at the background. */
-  --vex-alias-term-background: #00000000;
+  --vex-alias-term-background: #ffffff00;
   --vex-alias-term-foreground: var(--color-gray-800);
   --vex-alias-term-cursor: var(--vex-alias-accent-primary);
   --vex-alias-term-selection: rgba(10, 13, 24, 0.14);


### PR DESCRIPTION
## What changes

- **The terminal reports its real background.** xterm 6 answers OSC 10/11/12 from `options.theme` and drops the alpha, so `#00000000` in both themes told every guest program the pane is black. Claude Code in "auto" mode picked its dark theme inside a light pane (grey text at 2.5:1, a truecolor black placeholder box); the owner's screenshots show our own palette resolving correctly and the guest's chrome being the illegible part. The token now carries the painted surface's RGB under alpha 00 (chronos `#0a0d1800`, celeris `#ffffff00`), the watermark still shows through, and the real-pty measurement on the built app flips the answer from black in both themes to `rgb:0a0a/0d0d/1818` and `rgb:ffff/ffff/ffff`.
- **Reverse video in light mode** is lifted from 1.6:1 to 13.1:1 by the same change on the WebGL path (the addon paints inverse glyphs in the background colour); asserted by the e2e only where a WebGL renderer runs, recorded as unmeasured under the DOM renderer.
- **Tests**: a theme-resolution suite (VS Code shape, whole `ITheme` per theme, flip, neutral fallback), the token invariant (8-digit hex, alpha 00, RGB equals the theme's base surface), and the OSC 11 probe in the glass e2e for both themes. The glass spec's measurement owners move to `e2e/fixtures/terminal-glass-probes.ts` (spec 931 to 323 lines).

## What the owner has to do to see it

Claude Code ignores the answer while `~/.claude/settings.json` pins `"theme": "dark"`; set the theme to "Auto (match terminal)". Every other guest (bat, delta, nvim, starship, Codex) switches to light rendering in celeris on its own.

## Findings for follow-up (not this PR)

- Without WebGL2 (xvfb, WSLg on the build machine) xterm falls back to its DOM renderer, whose colour sheet is injected inline and refused by the renderer CSP: the terminal is colourless there, no ANSI colours, no reverse video. Every e2e on this machine runs on that path.
- `terminal-palette-tokens.test.ts` measures contrast against `bg-layer-1` (gray-875 in chronos) while the pane paints from `bg-base` (gray-1000); the floor holds, the reference surface is stale.

## Verification

- `vex-app` vitest on `features/appShell/studio/terminal` and `styles`: 19 files, 373 tests (5 red before the fix, all green after); `lint:tsc` green; em-dash and unsafe-escapes gates green; `playwright test --list`: 28 tests in 11 files, the fixture not collected.
- `studio-terminal-glass.spec.ts` on the built app under xvfb: 1 failed before the fix (chronos answered black), 1 passed after (twice, xvfb and WSLg), and 1 passed again after the fixture extraction. Screenshots and OSC replies archived with provenance.

Reference reading: VS Code `xtermTerminal.ts` `getXtermTheme` (the background is the resolved surface colour, adopted under alpha 00 rather than opaque), `xtermTerminal.test.ts` theme suite (adopted test shape), `terminalColorRegistry.ts`; github-mcp-server `e2e_test.go` for the fixture extraction.
