### PR TITLE
refactor(tools): one owner for the authorizing-quote mapping, honest fixed-alias descriptions, byte-measured hot-set bound

### DIFF
--- a/src/__tests__/vex-agent/engine/core/approval-intent-preview-client-name.test.ts
+++ b/src/__tests__/vex-agent/engine/core/approval-intent-preview-client-name.test.ts
@@ -1,0 +1,187 @@
+/**
+ * The requesting client's name, as the approval card will show it -
+ * pure-function tests.
+ *
+ * Split out of `approval-intent-preview.test.ts` (2026-09-04) when that file
+ * passed the 750-line gate. It earns a file of its own for the reason its own
+ * header below already gives: this is the ONE field on the card that an
+ * external process chooses for itself, so these are boundary tests over
+ * hostile input rather than formatting tests over ours. Assertions are
+ * unchanged by the move.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { InternalToolContext } from "@vex-agent/tools/internal/types.js";
+import { makeTestContext } from "../../tools/_test-context.js";
+import {
+  buildIntentPreview,
+  buildPolicySnapshot,
+  sanitizeRequestingClientName,
+  REQUESTING_CLIENT_NAME_MAX,
+} from "@vex-agent/engine/core/approval-intent-preview.js";
+
+/**
+ * WHO ASKED, as the approval card will show it.
+ *
+ * The name is the one field on the card that an EXTERNAL PROCESS chooses for
+ * itself (an MCP client's `initialize` handshake), so these are boundary tests
+ * rather than formatting tests: every case below is a value another process can
+ * put on the wire, and the assertion is what a human ends up reading because
+ * of it.
+ */
+describe("sanitizeRequestingClientName", () => {
+  const context: InternalToolContext = makeTestContext({
+    sessionId: "00000000-0000-4000-8000-000000000002",
+  });
+
+  it("keeps a plain client name, trimmed", () => {
+    expect(sanitizeRequestingClientName("  Claude Code  ")).toBe("Claude Code");
+  });
+
+  // Control characters are refused because the actor row is a LINE a human
+  // reads on a money-path card: a newline inside the name forges a second one.
+  it.each([
+    ["a newline", "Claude Code\nVEX APPROVED"],
+    ["a carriage return", "Claude\rCode"],
+    ["a NUL", "Claude\u0000Code"],
+    ["an ANSI escape introducer", "\u001b[31mClaude Code"],
+    ["DEL", "Claude\u007fCode"],
+  ])("refuses %s rather than rendering it", (_label, name) => {
+    expect(sanitizeRequestingClientName(name)).toBeNull();
+  });
+
+  /**
+   * The Codex-final-review defect: refusing only ASCII controls left every
+   * Unicode class that can make the rendered line lie. Each case here is a name
+   * a human would read as something OTHER than what the client declared.
+   *
+   * The suffix under attack is `approvalActorLine`'s "(an MCP client)" - the
+   * three words that tell the reader this name is self-declared provenance and
+   * not an identity Vex verified. A right-to-left override placed inside the
+   * name reorders the glyphs that follow it, so the suffix can be painted
+   * backwards or dragged behind the name; a zero-width joiner or space makes two
+   * different clients render identically. Both are refused WHOLE, so the card
+   * falls back to "an MCP client" and claims nothing it cannot show.
+   */
+  it.each([
+    ["a right-to-left override (U+202E)", "Claude \u202eedoC"],
+    ["a left-to-right override (U+202D)", "\u202dClaude Code"],
+    ["a right-to-left embedding (U+202B)", "Claude\u202bCode"],
+    ["a first-strong isolate (U+2068)", "Claude\u2068Code"],
+    ["a pop directional isolate (U+2069)", "Claude Code\u2069"],
+    ["a zero-width joiner (U+200D)", "Claude\u200d Code"],
+    ["a zero-width non-joiner (U+200C)", "Clau\u200cde Code"],
+    ["a zero-width space (U+200B)", "Claude\u200bCode"],
+    ["a soft hyphen (U+00AD)", "Clau\u00adde Code"],
+    ["a line separator (U+2028)", "Claude Code\u2028VEX APPROVED"],
+    ["a paragraph separator (U+2029)", "Claude Code\u2029VEX APPROVED"],
+    ["a C1 control (U+0085 NEL)", "Claude\u0085Code"],
+    ["a lone high surrogate", "Claude \ud800Code"],
+  ])("refuses %s rather than rendering it", (_label, name) => {
+    expect(sanitizeRequestingClientName(name)).toBeNull();
+  });
+
+  /**
+   * The other half of the same invariant, and the reason the rule is a
+   * CATEGORY test and not "ASCII only": a client whose name is written in the
+   * reader's own script is a client with a name. Refusing these would push every
+   * non-English client onto the anonymous label, which is the same loss of
+   * provenance the hardening exists to prevent.
+   */
+  it.each([
+    ["Polish letters", "Zażółć gęślą jaźń"],
+    ["CJK", "克劳德代码"],
+    ["Cyrillic", "Клод Код"],
+    ["an astral pictograph (paired surrogates)", "Claude Code \u{1f4bb}"],
+    ["a combining mark", "Cláude Côde"],
+  ])("keeps a benign non-ASCII name: %s", (_label, name) => {
+    expect(sanitizeRequestingClientName(name)).toBe(name);
+  });
+
+  /**
+   * A refusal is NOT a strip. `String.prototype.trim` eats U+2028, U+2029 and
+   * U+FEFF, so a check placed after the trim would quietly accept
+   * `"\u2028Claude Code"` as `"Claude Code"` - a name the client never declared,
+   * shown to a human as if it had. The class is therefore tested on the raw
+   * value, and this test is what goes red if that order is swapped back.
+   */
+  it.each([
+    ["a leading line separator", "\u2028Claude Code"],
+    ["a trailing paragraph separator", "Claude Code\u2029"],
+    ["a leading BOM", "\ufeffClaude Code"],
+  ])("refuses %s instead of silently trimming it away", (_label, name) => {
+    expect(name.trim()).not.toBe(name);
+    expect(sanitizeRequestingClientName(name)).toBeNull();
+  });
+
+  it.each([
+    ["a number", 42],
+    ["undefined", undefined],
+    ["an object", { name: "Claude Code" }],
+    ["the empty string", ""],
+    ["whitespace only", "   "],
+  ])("refuses %s", (_label, value) => {
+    expect(sanitizeRequestingClientName(value)).toBeNull();
+  });
+
+  it("keeps a name exactly at the bound", () => {
+    const name = "c".repeat(REQUESTING_CLIENT_NAME_MAX);
+    expect(sanitizeRequestingClientName(name)).toBe(name);
+  });
+
+  /**
+   * The invariant a "just shorten it" change would break: "Claude Cod..." and
+   * "Claude Code" read the same to a human deciding a transfer, and only one of
+   * them is a name that person can verify. An over-long name is DROPPED whole,
+   * and the card then says "an MCP client", which claims less rather than more.
+   */
+  it("DROPS an over-long name whole, never shortens it", () => {
+    const name = "c".repeat(REQUESTING_CLIENT_NAME_MAX + 1);
+    expect(sanitizeRequestingClientName(name)).toBeNull();
+  });
+
+  it("carries a sanitized name onto the policy snapshot the card reads", () => {
+    expect(buildPolicySnapshot(context, " Claude Code ").requestedByClient).toBe(
+      "Claude Code",
+    );
+  });
+
+  it("records no client for Vex's own agent loop", () => {
+    expect(buildPolicySnapshot(context).requestedByClient).toBeNull();
+  });
+
+  it("records no client when the declared name is unusable", () => {
+    expect(
+      buildPolicySnapshot(context, "Claude\nCode").requestedByClient,
+    ).toBeNull();
+  });
+
+  // The snapshot is the value that lands in `policy_json` and travels to the
+  // card, so the boundary that matters is proven at the boundary, not only on
+  // the helper.
+  it("records no client when the declared name reorders the line it would be shown on", () => {
+    expect(
+      buildPolicySnapshot(context, "Claude \u202eedoC").requestedByClient,
+    ).toBeNull();
+  });
+
+  it("carries a non-ASCII client name through to the snapshot", () => {
+    expect(buildPolicySnapshot(context, " Zażółć gęślą jaźń ").requestedByClient).toBe(
+      "Zażółć gęślą jaźń",
+    );
+  });
+
+  /**
+   * The card must never show a fee, a rate or a destination that came from the
+   * client's NAME. Nothing branches on this value; it lands in `policy_json`
+   * and stops there.
+   */
+  it("keeps the client name out of the preview the digest binds", () => {
+    const preview = buildIntentPreview("WalletSendConfirm", {
+      intentId: "int-1",
+      clientName: "Claude Code",
+    });
+    expect(preview.criticalArgs).not.toHaveProperty("clientName");
+    expect(preview.criticalArgs).not.toHaveProperty("requestedByClient");
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/approval-intent-preview-client-name.test.ts
+++ b/src/__tests__/vex-agent/engine/core/approval-intent-preview-client-name.test.ts
@@ -51,7 +51,7 @@ describe("sanitizeRequestingClientName", () => {
   });
 
   /**
-   * The Codex-final-review defect: refusing only ASCII controls left every
+   * The defect this closes: refusing only ASCII controls left every
    * Unicode class that can make the rendered line lie. Each case here is a name
    * a human would read as something OTHER than what the client declared.
    *

--- a/src/__tests__/vex-agent/engine/core/approval-intent-preview-policy-snapshot.test.ts
+++ b/src/__tests__/vex-agent/engine/core/approval-intent-preview-policy-snapshot.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The policy snapshot an approval is enqueued with - pure-function tests.
+ *
+ * Split out of `approval-intent-preview.test.ts` (2026-09-04) when that file
+ * passed the 750-line gate. It is a different contract from the preview: the
+ * snapshot records WHO asked and UNDER WHAT PERMISSION, and it is read by the
+ * audit row rather than bound by the approval digest. Assertions are unchanged
+ * by the move.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { InternalToolContext } from "@vex-agent/tools/internal/types.js";
+import { makeTestContext } from "../../tools/_test-context.js";
+import { buildPolicySnapshot } from "@vex-agent/engine/core/approval-intent-preview.js";
+
+describe("buildPolicySnapshot", () => {
+  const baseContext: InternalToolContext = makeTestContext({
+    sessionId: "00000000-0000-4000-8000-000000000001",
+    missionRunId: "run-1",
+    missionId: "mission-1",
+    sessionKind: "mission",
+    contextUsageBand: "warning",
+  });
+
+  it("snapshots the documented policy fields verbatim", () => {
+    const snap = buildPolicySnapshot(baseContext);
+    expect(snap).toEqual({
+      permission: "restricted",
+      sessionKind: "mission",
+      missionRunActive: true,
+      contextUsageBand: "warning",
+      missionId: "mission-1",
+      missionRunId: "run-1",
+      // Nobody external asked: this is Vex's own agent loop, so the snapshot
+      // records no client and the card names none rather than inventing one.
+      requestedByClient: null,
+    });
+  });
+
+  it("derives missionRunActive=false when missionRunId is null", () => {
+    const snap = buildPolicySnapshot({ ...baseContext, missionRunId: null });
+    expect(snap.missionRunActive).toBe(false);
+    expect(snap.missionRunId).toBeNull();
+  });
+
+  it("captures permission='full' in the approval audit snapshot", () => {
+    const snap = buildPolicySnapshot({ ...baseContext, sessionPermission: "full" });
+    expect(snap.permission).toBe("full");
+  });
+
+  it("captures contextUsageBand at enqueue time (not re-derived later)", () => {
+    const snap = buildPolicySnapshot({ ...baseContext, contextUsageBand: "critical" });
+    expect(snap.contextUsageBand).toBe("critical");
+  });
+});

--- a/src/__tests__/vex-agent/engine/core/approval-intent-preview.test.ts
+++ b/src/__tests__/vex-agent/engine/core/approval-intent-preview.test.ts
@@ -1,19 +1,17 @@
 /**
- * Approval intent preview + policy snapshot builders — pure-function tests.
+ * The approval intent preview builder - pure-function tests.
  *
  * Puzzle 5 phase 2 (2026-05-23). Pins the renderer-safe projection:
  * allow-listed keys only, coerced scalars, no nested blobs / bigints / leaks.
+ *
+ * Its two siblings own the other two builders in the same module, split out
+ * when this file passed the 750-line gate (2026-09-04):
+ * `approval-intent-preview-policy-snapshot.test.ts` and
+ * `approval-intent-preview-client-name.test.ts`.
  */
 
 import { describe, it, expect } from "vitest";
-import type { InternalToolContext } from "@vex-agent/tools/internal/types.js";
-import { makeTestContext } from "../../tools/_test-context.js";
-import {
-  buildIntentPreview,
-  buildPolicySnapshot,
-  sanitizeRequestingClientName,
-  REQUESTING_CLIENT_NAME_MAX,
-} from "@vex-agent/engine/core/approval-intent-preview.js";
+import { buildIntentPreview } from "@vex-agent/engine/core/approval-intent-preview.js";
 
 /**
  * The Vex fee statement a matched quote made, as the prequote gate hands it to
@@ -630,212 +628,5 @@ describe("buildIntentPreview — execute_tool wrapper unwrap", () => {
     expect(preview.toolName).toBe("some_other_tool");
     // criticalArgs come from wrapper args (params is not in allowlist; toolId neither)
     expect(preview.criticalArgs).toEqual({});
-  });
-});
-
-describe("buildPolicySnapshot", () => {
-  const baseContext: InternalToolContext = makeTestContext({
-    sessionId: "00000000-0000-4000-8000-000000000001",
-    missionRunId: "run-1",
-    missionId: "mission-1",
-    sessionKind: "mission",
-    contextUsageBand: "warning",
-  });
-
-  it("snapshots the documented policy fields verbatim", () => {
-    const snap = buildPolicySnapshot(baseContext);
-    expect(snap).toEqual({
-      permission: "restricted",
-      sessionKind: "mission",
-      missionRunActive: true,
-      contextUsageBand: "warning",
-      missionId: "mission-1",
-      missionRunId: "run-1",
-      // Nobody external asked: this is Vex's own agent loop, so the snapshot
-      // records no client and the card names none rather than inventing one.
-      requestedByClient: null,
-    });
-  });
-
-  it("derives missionRunActive=false when missionRunId is null", () => {
-    const snap = buildPolicySnapshot({ ...baseContext, missionRunId: null });
-    expect(snap.missionRunActive).toBe(false);
-    expect(snap.missionRunId).toBeNull();
-  });
-
-  it("captures permission='full' in the approval audit snapshot", () => {
-    const snap = buildPolicySnapshot({ ...baseContext, sessionPermission: "full" });
-    expect(snap.permission).toBe("full");
-  });
-
-  it("captures contextUsageBand at enqueue time (not re-derived later)", () => {
-    const snap = buildPolicySnapshot({ ...baseContext, contextUsageBand: "critical" });
-    expect(snap.contextUsageBand).toBe("critical");
-  });
-});
-
-/**
- * WHO ASKED, as the approval card will show it.
- *
- * The name is the one field on the card that an EXTERNAL PROCESS chooses for
- * itself (an MCP client's `initialize` handshake), so these are boundary tests
- * rather than formatting tests: every case below is a value another process can
- * put on the wire, and the assertion is what a human ends up reading because
- * of it.
- */
-describe("sanitizeRequestingClientName", () => {
-  const context: InternalToolContext = makeTestContext({
-    sessionId: "00000000-0000-4000-8000-000000000002",
-  });
-
-  it("keeps a plain client name, trimmed", () => {
-    expect(sanitizeRequestingClientName("  Claude Code  ")).toBe("Claude Code");
-  });
-
-  // Control characters are refused because the actor row is a LINE a human
-  // reads on a money-path card: a newline inside the name forges a second one.
-  it.each([
-    ["a newline", "Claude Code\nVEX APPROVED"],
-    ["a carriage return", "Claude\rCode"],
-    ["a NUL", "Claude\u0000Code"],
-    ["an ANSI escape introducer", "\u001b[31mClaude Code"],
-    ["DEL", "Claude\u007fCode"],
-  ])("refuses %s rather than rendering it", (_label, name) => {
-    expect(sanitizeRequestingClientName(name)).toBeNull();
-  });
-
-  /**
-   * The Codex-final-review defect: refusing only ASCII controls left every
-   * Unicode class that can make the rendered line lie. Each case here is a name
-   * a human would read as something OTHER than what the client declared.
-   *
-   * The suffix under attack is `approvalActorLine`'s "(an MCP client)" - the
-   * three words that tell the reader this name is self-declared provenance and
-   * not an identity Vex verified. A right-to-left override placed inside the
-   * name reorders the glyphs that follow it, so the suffix can be painted
-   * backwards or dragged behind the name; a zero-width joiner or space makes two
-   * different clients render identically. Both are refused WHOLE, so the card
-   * falls back to "an MCP client" and claims nothing it cannot show.
-   */
-  it.each([
-    ["a right-to-left override (U+202E)", "Claude \u202eedoC"],
-    ["a left-to-right override (U+202D)", "\u202dClaude Code"],
-    ["a right-to-left embedding (U+202B)", "Claude\u202bCode"],
-    ["a first-strong isolate (U+2068)", "Claude\u2068Code"],
-    ["a pop directional isolate (U+2069)", "Claude Code\u2069"],
-    ["a zero-width joiner (U+200D)", "Claude\u200d Code"],
-    ["a zero-width non-joiner (U+200C)", "Clau\u200cde Code"],
-    ["a zero-width space (U+200B)", "Claude\u200bCode"],
-    ["a soft hyphen (U+00AD)", "Clau\u00adde Code"],
-    ["a line separator (U+2028)", "Claude Code\u2028VEX APPROVED"],
-    ["a paragraph separator (U+2029)", "Claude Code\u2029VEX APPROVED"],
-    ["a C1 control (U+0085 NEL)", "Claude\u0085Code"],
-    ["a lone high surrogate", "Claude \ud800Code"],
-  ])("refuses %s rather than rendering it", (_label, name) => {
-    expect(sanitizeRequestingClientName(name)).toBeNull();
-  });
-
-  /**
-   * The other half of the same invariant, and the reason the rule is a
-   * CATEGORY test and not "ASCII only": a client whose name is written in the
-   * reader's own script is a client with a name. Refusing these would push every
-   * non-English client onto the anonymous label, which is the same loss of
-   * provenance the hardening exists to prevent.
-   */
-  it.each([
-    ["Polish letters", "Zażółć gęślą jaźń"],
-    ["CJK", "克劳德代码"],
-    ["Cyrillic", "Клод Код"],
-    ["an astral pictograph (paired surrogates)", "Claude Code \u{1f4bb}"],
-    ["a combining mark", "Cláude Côde"],
-  ])("keeps a benign non-ASCII name: %s", (_label, name) => {
-    expect(sanitizeRequestingClientName(name)).toBe(name);
-  });
-
-  /**
-   * A refusal is NOT a strip. `String.prototype.trim` eats U+2028, U+2029 and
-   * U+FEFF, so a check placed after the trim would quietly accept
-   * `"\u2028Claude Code"` as `"Claude Code"` - a name the client never declared,
-   * shown to a human as if it had. The class is therefore tested on the raw
-   * value, and this test is what goes red if that order is swapped back.
-   */
-  it.each([
-    ["a leading line separator", "\u2028Claude Code"],
-    ["a trailing paragraph separator", "Claude Code\u2029"],
-    ["a leading BOM", "\ufeffClaude Code"],
-  ])("refuses %s instead of silently trimming it away", (_label, name) => {
-    expect(name.trim()).not.toBe(name);
-    expect(sanitizeRequestingClientName(name)).toBeNull();
-  });
-
-  it.each([
-    ["a number", 42],
-    ["undefined", undefined],
-    ["an object", { name: "Claude Code" }],
-    ["the empty string", ""],
-    ["whitespace only", "   "],
-  ])("refuses %s", (_label, value) => {
-    expect(sanitizeRequestingClientName(value)).toBeNull();
-  });
-
-  it("keeps a name exactly at the bound", () => {
-    const name = "c".repeat(REQUESTING_CLIENT_NAME_MAX);
-    expect(sanitizeRequestingClientName(name)).toBe(name);
-  });
-
-  /**
-   * The invariant a "just shorten it" change would break: "Claude Cod..." and
-   * "Claude Code" read the same to a human deciding a transfer, and only one of
-   * them is a name that person can verify. An over-long name is DROPPED whole,
-   * and the card then says "an MCP client", which claims less rather than more.
-   */
-  it("DROPS an over-long name whole, never shortens it", () => {
-    const name = "c".repeat(REQUESTING_CLIENT_NAME_MAX + 1);
-    expect(sanitizeRequestingClientName(name)).toBeNull();
-  });
-
-  it("carries a sanitized name onto the policy snapshot the card reads", () => {
-    expect(buildPolicySnapshot(context, " Claude Code ").requestedByClient).toBe(
-      "Claude Code",
-    );
-  });
-
-  it("records no client for Vex's own agent loop", () => {
-    expect(buildPolicySnapshot(context).requestedByClient).toBeNull();
-  });
-
-  it("records no client when the declared name is unusable", () => {
-    expect(
-      buildPolicySnapshot(context, "Claude\nCode").requestedByClient,
-    ).toBeNull();
-  });
-
-  // The snapshot is the value that lands in `policy_json` and travels to the
-  // card, so the boundary that matters is proven at the boundary, not only on
-  // the helper.
-  it("records no client when the declared name reorders the line it would be shown on", () => {
-    expect(
-      buildPolicySnapshot(context, "Claude \u202eedoC").requestedByClient,
-    ).toBeNull();
-  });
-
-  it("carries a non-ASCII client name through to the snapshot", () => {
-    expect(buildPolicySnapshot(context, " Zażółć gęślą jaźń ").requestedByClient).toBe(
-      "Zażółć gęślą jaźń",
-    );
-  });
-
-  /**
-   * The card must never show a fee, a rate or a destination that came from the
-   * client's NAME. Nothing branches on this value; it lands in `policy_json`
-   * and stops there.
-   */
-  it("keeps the client name out of the preview the digest binds", () => {
-    const preview = buildIntentPreview("WalletSendConfirm", {
-      intentId: "int-1",
-      clientName: "Claude Code",
-    });
-    expect(preview.criticalArgs).not.toHaveProperty("clientName");
-    expect(preview.criticalArgs).not.toHaveProperty("requestedByClient");
   });
 });

--- a/src/__tests__/vex-agent/mcp/inventory.test.ts
+++ b/src/__tests__/vex-agent/mcp/inventory.test.ts
@@ -44,6 +44,32 @@ function byteLength(value: string): number {
   return Buffer.byteLength(value, "utf8");
 }
 
+/**
+ * BOTH READINGS OF THE HOT-SET BOUND over one description, from one place.
+ *
+ * The character reading is the measured contract (Claude Code cuts at 2048 code
+ * points); the byte reading is the second, for any client that counts the
+ * encoded string. They are computed together so the two table lints below and
+ * the synthetic threshold case cannot drift into measuring different things -
+ * the whole point of the synthetic case is that it fails if `bytes` ever stops
+ * counting bytes.
+ */
+function boundReadings(description: string): {
+  readonly characters: number;
+  readonly bytes: number;
+  readonly fitsInCharacters: boolean;
+  readonly fitsInBytes: boolean;
+} {
+  const characters = [...description].length;
+  const bytes = byteLength(description);
+  return {
+    characters,
+    bytes,
+    fitsInCharacters: characters <= ALWAYS_LOADED_DESCRIPTION_MAX_CHARACTERS,
+    fitsInBytes: bytes <= ALWAYS_LOADED_DESCRIPTION_MAX_CHARACTERS,
+  };
+}
+
 /** The first `limit` BYTES of a string, decoded back. */
 function head(value: string, limit: number): string {
   return Buffer.from(value, "utf8").subarray(0, limit).toString("utf8");
@@ -372,10 +398,13 @@ describe("the description budget (O23)", () => {
   it.each(
     buildStudioInventory()
       .filter((tool) => tool.alwaysLoad)
-      .map((tool) => [tool.publicName, [...tool.description].length] as const),
-  )("%s fits the always-loaded description bound whole (%i characters)", (_name, characters) => {
-    expect(characters).toBeLessThanOrEqual(ALWAYS_LOADED_DESCRIPTION_MAX_CHARACTERS);
-  });
+      .map((tool) => [tool.publicName, [...tool.description].length, tool.description] as const),
+  )(
+    "%s fits the always-loaded description bound whole (%i characters)",
+    (_name, _characters, description) => {
+      expect(boundReadings(description).fitsInCharacters).toBe(true);
+    },
+  );
 
   /**
    * THE SAME BOUND, COUNTED IN BYTES.
@@ -397,9 +426,29 @@ describe("the description budget (O23)", () => {
   it.each(
     buildStudioInventory()
       .filter((tool) => tool.alwaysLoad)
-      .map((tool) => [tool.publicName, byteLength(tool.description)] as const),
-  )("%s fits the same bound in UTF-8 bytes (%i bytes)", (_name, bytes) => {
-    expect(bytes).toBeLessThanOrEqual(ALWAYS_LOADED_DESCRIPTION_MAX_CHARACTERS);
+      .map((tool) => [tool.publicName, byteLength(tool.description), tool.description] as const),
+  )("%s fits the same bound in UTF-8 bytes (%i bytes)", (_name, _bytes, description) => {
+    expect(boundReadings(description).fitsInBytes).toBe(true);
+  });
+
+  it("the BYTE reading is the one that catches a non-ASCII description at the threshold", () => {
+    // The live hot set cannot prove this on its own: its longest description is
+    // 2047 bytes over 2046 characters, so replacing the byte count above with a
+    // second character count would keep the suite green and the gap would be
+    // back. This is the case that only the byte reading can fail - a synthetic
+    // description one code point UNDER the bound whose UTF-8 encoding is two
+    // bytes OVER it, which is what an edit that trades two ASCII characters for
+    // one arrow produces.
+    const synthetic = `${"a".repeat(ALWAYS_LOADED_DESCRIPTION_MAX_CHARACTERS - 1)}\u2192`;
+    const readings = boundReadings(synthetic);
+
+    expect(readings.characters).toBe(ALWAYS_LOADED_DESCRIPTION_MAX_CHARACTERS);
+    expect(readings.bytes).toBe(ALWAYS_LOADED_DESCRIPTION_MAX_CHARACTERS + 2);
+    // The character lint accepts it, so it is not the one holding the line.
+    expect(readings.fitsInCharacters).toBe(true);
+    // The byte lint refuses it. If `boundReadings.bytes` ever counted code
+    // points, this is the assertion that goes red.
+    expect(readings.fitsInBytes).toBe(false);
   });
 
   it("keeps the byte reading honest: the hot set is not pure ASCII", () => {
@@ -411,7 +460,10 @@ describe("the description budget (O23)", () => {
     // answer to that failure is to delete this case, not to add a character.
     const differing = buildStudioInventory()
       .filter((tool) => tool.alwaysLoad)
-      .filter((tool) => byteLength(tool.description) !== [...tool.description].length);
+      .filter((tool) => {
+        const readings = boundReadings(tool.description);
+        return readings.bytes !== readings.characters;
+      });
     expect(differing.length).toBeGreaterThan(0);
   });
 

--- a/src/__tests__/vex-agent/mcp/inventory.test.ts
+++ b/src/__tests__/vex-agent/mcp/inventory.test.ts
@@ -377,6 +377,44 @@ describe("the description budget (O23)", () => {
     expect(characters).toBeLessThanOrEqual(ALWAYS_LOADED_DESCRIPTION_MAX_CHARACTERS);
   });
 
+  /**
+   * THE SAME BOUND, COUNTED IN BYTES.
+   *
+   * The measured cut is by CHARACTERS - four independent counts on four tools
+   * landed on 2048 characters of the original string, which is why the bound
+   * above is the contract. This is the second reading of it, and it is not
+   * ceremony: the hot set is NO LONGER pure ASCII. `SwapExecute` and `SwapQuote`
+   * each carry a U+2192 arrow, so they sit at 2045 characters but 2047 UTF-8
+   * bytes - ONE byte under the same number. A description is authored in
+   * characters and travels as bytes, so an edit that swaps two ASCII characters
+   * for one arrow keeps the character count falling and pushes the byte count
+   * over, and any client that counts the encoded string rather than the code
+   * points would cut a tool contract mid-word with nothing here noticing.
+   *
+   * Asserting both readings costs one comparison and closes that gap whichever
+   * way a client counts.
+   */
+  it.each(
+    buildStudioInventory()
+      .filter((tool) => tool.alwaysLoad)
+      .map((tool) => [tool.publicName, byteLength(tool.description)] as const),
+  )("%s fits the same bound in UTF-8 bytes (%i bytes)", (_name, bytes) => {
+    expect(bytes).toBeLessThanOrEqual(ALWAYS_LOADED_DESCRIPTION_MAX_CHARACTERS);
+  });
+
+  it("keeps the byte reading honest: the hot set is not pure ASCII", () => {
+    // If every description were ASCII the byte lint above would be a copy of
+    // the character one. It is not - measured 2026-09-04, `SwapExecute` and
+    // `SwapQuote` carry a U+2192 arrow. The assertion is on the COUNT rather
+    // than on those two names, so an arrow moving to another tool is not a
+    // failure; only a hot set that went back to pure ASCII is, and the honest
+    // answer to that failure is to delete this case, not to add a character.
+    const differing = buildStudioInventory()
+      .filter((tool) => tool.alwaysLoad)
+      .filter((tool) => byteLength(tool.description) !== [...tool.description].length);
+    expect(differing.length).toBeGreaterThan(0);
+  });
+
   it("bounds every always-loaded description and no protocol one", () => {
     // The bound is the HOT SET's, deliberately: a protocol description is
     // loaded through a client's own tool-search step, which does not re-cut it.

--- a/src/__tests__/vex-agent/mcp/mutating-alias-fixed-targets.test.ts
+++ b/src/__tests__/vex-agent/mcp/mutating-alias-fixed-targets.test.ts
@@ -1,0 +1,112 @@
+/**
+ * WHICH MUTATING ALIASES ACTUALLY RESOLVE A VENUE - the fact
+ * `vex_ToolDescribe.quoteGate` is published from.
+ *
+ * The false contract this pins: every mutating alias answered
+ * `venue_resolved_per_call`, which says of a call that moves money that its
+ * venue - and therefore the quote that authorizes it - cannot be known until
+ * the call happens. For two of the four that is simply untrue:
+ * `SwapExecuteUniswap` and `BridgeExecuteRelay` name their venue in their own
+ * name and dispatch to ONE protocol tool, whatever the arguments. An agent told
+ * otherwise has no way to learn which quote to take first.
+ *
+ * So the declaration in `tools/mutating-aliases.ts` is tested here against the
+ * ROUTERS THEMSELVES, exercised over every chain and shape they accept: the
+ * only thing that could make the published answer wrong is a router that can
+ * reach a second venue, and that is exactly what these cases would catch.
+ * `tool-describe-export.test.ts` then asserts the description is that target's
+ * own gate, without restating the pairing.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  FIXED_MUTATING_ALIAS_TARGETS,
+  MUTATING_PROTOCOL_ALIAS_ROUTERS,
+  fixedTargetOfMutatingAlias,
+} from "@vex-agent/tools/mutating-aliases.js";
+
+const SESSION_ID = "00000000-0000-4000-8000-000000000042";
+const WETH = "0x4200000000000000000000000000000000000006";
+const USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+function route(alias: string, args: Record<string, unknown>) {
+  const router = MUTATING_PROTOCOL_ALIAS_ROUTERS[alias];
+  if (router === undefined) throw new Error(`${alias} is not a mutating alias`);
+  return router(args, SESSION_ID);
+}
+
+/** Every chain shape `SwapExecuteUniswap` accepts, including a bare chain id. */
+const UNISWAP_CHAINS = ["ethereum", "base", "arbitrum", "optimism", "polygon", "bsc", "8453", 8453];
+
+/** Chain pairs `BridgeExecuteRelay` accepts, across families and directions. */
+const RELAY_PAIRS = [
+  ["base", "arbitrum"],
+  ["ethereum", "solana"],
+  ["solana", "base"],
+  ["arbitrum", "ethereum"],
+];
+
+describe("the two venue-named aliases have ONE target, whatever the arguments", () => {
+  it.each(UNISWAP_CHAINS)("SwapExecuteUniswap on %s dispatches to uniswap.swap.execute", async (chain) => {
+    const target = await route("SwapExecuteUniswap", {
+      chain,
+      tokenIn: WETH,
+      tokenOut: USDC,
+      amountIn: "1.5",
+    });
+    expect(target.toolId).toBe(FIXED_MUTATING_ALIAS_TARGETS.SwapExecuteUniswap);
+    expect(target.toolId).toBe("uniswap.swap.execute");
+  });
+
+  it.each(RELAY_PAIRS)("BridgeExecuteRelay from %s to %s dispatches to relay.bridge", async (fromChain, toChain) => {
+    const target = await route("BridgeExecuteRelay", {
+      fromChain,
+      fromToken: WETH,
+      toChain,
+      toToken: USDC,
+      amountRaw: "1000000",
+    });
+    expect(target.toolId).toBe(FIXED_MUTATING_ALIAS_TARGETS.BridgeExecuteRelay);
+    expect(target.toolId).toBe("relay.bridge");
+  });
+
+  it("declares a fixed target for exactly those two", () => {
+    const declared = Object.keys(MUTATING_PROTOCOL_ALIAS_ROUTERS)
+      .filter((alias) => fixedTargetOfMutatingAlias(alias) !== undefined)
+      .sort();
+    expect(declared).toEqual(["BridgeExecuteRelay", "SwapExecuteUniswap"]);
+  });
+});
+
+describe("the two router aliases really do choose a venue", () => {
+  // Not an assumption: `SwapExecute` is shown reaching two different protocol
+  // tools from two different argument sets, which is what makes
+  // `venue_resolved_per_call` an honest answer for it and a false one for the
+  // pair above.
+  it("SwapExecute reaches a different tool for an EVM chain than for Solana", async () => {
+    const evm = await route("SwapExecute", {
+      chain: "base",
+      tokenIn: WETH,
+      tokenOut: USDC,
+      amountIn: "1.5",
+    });
+    const solana = await route("SwapExecute", {
+      chain: "solana",
+      tokenIn: SOL_MINT,
+      tokenOut: USDC_MINT,
+      amountIn: "1.5",
+    });
+    expect(evm.toolId).not.toBe(solana.toolId);
+    expect(fixedTargetOfMutatingAlias("SwapExecute")).toBeUndefined();
+  });
+
+  it("BridgeExecute declares no fixed target, because it asks the venue registry", () => {
+    // Its venue comes from `resolveBridgeVenue`, a live registry read, so the
+    // answer is not knowable from the arguments alone - which is precisely what
+    // `venue_resolved_per_call` says.
+    expect(fixedTargetOfMutatingAlias("BridgeExecute")).toBeUndefined();
+  });
+});

--- a/src/__tests__/vex-agent/mcp/tool-describe-export.test.ts
+++ b/src/__tests__/vex-agent/mcp/tool-describe-export.test.ts
@@ -111,7 +111,10 @@ describe("vex_ToolDescribe returns one tool's whole contract", () => {
     }
   });
 
-  it("keeps venue_resolved_per_call for exactly the four mutating alias routers", () => {
+  it("keeps venue_resolved_per_call for exactly the two aliases that resolve a venue", () => {
+    // The other two name their venue in their own name and always dispatch to
+    // ONE tool, so a per-call answer was a false contract: it told an agent the
+    // authorizing quote could not be known until the call, when it was fixed.
     const perCall = buildStudioInventory()
       .filter((row) => {
         const outcome = describeExportedTool({ name: row.publicName });
@@ -119,12 +122,32 @@ describe("vex_ToolDescribe returns one tool's whole contract", () => {
       })
       .map((row) => row.publicName)
       .sort();
-    expect(perCall).toEqual([
-      "BridgeExecute",
-      "BridgeExecuteRelay",
-      "SwapExecute",
-      "SwapExecuteUniswap",
-    ]);
+    expect(perCall).toEqual(["BridgeExecute", "SwapExecute"]);
+  });
+
+  /**
+   * A FIXED alias is described through the tool it always resolves to.
+   *
+   * The pairing is not restated here: the expected quote is the one the TARGET
+   * tool publishes, so a change to the recorder-owned mapping moves both rows
+   * together, and a router that started choosing another venue would fail
+   * `mutating-alias-fixed-targets.test.ts` instead of quietly publishing the
+   * wrong quote here.
+   */
+  it.each([
+    ["SwapExecuteUniswap", "uniswap__swap_execute"],
+    ["BridgeExecuteRelay", "relay__bridge_execute"],
+  ])("%s publishes the gate of %s, not a per-call resolution", (alias, target) => {
+    const aliasGate = contractOf(alias).quoteGate;
+    const targetGate = contractOf(target).quoteGate;
+    expect(aliasGate.status).toBe("gated");
+    expect(targetGate.status).toBe("gated");
+    if (aliasGate.status !== "gated" || targetGate.status !== "gated") return;
+    expect(aliasGate.prequoteKind).toBe(targetGate.prequoteKind);
+    expect(aliasGate.authorizedBy).toEqual(targetGate.authorizedBy);
+    expect(aliasGate.authorizedBy.length).toBeGreaterThan(0);
+    expect(aliasGate.note).toContain("does NOT resolve a venue per call");
+    expect(aliasGate.note).toContain(target);
   });
 
   it("reports an ungated protocol tool as ungated rather than unknown", () => {
@@ -166,8 +189,9 @@ describe("vex_ToolDescribe returns one tool's whole contract", () => {
       expect(contract.vexFee.bps).toBe(25);
       expect(contract.vexFee.when).toContain("AFTER the deposit lands");
     }
-    // The internal alias resolves its venue per call, so the registries cannot
-    // answer for it - and it says so instead of naming a venue.
+    // `BridgeExecute` is a genuine router (Khalani, with a local-chain Relay
+    // exception), so the registries cannot answer for it - and it says so
+    // instead of naming a venue.
     expect(contract.quoteGate).toMatchObject({ status: "venue_resolved_per_call" });
   });
 

--- a/src/__tests__/vex-agent/tools/protocols/prequote/morpho-lane-record-to-gate.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/prequote/morpho-lane-record-to-gate.test.ts
@@ -1,0 +1,342 @@
+/**
+ * THE LEND LANE UNDER THE REAL HASH: the digest a Morpho quote RECORDS and the
+ * digest its execute's gate ASKS FOR, computed by the production functions and
+ * compared.
+ *
+ * `recorder-owned-gate-targets.test.ts` substitutes the metadata with the match
+ * hash stubbed, which is what lets it move a kind through every recorder without
+ * the hash dispatcher rejecting the identity. That stub is also its blind spot:
+ * the lane's real consequence is which MATERIAL `computePrequoteMatchHash`
+ * takes the digest over (`identity/hash.ts` dispatches `lend_deposit` /
+ * `lend_withdraw` on `lane`), and which identity `computeGateMatch` builds
+ * (`gate/identity.ts` reads the registration's lane). Neither is observable
+ * behind a constant digest.
+ *
+ * So this file runs the same recorders with the REAL hash and asserts the thing
+ * the gate actually does at execute time:
+ *
+ *   1. every lend registration's gate digest EQUALS the digest its quote
+ *      recorded, on both lanes and both directions - the collision the whole
+ *      quote-before-transaction gate depends on;
+ *   2. the two lanes never meet: a vault quote's row cannot answer a market
+ *      execute's question, or the reverse;
+ *   3. RENAME BOTH LANES to values nothing else spells, and every pair still
+ *      collides - which is only possible when the identity builders, the hash
+ *      dispatcher, the gate's switch and the execute registrations all read the
+ *      one owner. A literal restored at any of them is left behind by the
+ *      rename and its pair stops meeting;
+ *   4. COLLAPSE the two lanes onto one value, from EITHER side, and both halves
+ *      refuse the vault together: the recorder can no longer hash a vault
+ *      identity and the gate can no longer build one. The two directions catch
+ *      different literals - a stale vault spelling is invisible until the
+ *      values are made to meet, because the vault lane is never compared to
+ *      anything but the market one.
+ *
+ * The DB write and the wallet resolution are stubbed; nothing else is. No IO:
+ * both lend identities are readable from params alone, which is itself a
+ * property of this lane (`identity/hash/morpho-borrow.ts`).
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
+
+import { definedValue, mutableRecord } from "../../../../_test-value-guards.js";
+import {
+  SESSION_ID,
+  WALLET,
+  morphoMarketExecuteParams,
+  morphoMarketQuoteParams,
+  morphoMarketQuoteResult,
+  morphoVaultExecuteParams,
+  morphoVaultQuoteParams,
+  morphoVaultQuoteResult,
+} from "./recorder-quote-fixtures.js";
+
+type LaneOwner = typeof import("@vex-agent/tools/protocols/prequote/identity/lane.js");
+
+const LANE_MODULE = "@vex-agent/tools/protocols/prequote/identity/lane.js";
+
+const mockCreate: Mock<(input: unknown) => Promise<void>> = vi
+  .fn<(input: unknown) => Promise<void>>()
+  .mockResolvedValue(undefined);
+
+vi.mock("@vex-agent/db/repos/swap-prequotes.js", () => ({
+  create: (input: unknown) => mockCreate(input),
+  findLatestFreshByMatch: async () => null,
+  existsFreshFailByMatch: async () => false,
+}));
+
+vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
+  resolveSelectedAddress: () => WALLET,
+}));
+
+function ctx(): ProtocolExecutionContext {
+  return {
+    sessionPermission: "full",
+    approved: true,
+    walletResolution: { source: "default" },
+    walletPolicy: { kind: "none" },
+    sessionId: SESSION_ID,
+  };
+}
+
+interface LaneModules {
+  readonly prequote: typeof import("@vex-agent/tools/protocols/swap-prequote.js");
+  readonly registry: typeof import("@vex-agent/tools/protocols/prequote/registry.js");
+  readonly gate: typeof import("@vex-agent/tools/protocols/prequote/gate/identity.js");
+}
+
+/**
+ * Load the recorder, the registry and the gate's identity extractor, optionally
+ * with the lane owner substituted. The reset is what makes the substitution
+ * reach every module that read the owner at evaluation time.
+ */
+async function loadModules(lane?: (actual: LaneOwner) => Record<string, string>): Promise<LaneModules> {
+  vi.resetModules();
+  if (lane) {
+    vi.doMock(LANE_MODULE, async (importOriginal) => {
+      const actual = await importOriginal<LaneOwner>();
+      return { ...actual, ...lane(actual) };
+    });
+  }
+  const [prequote, registry, gate] = await Promise.all([
+    import("@vex-agent/tools/protocols/swap-prequote.js"),
+    import("@vex-agent/tools/protocols/prequote/registry.js"),
+    import("@vex-agent/tools/protocols/prequote/gate/identity.js"),
+  ]);
+  return { prequote, registry, gate };
+}
+
+/** The `match_hash` the recorder persisted, or a loud failure naming the tool. */
+function recordedMatchHash(quoteToolId: string): unknown {
+  return mutableRecord(
+    definedValue(mockCreate.mock.calls[0], `${quoteToolId} recorder call`)[0],
+    `${quoteToolId} recorded row`,
+  ).matchHash;
+}
+
+/** The digest one gated execute asks for, through the gate's own extractor. */
+async function gateDigest(
+  modules: LaneModules,
+  executeToolId: string,
+  params: Record<string, unknown>,
+): Promise<string> {
+  const gated = definedValue(
+    modules.registry.EXECUTE_GATE_TOOLS[executeToolId],
+    `gate ${executeToolId}`,
+  );
+  const asked = await modules.gate.computeGateMatch(gated, SESSION_ID, params, ctx());
+  return asked.matchHash;
+}
+
+beforeEach(() => {
+  mockCreate.mockClear();
+  vi.doUnmock(LANE_MODULE);
+});
+
+/** The four lend registrations, and the quote direction each is authorized by. */
+const LEND_PAIRS = [
+  {
+    lane: "vault",
+    direction: "deposit",
+    quoteToolId: "morpho.vault.quote",
+    executeToolId: "morpho.vault.deposit",
+    quoteParams: morphoVaultQuoteParams("deposit"),
+    quoteResult: morphoVaultQuoteResult("deposit"),
+    executeParams: morphoVaultExecuteParams("deposit"),
+  },
+  {
+    lane: "vault",
+    direction: "withdraw",
+    quoteToolId: "morpho.vault.quote",
+    executeToolId: "morpho.vault.withdraw",
+    quoteParams: morphoVaultQuoteParams("withdraw"),
+    quoteResult: morphoVaultQuoteResult("withdraw"),
+    executeParams: morphoVaultExecuteParams("withdraw"),
+  },
+  {
+    lane: "market",
+    direction: "supply",
+    quoteToolId: "morpho.market.quote",
+    executeToolId: "morpho.market.supply",
+    quoteParams: morphoMarketQuoteParams("supply"),
+    quoteResult: morphoMarketQuoteResult("supply"),
+    executeParams: morphoMarketExecuteParams("supply"),
+  },
+  {
+    lane: "market",
+    direction: "withdraw",
+    quoteToolId: "morpho.market.quote",
+    executeToolId: "morpho.market.withdraw",
+    quoteParams: morphoMarketQuoteParams("withdraw"),
+    quoteResult: morphoMarketQuoteResult("withdraw"),
+    executeParams: morphoMarketExecuteParams("withdraw"),
+  },
+] as const;
+
+describe("a lend quote's recorded digest is the one its execute's gate asks for", () => {
+  it.each(LEND_PAIRS)(
+    "$lane lane, $direction: $quoteToolId records what $executeToolId asks",
+    async (pair) => {
+      const modules = await loadModules();
+
+      await modules.prequote.recordPrequoteFromQuote(
+        pair.quoteToolId,
+        pair.quoteParams,
+        pair.quoteResult,
+        ctx(),
+      );
+
+      expect(recordedMatchHash(pair.quoteToolId)).toBe(
+        await gateDigest(modules, pair.executeToolId, pair.executeParams),
+      );
+    },
+  );
+
+  it("a vault deposit row cannot answer a market supply gate, or the reverse", async () => {
+    const modules = await loadModules();
+
+    await modules.prequote.recordPrequoteFromQuote(
+      "morpho.vault.quote",
+      morphoVaultQuoteParams("deposit"),
+      morphoVaultQuoteResult("deposit"),
+      ctx(),
+    );
+    const vaultRow = recordedMatchHash("morpho.vault.quote");
+    mockCreate.mockClear();
+
+    await modules.prequote.recordPrequoteFromQuote(
+      "morpho.market.quote",
+      morphoMarketQuoteParams("supply"),
+      morphoMarketQuoteResult("supply"),
+      ctx(),
+    );
+    const marketRow = recordedMatchHash("morpho.market.quote");
+
+    // They share the `lend_deposit` kind, so the gate DOES look at the row. The
+    // digests are what refuse it, and they come from different materials.
+    expect(vaultRow).not.toBe(marketRow);
+    expect(vaultRow).not.toBe(
+      await gateDigest(modules, "morpho.market.supply", morphoMarketExecuteParams("supply")),
+    );
+    expect(marketRow).not.toBe(
+      await gateDigest(modules, "morpho.vault.deposit", morphoVaultExecuteParams("deposit")),
+    );
+  });
+});
+
+describe("every lane site reads the one owner, proved by renaming both lanes", () => {
+  /**
+   * Both lanes given values nothing else in the tree spells.
+   *
+   * Under this rename the product must behave EXACTLY as before: every site
+   * that decides a lane - the two market identity builders, the hash
+   * dispatcher, the gate's identity switch and the execute registrations -
+   * reads the same owner, so they move together and the digests still meet. A
+   * literal restored at any ONE of them is left behind by the rename, and the
+   * pair it belongs to stops colliding: the recorder hashes one material while
+   * the gate asks for the other, or the gate builds the wrong lane's identity
+   * from params that lane does not have and fails closed.
+   */
+  const renameLanes = (): Record<string, string> => ({
+    MORPHO_VAULT_LANE: "vault_probe",
+    MORPHO_MARKET_LANE: "market_probe",
+  });
+
+  it.each(LEND_PAIRS)(
+    "$lane lane, $direction: the renamed lane still pairs the row with its gate",
+    async (pair) => {
+      const modules = await loadModules(renameLanes);
+
+      await modules.prequote.recordPrequoteFromQuote(
+        pair.quoteToolId,
+        pair.quoteParams,
+        pair.quoteResult,
+        ctx(),
+      );
+
+      expect(recordedMatchHash(pair.quoteToolId)).toBe(
+        await gateDigest(modules, pair.executeToolId, pair.executeParams),
+      );
+    },
+  );
+});
+
+/**
+ * The two ways to make the lanes indistinguishable, and BOTH are run: each
+ * catches a literal the other cannot. Renaming the market lane onto the vault's
+ * value leaves a restored market literal behind; renaming the vault lane onto
+ * the market's value leaves a restored VAULT literal behind, which is otherwise
+ * invisible - the vault lane is never compared to anything except the market
+ * one, so a stale `"vault"` spelling changes no digest until the two values are
+ * made to meet.
+ */
+const COLLAPSES = [
+  {
+    named: "market lane onto the vault's value",
+    patch: (actual: LaneOwner): Record<string, string> => ({
+      MORPHO_MARKET_LANE: actual.MORPHO_VAULT_LANE,
+    }),
+  },
+  {
+    named: "vault lane onto the market's value",
+    patch: (actual: LaneOwner): Record<string, string> => ({
+      MORPHO_VAULT_LANE: actual.MORPHO_MARKET_LANE,
+    }),
+  },
+] as const;
+
+describe.each(COLLAPSES)(
+  "collapsing the $named fails the vault closed on BOTH sides",
+  ({ patch: collapseLanes }) => {
+  it("the recorder can no longer hash a vault deposit identity", async () => {
+    const modules = await loadModules(collapseLanes);
+
+    // With the two lanes spelled alike, the hash dispatcher sends the vault
+    // identity through the MARKET material, which is anchored on a market id the
+    // vault identity does not have. The recorder cannot produce a digest, and
+    // nothing is written: a row under an identity nobody can ask for would be
+    // worse than no row, since the gate blocks in the absence of one.
+    await expect(
+      modules.prequote.recordPrequoteFromQuote(
+        "morpho.vault.quote",
+        morphoVaultQuoteParams("deposit"),
+        morphoVaultQuoteResult("deposit"),
+        ctx(),
+      ),
+    ).rejects.toThrow();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("the gate can no longer build a vault deposit identity", async () => {
+    const modules = await loadModules(collapseLanes);
+
+    // The same collapse on the gate's side: the registration's lane now reads as
+    // the market lane, so the gate builds a market identity from vault params
+    // and fails closed rather than guessing.
+    await expect(
+      gateDigest(modules, "morpho.vault.deposit", morphoVaultExecuteParams("deposit")),
+    ).rejects.toThrow();
+  });
+
+  it("the market lane still records the digest its own gate asks for", async () => {
+    const modules = await loadModules(collapseLanes);
+
+    // The market side moved as one: the recorder's identity, the hash dispatch
+    // and the gate registration all read the same substituted owner, so their
+    // digests still meet. This is what makes the two failures above a statement
+    // about the LANE rather than about a broken import.
+    await modules.prequote.recordPrequoteFromQuote(
+      "morpho.market.quote",
+      morphoMarketQuoteParams("supply"),
+      morphoMarketQuoteResult("supply"),
+      ctx(),
+    );
+
+    expect(recordedMatchHash("morpho.market.quote")).toBe(
+      await gateDigest(modules, "morpho.market.supply", morphoMarketExecuteParams("supply")),
+    );
+  });
+  },
+);

--- a/src/__tests__/vex-agent/tools/protocols/prequote/recorder-owned-gate-targets.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/prequote/recorder-owned-gate-targets.test.ts
@@ -1,0 +1,136 @@
+/**
+ * ONE SOURCE FOR THE ROW A QUOTE WRITES - proved by substituting it.
+ *
+ * The mapping from a quote's direction to the gate row it records used to exist
+ * three times: in the recorder that persists the row, in `prequote/registry.ts`
+ * as a second literal table, and in the registry test as a third. Two of those
+ * were copies, so a recorder could change the row it writes and leave both
+ * green: `vex_ToolDescribe.quoteGate.authorizedBy` would keep advertising an
+ * authorization the gate refuses, on a call that moves money.
+ *
+ * There is now ONE table (`record/gate-targets.ts`), and this test is the
+ * evidence that it really is one: the metadata is SUBSTITUTED at the module
+ * boundary, and both consumers are then observed to have moved with it - the
+ * row the recorder persists, and the authorization the registry publishes. A
+ * second copy anywhere would make one of the two assertions below fail.
+ *
+ * The DB and the wallet resolution are stubbed exactly as in
+ * `swap-prequote/morpho-market-gate.test.ts`, whose harness this borrows: what
+ * is under test is which kind the row carries, not the repository.
+ */
+
+import { describe, it, expect, vi, type Mock } from "vitest";
+
+import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
+
+import { definedValue, mutableRecord } from "../../../../_test-value-guards.js";
+
+const SESSION_ID = "00000000-0000-4000-8000-000000000042";
+const WALLET = "0xaaaabbbbccccddddeeeeffff0000111122223333";
+const MARKET_ID = "0x9103c3b4e834476c9a62ea009ba2c884ee42e94e6e314a26f04d312434191836";
+const LOAN_TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+const AMOUNT = "1000000";
+
+/**
+ * THE SUBSTITUTION. `morpho.market.quote` really records `lend_borrow` for a
+ * borrow; here its recorder-owned metadata says `lend_repay` instead. Nothing
+ * else is touched, and neither the registry nor the recorder is edited.
+ */
+const SUBSTITUTED_KIND = "lend_repay";
+
+const mockCreate: Mock<(input: unknown) => Promise<void>> = vi
+  .fn<(input: unknown) => Promise<void>>()
+  .mockResolvedValue(undefined);
+
+vi.mock("@vex-agent/db/repos/swap-prequotes.js", () => ({
+  create: (input: unknown) => mockCreate(input),
+  findLatestFreshByMatch: async () => null,
+  existsFreshFailByMatch: async () => false,
+}));
+
+vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
+  resolveSelectedAddress: () => WALLET,
+}));
+
+vi.mock("@vex-agent/tools/protocols/prequote/record/gate-targets.js", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@vex-agent/tools/protocols/prequote/record/gate-targets.js")
+  >();
+  return {
+    ...actual,
+    MORPHO_MARKET_QUOTE_GATE_TARGETS: {
+      ...actual.MORPHO_MARKET_QUOTE_GATE_TARGETS,
+      borrow: { kind: SUBSTITUTED_KIND },
+    },
+  };
+});
+
+const prequote = await import("@vex-agent/tools/protocols/swap-prequote.js");
+const registry = await import("@vex-agent/tools/protocols/prequote/registry.js");
+
+function ctx(): ProtocolExecutionContext {
+  return {
+    sessionPermission: "full",
+    approved: true,
+    walletResolution: { source: "default" },
+    walletPolicy: { kind: "none" },
+    sessionId: SESSION_ID,
+  } as ProtocolExecutionContext;
+}
+
+function borrowQuoteParams(): Record<string, unknown> {
+  return { marketId: MARKET_ID, chain: "base", direction: "borrow", borrowAmountRaw: AMOUNT };
+}
+
+function borrowQuoteResult(): Record<string, unknown> {
+  return {
+    toolId: "morpho.market.quote",
+    direction: "borrow",
+    market: { marketId: MARKET_ID, chainId: 8453 },
+    leg: {
+      direction: "out",
+      tokenAddress: LOAN_TOKEN,
+      tokenSymbol: "USDC",
+      decimals: 6,
+      amountRaw: AMOUNT,
+    },
+    preflight: { verdict: "ok", explanation: "simulated" },
+  };
+}
+
+function gateOf(gateToolId: string) {
+  return definedValue(registry.EXECUTE_GATE_TOOLS[gateToolId], `gate ${gateToolId}`);
+}
+
+describe("the recorder-owned gate targets drive persistence and the published contract alike", () => {
+  it("persists the substituted kind, so the recorder reads that metadata", async () => {
+    await prequote.recordPrequoteFromQuote(
+      "morpho.market.quote",
+      borrowQuoteParams(),
+      borrowQuoteResult(),
+      ctx(),
+    );
+    const row = mutableRecord(
+      definedValue(mockCreate.mock.calls[0], "recorder call")[0],
+      "recorded row",
+    );
+    expect(row.kind).toBe(SUBSTITUTED_KIND);
+  });
+
+  it("publishes the substituted authorization, so the description reads the SAME metadata", () => {
+    // `quoteToolsAuthorizing` is what `vex_ToolDescribe.quoteGate.authorizedBy`
+    // is built from (`mcp/tool-describe-export.ts`). Under the substitution the
+    // market quote no longer writes the row the borrow execute is gated on, so
+    // the published answer must stop naming it - and must name it on the repay
+    // execute, whose kind it now writes.
+    expect(registry.quoteToolsAuthorizing(gateOf("morpho.market.borrow"))).toEqual([]);
+    expect(registry.quoteToolsAuthorizing(gateOf("morpho.market.repay"))).toEqual([
+      "morpho.market.quote",
+    ]);
+    // Untouched directions are unaffected: the substitution moved one row, not
+    // the whole table.
+    expect(registry.quoteToolsAuthorizing(gateOf("morpho.market.supplyCollateral"))).toEqual([
+      "morpho.market.quote",
+    ]);
+  });
+});

--- a/src/__tests__/vex-agent/tools/protocols/prequote/recorder-owned-gate-targets.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/prequote/recorder-owned-gate-targets.test.ts
@@ -1,5 +1,6 @@
 /**
- * ONE SOURCE FOR THE ROW A QUOTE WRITES - proved by substituting it.
+ * ONE SOURCE FOR THE ROW A QUOTE WRITES - proved by substituting it, on every
+ * recorder family and on the lane that separates the two lend lanes.
  *
  * The mapping from a quote's direction to the gate row it records used to exist
  * three times: in the recorder that persists the row, in `prequote/registry.ts`
@@ -8,35 +9,104 @@
  * green: `vex_ToolDescribe.quoteGate.authorizedBy` would keep advertising an
  * authorization the gate refuses, on a call that moves money.
  *
- * There is now ONE table (`record/gate-targets.ts`), and this test is the
- * evidence that it really is one: the metadata is SUBSTITUTED at the module
- * boundary, and both consumers are then observed to have moved with it - the
- * row the recorder persists, and the authorization the registry publishes. A
- * second copy anywhere would make one of the two assertions below fail.
+ * There is now ONE table (`record/gate-targets.ts`) and ONE lane owner
+ * (`identity/lane.ts`), and this file is the evidence that they really are one.
+ * Each case SUBSTITUTES the metadata at the module boundary and then observes
+ * BOTH consumers move with it:
  *
- * The DB and the wallet resolution are stubbed exactly as in
- * `swap-prequote/morpho-market-gate.test.ts`, whose harness this borrows: what
- * is under test is which kind the row carries, not the repository.
+ *   - the row the recorder persists (or, for the lane, the identity it hashes
+ *     the row's `match_hash` from), and
+ *   - the authorization `quoteToolsAuthorizing` publishes, which is what
+ *     `mcp/tool-describe-export.ts` puts in `quoteGate.authorizedBy`.
+ *
+ * A literal restored ANYWHERE - in a recorder, in the registry, in an identity
+ * builder - leaves one of the two halves standing still and fails an assertion
+ * here. Every recorder family is covered, not one: swap, bridge, Pendle PT, PY
+ * and LP, and both Morpho lanes.
+ *
+ * SUBSTITUTION MECHANICS. Each case resets the module registry, registers its
+ * own `vi.doMock` over the metadata module, and only then imports the recorder
+ * and the registry. Both halves are necessary: `PREQUOTE_QUOTE_WRITES` is
+ * composed once at module evaluation, so an already-loaded registry would still
+ * carry the real table, and a hoisted `vi.mock` factory is evaluated once for
+ * the whole file, so every case would see whichever substitution ran first.
+ *
+ * The DB, the wallet resolution, the Khalani chain registry and the Pendle
+ * market lookup are stubbed so the suite is offline and deterministic: what is
+ * under test is which row and which lane the metadata produces, never the
+ * repository or a provider.
  */
 
-import { describe, it, expect, vi, type Mock } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 
 import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
+import type { PendleMarket } from "@tools/pendle/types.js";
+import { VexError, ErrorCodes } from "../../../../../errors.js";
 
 import { definedValue, mutableRecord } from "../../../../_test-value-guards.js";
+import { venueBridgeVexFee, venueSwapVexFee } from "./vex-fee-fixtures.js";
+
+type GateTargets = typeof import("@vex-agent/tools/protocols/prequote/record/gate-targets.js");
+type LaneOwner = typeof import("@vex-agent/tools/protocols/prequote/identity/lane.js");
 
 const SESSION_ID = "00000000-0000-4000-8000-000000000042";
 const WALLET = "0xaaaabbbbccccddddeeeeffff0000111122223333";
 const MARKET_ID = "0x9103c3b4e834476c9a62ea009ba2c884ee42e94e6e314a26f04d312434191836";
 const LOAN_TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+const VAULT = "0xbeef0e0834849acc03f0089f01f4f1eeb06873c9";
+const EVM_TOKEN_IN = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const EVM_TOKEN_OUT = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const PT = "0x1111111111111111111111111111111111111111";
+const YT = "0x2222222222222222222222222222222222222222";
+const LP_MARKET = "0x3333333333333333333333333333333333333333";
+const UNDERLYING = "0x4444444444444444444444444444444444444444";
 const AMOUNT = "1000000";
 
+// ── The substitution holders, and the two mocks that read them ────────────
+
+const GATE_TARGETS_MODULE = "@vex-agent/tools/protocols/prequote/record/gate-targets.js";
+const LANE_MODULE = "@vex-agent/tools/protocols/prequote/identity/lane.js";
+
 /**
- * THE SUBSTITUTION. `morpho.market.quote` really records `lend_borrow` for a
- * borrow; here its recorder-owned metadata says `lend_repay` instead. Nothing
- * else is touched, and neither the registry nor the recorder is edited.
+ * Register the two substitutions for the NEXT import graph.
+ *
+ * `vi.doMock` rather than the hoisted `vi.mock`: a hoisted factory is evaluated
+ * once and its result is kept for the file, so every case here would see
+ * whichever substitution ran first. `doMock` re-registers per case, and the
+ * module reset below is what forces the recorder and the registry to be built
+ * again from the substituted metadata.
  */
-const SUBSTITUTED_KIND = "lend_repay";
+function installSubstitution(
+  gateTargets: Record<string, unknown>,
+  lane: Record<string, unknown>,
+): void {
+  vi.doMock(GATE_TARGETS_MODULE, async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return { ...actual, ...gateTargets };
+  });
+  vi.doMock(LANE_MODULE, async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return { ...actual, ...lane };
+  });
+}
+
+// ── Offline boundaries ────────────────────────────────────────────────────
+
+/**
+ * The match hash is stubbed, and that is deliberate rather than convenient.
+ *
+ * `computePrequoteMatchHash` dispatches its MATERIAL on the identity's kind, so
+ * a substituted kind would send a swap identity through the bridge material and
+ * die on a field that identity does not have. That dispatch is a real safety
+ * property with its own suites (`identity/hash.ts` and the per-venue collision
+ * tests); it is not what this file is proving. Here the question is only WHICH
+ * ROW the recorder writes, so the digest is a constant and the row is the
+ * evidence.
+ */
+vi.mock("@vex-agent/tools/protocols/prequote/identity/hash.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, computePrequoteMatchHash: () => "f".repeat(64) };
+});
 
 const mockCreate: Mock<(input: unknown) => Promise<void>> = vi
   .fn<(input: unknown) => Promise<void>>()
@@ -52,21 +122,52 @@ vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
   resolveSelectedAddress: () => WALLET,
 }));
 
-vi.mock("@vex-agent/tools/protocols/prequote/record/gate-targets.js", async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import("@vex-agent/tools/protocols/prequote/record/gate-targets.js")
-  >();
-  return {
-    ...actual,
-    MORPHO_MARKET_QUOTE_GATE_TARGETS: {
-      ...actual.MORPHO_MARKET_QUOTE_GATE_TARGETS,
-      borrow: { kind: SUBSTITUTED_KIND },
-    },
-  };
-});
+vi.mock("@tools/khalani/chains.js", () => ({
+  getCachedKhalaniChains: async () => [],
+  resolveChainId: (input: string) => {
+    const known: Record<string, number> = { base: 8453, ethereum: 1, eth: 1, "8453": 8453 };
+    const id = known[input.trim().toLowerCase()];
+    if (id === undefined) {
+      throw new VexError(ErrorCodes.KHALANI_UNSUPPORTED_CHAIN, `Unsupported chain: ${input}`);
+    }
+    return id;
+  },
+  getChainFamily: () => "eip155",
+}));
 
-const prequote = await import("@vex-agent/tools/protocols/swap-prequote.js");
-const registry = await import("@vex-agent/tools/protocols/prequote/registry.js");
+function pendleMarket(): PendleMarket {
+  return {
+    address: LP_MARKET,
+    name: "PT-TEST",
+    expiry: "2099-01-01T00:00:00.000Z",
+    pt: PT,
+    yt: YT,
+    sy: null,
+    underlyingAsset: UNDERLYING,
+    details: {
+      liquidity: 5_000_000,
+      impliedApy: null,
+      pendleApy: null,
+      aggregatedApy: null,
+      maxBoostedApy: null,
+      feeRate: null,
+    },
+    categoryIds: [],
+    isNew: false,
+    isPrime: false,
+  };
+}
+
+vi.mock("@vex-agent/tools/protocols/pendle/market-lookup.js", () => ({
+  resolveMarketByPt: async () => pendleMarket(),
+  resolveMarketByAddress: async () => pendleMarket(),
+  resolveMarketByYt: async () => pendleMarket(),
+  resolveYtForPt: async () => YT,
+  buildAssetMap: async () => new Map(),
+  priceUsdFor: () => null,
+}));
+
+// ── Harness ───────────────────────────────────────────────────────────────
 
 function ctx(): ProtocolExecutionContext {
   return {
@@ -78,11 +179,133 @@ function ctx(): ProtocolExecutionContext {
   } as ProtocolExecutionContext;
 }
 
-function borrowQuoteParams(): Record<string, unknown> {
-  return { marketId: MARKET_ID, chain: "base", direction: "borrow", borrowAmountRaw: AMOUNT };
+interface SubstitutedModules {
+  readonly prequote: typeof import("@vex-agent/tools/protocols/swap-prequote.js");
+  readonly registry: typeof import("@vex-agent/tools/protocols/prequote/registry.js");
+  readonly identity: typeof import("@vex-agent/tools/protocols/prequote/identity/morpho-borrow.js");
 }
 
-function borrowQuoteResult(): Record<string, unknown> {
+/**
+ * Install a substitution, re-evaluate the modules that read it, and hand back
+ * the recorder entry point, the published registry and the identity builders.
+ *
+ * The reset is the point: `PREQUOTE_QUOTE_WRITES` is composed at module
+ * evaluation from the very metadata under substitution, so a module already in
+ * the registry would still be carrying the real table.
+ */
+async function withSubstitution(patch: {
+  readonly gateTargets?: Partial<GateTargets>;
+  readonly lane?: Partial<LaneOwner>;
+}): Promise<SubstitutedModules> {
+  vi.resetModules();
+  installSubstitution({ ...patch.gateTargets }, { ...patch.lane });
+  const [prequote, registry, identity] = await Promise.all([
+    import("@vex-agent/tools/protocols/swap-prequote.js"),
+    import("@vex-agent/tools/protocols/prequote/registry.js"),
+    import("@vex-agent/tools/protocols/prequote/identity/morpho-borrow.js"),
+  ]);
+  return { prequote, registry, identity };
+}
+
+/** The row the recorder persisted, or a loud failure naming the quote tool. */
+function recordedRow(quoteToolId: string): Record<string, unknown> {
+  return mutableRecord(
+    definedValue(mockCreate.mock.calls[0], `${quoteToolId} recorder call`)[0],
+    `${quoteToolId} recorded row`,
+  );
+}
+
+function authorizing(
+  registry: SubstitutedModules["registry"],
+  gateToolId: string,
+): readonly string[] {
+  const gate = definedValue(registry.EXECUTE_GATE_TOOLS[gateToolId], `gate ${gateToolId}`);
+  return registry.quoteToolsAuthorizing(gate);
+}
+
+beforeEach(() => {
+  mockCreate.mockClear();
+  vi.doUnmock(GATE_TARGETS_MODULE);
+  vi.doUnmock(LANE_MODULE);
+});
+
+// ── Fixtures, one per recorder family ─────────────────────────────────────
+
+function swapResult(): Record<string, unknown> {
+  return {
+    chain: "base",
+    chainId: 8453,
+    tokenIn: { address: EVM_TOKEN_IN, symbol: "AAA", decimals: 18 },
+    tokenOut: { address: EVM_TOKEN_OUT, symbol: "BBB", decimals: 18 },
+    routeSummary: { foo: "bar" },
+    routerAddress: "0xROUTER",
+    safety: {
+      tokenIn: { isHoneypot: false, isFOT: false, tax: 0 },
+      tokenOut: { native: true },
+    },
+    vexFee: venueSwapVexFee(),
+  };
+}
+
+function pendlePtSwapResult(): Record<string, unknown> {
+  return {
+    action: "swap",
+    direction: "buy",
+    chainId: 1,
+    tokenIn: { address: EVM_TOKEN_IN },
+    tokenOut: { address: PT },
+    pt: PT,
+    yt: YT,
+    market: LP_MARKET,
+    receiver: null,
+    expiry: "2099-01-01T00:00:00.000Z",
+    liquidityUsd: 5_000_000,
+    priceImpact: 0.001,
+  };
+}
+
+function pendlePyMintResult(): Record<string, unknown> {
+  return {
+    direction: "mint",
+    chainId: 1,
+    tokenIn: { address: EVM_TOKEN_IN },
+    tokenOut: { address: PT },
+    pt: PT,
+    yt: YT,
+    market: LP_MARKET,
+    expiry: "2099-01-01T00:00:00.000Z",
+    liquidityUsd: 5_000_000,
+    priceImpact: 0.001,
+  };
+}
+
+function pendleLpAddResult(): Record<string, unknown> {
+  return {
+    direction: "add",
+    chainId: 1,
+    tokenIn: { address: EVM_TOKEN_IN },
+    tokenOut: { address: LP_MARKET },
+    market: LP_MARKET,
+    expiry: "2099-01-01T00:00:00.000Z",
+    liquidityUsd: 5_000_000,
+    priceImpact: 0.001,
+  };
+}
+
+function morphoVaultDepositResult(): Record<string, unknown> {
+  return {
+    quote: {
+      chainId: 8453,
+      direction: "deposit",
+      vault: { address: VAULT, asset: LOAN_TOKEN },
+      sharePrice: { slippageBps: 50 },
+      preflight: { verdict: "ok" },
+    },
+    governance: { status: "read" },
+  };
+}
+
+function morphoMarketBorrowResult(): Record<string, unknown> {
   return {
     toolId: "morpho.market.quote",
     direction: "borrow",
@@ -98,39 +321,204 @@ function borrowQuoteResult(): Record<string, unknown> {
   };
 }
 
-function gateOf(gateToolId: string) {
-  return definedValue(registry.EXECUTE_GATE_TOOLS[gateToolId], `gate ${gateToolId}`);
-}
+// ── The families ──────────────────────────────────────────────────────────
 
-describe("the recorder-owned gate targets drive persistence and the published contract alike", () => {
-  it("persists the substituted kind, so the recorder reads that metadata", async () => {
+describe("every recorder family reads the one gate-target table", () => {
+  it("swap: the venue swap quotes persist and publish the substituted row", async () => {
+    const { prequote, registry } = await withSubstitution({
+      gateTargets: { SWAP_QUOTE_GATE_TARGET: { kind: "bridge" } },
+    });
+
     await prequote.recordPrequoteFromQuote(
-      "morpho.market.quote",
-      borrowQuoteParams(),
-      borrowQuoteResult(),
+      "kyberswap.swap.quote",
+      { amountIn: "1.0", slippageBps: 30 },
+      swapResult(),
       ctx(),
     );
-    const row = mutableRecord(
-      definedValue(mockCreate.mock.calls[0], "recorder call")[0],
-      "recorded row",
-    );
-    expect(row.kind).toBe(SUBSTITUTED_KIND);
+
+    expect(recordedRow("kyberswap.swap.quote").kind).toBe("bridge");
+    // The swap execute is gated on `swap`, which nothing writes any more.
+    expect(authorizing(registry, "kyberswap.swap.execute")).toEqual([]);
+    expect(authorizing(registry, "uniswap.swap.execute")).toEqual([]);
   });
 
-  it("publishes the substituted authorization, so the description reads the SAME metadata", () => {
-    // `quoteToolsAuthorizing` is what `vex_ToolDescribe.quoteGate.authorizedBy`
-    // is built from (`mcp/tool-describe-export.ts`). Under the substitution the
-    // market quote no longer writes the row the borrow execute is gated on, so
-    // the published answer must stop naming it - and must name it on the repay
-    // execute, whose kind it now writes.
-    expect(registry.quoteToolsAuthorizing(gateOf("morpho.market.borrow"))).toEqual([]);
-    expect(registry.quoteToolsAuthorizing(gateOf("morpho.market.repay"))).toEqual([
+  it("bridge: both bridge quotes persist and publish the substituted row", async () => {
+    const { prequote, registry } = await withSubstitution({
+      gateTargets: { BRIDGE_QUOTE_GATE_TARGET: { kind: "swap" } },
+    });
+
+    await prequote.recordPrequoteFromQuote(
+      "khalani.quote.get",
+      {
+        fromChain: "base",
+        fromToken: EVM_TOKEN_IN,
+        toChain: "ethereum",
+        toToken: EVM_TOKEN_OUT,
+        amountRaw: AMOUNT,
+      },
+      { quoteId: "q1", routes: [{ routeId: "r1" }], vexFee: venueBridgeVexFee() },
+      ctx(),
+    );
+
+    expect(recordedRow("khalani.quote.get").kind).toBe("swap");
+    expect(authorizing(registry, "khalani.bridge")).toEqual([]);
+    expect(authorizing(registry, "relay.bridge")).toEqual([]);
+  });
+
+  it("pendle PT: the shared PT/YT recorder persists and publishes the substituted row", async () => {
+    const { prequote, registry } = await withSubstitution({
+      gateTargets: {
+        PENDLE_PT_QUOTE_GATE_TARGETS: { swap: { kind: "mint" }, redeem: { kind: "redeem" } },
+      },
+    });
+
+    await prequote.recordPrequoteFromQuote(
+      "pendle.pt.quote",
+      { chain: "ethereum", pt: PT, amountIn: AMOUNT, slippageBps: 50 },
+      pendlePtSwapResult(),
+      ctx(),
+    );
+
+    expect(recordedRow("pendle.pt.quote").kind).toBe("mint");
+    // Both Pendle swap executes lose their authorization together, because the
+    // YT registration narrows the SAME recorder metadata rather than copying it.
+    expect(authorizing(registry, "pendle.pt.buy")).toEqual([]);
+    expect(authorizing(registry, "pendle.yt.buy")).toEqual([]);
+    // The untouched action is unaffected: one row moved, not the table.
+    expect(authorizing(registry, "pendle.pt.redeem")).toEqual(["pendle.pt.quote"]);
+  });
+
+  it("pendle PY: the PY recorder persists and publishes the substituted row", async () => {
+    const { prequote, registry } = await withSubstitution({
+      gateTargets: {
+        PENDLE_PY_QUOTE_GATE_TARGETS: { mint: { kind: "lp_add" }, redeem: { kind: "redeem_py" } },
+      },
+    });
+
+    await prequote.recordPrequoteFromQuote(
+      "pendle.py.quote",
+      { chain: "ethereum", pt: PT, tokenIn: EVM_TOKEN_IN, amountIn: AMOUNT, slippageBps: 50 },
+      pendlePyMintResult(),
+      ctx(),
+    );
+
+    expect(recordedRow("pendle.py.quote").kind).toBe("lp_add");
+    expect(authorizing(registry, "pendle.py.mint")).toEqual([]);
+    expect(authorizing(registry, "pendle.py.redeem")).toEqual(["pendle.py.quote"]);
+  });
+
+  it("pendle LP: the LP recorder persists and publishes the substituted row", async () => {
+    const { prequote, registry } = await withSubstitution({
+      gateTargets: {
+        PENDLE_LP_QUOTE_GATE_TARGETS: { add: { kind: "mint" }, remove: { kind: "lp_remove" } },
+      },
+    });
+
+    await prequote.recordPrequoteFromQuote(
+      "pendle.lp.quote",
+      { chain: "ethereum", market: LP_MARKET, tokenIn: EVM_TOKEN_IN, amountIn: AMOUNT, slippageBps: 50 },
+      pendleLpAddResult(),
+      ctx(),
+    );
+
+    expect(recordedRow("pendle.lp.quote").kind).toBe("mint");
+    expect(authorizing(registry, "pendle.lp.add")).toEqual([]);
+    expect(authorizing(registry, "pendle.lp.remove")).toEqual(["pendle.lp.quote"]);
+  });
+
+  it("morpho vault: the lend recorder persists and publishes the substituted row", async () => {
+    const { prequote, registry } = await withSubstitution({
+      gateTargets: {
+        MORPHO_LEND_QUOTE_GATE_TARGETS: {
+          // A deposit quote that writes the WITHDRAWAL row: the direction that
+          // decides whether the wallet's money goes in or comes out.
+          deposit: { kind: "lend_withdraw", lane: "vault" },
+          withdraw: { kind: "lend_withdraw", lane: "vault" },
+        },
+      },
+    });
+
+    await prequote.recordPrequoteFromQuote(
+      "morpho.vault.quote",
+      {
+        vaultAddress: VAULT,
+        chain: "base",
+        direction: "deposit",
+        depositAmountRaw: AMOUNT,
+        slippageBps: 50,
+      },
+      morphoVaultDepositResult(),
+      ctx(),
+    );
+
+    expect(recordedRow("morpho.vault.quote").kind).toBe("lend_withdraw");
+    expect(authorizing(registry, "morpho.vault.deposit")).toEqual([]);
+    expect(authorizing(registry, "morpho.vault.withdraw")).toEqual(["morpho.vault.quote"]);
+  });
+
+  it("morpho market: the market recorder persists and publishes the substituted row", async () => {
+    const { prequote, registry } = await withSubstitution({
+      gateTargets: {
+        MORPHO_MARKET_QUOTE_GATE_TARGETS: {
+          supplyCollateral: { kind: "lend_supply_collateral" },
+          withdrawCollateral: { kind: "lend_withdraw_collateral" },
+          // The market quote really records `lend_borrow` for a borrow; here its
+          // recorder-owned metadata says `lend_repay` instead.
+          borrow: { kind: "lend_repay" },
+          repay: { kind: "lend_repay" },
+          supply: { kind: "lend_deposit", lane: "market" },
+          withdraw: { kind: "lend_withdraw", lane: "market" },
+        },
+      },
+    });
+
+    await prequote.recordPrequoteFromQuote(
+      "morpho.market.quote",
+      { marketId: MARKET_ID, chain: "base", direction: "borrow", borrowAmountRaw: AMOUNT },
+      morphoMarketBorrowResult(),
+      ctx(),
+    );
+
+    expect(recordedRow("morpho.market.quote").kind).toBe("lend_repay");
+    // Under the substitution the market quote no longer writes the row the
+    // borrow execute is gated on, so the published answer must stop naming it -
+    // and must keep naming it on the repay execute, whose kind it now writes.
+    expect(authorizing(registry, "morpho.market.borrow")).toEqual([]);
+    expect(authorizing(registry, "morpho.market.repay")).toEqual(["morpho.market.quote"]);
+    expect(authorizing(registry, "morpho.market.supplyCollateral")).toEqual([
       "morpho.market.quote",
     ]);
-    // Untouched directions are unaffected: the substitution moved one row, not
-    // the whole table.
-    expect(registry.quoteToolsAuthorizing(gateOf("morpho.market.supplyCollateral"))).toEqual([
+  });
+});
+
+describe("the lend lane has one owner, and the identity reads it too", () => {
+  it("moves the persisted identity and the published authorization together", async () => {
+    // THE SUBSTITUTION. The Blue market lane is really "market"; here its one
+    // owner says "vault", which is the vault lane's own value - the sharpest
+    // case, because the two lanes are the only thing separating "put money in a
+    // curated vault" from "lend into a Blue market" under one shared kind.
+    const { registry, identity } = await withSubstitution({
+      lane: { MORPHO_MARKET_LANE: "vault" },
+    });
+
+    // Half one: the identity the recorder hashes its row's `match_hash` from.
+    // A `lane: "market"` literal restored in the builder fails here.
+    const built = identity.buildMorphoBorrowIdentityFor("supply", SESSION_ID, {
+      marketId: MARKET_ID,
+      chain: "base",
+      supplyAmountRaw: AMOUNT,
+    }, ctx());
+    expect(built.lane).toBe("vault");
+
+    // Half two: the published contract. With both lend lanes now spelled the
+    // same, the market supply execute is authorized by the vault quote as well -
+    // which is exactly the false pairing the lane exists to prevent, and it can
+    // only appear when the one owner says so.
+    expect(authorizing(registry, "morpho.market.supply")).toEqual([
       "morpho.market.quote",
+      "morpho.vault.quote",
     ]);
+    // The borrower's four carry no lane at all, so nothing about them moves.
+    expect(authorizing(registry, "morpho.market.borrow")).toEqual(["morpho.market.quote"]);
   });
 });

--- a/src/__tests__/vex-agent/tools/protocols/prequote/recorder-owned-gate-targets.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/prequote/recorder-owned-gate-targets.test.ts
@@ -1,6 +1,6 @@
 /**
  * ONE SOURCE FOR THE ROW A QUOTE WRITES - proved by substituting it, on every
- * recorder family and on the lane that separates the two lend lanes.
+ * recorder DIRECTION and on the lane that separates the two lend lanes.
  *
  * The mapping from a quote's direction to the gate row it records used to exist
  * three times: in the recorder that persists the row, in `prequote/registry.ts`
@@ -12,17 +12,28 @@
  * There is now ONE table (`record/gate-targets.ts`) and ONE lane owner
  * (`identity/lane.ts`), and this file is the evidence that they really are one.
  * Each case SUBSTITUTES the metadata at the module boundary and then observes
- * BOTH consumers move with it:
+ * THREE consumers move with it:
  *
- *   - the row the recorder persists (or, for the lane, the identity it hashes
- *     the row's `match_hash` from), and
+ *   - the row the recorder persists,
+ *   - the IDENTITY the recorder hands to `computePrequoteMatchHash`, wherever
+ *     that identity reads the same metadata (the swap and Pendle-swap hash
+ *     inputs take their `kind` from the table; the two Morpho market builders
+ *     take their `lane` from the lane owner), and
  *   - the authorization `quoteToolsAuthorizing` publishes, which is what
  *     `mcp/tool-describe-export.ts` puts in `quoteGate.authorizedBy`.
  *
- * A literal restored ANYWHERE - in a recorder, in the registry, in an identity
- * builder - leaves one of the two halves standing still and fails an assertion
- * here. Every recorder family is covered, not one: swap, bridge, Pendle PT, PY
- * and LP, and both Morpho lanes.
+ * A literal restored ANYWHERE - in a recorder's row, in the same recorder's
+ * hash input, in the registry, in an identity builder - leaves one of those
+ * three standing still and fails an assertion here. EVERY direction is covered,
+ * not one per family: swap, bridge, the two Pendle PT actions, the two PY and
+ * the two LP directions, both vault directions and all six market ones.
+ *
+ * A FOURTH substitution, at the bottom, reaches the one derivation the others
+ * cannot: they replace the COMPOSED gate-target map, so a kind map restored
+ * INSIDE `record/gate-targets.ts` still answers them. That case substitutes
+ * `morphoBorrowKindForDirection` - the identity side's own kind table - and
+ * leaves the map real, so the map is composed from the substituted answer or
+ * from a literal, and the row says which.
  *
  * SUBSTITUTION MECHANICS. Each case resets the module registry, registers its
  * own `vi.doMock` over the metadata module, and only then imports the recorder
@@ -31,41 +42,85 @@
  * carry the real table, and a hoisted `vi.mock` factory is evaluated once for
  * the whole file, so every case would see whichever substitution ran first.
  *
- * The DB, the wallet resolution, the Khalani chain registry and the Pendle
- * market lookup are stubbed so the suite is offline and deterministic: what is
- * under test is which row and which lane the metadata produces, never the
- * repository or a provider.
+ * A substitution is expressed as a FUNCTION OF THE REAL TABLE ("the borrow
+ * direction now writes the repay row"), never as a hand-written row: a literal
+ * expectation here would be the fourth copy this file exists to abolish.
+ *
+ * WHAT IS STUBBED, AND WHY THE HASH IS. `computePrequoteMatchHash` dispatches
+ * its MATERIAL on the identity's kind, so a substituted kind would send a swap
+ * identity through the bridge material and die on a field that identity does not
+ * have. That dispatch is a real safety property with its own suites
+ * (`identity/hash.ts` and the per-venue collision tests) and the record-to-gate
+ * digest agreement is proved under the REAL hash in
+ * `morpho-lane-record-to-gate.test.ts`. Here the digest is a constant, and the
+ * stub CAPTURES the identity it was given so the assertions can read it. The DB,
+ * the wallet resolution, the Khalani chain registry and the Pendle market
+ * lookups are stubbed so the suite is offline and deterministic.
  */
 
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 
 import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
-import type { PendleMarket } from "@tools/pendle/types.js";
+import type { PrequoteGateTarget } from "@vex-agent/tools/protocols/prequote/registry.js";
 import { VexError, ErrorCodes } from "../../../../../errors.js";
 
 import { definedValue, mutableRecord } from "../../../../_test-value-guards.js";
 import { venueBridgeVexFee, venueSwapVexFee } from "./vex-fee-fixtures.js";
+import {
+  MARKET_ID,
+  MORPHO_MARKET_DIRECTIONS,
+  AMOUNT,
+  SESSION_ID,
+  WALLET,
+  YT,
+  bridgeQuoteParams,
+  bridgeQuoteResult,
+  morphoMarketQuoteParams,
+  morphoMarketQuoteResult,
+  morphoVaultQuoteParams,
+  morphoVaultQuoteResult,
+  pendleLpQuoteParams,
+  pendleLpQuoteResult,
+  pendleMarketFixture,
+  pendlePtQuoteParams,
+  pendlePtQuoteResult,
+  pendlePyQuoteParams,
+  pendlePyQuoteResult,
+  swapQuoteParams,
+  swapQuoteResult,
+} from "./recorder-quote-fixtures.js";
 
 type GateTargets = typeof import("@vex-agent/tools/protocols/prequote/record/gate-targets.js");
 type LaneOwner = typeof import("@vex-agent/tools/protocols/prequote/identity/lane.js");
 
-const SESSION_ID = "00000000-0000-4000-8000-000000000042";
-const WALLET = "0xaaaabbbbccccddddeeeeffff0000111122223333";
-const MARKET_ID = "0x9103c3b4e834476c9a62ea009ba2c884ee42e94e6e314a26f04d312434191836";
-const LOAN_TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
-const VAULT = "0xbeef0e0834849acc03f0089f01f4f1eeb06873c9";
-const EVM_TOKEN_IN = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-const EVM_TOKEN_OUT = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
-const PT = "0x1111111111111111111111111111111111111111";
-const YT = "0x2222222222222222222222222222222222222222";
-const LP_MARKET = "0x3333333333333333333333333333333333333333";
-const UNDERLYING = "0x4444444444444444444444444444444444444444";
-const AMOUNT = "1000000";
+/**
+ * What a substitution may put in place of one gate-target export: a single row,
+ * or a direction-keyed map of rows. Nothing else is exported as data there, so
+ * this is the whole vocabulary and no cast is needed to write a patch.
+ */
+type GateTargetPatch = Readonly<
+  Partial<
+    Record<keyof GateTargets, PrequoteGateTarget | Readonly<Record<string, PrequoteGateTarget>>>
+  >
+>;
+type LanePatch = Readonly<Partial<Record<keyof LaneOwner, string>>>;
+
+/**
+ * The identity side's own kind table, substituted through the function
+ * `record/gate-targets.ts` asks rather than through the table it publishes.
+ * That is the one derivation the gate-target substitutions above cannot reach:
+ * they replace the composed map, so a hand-written map restored INSIDE
+ * `morphoMarketGateTarget` would still answer them.
+ */
+type BorrowIdentityOwner =
+  typeof import("@vex-agent/tools/protocols/prequote/identity/morpho-borrow.js");
+type BorrowKindPatch = Readonly<Pick<BorrowIdentityOwner, "morphoBorrowKindForDirection">>;
 
 // ── The substitution holders, and the two mocks that read them ────────────
 
 const GATE_TARGETS_MODULE = "@vex-agent/tools/protocols/prequote/record/gate-targets.js";
 const LANE_MODULE = "@vex-agent/tools/protocols/prequote/identity/lane.js";
+const MORPHO_BORROW_MODULE = "@vex-agent/tools/protocols/prequote/identity/morpho-borrow.js";
 
 /**
  * Register the two substitutions for the NEXT import graph.
@@ -75,37 +130,47 @@ const LANE_MODULE = "@vex-agent/tools/protocols/prequote/identity/lane.js";
  * whichever substitution ran first. `doMock` re-registers per case, and the
  * module reset below is what forces the recorder and the registry to be built
  * again from the substituted metadata.
+ *
+ * Each patch is a function of the REAL module, so a case says which row moves
+ * onto which other row without ever restating a row's contents.
  */
 function installSubstitution(
-  gateTargets: Record<string, unknown>,
-  lane: Record<string, unknown>,
+  gateTargets: (actual: GateTargets) => GateTargetPatch,
+  lane: (actual: LaneOwner) => LanePatch,
+  borrowKind?: (actual: BorrowIdentityOwner) => BorrowKindPatch,
 ): void {
   vi.doMock(GATE_TARGETS_MODULE, async (importOriginal) => {
-    const actual = await importOriginal<Record<string, unknown>>();
-    return { ...actual, ...gateTargets };
+    const actual = await importOriginal<GateTargets>();
+    return { ...actual, ...gateTargets(actual) };
   });
   vi.doMock(LANE_MODULE, async (importOriginal) => {
-    const actual = await importOriginal<Record<string, unknown>>();
-    return { ...actual, ...lane };
+    const actual = await importOriginal<LaneOwner>();
+    return { ...actual, ...lane(actual) };
   });
+  // Only when a case asks for it: this module carries the recorder's identity
+  // builders as well, and every case above wants those real.
+  if (borrowKind) {
+    vi.doMock(MORPHO_BORROW_MODULE, async (importOriginal) => {
+      const actual = await importOriginal<BorrowIdentityOwner>();
+      return { ...actual, ...borrowKind(actual) };
+    });
+  }
 }
 
 // ── Offline boundaries ────────────────────────────────────────────────────
 
-/**
- * The match hash is stubbed, and that is deliberate rather than convenient.
- *
- * `computePrequoteMatchHash` dispatches its MATERIAL on the identity's kind, so
- * a substituted kind would send a swap identity through the bridge material and
- * die on a field that identity does not have. That dispatch is a real safety
- * property with its own suites (`identity/hash.ts` and the per-venue collision
- * tests); it is not what this file is proving. Here the question is only WHICH
- * ROW the recorder writes, so the digest is a constant and the row is the
- * evidence.
- */
+/** Every identity handed to the hash, in call order. Reset per case. */
+const hashProbe = vi.hoisted(() => ({ identities: [] as unknown[] }));
+
 vi.mock("@vex-agent/tools/protocols/prequote/identity/hash.js", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, computePrequoteMatchHash: () => "f".repeat(64) };
+  return {
+    ...actual,
+    computePrequoteMatchHash: (input: unknown): string => {
+      hashProbe.identities.push(input);
+      return "f".repeat(64);
+    },
+  };
 });
 
 const mockCreate: Mock<(input: unknown) => Promise<void>> = vi
@@ -135,36 +200,19 @@ vi.mock("@tools/khalani/chains.js", () => ({
   getChainFamily: () => "eip155",
 }));
 
-function pendleMarket(): PendleMarket {
-  return {
-    address: LP_MARKET,
-    name: "PT-TEST",
-    expiry: "2099-01-01T00:00:00.000Z",
-    pt: PT,
-    yt: YT,
-    sy: null,
-    underlyingAsset: UNDERLYING,
-    details: {
-      liquidity: 5_000_000,
-      impliedApy: null,
-      pendleApy: null,
-      aggregatedApy: null,
-      maxBoostedApy: null,
-      feeRate: null,
-    },
-    categoryIds: [],
-    isNew: false,
-    isPrime: false,
-  };
-}
-
 vi.mock("@vex-agent/tools/protocols/pendle/market-lookup.js", () => ({
-  resolveMarketByPt: async () => pendleMarket(),
-  resolveMarketByAddress: async () => pendleMarket(),
-  resolveMarketByYt: async () => pendleMarket(),
+  resolveMarketByPt: async () => pendleMarketFixture(),
+  resolveMarketByAddress: async () => pendleMarketFixture(),
+  resolveMarketByYt: async () => pendleMarketFixture(),
   resolveYtForPt: async () => YT,
   buildAssetMap: async () => new Map(),
   priceUsdFor: () => null,
+}));
+
+vi.mock("@vex-agent/tools/protocols/pendle/matured-market-lookup.js", () => ({
+  resolveExitMarketByPt: async () => ({ market: pendleMarketFixture(), maturity: "active" }),
+  resolveExitMarketByAddress: async () => ({ market: pendleMarketFixture(), maturity: "active" }),
+  resolveExitYtForPt: async () => YT,
 }));
 
 // ── Harness ───────────────────────────────────────────────────────────────
@@ -176,7 +224,7 @@ function ctx(): ProtocolExecutionContext {
     walletResolution: { source: "default" },
     walletPolicy: { kind: "none" },
     sessionId: SESSION_ID,
-  } as ProtocolExecutionContext;
+  };
 }
 
 interface SubstitutedModules {
@@ -194,16 +242,27 @@ interface SubstitutedModules {
  * the registry would still be carrying the real table.
  */
 async function withSubstitution(patch: {
-  readonly gateTargets?: Partial<GateTargets>;
-  readonly lane?: Partial<LaneOwner>;
+  readonly gateTargets?: (actual: GateTargets) => GateTargetPatch;
+  readonly lane?: (actual: LaneOwner) => LanePatch;
+  readonly borrowKind?: (actual: BorrowIdentityOwner) => BorrowKindPatch;
 }): Promise<SubstitutedModules> {
   vi.resetModules();
-  installSubstitution({ ...patch.gateTargets }, { ...patch.lane });
-  const [prequote, registry, identity] = await Promise.all([
-    import("@vex-agent/tools/protocols/swap-prequote.js"),
-    import("@vex-agent/tools/protocols/prequote/registry.js"),
-    import("@vex-agent/tools/protocols/prequote/identity/morpho-borrow.js"),
-  ]);
+  installSubstitution(
+    patch.gateTargets ?? (() => ({})),
+    patch.lane ?? (() => ({})),
+    patch.borrowKind,
+  );
+  // SEQUENTIAL, and the substituted identity module LAST. Measured: importing a
+  // module that is itself under `doMock` runs its factory, and the factory's
+  // `importOriginal` pulls that module's WHOLE subgraph unmocked - so a
+  // `Promise.all` that raced this import against the recorder's could leave
+  // `record/gate-targets.ts` cached with the real function and quietly answer a
+  // substitution that never took effect.
+  const prequote = await import("@vex-agent/tools/protocols/swap-prequote.js");
+  const registry = await import("@vex-agent/tools/protocols/prequote/registry.js");
+  const identity = await import(
+    "@vex-agent/tools/protocols/prequote/identity/morpho-borrow.js"
+  );
   return { prequote, registry, identity };
 }
 
@@ -212,6 +271,14 @@ function recordedRow(quoteToolId: string): Record<string, unknown> {
   return mutableRecord(
     definedValue(mockCreate.mock.calls[0], `${quoteToolId} recorder call`)[0],
     `${quoteToolId} recorded row`,
+  );
+}
+
+/** The identity that recorder handed to the match hash. */
+function hashedIdentity(quoteToolId: string): Record<string, unknown> {
+  return mutableRecord(
+    definedValue(hashProbe.identities[0], `${quoteToolId} hashed identity`),
+    `${quoteToolId} hashed identity`,
   );
 }
 
@@ -225,281 +292,334 @@ function authorizing(
 
 beforeEach(() => {
   mockCreate.mockClear();
+  hashProbe.identities.length = 0;
   vi.doUnmock(GATE_TARGETS_MODULE);
   vi.doUnmock(LANE_MODULE);
+  vi.doUnmock(MORPHO_BORROW_MODULE);
 });
 
-// ── Fixtures, one per recorder family ─────────────────────────────────────
+// ── One case per recorder direction ───────────────────────────────────────
 
-function swapResult(): Record<string, unknown> {
-  return {
-    chain: "base",
-    chainId: 8453,
-    tokenIn: { address: EVM_TOKEN_IN, symbol: "AAA", decimals: 18 },
-    tokenOut: { address: EVM_TOKEN_OUT, symbol: "BBB", decimals: 18 },
-    routeSummary: { foo: "bar" },
-    routerAddress: "0xROUTER",
-    safety: {
-      tokenIn: { isHoneypot: false, isFOT: false, tax: 0 },
-      tokenOut: { native: true },
-    },
-    vexFee: venueSwapVexFee(),
-  };
+interface DirectionCase {
+  /** The scenario, in the vocabulary of the recorder under test. */
+  readonly title: string;
+  readonly quoteToolId: string;
+  readonly params: Record<string, unknown>;
+  readonly result: Record<string, unknown>;
+  /** Which row this direction is made to write instead of its own. */
+  readonly gateTargets: (actual: GateTargets) => GateTargetPatch;
+  /** The kind the persisted row must now carry. */
+  readonly rowKind: string;
+  /**
+   * The kind on the identity handed to the hash. It MOVES with the table where
+   * the recorder builds its hash input from the same metadata (swap, Pendle PT
+   * swap), and stays at the identity builder's own value where a dedicated
+   * builder owns it - which is itself the fact under test.
+   */
+  readonly identityKind: string;
+  /** Executes that must lose their published authorization entirely. */
+  readonly losesAuthorization: readonly string[];
+  /** Executes that must keep exactly these authorizing quote tools. */
+  readonly keepsAuthorization: readonly (readonly [string, readonly string[]])[];
 }
 
-function pendlePtSwapResult(): Record<string, unknown> {
-  return {
-    action: "swap",
-    direction: "buy",
-    chainId: 1,
-    tokenIn: { address: EVM_TOKEN_IN },
-    tokenOut: { address: PT },
-    pt: PT,
-    yt: YT,
-    market: LP_MARKET,
-    receiver: null,
-    expiry: "2099-01-01T00:00:00.000Z",
-    liquidityUsd: 5_000_000,
-    priceImpact: 0.001,
-  };
-}
+const SWAP_AND_BRIDGE: readonly DirectionCase[] = [
+  {
+    title: "swap: the venue swap quotes persist, hash and publish the substituted row",
+    quoteToolId: "kyberswap.swap.quote",
+    params: swapQuoteParams(),
+    result: swapQuoteResult(venueSwapVexFee()),
+    gateTargets: (actual) => ({ SWAP_QUOTE_GATE_TARGET: actual.BRIDGE_QUOTE_GATE_TARGET }),
+    rowKind: "bridge",
+    // The swap recorder builds its hash input's `kind` from the SAME table entry
+    // as the row, so a literal restored in either place is caught here.
+    identityKind: "bridge",
+    losesAuthorization: [
+      "kyberswap.swap.execute",
+      "uniswap.swap.execute",
+      "trench.trade_execute",
+      "solana.swap.execute",
+    ],
+    // Pendle's swap executes read the Pendle table, which did not move.
+    keepsAuthorization: [["pendle.pt.buy", ["pendle.pt.quote", "pendle.yt.quote"]]],
+  },
+  {
+    title: "bridge: both bridge quotes persist and publish the substituted row",
+    quoteToolId: "khalani.quote.get",
+    params: bridgeQuoteParams(),
+    result: bridgeQuoteResult(venueBridgeVexFee()),
+    gateTargets: (actual) => ({ BRIDGE_QUOTE_GATE_TARGET: actual.SWAP_QUOTE_GATE_TARGET }),
+    rowKind: "swap",
+    // `buildBridgeIdentity` owns the bridge identity's kind, so it does NOT move
+    // with the row: the table decides what is written and published, not the
+    // material the digest is taken over.
+    identityKind: "bridge",
+    losesAuthorization: ["khalani.bridge", "relay.bridge"],
+    // A bridge quote writing a swap row still cannot authorize a swap execute:
+    // the venue binding is checked before the row.
+    keepsAuthorization: [["kyberswap.swap.execute", ["kyberswap.swap.quote"]]],
+  },
+];
 
-function pendlePyMintResult(): Record<string, unknown> {
-  return {
-    direction: "mint",
-    chainId: 1,
-    tokenIn: { address: EVM_TOKEN_IN },
-    tokenOut: { address: PT },
-    pt: PT,
-    yt: YT,
-    market: LP_MARKET,
-    expiry: "2099-01-01T00:00:00.000Z",
-    liquidityUsd: 5_000_000,
-    priceImpact: 0.001,
-  };
-}
-
-function pendleLpAddResult(): Record<string, unknown> {
-  return {
-    direction: "add",
-    chainId: 1,
-    tokenIn: { address: EVM_TOKEN_IN },
-    tokenOut: { address: LP_MARKET },
-    market: LP_MARKET,
-    expiry: "2099-01-01T00:00:00.000Z",
-    liquidityUsd: 5_000_000,
-    priceImpact: 0.001,
-  };
-}
-
-function morphoVaultDepositResult(): Record<string, unknown> {
-  return {
-    quote: {
-      chainId: 8453,
-      direction: "deposit",
-      vault: { address: VAULT, asset: LOAN_TOKEN },
-      sharePrice: { slippageBps: 50 },
-      preflight: { verdict: "ok" },
-    },
-    governance: { status: "read" },
-  };
-}
-
-function morphoMarketBorrowResult(): Record<string, unknown> {
-  return {
-    toolId: "morpho.market.quote",
-    direction: "borrow",
-    market: { marketId: MARKET_ID, chainId: 8453 },
-    leg: {
-      direction: "out",
-      tokenAddress: LOAN_TOKEN,
-      tokenSymbol: "USDC",
-      decimals: 6,
-      amountRaw: AMOUNT,
-    },
-    preflight: { verdict: "ok", explanation: "simulated" },
-  };
-}
-
-// ── The families ──────────────────────────────────────────────────────────
-
-describe("every recorder family reads the one gate-target table", () => {
-  it("swap: the venue swap quotes persist and publish the substituted row", async () => {
-    const { prequote, registry } = await withSubstitution({
-      gateTargets: { SWAP_QUOTE_GATE_TARGET: { kind: "bridge" } },
-    });
-
-    await prequote.recordPrequoteFromQuote(
-      "kyberswap.swap.quote",
-      { amountIn: "1.0", slippageBps: 30 },
-      swapResult(),
-      ctx(),
-    );
-
-    expect(recordedRow("kyberswap.swap.quote").kind).toBe("bridge");
-    // The swap execute is gated on `swap`, which nothing writes any more.
-    expect(authorizing(registry, "kyberswap.swap.execute")).toEqual([]);
-    expect(authorizing(registry, "uniswap.swap.execute")).toEqual([]);
-  });
-
-  it("bridge: both bridge quotes persist and publish the substituted row", async () => {
-    const { prequote, registry } = await withSubstitution({
-      gateTargets: { BRIDGE_QUOTE_GATE_TARGET: { kind: "swap" } },
-    });
-
-    await prequote.recordPrequoteFromQuote(
-      "khalani.quote.get",
-      {
-        fromChain: "base",
-        fromToken: EVM_TOKEN_IN,
-        toChain: "ethereum",
-        toToken: EVM_TOKEN_OUT,
-        amountRaw: AMOUNT,
+const PENDLE: readonly DirectionCase[] = [
+  {
+    title: "pendle PT swap: the shared PT/YT recorder writes and hashes the substituted row",
+    quoteToolId: "pendle.pt.quote",
+    params: pendlePtQuoteParams("swap"),
+    result: pendlePtQuoteResult("swap"),
+    gateTargets: (actual) => ({
+      PENDLE_PT_QUOTE_GATE_TARGETS: {
+        ...actual.PENDLE_PT_QUOTE_GATE_TARGETS,
+        swap: actual.PENDLE_PT_QUOTE_GATE_TARGETS.redeem,
       },
-      { quoteId: "q1", routes: [{ routeId: "r1" }], vexFee: venueBridgeVexFee() },
-      ctx(),
-    );
-
-    expect(recordedRow("khalani.quote.get").kind).toBe("swap");
-    expect(authorizing(registry, "khalani.bridge")).toEqual([]);
-    expect(authorizing(registry, "relay.bridge")).toEqual([]);
-  });
-
-  it("pendle PT: the shared PT/YT recorder persists and publishes the substituted row", async () => {
-    const { prequote, registry } = await withSubstitution({
-      gateTargets: {
-        PENDLE_PT_QUOTE_GATE_TARGETS: { swap: { kind: "mint" }, redeem: { kind: "redeem" } },
-      },
-    });
-
-    await prequote.recordPrequoteFromQuote(
-      "pendle.pt.quote",
-      { chain: "ethereum", pt: PT, amountIn: AMOUNT, slippageBps: 50 },
-      pendlePtSwapResult(),
-      ctx(),
-    );
-
-    expect(recordedRow("pendle.pt.quote").kind).toBe("mint");
+    }),
+    rowKind: "redeem",
+    // The PT swap branch takes its hash input's `kind` from the same entry.
+    identityKind: "redeem",
     // Both Pendle swap executes lose their authorization together, because the
     // YT registration narrows the SAME recorder metadata rather than copying it.
-    expect(authorizing(registry, "pendle.pt.buy")).toEqual([]);
-    expect(authorizing(registry, "pendle.yt.buy")).toEqual([]);
-    // The untouched action is unaffected: one row moved, not the table.
-    expect(authorizing(registry, "pendle.pt.redeem")).toEqual(["pendle.pt.quote"]);
-  });
-
-  it("pendle PY: the PY recorder persists and publishes the substituted row", async () => {
-    const { prequote, registry } = await withSubstitution({
-      gateTargets: {
-        PENDLE_PY_QUOTE_GATE_TARGETS: { mint: { kind: "lp_add" }, redeem: { kind: "redeem_py" } },
+    losesAuthorization: ["pendle.pt.buy", "pendle.pt.sell", "pendle.yt.buy", "pendle.yt.sell"],
+    keepsAuthorization: [["pendle.pt.redeem", ["pendle.pt.quote", "pendle.yt.quote"]]],
+  },
+  {
+    title: "pendle PT redeem: the matured-redeem branch writes the substituted row",
+    quoteToolId: "pendle.pt.quote",
+    params: pendlePtQuoteParams("redeem"),
+    result: pendlePtQuoteResult("redeem"),
+    gateTargets: (actual) => ({
+      PENDLE_PT_QUOTE_GATE_TARGETS: {
+        ...actual.PENDLE_PT_QUOTE_GATE_TARGETS,
+        redeem: actual.PENDLE_PT_QUOTE_GATE_TARGETS.swap,
       },
-    });
-
-    await prequote.recordPrequoteFromQuote(
-      "pendle.py.quote",
-      { chain: "ethereum", pt: PT, tokenIn: EVM_TOKEN_IN, amountIn: AMOUNT, slippageBps: 50 },
-      pendlePyMintResult(),
-      ctx(),
-    );
-
-    expect(recordedRow("pendle.py.quote").kind).toBe("lp_add");
-    expect(authorizing(registry, "pendle.py.mint")).toEqual([]);
-    expect(authorizing(registry, "pendle.py.redeem")).toEqual(["pendle.py.quote"]);
-  });
-
-  it("pendle LP: the LP recorder persists and publishes the substituted row", async () => {
-    const { prequote, registry } = await withSubstitution({
-      gateTargets: {
-        PENDLE_LP_QUOTE_GATE_TARGETS: { add: { kind: "mint" }, remove: { kind: "lp_remove" } },
+    }),
+    rowKind: "swap",
+    // The dedicated redeem builder owns this identity's kind.
+    identityKind: "redeem",
+    losesAuthorization: ["pendle.pt.redeem"],
+    keepsAuthorization: [["pendle.pt.buy", ["pendle.pt.quote", "pendle.yt.quote"]]],
+  },
+  {
+    title: "pendle PY mint: the PY recorder writes the substituted row",
+    quoteToolId: "pendle.py.quote",
+    params: pendlePyQuoteParams("mint"),
+    result: pendlePyQuoteResult("mint"),
+    gateTargets: (actual) => ({
+      PENDLE_PY_QUOTE_GATE_TARGETS: {
+        ...actual.PENDLE_PY_QUOTE_GATE_TARGETS,
+        mint: actual.PENDLE_PY_QUOTE_GATE_TARGETS.redeem,
       },
-    });
+    }),
+    rowKind: "redeem_py",
+    identityKind: "mint",
+    losesAuthorization: ["pendle.py.mint"],
+    keepsAuthorization: [["pendle.py.redeem", ["pendle.py.quote"]]],
+  },
+  {
+    title: "pendle PY redeem: the pre-expiry redeem branch writes the substituted row",
+    quoteToolId: "pendle.py.quote",
+    params: pendlePyQuoteParams("redeem"),
+    result: pendlePyQuoteResult("redeem"),
+    gateTargets: (actual) => ({
+      PENDLE_PY_QUOTE_GATE_TARGETS: {
+        ...actual.PENDLE_PY_QUOTE_GATE_TARGETS,
+        redeem: actual.PENDLE_PY_QUOTE_GATE_TARGETS.mint,
+      },
+    }),
+    rowKind: "mint",
+    identityKind: "redeem_py",
+    losesAuthorization: ["pendle.py.redeem"],
+    keepsAuthorization: [["pendle.py.mint", ["pendle.py.quote"]]],
+  },
+  {
+    title: "pendle LP add: the LP recorder writes the substituted row",
+    quoteToolId: "pendle.lp.quote",
+    params: pendleLpQuoteParams("add"),
+    result: pendleLpQuoteResult("add"),
+    gateTargets: (actual) => ({
+      PENDLE_LP_QUOTE_GATE_TARGETS: {
+        ...actual.PENDLE_LP_QUOTE_GATE_TARGETS,
+        add: actual.PENDLE_LP_QUOTE_GATE_TARGETS.remove,
+      },
+    }),
+    rowKind: "lp_remove",
+    identityKind: "lp_add",
+    losesAuthorization: ["pendle.lp.add"],
+    keepsAuthorization: [["pendle.lp.remove", ["pendle.lp.quote"]]],
+  },
+  {
+    title: "pendle LP remove: the exit branch writes the substituted row",
+    quoteToolId: "pendle.lp.quote",
+    params: pendleLpQuoteParams("remove"),
+    result: pendleLpQuoteResult("remove"),
+    gateTargets: (actual) => ({
+      PENDLE_LP_QUOTE_GATE_TARGETS: {
+        ...actual.PENDLE_LP_QUOTE_GATE_TARGETS,
+        remove: actual.PENDLE_LP_QUOTE_GATE_TARGETS.add,
+      },
+    }),
+    rowKind: "lp_add",
+    identityKind: "lp_remove",
+    losesAuthorization: ["pendle.lp.remove"],
+    keepsAuthorization: [["pendle.lp.add", ["pendle.lp.quote"]]],
+  },
+];
 
-    await prequote.recordPrequoteFromQuote(
-      "pendle.lp.quote",
-      { chain: "ethereum", market: LP_MARKET, tokenIn: EVM_TOKEN_IN, amountIn: AMOUNT, slippageBps: 50 },
-      pendleLpAddResult(),
-      ctx(),
-    );
-
-    expect(recordedRow("pendle.lp.quote").kind).toBe("mint");
-    expect(authorizing(registry, "pendle.lp.add")).toEqual([]);
-    expect(authorizing(registry, "pendle.lp.remove")).toEqual(["pendle.lp.quote"]);
-  });
-
-  it("morpho vault: the lend recorder persists and publishes the substituted row", async () => {
-    const { prequote, registry } = await withSubstitution({
-      gateTargets: {
+const MORPHO_VAULT: readonly DirectionCase[] = (["deposit", "withdraw"] as const).map(
+  (direction) => {
+    const mirror = direction === "deposit" ? "withdraw" : "deposit";
+    return {
+      // A deposit quote made to write the WITHDRAWAL row, and the reverse: the
+      // direction that decides whether the wallet's money goes in or comes out.
+      title: `morpho vault ${direction}: the lend recorder writes the ${mirror} row`,
+      quoteToolId: "morpho.vault.quote",
+      params: morphoVaultQuoteParams(direction),
+      result: morphoVaultQuoteResult(direction),
+      gateTargets: (actual) => ({
         MORPHO_LEND_QUOTE_GATE_TARGETS: {
-          // A deposit quote that writes the WITHDRAWAL row: the direction that
-          // decides whether the wallet's money goes in or comes out.
-          deposit: { kind: "lend_withdraw", lane: "vault" },
-          withdraw: { kind: "lend_withdraw", lane: "vault" },
+          ...actual.MORPHO_LEND_QUOTE_GATE_TARGETS,
+          [direction]: actual.MORPHO_LEND_QUOTE_GATE_TARGETS[mirror],
         },
+      }),
+      rowKind: mirror === "deposit" ? "lend_deposit" : "lend_withdraw",
+      identityKind: direction === "deposit" ? "lend_deposit" : "lend_withdraw",
+      losesAuthorization: [`morpho.vault.${direction}`],
+      keepsAuthorization: [[`morpho.vault.${mirror}`, ["morpho.vault.quote"]]],
+    } satisfies DirectionCase;
+  },
+);
+
+/** The mirror each market direction is made to write instead of its own. */
+const MARKET_MIRROR = {
+  supplyCollateral: "withdrawCollateral",
+  withdrawCollateral: "supplyCollateral",
+  borrow: "repay",
+  repay: "borrow",
+  supply: "withdraw",
+  withdraw: "supply",
+} as const;
+
+/** The kind each market direction's own identity carries. */
+const MARKET_IDENTITY_KIND = {
+  supplyCollateral: "lend_supply_collateral",
+  withdrawCollateral: "lend_withdraw_collateral",
+  borrow: "lend_borrow",
+  repay: "lend_repay",
+  supply: "lend_deposit",
+  withdraw: "lend_withdraw",
+} as const;
+
+const MORPHO_MARKET: readonly DirectionCase[] = MORPHO_MARKET_DIRECTIONS.map((direction) => {
+  const mirror = MARKET_MIRROR[direction];
+  return {
+    // The sharpest of the six is the borrower's pair: a collateral or repayment
+    // quote publishing a borrow's authorization would turn "put money in" into
+    // "take debt out".
+    title: `morpho market ${direction}: the market recorder writes the ${mirror} row`,
+    quoteToolId: "morpho.market.quote",
+    params: morphoMarketQuoteParams(direction),
+    result: morphoMarketQuoteResult(direction),
+    gateTargets: (actual) => ({
+      MORPHO_MARKET_QUOTE_GATE_TARGETS: {
+        ...actual.MORPHO_MARKET_QUOTE_GATE_TARGETS,
+        [direction]: actual.MORPHO_MARKET_QUOTE_GATE_TARGETS[mirror],
       },
-    });
+    }),
+    rowKind: MARKET_IDENTITY_KIND[mirror],
+    identityKind: MARKET_IDENTITY_KIND[direction],
+    // Under the substitution this quote no longer writes the row its own
+    // execute is gated on, so the published answer must stop naming it.
+    losesAuthorization: [`morpho.market.${direction}`],
+    keepsAuthorization: [
+      [`morpho.market.${mirror}`, ["morpho.market.quote"]],
+      // The vault lane is a different owner's row and must not move with it.
+      ["morpho.vault.deposit", ["morpho.vault.quote"]],
+    ],
+  } satisfies DirectionCase;
+});
+
+describe("every recorder direction reads the one gate-target table", () => {
+  const cases = [...SWAP_AND_BRIDGE, ...PENDLE, ...MORPHO_VAULT, ...MORPHO_MARKET];
+
+  it.each(cases)("$title", async (testCase) => {
+    const { prequote, registry } = await withSubstitution({ gateTargets: testCase.gateTargets });
 
     await prequote.recordPrequoteFromQuote(
-      "morpho.vault.quote",
-      {
-        vaultAddress: VAULT,
-        chain: "base",
-        direction: "deposit",
-        depositAmountRaw: AMOUNT,
-        slippageBps: 50,
-      },
-      morphoVaultDepositResult(),
+      testCase.quoteToolId,
+      testCase.params,
+      testCase.result,
       ctx(),
     );
 
-    expect(recordedRow("morpho.vault.quote").kind).toBe("lend_withdraw");
-    expect(authorizing(registry, "morpho.vault.deposit")).toEqual([]);
-    expect(authorizing(registry, "morpho.vault.withdraw")).toEqual(["morpho.vault.quote"]);
+    expect(recordedRow(testCase.quoteToolId).kind).toBe(testCase.rowKind);
+    expect(hashedIdentity(testCase.quoteToolId).kind).toBe(testCase.identityKind);
+    for (const gateToolId of testCase.losesAuthorization) {
+      expect(authorizing(registry, gateToolId), `${gateToolId} authorization`).toEqual([]);
+    }
+    for (const [gateToolId, quotes] of testCase.keepsAuthorization) {
+      expect(authorizing(registry, gateToolId), `${gateToolId} authorization`).toEqual(quotes);
+    }
   });
+});
 
-  it("morpho market: the market recorder persists and publishes the substituted row", async () => {
+describe("the market row's KIND is asked for, not restated", () => {
+  /**
+   * The one derivation the substitutions above cannot reach. They replace the
+   * COMPOSED map `record/gate-targets.ts` exports, so a hand-written kind map
+   * restored inside `morphoMarketGateTarget` still answers every one of them:
+   * the case swaps two rows of the finished table and never notices that the
+   * table stopped asking the identity side for them.
+   *
+   * So this case substitutes the FUNCTION instead - `morphoBorrowKindForDirection`,
+   * the identity side's own table - and leaves the gate targets real. The map is
+   * composed at module evaluation, so it is built from the substituted answer,
+   * and what follows says whether it really asked.
+   *
+   * The identity builders spell their own kind, and internal calls do not go
+   * through the module boundary, so the identity does NOT move. That asymmetry
+   * is the assertion: the row and the published authorization follow the
+   * function, the hashed identity follows the builder, and a literal restored in
+   * the map leaves the first two standing on the borrower's own kind.
+   */
+  it("follows the identity side's table onto the row and the published authorization", async () => {
     const { prequote, registry } = await withSubstitution({
-      gateTargets: {
-        MORPHO_MARKET_QUOTE_GATE_TARGETS: {
-          supplyCollateral: { kind: "lend_supply_collateral" },
-          withdrawCollateral: { kind: "lend_withdraw_collateral" },
-          // The market quote really records `lend_borrow` for a borrow; here its
-          // recorder-owned metadata says `lend_repay` instead.
-          borrow: { kind: "lend_repay" },
-          repay: { kind: "lend_repay" },
-          supply: { kind: "lend_deposit", lane: "market" },
-          withdraw: { kind: "lend_withdraw", lane: "market" },
-        },
-      },
+      borrowKind: (actual) => ({
+        // The borrow direction now answers with the REPAY kind: taking debt on
+        // reported as paying it back, which is the pair worth catching.
+        morphoBorrowKindForDirection: (direction) =>
+          actual.morphoBorrowKindForDirection(direction === "borrow" ? "repay" : direction),
+      }),
     });
 
     await prequote.recordPrequoteFromQuote(
       "morpho.market.quote",
-      { marketId: MARKET_ID, chain: "base", direction: "borrow", borrowAmountRaw: AMOUNT },
-      morphoMarketBorrowResult(),
+      morphoMarketQuoteParams("borrow"),
+      morphoMarketQuoteResult("borrow"),
       ctx(),
     );
 
     expect(recordedRow("morpho.market.quote").kind).toBe("lend_repay");
-    // Under the substitution the market quote no longer writes the row the
-    // borrow execute is gated on, so the published answer must stop naming it -
-    // and must keep naming it on the repay execute, whose kind it now writes.
+    expect(hashedIdentity("morpho.market.quote").kind).toBe("lend_borrow");
+    // No quote writes `lend_borrow` any more, so the borrow execute's published
+    // authorization must empty rather than keep advertising a pairing the gate
+    // would refuse.
     expect(authorizing(registry, "morpho.market.borrow")).toEqual([]);
     expect(authorizing(registry, "morpho.market.repay")).toEqual(["morpho.market.quote"]);
-    expect(authorizing(registry, "morpho.market.supplyCollateral")).toEqual([
-      "morpho.market.quote",
-    ]);
   });
 });
 
 describe("the lend lane has one owner, and the identity reads it too", () => {
-  it("moves the persisted identity and the published authorization together", async () => {
-    // THE SUBSTITUTION. The Blue market lane is really "market"; here its one
-    // owner says "vault", which is the vault lane's own value - the sharpest
-    // case, because the two lanes are the only thing separating "put money in a
-    // curated vault" from "lend into a Blue market" under one shared kind.
-    const { registry, identity } = await withSubstitution({
-      lane: { MORPHO_MARKET_LANE: "vault" },
-    });
+  /**
+   * THE SUBSTITUTION. The Blue market lane is really "market"; here its one
+   * owner says what the VAULT lane says, which is the sharpest case: the two
+   * lanes are the only thing separating "put money in a curated vault" from
+   * "lend into a Blue market" under one shared kind.
+   */
+  const collapseLanes = (actual: LaneOwner): LanePatch => ({
+    MORPHO_MARKET_LANE: actual.MORPHO_VAULT_LANE,
+  });
+
+  it("moves the built identity and the published authorization together", async () => {
+    const { registry, identity } = await withSubstitution({ lane: collapseLanes });
 
     // Half one: the identity the recorder hashes its row's `match_hash` from.
     // A `lane: "market"` literal restored in the builder fails here.
@@ -521,4 +641,46 @@ describe("the lend lane has one owner, and the identity reads it too", () => {
     // The borrower's four carry no lane at all, so nothing about them moves.
     expect(authorizing(registry, "morpho.market.borrow")).toEqual(["morpho.market.quote"]);
   });
+
+  it("moves the VAULT lane's published rows too, when its own value is the one renamed", async () => {
+    // The mirror substitution, and it catches what the one above cannot: the
+    // vault lane is never compared to anything except the market lane, so a
+    // stale "vault" literal in the vault's own gate target agrees with
+    // everything until the two values are made to meet. Renamed onto the market
+    // lane, the vault's rows must travel with the registration that reads the
+    // same owner - a literal left behind takes `morpho.vault.deposit`'s
+    // authorization away entirely.
+    const { registry } = await withSubstitution({
+      lane: (actual) => ({ MORPHO_VAULT_LANE: actual.MORPHO_MARKET_LANE }),
+    });
+
+    expect(authorizing(registry, "morpho.vault.deposit")).toEqual([
+      "morpho.market.quote",
+      "morpho.vault.quote",
+    ]);
+    expect(authorizing(registry, "morpho.vault.withdraw")).toEqual([
+      "morpho.market.quote",
+      "morpho.vault.quote",
+    ]);
+  });
+
+  it.each(["supply", "withdraw"] as const)(
+    "carries the substituted lane onto the identity the %s recorder hashes",
+    async (direction) => {
+      // The builder above is called directly; this drives the SAME lane through
+      // the recorder, which is the path that actually persists a row. A lane
+      // literal restored between the builder and the recorder would leave the
+      // first case green and this one red.
+      const { prequote } = await withSubstitution({ lane: collapseLanes });
+
+      await prequote.recordPrequoteFromQuote(
+        "morpho.market.quote",
+        morphoMarketQuoteParams(direction),
+        morphoMarketQuoteResult(direction),
+        ctx(),
+      );
+
+      expect(hashedIdentity("morpho.market.quote").lane).toBe("vault");
+    },
+  );
 });

--- a/src/__tests__/vex-agent/tools/protocols/prequote/recorder-quote-fixtures.ts
+++ b/src/__tests__/vex-agent/tools/protocols/prequote/recorder-quote-fixtures.ts
@@ -1,0 +1,272 @@
+/**
+ * Shared QUOTE fixtures for the recorder suites: one params/result pair per
+ * recorder DIRECTION, plus the execute params each direction's gate takes.
+ *
+ * A helper MODULE, not a spec. It exists because two suites now drive the same
+ * recorders from opposite ends - `recorder-owned-gate-targets.test.ts`
+ * substitutes the metadata and reads the row, `morpho-lane-record-to-gate.test.ts`
+ * keeps the real hash and compares the row against `computeGateMatch` - and both
+ * need every direction a recorder can take. Hand-copied payloads in two files
+ * would drift the moment an extractor's schema does.
+ *
+ * The shapes mirror what each quote HANDLER returns (the extractors validate
+ * them) and what each execute manifest accepts; the amount keys are the manifest
+ * vocabulary, which is why they are spelled here rather than imported: a test
+ * that read the production key map could not notice the map changing under it.
+ */
+
+import type { MorphoBorrowDirection } from "@vex-agent/tools/protocols/prequote/identity/morpho-borrow.js";
+
+export const SESSION_ID = "00000000-0000-4000-8000-000000000042";
+export const WALLET = "0xaaaabbbbccccddddeeeeffff0000111122223333";
+export const MARKET_ID = "0x9103c3b4e834476c9a62ea009ba2c884ee42e94e6e314a26f04d312434191836";
+export const LOAN_TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+export const VAULT = "0xbeef0e0834849acc03f0089f01f4f1eeb06873c9";
+export const EVM_TOKEN_IN = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+export const EVM_TOKEN_OUT = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+export const PT = "0x1111111111111111111111111111111111111111";
+export const YT = "0x2222222222222222222222222222222222222222";
+export const LP_MARKET = "0x3333333333333333333333333333333333333333";
+export const UNDERLYING = "0x4444444444444444444444444444444444444444";
+export const AMOUNT = "1000000";
+export const SLIPPAGE_BPS = 50;
+
+/** The Pendle market every mocked lookup in these suites answers with. */
+export function pendleMarketFixture(): Record<string, unknown> {
+  return {
+    address: LP_MARKET,
+    name: "PT-TEST",
+    expiry: "2099-01-01T00:00:00.000Z",
+    pt: PT,
+    yt: YT,
+    sy: null,
+    underlyingAsset: UNDERLYING,
+    details: {
+      liquidity: 5_000_000,
+      impliedApy: null,
+      pendleApy: null,
+      aggregatedApy: null,
+      maxBoostedApy: null,
+      feeRate: null,
+    },
+    categoryIds: [],
+    isNew: false,
+    isPrime: false,
+  };
+}
+
+// ── Swap and bridge ───────────────────────────────────────────────────────
+
+export function swapQuoteParams(): Record<string, unknown> {
+  return { amountIn: "1.0", slippageBps: 30 };
+}
+
+export function swapQuoteResult(vexFee: Record<string, unknown>): Record<string, unknown> {
+  return {
+    chain: "base",
+    chainId: 8453,
+    tokenIn: { address: EVM_TOKEN_IN, symbol: "AAA", decimals: 18 },
+    tokenOut: { address: EVM_TOKEN_OUT, symbol: "BBB", decimals: 18 },
+    routeSummary: { foo: "bar" },
+    routerAddress: "0xROUTER",
+    safety: {
+      tokenIn: { isHoneypot: false, isFOT: false, tax: 0 },
+      tokenOut: { native: true },
+    },
+    vexFee,
+  };
+}
+
+export function bridgeQuoteParams(): Record<string, unknown> {
+  return {
+    fromChain: "base",
+    fromToken: EVM_TOKEN_IN,
+    toChain: "ethereum",
+    toToken: EVM_TOKEN_OUT,
+    amountRaw: AMOUNT,
+  };
+}
+
+export function bridgeQuoteResult(vexFee: Record<string, unknown>): Record<string, unknown> {
+  return { quoteId: "q1", routes: [{ routeId: "r1" }], vexFee };
+}
+
+// ── Pendle PT / YT (actions: swap, redeem) ────────────────────────────────
+
+export function pendlePtQuoteParams(action: "swap" | "redeem"): Record<string, unknown> {
+  return action === "swap"
+    ? { chain: "ethereum", pt: PT, amountIn: AMOUNT, slippageBps: SLIPPAGE_BPS }
+    : { chain: "ethereum", ptAddress: PT, amountIn: AMOUNT, slippageBps: SLIPPAGE_BPS };
+}
+
+export function pendlePtQuoteResult(action: "swap" | "redeem"): Record<string, unknown> {
+  return {
+    action,
+    direction: action === "swap" ? "buy" : "redeem",
+    chainId: 1,
+    tokenIn: { address: action === "swap" ? EVM_TOKEN_IN : PT },
+    tokenOut: { address: action === "swap" ? PT : UNDERLYING },
+    pt: PT,
+    yt: YT,
+    market: LP_MARKET,
+    receiver: null,
+    expiry: "2099-01-01T00:00:00.000Z",
+    liquidityUsd: 5_000_000,
+    priceImpact: 0.001,
+  };
+}
+
+// ── Pendle PY (directions: mint, redeem) ──────────────────────────────────
+
+export function pendlePyQuoteParams(direction: "mint" | "redeem"): Record<string, unknown> {
+  return direction === "mint"
+    ? { chain: "ethereum", pt: PT, tokenIn: EVM_TOKEN_IN, amountIn: AMOUNT, slippageBps: SLIPPAGE_BPS }
+    : { chain: "ethereum", pt: PT, tokenOut: UNDERLYING, amountIn: AMOUNT, slippageBps: SLIPPAGE_BPS };
+}
+
+export function pendlePyQuoteResult(direction: "mint" | "redeem"): Record<string, unknown> {
+  return {
+    direction,
+    chainId: 1,
+    tokenIn: { address: direction === "mint" ? EVM_TOKEN_IN : PT },
+    tokenOut: { address: direction === "mint" ? PT : UNDERLYING },
+    pt: PT,
+    yt: YT,
+    market: LP_MARKET,
+    expiry: "2099-01-01T00:00:00.000Z",
+    liquidityUsd: 5_000_000,
+    priceImpact: 0.001,
+  };
+}
+
+// ── Pendle LP (directions: add, remove) ───────────────────────────────────
+
+export function pendleLpQuoteParams(direction: "add" | "remove"): Record<string, unknown> {
+  return direction === "add"
+    ? { chain: "ethereum", market: LP_MARKET, tokenIn: EVM_TOKEN_IN, amountIn: AMOUNT, slippageBps: SLIPPAGE_BPS }
+    : { chain: "ethereum", market: LP_MARKET, tokenOut: UNDERLYING, amountIn: AMOUNT, slippageBps: SLIPPAGE_BPS };
+}
+
+export function pendleLpQuoteResult(direction: "add" | "remove"): Record<string, unknown> {
+  return {
+    direction,
+    chainId: 1,
+    tokenIn: { address: direction === "add" ? EVM_TOKEN_IN : LP_MARKET },
+    tokenOut: { address: direction === "add" ? LP_MARKET : UNDERLYING },
+    market: LP_MARKET,
+    expiry: "2099-01-01T00:00:00.000Z",
+    liquidityUsd: 5_000_000,
+    priceImpact: 0.001,
+  };
+}
+
+// ── Morpho vault lane (directions: deposit, withdraw) ─────────────────────
+
+/** The amount key each vault direction names. Distinct, and not interchangeable. */
+const VAULT_AMOUNT_KEY = {
+  deposit: "depositAmountRaw",
+  withdraw: "withdrawAmountRaw",
+} as const;
+
+export function morphoVaultQuoteParams(
+  direction: "deposit" | "withdraw",
+): Record<string, unknown> {
+  return {
+    vaultAddress: VAULT,
+    chain: "base",
+    direction,
+    [VAULT_AMOUNT_KEY[direction]]: AMOUNT,
+    slippageBps: SLIPPAGE_BPS,
+  };
+}
+
+/** The execute params for the paired vault execute: the same leg, no direction. */
+export function morphoVaultExecuteParams(
+  direction: "deposit" | "withdraw",
+): Record<string, unknown> {
+  return {
+    vaultAddress: VAULT,
+    chain: "base",
+    [VAULT_AMOUNT_KEY[direction]]: AMOUNT,
+    slippageBps: SLIPPAGE_BPS,
+  };
+}
+
+export function morphoVaultQuoteResult(
+  direction: "deposit" | "withdraw",
+): Record<string, unknown> {
+  return {
+    quote: {
+      chainId: 8453,
+      direction,
+      vault: { address: VAULT, asset: LOAN_TOKEN },
+      sharePrice: { slippageBps: SLIPPAGE_BPS },
+      preflight: { verdict: "ok" },
+    },
+    governance: { status: "read" },
+  };
+}
+
+// ── Morpho Blue market lane (six directions) ──────────────────────────────
+
+/** The amount key each market direction names, as the manifests spell them. */
+const MARKET_AMOUNT_KEY = {
+  supplyCollateral: "supplyCollateralAmountRaw",
+  withdrawCollateral: "withdrawCollateralAmountRaw",
+  borrow: "borrowAmountRaw",
+  repay: "repayAmountRaw",
+  supply: "supplyAmountRaw",
+  withdraw: "withdrawAmountRaw",
+} as const satisfies Readonly<Record<MorphoBorrowDirection, string>>;
+
+/** Every direction `morpho.market.quote` can price, for a table-driven suite. */
+export const MORPHO_MARKET_DIRECTIONS = [
+  "supplyCollateral",
+  "withdrawCollateral",
+  "borrow",
+  "repay",
+  "supply",
+  "withdraw",
+] as const satisfies readonly MorphoBorrowDirection[];
+
+export function morphoMarketQuoteParams(
+  direction: MorphoBorrowDirection,
+): Record<string, unknown> {
+  return {
+    marketId: MARKET_ID,
+    chain: "base",
+    direction,
+    [MARKET_AMOUNT_KEY[direction]]: AMOUNT,
+    slippageBps: SLIPPAGE_BPS,
+  };
+}
+
+/** The execute params for the paired market execute: the same leg, no direction. */
+export function morphoMarketExecuteParams(
+  direction: MorphoBorrowDirection,
+): Record<string, unknown> {
+  return {
+    marketId: MARKET_ID,
+    chain: "base",
+    [MARKET_AMOUNT_KEY[direction]]: AMOUNT,
+    slippageBps: SLIPPAGE_BPS,
+  };
+}
+
+export function morphoMarketQuoteResult(
+  direction: MorphoBorrowDirection,
+): Record<string, unknown> {
+  return {
+    toolId: "morpho.market.quote",
+    direction,
+    market: { marketId: MARKET_ID, chainId: 8453 },
+    leg: {
+      direction: direction === "borrow" || direction === "withdraw" ? "out" : "in",
+      tokenAddress: LOAN_TOKEN,
+      tokenSymbol: "USDC",
+      decimals: 6,
+      amountRaw: AMOUNT,
+    },
+    preflight: { verdict: "ok", explanation: "simulated" },
+  };
+}

--- a/src/__tests__/vex-agent/tools/protocols/prequote/registry-quote-gate-mapping.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/prequote/registry-quote-gate-mapping.test.ts
@@ -1,6 +1,6 @@
 /**
  * WHICH QUOTE AUTHORIZES WHICH EXECUTE - the published answer against the
- * registry's own recorder-to-gate-row mapping.
+ * recorders' own gate-target metadata.
  *
  * The defect this pins: `vex_ToolDescribe.quoteGate.authorizedBy` derived that
  * answer from `provider` equality alone, so it advertised pairings the gate
@@ -10,10 +10,21 @@
  * never even looked at, and publishing it as authorizing is a false contract
  * about a call that moves money.
  *
+ * NO EXPECTED TABLE LIVES HERE ANY MORE. The first version of this file
+ * restated the recorder-to-row mapping a third time (the registry held a second
+ * copy), which meant a recorder could change the row it writes and leave every
+ * copy green. `PREQUOTE_QUOTE_WRITES` is now composed from
+ * `record/gate-targets.ts`, the same metadata the recorders persist from, so
+ * what is left to test here is what a copied table could never prove: the
+ * STRUCTURAL invariants of the mapping, and the published pairings by name.
+ * Substituting the recorder metadata and watching both the persisted row and
+ * the published authorization move with it is
+ * `recorder-owned-gate-targets.test.ts`.
+ *
  * Every entry of `EXECUTE_GATE_TOOLS` is enumerated, not a chosen few, in the
- * shape `pkg/inventory/registry_test.go` uses in github-mcp-server: the export
- * is a projection of the registry, so the test walks the registry rather than a
- * sample. The six rows the recon named are pinned by name on top of the walk.
+ * shape github-mcp-server's tests use on their own registrations
+ * (`pkg/github/repositories_test.go`: the tool is asserted from the
+ * registration that produces it, never from a second expected table).
  */
 
 import { describe, it, expect } from "vitest";
@@ -27,38 +38,8 @@ import {
   quoteToolsAuthorizing,
 } from "@vex-agent/tools/protocols/prequote/registry.js";
 
-/** The mapping, restated from the RECORDERS rather than imported, so the test
- * fails when the data drifts from the code that writes the rows:
- *   swap        record/swap.ts:165,185
- *   bridge      record/bridge.ts:72
- *   pendle.pt   record/pendle-pt.ts:71 (redeem), :94,111 (swap)
- *   pendle.yt   pendle/handlers/yt/quote.ts:88 fixes action "swap"
- *   pendle.py   record/pendle-py.ts:55 (mint), :90 (redeem_py)
- *   pendle.lp   record/pendle-lp.ts:55 (lp_add), :90 (lp_remove)
- *   morpho.vault  record/morpho-lend.ts:62, vault lane identity/hash/morpho-lend.ts:61,87
- *   morpho.market record/morpho-borrow.ts:71 + identity/morpho-borrow.ts:61-72,199,213
- */
-const WRITES_FROM_RECORDERS: Readonly<Record<string, readonly string[]>> = {
-  "kyberswap.swap.quote": ["swap"],
-  "uniswap.swap.quote": ["swap"],
-  "trench.trade_quote": ["swap"],
-  "solana.swap.quote": ["swap"],
-  "khalani.quote.get": ["bridge"],
-  "relay.quote.get": ["bridge"],
-  "pendle.pt.quote": ["swap", "redeem"],
-  "pendle.yt.quote": ["swap"],
-  "pendle.py.quote": ["mint", "redeem_py"],
-  "pendle.lp.quote": ["lp_add", "lp_remove"],
-  "morpho.vault.quote": ["lend_deposit@vault", "lend_withdraw@vault"],
-  "morpho.market.quote": [
-    "lend_supply_collateral",
-    "lend_withdraw_collateral",
-    "lend_borrow",
-    "lend_repay",
-    "lend_deposit@market",
-    "lend_withdraw@market",
-  ],
-};
+/** The two kinds the vault lane and the Blue market lane SHARE. */
+const LANE_SHARED_KINDS: readonly string[] = ["lend_deposit", "lend_withdraw"];
 
 function labelsOf(quoteToolId: string): readonly string[] {
   return (PREQUOTE_QUOTE_WRITES[quoteToolId] ?? []).map(
@@ -72,27 +53,64 @@ function gateOf(gateToolId: string): ExecuteGateRegistration {
   return gate;
 }
 
-/** The authorizing set derived here from the recorder table, independently of
- * `quoteToolsAuthorizing`, so the two derivations must agree. */
+/**
+ * The authorizing set derived from the mapping itself, independently of
+ * `quoteToolsAuthorizing`, so the two derivations must agree.
+ */
 function expectedAuthorizers(gateToolId: string): readonly string[] {
   const gate = gateOf(gateToolId);
   const lane = laneOfGateRegistration(gate);
   const wanted = lane === undefined ? gate.kind : `${gate.kind}@${lane}`;
   return Object.keys(PREQUOTE_QUOTE_TOOLS)
     .filter((quoteToolId) => PREQUOTE_QUOTE_TOOLS[quoteToolId]?.provider === gate.provider)
-    .filter((quoteToolId) => (WRITES_FROM_RECORDERS[quoteToolId] ?? []).includes(wanted))
+    .filter((quoteToolId) => labelsOf(quoteToolId).includes(wanted))
     .sort();
 }
 
-describe("the recorder-to-gate-row mapping is complete and matches the recorders", () => {
-  it.each(Object.keys(PREQUOTE_QUOTE_TOOLS))("%s declares the rows its recorder writes", (quoteToolId) => {
-    expect([...labelsOf(quoteToolId)].sort()).toEqual([
-      ...(WRITES_FROM_RECORDERS[quoteToolId] ?? []),
-    ].sort());
+describe("the recorder-to-gate-row mapping holds its invariants", () => {
+  it.each(Object.keys(PREQUOTE_QUOTE_TOOLS))(
+    "%s declares at least one row it writes",
+    (quoteToolId) => {
+      // A quote tool that declares nothing authorizes nothing, which would make
+      // its whole registration silently inert.
+      expect(labelsOf(quoteToolId).length).toBeGreaterThan(0);
+    },
+  );
+
+  it("declares a row for every registered quote tool and no other", () => {
+    expect(Object.keys(PREQUOTE_QUOTE_WRITES).sort()).toEqual(
+      Object.keys(PREQUOTE_QUOTE_TOOLS).sort(),
+    );
   });
 
-  it("declares no quote tool the quote registry does not register", () => {
-    expect(Object.keys(PREQUOTE_QUOTE_WRITES).sort()).toEqual(Object.keys(PREQUOTE_QUOTE_TOOLS).sort());
+  it("carries a lane on exactly the two kinds the vault and market lanes share", () => {
+    // The lane is not decoration: it travels into the match hash, and it is the
+    // only thing between "put money in a curated vault" and "lend into a Blue
+    // market". A shared-kind row without it names two operations at once; a
+    // lane on any other kind would invent a distinction the hash does not make.
+    const laned = Object.entries(PREQUOTE_QUOTE_WRITES).flatMap(([quoteToolId, targets]) =>
+      targets.map((target) => ({
+        quoteToolId,
+        kind: target.kind,
+        laned: target.lane !== undefined,
+      })),
+    );
+    expect(laned.filter((row) => row.laned !== LANE_SHARED_KINDS.includes(row.kind))).toEqual([]);
+    // Not vacuous: both arms exist on the live surface.
+    expect(laned.some((row) => row.laned)).toBe(true);
+    expect(laned.some((row) => !row.laned)).toBe(true);
+  });
+
+  it("declares no row no gated execute could ever read", () => {
+    // A recorder that writes a kind nothing is gated on writes a row that
+    // authorizes nothing - dead authority, and a description that promises it.
+    const gatedKinds = new Set<string>(Object.values(EXECUTE_GATE_TOOLS).map((gate) => gate.kind));
+    const unreadable = Object.entries(PREQUOTE_QUOTE_WRITES)
+      .flatMap(([quoteToolId, targets]) =>
+        targets.map((target) => ({ quoteToolId, kind: target.kind })),
+      )
+      .filter((row) => !gatedKinds.has(row.kind));
+    expect(unreadable).toEqual([]);
   });
 
   it("covers every gate kind, so no gated execute is left with nothing that can authorize it", () => {
@@ -105,13 +123,13 @@ describe("the recorder-to-gate-row mapping is complete and matches the recorders
 
 describe("every gated execute names exactly the quotes that can authorize it", () => {
   it.each(Object.keys(EXECUTE_GATE_TOOLS))("%s", (gateToolId) => {
-    expect(quoteToolsAuthorizing(gateOf(gateToolId))).toEqual(
-      expectedAuthorizers(gateToolId),
-    );
+    expect(quoteToolsAuthorizing(gateOf(gateToolId))).toEqual(expectedAuthorizers(gateToolId));
   });
 
   // The six rows the recon measured as published-but-false, by name, so a
-  // regression names the operation rather than a table row number.
+  // regression names the operation rather than a table row number. These are
+  // the PUBLISHED contract, not a copy of the mapping: a recorder that starts
+  // writing another row fails them without any table here being edited.
   const NAMED: ReadonlyArray<readonly [string, readonly string[]]> = [
     ["morpho.market.borrow", ["morpho.market.quote"]],
     ["morpho.vault.deposit", ["morpho.vault.quote"]],
@@ -148,12 +166,12 @@ describe("every gated execute names exactly the quotes that can authorize it", (
   });
 
   it("lets a YT quote authorize a swap but never a PT redeem", () => {
-    // Both Pendle instrument quotes record through the same recorder, and the
-    // registration cannot tell them apart - the YT HANDLER fixes
-    // `action: "swap"`, which is why the mapping is per quote tool.
+    // Both Pendle instrument quotes record through the SAME recorder, so the
+    // narrowing cannot be the recorder's: the YT HANDLER fixes `action: "swap"`,
+    // and the registration says so with `actions: ["swap"]`.
+    expect(labelsOf("pendle.yt.quote")).toEqual(["swap"]);
+    expect([...labelsOf("pendle.pt.quote")].sort()).toEqual(["redeem", "swap"]);
     expect(quoteToolsAuthorizing(gateOf("pendle.yt.buy"))).toContain("pendle.yt.quote");
-    expect(quoteToolsAuthorizing(gateOf("pendle.pt.redeem"))).not.toContain(
-      "pendle.yt.quote",
-    );
+    expect(quoteToolsAuthorizing(gateOf("pendle.pt.redeem"))).not.toContain("pendle.yt.quote");
   });
 });

--- a/src/vex-agent/mcp/inventory/types.ts
+++ b/src/vex-agent/mcp/inventory/types.ts
@@ -28,9 +28,10 @@ import type { JsonSchema } from "../../tools/types.js";
  * preconditions still lead, and the field-by-field result list moves out to
  * `vex_ToolDescribe`, whose RESULT no client truncates.
  *
- * CHARACTERS, not bytes, because that is what was measured. Every description
- * is ASCII today, so the two counts agree; the lint asserts the character
- * count so it stays right if one ever stops being ASCII.
+ * CHARACTERS, not bytes, because that is what was measured. The hot set is
+ * NOT pure ASCII: `SwapExecute` and `SwapQuote` carry a U+2192 arrow, so they
+ * sit at 2045 characters and 2047 UTF-8 bytes. The lint asserts BOTH counts
+ * against the bound, so a non-ASCII edit cannot cross it in bytes unnoticed.
  *
  * The bound applies to the HOT SET only. A protocol description is loaded by a
  * client's own tool-search step, after which nothing re-cuts it.

--- a/src/vex-agent/mcp/tool-describe-export.ts
+++ b/src/vex-agent/mcp/tool-describe-export.ts
@@ -46,8 +46,9 @@ import type { ActionKind } from "../tools/taxonomy.js";
 import {
   EXECUTE_GATE_TOOLS,
   quoteToolsAuthorizing,
+  type ExecuteGateRegistration,
 } from "../tools/protocols/prequote/registry.js";
-import { isMutatingProtocolAlias } from "../tools/mutating-aliases.js";
+import { fixedTargetOfMutatingAlias, isMutatingProtocolAlias } from "../tools/mutating-aliases.js";
 import { EXPORTED_TOOL_SEARCH_NAME } from "./export-scope.js";
 import { EXPORTED_TOOL_SEARCH_PUBLIC_NAME } from "./tool-search-export.js";
 import { buildStudioInventory } from "./inventory/index.js";
@@ -289,19 +290,38 @@ function approvalCardFor(tool: StudioTool): { raised: boolean; note: string } {
  * The quote-gate answer for an INTERNAL row.
  *
  * `venue_resolved_per_call` is a claim about a venue and an authorizing quote,
- * so only the four mutating alias routers may carry it: they are the internal
- * tools that resolve a protocol venue per call and whose own description names
- * the quote pair (`tools/mutating-aliases.ts`). Every other internal tool used
- * to carry it too, which told a caller that `WalletBalances` and `TokenFind`
- * resolve a venue and are authorized by a quote - two false contracts on a row
- * that resolves nothing and spends nothing. A read and a local write answer
- * `ungated` because no quote authorizes them: they move no funds. Anything else
- * internal answers `ungated` too, because the prequote gate is keyed by
- * protocol toolId and never sees it; its authority is the user's approval card,
- * reported one field up in `approvalCard`.
+ * so only a router that actually chooses a venue may carry it. TWO of the four
+ * mutating aliases do: `SwapExecute` picks its venue from the token family and
+ * the chain, and `BridgeExecute` from the bridge venue registry
+ * (`tools/mutating-aliases.ts`).
+ *
+ * THE OTHER TWO DO NOT, and used to be described as if they did.
+ * `SwapExecuteUniswap` always resolves to `uniswap.swap.execute` and
+ * `BridgeExecuteRelay` always to `relay.bridge` - naming the venue is the whole
+ * point of them. Telling an agent that their venue, and therefore the quote
+ * that authorizes them, is decided at call time left it with no way to learn
+ * which quote to take before a call that moves money, while the answer was
+ * known and fixed. They are now described through the tool they resolve to:
+ * the SAME gate, the SAME prequote kind and the SAME authorizing quotes as
+ * calling that tool directly, because the alias dispatches straight into it
+ * (`executeProtocolTool` is where the prequote gate runs, keyed by the resolved
+ * protocol toolId).
+ *
+ * Every other internal tool used to carry `venue_resolved_per_call` too, which
+ * told a caller that `WalletBalances` and `TokenFind` resolve a venue and are
+ * authorized by a quote - two false contracts on a row that resolves nothing
+ * and spends nothing. A read and a local write answer `ungated` because no
+ * quote authorizes them: they move no funds. Anything else internal answers
+ * `ungated` too, because the prequote gate is keyed by protocol toolId and
+ * never sees it; its authority is the user's approval card, reported one field
+ * up in `approvalCard`.
  */
 function internalQuoteGateFor(tool: StudioTool): QuoteGate {
   if (isMutatingProtocolAlias(tool.publicName)) {
+    const fixedTarget = fixedTargetOfMutatingAlias(tool.publicName);
+    if (fixedTarget !== undefined) {
+      return fixedAliasQuoteGate(tool.publicName, fixedTarget);
+    }
     return {
       status: "venue_resolved_per_call",
       note:
@@ -328,7 +348,42 @@ function internalQuoteGateFor(tool: StudioTool): QuoteGate {
 }
 
 /**
- * The quote tools whose fresh quote can authorize this execute.
+ * The gate answer for an alias with ONE fixed target, read from that target's
+ * own registration.
+ *
+ * Nothing is restated here: the kind and the authorizing quotes come from the
+ * same `EXECUTE_GATE_TOOLS` row and the same `quoteToolsAuthorizing` derivation
+ * that answer for the protocol tool itself, so the alias and its target can
+ * never publish two different authorizations. A fixed target that is somehow
+ * not a gated execute is reported as ungated on the target's name rather than
+ * as a per-call resolution, because the venue is still not in question.
+ */
+function fixedAliasQuoteGate(aliasName: string, targetToolId: string): QuoteGate {
+  const targetName = getProtocolManifest(targetToolId)?.publicName ?? targetToolId;
+  const gate = EXECUTE_GATE_TOOLS[targetToolId];
+  if (gate === undefined) {
+    return {
+      status: "ungated",
+      note:
+        `No quote gate: ${aliasName} always resolves to ${targetName}, which is not registered as `
+        + "a gated execute.",
+    };
+  }
+  return {
+    status: "gated",
+    prequoteKind: gate.kind,
+    authorizedBy: authorizingQuoteNames(gate),
+    note:
+      `${aliasName} does NOT resolve a venue per call: it always dispatches to ${targetName}, so `
+      + "this is that tool's own gate. The quote must be fresh (15 minutes), from the SAME "
+      + "provider, and match this call's parameters exactly; a quote authorizes exactly one "
+      + "execute and is consumed by it.",
+  };
+}
+
+/**
+ * The quote tools whose fresh quote can authorize this execute, under the names
+ * an agent calls them by.
  *
  * `authorizedBy` is READ from the registry's own recorder-to-gate-row mapping
  * (`prequote/registry.ts`, `quoteToolsAuthorizing`), never from provider
@@ -338,7 +393,17 @@ function internalQuoteGateFor(tool: StudioTool): QuoteGate {
  * alone advertised pairings the gate refuses - a vault quote for a market
  * supply, a PT quote for an LP add - which is a false contract about what
  * authorizes a call that moves money.
+ *
+ * ONE projection for both callers, so a gated protocol tool and an alias fixed
+ * to it cannot publish two different answers.
  */
+function authorizingQuoteNames(gate: ExecuteGateRegistration): readonly string[] {
+  return quoteToolsAuthorizing(gate)
+    .map((quoteToolId) => getProtocolManifest(quoteToolId)?.publicName ?? quoteToolId)
+    .sort();
+}
+
+/** The quote-gate answer for one exported row, internal or protocol. */
 function quoteGateFor(tool: StudioTool): QuoteGate {
   if (tool.kind !== "protocol" || tool.toolId === undefined) {
     return internalQuoteGateFor(tool);
@@ -350,13 +415,10 @@ function quoteGateFor(tool: StudioTool): QuoteGate {
       note: "No quote gate: this tool is not registered as a gated execute.",
     };
   }
-  const authorizedBy = quoteToolsAuthorizing(gate)
-    .map((quoteToolId) => getProtocolManifest(quoteToolId)?.publicName ?? quoteToolId)
-    .sort();
   return {
     status: "gated",
     prequoteKind: gate.kind,
-    authorizedBy,
+    authorizedBy: authorizingQuoteNames(gate),
     note:
       "The quote must be fresh (15 minutes), from the SAME provider, and match this call's "
       + "parameters exactly; a quote authorizes exactly one execute and is consumed by it.",

--- a/src/vex-agent/tools/mutating-aliases.ts
+++ b/src/vex-agent/tools/mutating-aliases.ts
@@ -54,6 +54,36 @@ import { khalaniSlippageRejection } from "./protocols/khalani/slippage-unsupport
 import { bridgeRecipientAliasRefusal } from "./protocols/bridge-recipient-param.js";
 import { resolveUniswapDeployment } from "@tools/uniswap/chains.js";
 
+/**
+ * THE ALIASES WHOSE TARGET IS FIXED, and the protocol tool each one always
+ * resolves to.
+ *
+ * `SwapExecute` and `BridgeExecute` are routers: they choose a venue per call
+ * (`classifySwapFamily`, `resolveBridgeVenue`). These two are not - naming the
+ * venue is the whole point of them, so their router returns ONE toolId
+ * unconditionally and refuses everything it cannot route there.
+ *
+ * Declared here because the published contract needs it: `vex_ToolDescribe`
+ * described every mutating alias as `venue_resolved_per_call`, which said of
+ * these two that the venue and therefore the authorizing quote are decided at
+ * call time. They are not, and an agent reading that has no way to learn which
+ * quote to take before a call that moves money. The routers below return these
+ * values, so the description and the routing cannot disagree.
+ */
+export const FIXED_MUTATING_ALIAS_TARGETS = {
+  SwapExecuteUniswap: "uniswap.swap.execute",
+  BridgeExecuteRelay: "relay.bridge",
+} as const satisfies Readonly<Record<string, string>>;
+
+/**
+ * The protocol toolId `name` always resolves to, or `undefined` when it is a
+ * genuine router (or not an alias at all).
+ */
+export function fixedTargetOfMutatingAlias(name: string): string | undefined {
+  const targets: Readonly<Record<string, string | undefined>> = FIXED_MUTATING_ALIAS_TARGETS;
+  return targets[name];
+}
+
 /** A resolved target for a mutating protocol-alias. */
 export interface ResolvedAliasTarget {
   readonly toolId: string;
@@ -252,7 +282,7 @@ function routeSwapExecuteUniswap(
     amountIn: a.amountIn,
     ...(a.slippageBps !== undefined ? { slippageBps: a.slippageBps } : {}),
   };
-  return { toolId: "uniswap.swap.execute", params };
+  return { toolId: FIXED_MUTATING_ALIAS_TARGETS.SwapExecuteUniswap, params };
 }
 
 // ── BridgeExecute - Khalani cross-chain bridge EXECUTE router ─────────────────────
@@ -459,7 +489,7 @@ function routeBridgeExecuteRelay(
   };
   if (a.tradeType !== undefined) params.tradeType = a.tradeType;
   if (a.slippageBps !== undefined) params.slippageBps = a.slippageBps;
-  return { toolId: "relay.bridge", params };
+  return { toolId: FIXED_MUTATING_ALIAS_TARGETS.BridgeExecuteRelay, params };
 }
 
 // ── Registry ──────────────────────────────────────────────────────────────

--- a/src/vex-agent/tools/protocols/conventions.ts
+++ b/src/vex-agent/tools/protocols/conventions.ts
@@ -666,6 +666,14 @@ export const CANONICAL_HUMAN_AMOUNT_SENTENCE =
  * (`mcp/inventory/types.ts`) and the budget is the consumer's, not this
  * sentence's.
  *
+ * THAT 2047 IS BYTES AS WELL AS CHARACTERS, and the two readings have stopped
+ * agreeing. The measured cut is by characters, so characters remain the
+ * contract; but `SwapExecute` and `SwapQuote` each carry a U+2192 arrow, which
+ * puts them at 2045 characters and 2047 UTF-8 bytes - one byte of headroom
+ * under the same number. Adding a word to this sentence therefore spends both
+ * budgets at once, and `__tests__/vex-agent/mcp/inventory.test.ts` asserts both
+ * so a non-ASCII edit cannot cross either unnoticed.
+ *
  * The card clause answers the second measured confusion: two sessions read their
  * own harness rule ("confirm before an irreversible action") against a card they
  * had already been told about, and hesitated (pass 2, A-8). The card IS the

--- a/src/vex-agent/tools/protocols/prequote/gate/identity.ts
+++ b/src/vex-agent/tools/protocols/prequote/gate/identity.ts
@@ -15,6 +15,7 @@ import { resolveSelectedAddress } from "@vex-agent/tools/internal/wallet/resolve
 import { resolveUniswapChainId } from "@tools/uniswap/chains.js";
 import { resolvePendleChainId } from "@tools/pendle/chains.js";
 import { resolveLocalChainId } from "@tools/evm-chains/registry.js";
+import { MORPHO_MARKET_LANE } from "../identity/lane.js";
 import {
   canonicalizeJupiterFeeTail,
   resolveJupiterFeeSwapKnobs,
@@ -299,7 +300,7 @@ export async function computeGateMatch(
     // which, and it must be read here rather than guessed from the params: a
     // gate that inferred the lane from which key happened to be present would
     // let a caller choose its own identity path.
-    const identity = gated.lane === "market"
+    const identity = gated.lane === MORPHO_MARKET_LANE
       ? buildMorphoBorrowIdentityFor(
         gated.kind === "lend_deposit" ? "supply" : "withdraw",
         sessionId,

--- a/src/vex-agent/tools/protocols/prequote/identity/hash.ts
+++ b/src/vex-agent/tools/protocols/prequote/identity/hash.ts
@@ -37,6 +37,7 @@ import { redeemHashMaterial, ptRolloverHashMaterial } from "./hash/pendle-pt.js"
 import { mintHashMaterial, redeemPyHashMaterial } from "./hash/pendle-py.js";
 import { syHashMaterial } from "./hash/pendle-sy.js";
 import { swapHashMaterial } from "./hash/swap.js";
+import { MORPHO_MARKET_LANE } from "./lane.js";
 
 import type { BridgeMatchInput, BridgeTradeType } from "./hash/bridge.js";
 import type {
@@ -205,7 +206,7 @@ export function computePrequoteMatchHash(input: PrequoteMatchInput): string {
       // on the registration precisely so this dispatch can read it. The vault
       // material is UNCHANGED and `lane` is in neither material - see
       // `hash/morpho-borrow.ts` for why the two can never collide anyway.
-      material = input.lane === "market"
+      material = input.lane === MORPHO_MARKET_LANE
         ? morphoBorrowHashMaterial(input)
         : lendHashMaterial(input);
       break;

--- a/src/vex-agent/tools/protocols/prequote/identity/hash/morpho-borrow.ts
+++ b/src/vex-agent/tools/protocols/prequote/identity/hash/morpho-borrow.ts
@@ -54,6 +54,7 @@
  */
 
 import { canonAddress, canonAmount } from "./canonicalize.js";
+import { MORPHO_MARKET_LANE } from "../lane.js";
 
 /**
  * Canonicalize a Morpho Blue market id (a bytes32 hex string) for the hash. Hex
@@ -156,12 +157,12 @@ export interface LendRepayMatchInput extends MorphoBorrowLegBase {
  */
 export interface LendMarketSupplyMatchInput extends MorphoBorrowLegBase {
   readonly kind: "lend_deposit";
-  readonly lane: "market";
+  readonly lane: typeof MORPHO_MARKET_LANE;
 }
 
 export interface LendMarketWithdrawMatchInput extends MorphoBorrowLegBase {
   readonly kind: "lend_withdraw";
-  readonly lane: "market";
+  readonly lane: typeof MORPHO_MARKET_LANE;
 }
 
 export type MorphoBorrowMatchInput =

--- a/src/vex-agent/tools/protocols/prequote/identity/hash/morpho-lend.ts
+++ b/src/vex-agent/tools/protocols/prequote/identity/hash/morpho-lend.ts
@@ -28,6 +28,7 @@
  */
 
 import { canonAddress, canonAmount } from "./canonicalize.js";
+import { MORPHO_VAULT_LANE } from "../lane.js";
 
 /**
  * Morpho vault DEPOSIT identity. Material (FIXED order): ["lend_deposit",
@@ -57,8 +58,11 @@ export interface LendDepositMatchInput {
    * digest already recorded here, and the two materials cannot collide anyway
    * (9 fields with a 40-hex vault in position 5 against 8 with a 64-hex market
    * id). Optional so an omitted value still reads as the vault lane.
+   *
+   * The VALUE has one owner (`identity/lane.ts`), because the same lane is read
+   * by the gate registration and published by ToolDescribe.
    */
-  readonly lane?: "vault";
+  readonly lane?: typeof MORPHO_VAULT_LANE;
 }
 
 /**
@@ -84,7 +88,7 @@ export interface LendWithdrawMatchInput {
   /** Approved price protection (integer bps string), default-normalized. */
   readonly slippageBps: string;
   /** VAULT lane. Not hashed - see `LendDepositMatchInput.lane`. */
-  readonly lane?: "vault";
+  readonly lane?: typeof MORPHO_VAULT_LANE;
 }
 
 /** Fixed-order material for both lend kinds. The `kind` tag leads it. */

--- a/src/vex-agent/tools/protocols/prequote/identity/lane.ts
+++ b/src/vex-agent/tools/protocols/prequote/identity/lane.ts
@@ -1,0 +1,37 @@
+/**
+ * THE LEND LANE, and the only place either of its two values is written.
+ *
+ * `lend_deposit` and `lend_withdraw` name TWO different operations: a curated
+ * Morpho VAULT deposit/redeem, and a Blue MARKET supply/withdraw of the loan
+ * asset. Supplying a loan asset IS lending, so the two reuse one kind rather
+ * than minting a venue-shape-specific one that would fragment the agent's own
+ * history - and `lane` is then the only thing between "put money in a curated
+ * vault" and "lend into a Blue market".
+ *
+ * It is therefore not decoration, and it must have ONE owner. The lane travels
+ * on the match input into `computePrequoteMatchHash` (`identity/hash.ts` reads
+ * it to pick the material), it is what the execute registration is keyed on
+ * (`prequote/registry.ts`), and it is what `vex_ToolDescribe.quoteGate` publishes
+ * through the recorders' gate targets (`record/gate-targets.ts`). Written as a
+ * literal in each of those, a lane could move on one side and stay put on the
+ * others: the description would advertise an authorization the gate refuses, or
+ * the recorder would persist an identity under a lane nothing looks for, on a
+ * call that moves money.
+ *
+ * So every one of those sites reads THESE constants, and
+ * `recorder-owned-gate-targets.test.ts` substitutes this module to prove it:
+ * under the substitution both the identity the recorder persists and the
+ * authorization ToolDescribe publishes move together. A literal restored
+ * anywhere makes one of the two halves stand still, and the test goes red.
+ *
+ * Pure constants. No IO, no imports.
+ */
+
+/** The curated-vault lane: `morpho.vault.*` and what `morpho.vault.quote` writes. */
+export const MORPHO_VAULT_LANE = "vault" as const;
+
+/** The Blue market lane: `morpho.market.*` and what `morpho.market.quote` writes. */
+export const MORPHO_MARKET_LANE = "market" as const;
+
+/** The lane a shared lend kind must name. */
+export type MorphoLendLane = typeof MORPHO_VAULT_LANE | typeof MORPHO_MARKET_LANE;

--- a/src/vex-agent/tools/protocols/prequote/identity/morpho-borrow.ts
+++ b/src/vex-agent/tools/protocols/prequote/identity/morpho-borrow.ts
@@ -29,6 +29,7 @@ import { resolveMorphoChainId } from "@tools/morpho/chains.js";
 import { resolveSelectedAddress } from "@vex-agent/tools/internal/wallet/resolve.js";
 
 import { VexError, ErrorCodes } from "../../../../../errors.js";
+import { MORPHO_MARKET_LANE, type MorphoLendLane } from "./lane.js";
 import { VEX_DEFAULT_SLIPPAGE_BPS } from "../../slippage-policy.js";
 import { canonSlippageBpsWithDefault } from "../slippage.js";
 import type { ProtocolExecutionContext } from "../../types.js";
@@ -65,8 +66,9 @@ const KIND_FOR_DIRECTION = {
   borrow: "lend_borrow",
   repay: "lend_repay",
   // The LENDER'S side reuses the VAULT lane's kinds, because supplying a loan
-  // asset IS lending. The `lane: "market"` field on the identity is what keeps
-  // the two apart in the hash - see `./hash/morpho-borrow.ts`.
+  // asset IS lending. The lane field on the identity is what keeps the two
+  // apart in the hash - see `./hash/morpho-borrow.ts`, and `./lane.ts` for the
+  // one place either lane's value is written.
   supply: "lend_deposit",
   withdraw: "lend_withdraw",
 } as const;
@@ -75,6 +77,22 @@ export type MorphoBorrowKind = (typeof KIND_FOR_DIRECTION)[MorphoBorrowDirection
 
 export function morphoBorrowKindForDirection(direction: MorphoBorrowDirection): MorphoBorrowKind {
   return KIND_FOR_DIRECTION[direction];
+}
+
+/**
+ * The lane the identity for this direction CARRIES, or `undefined` when its kind
+ * belongs to the market lane alone and needs no discriminator.
+ *
+ * The two builders below are the only ones that set a lane, and they set THIS
+ * value; `record/gate-targets.ts` asks this function rather than restating the
+ * rule, so the row a recorder writes and the authorization ToolDescribe
+ * publishes cannot name a different lane than the identity does.
+ */
+export function morphoMarketLaneForDirection(
+  direction: MorphoBorrowDirection,
+): MorphoLendLane | undefined {
+  const kind = KIND_FOR_DIRECTION[direction];
+  return kind === "lend_deposit" || kind === "lend_withdraw" ? MORPHO_MARKET_LANE : undefined;
 }
 
 function pStr(params: Record<string, unknown>, key: string): string {
@@ -196,7 +214,7 @@ export function buildMorphoMarketSupplyIdentity(
   return {
     ...resolveBorrowLeg(params, context),
     kind: "lend_deposit",
-    lane: "market",
+    lane: MORPHO_MARKET_LANE,
     sessionId,
     amount: requireAmount(params, "supply"),
   };
@@ -210,7 +228,7 @@ export function buildMorphoMarketWithdrawIdentity(
   return {
     ...resolveBorrowLeg(params, context),
     kind: "lend_withdraw",
-    lane: "market",
+    lane: MORPHO_MARKET_LANE,
     sessionId,
     amount: requireAmount(params, "withdraw"),
   };

--- a/src/vex-agent/tools/protocols/prequote/identity/morpho-lend.ts
+++ b/src/vex-agent/tools/protocols/prequote/identity/morpho-lend.ts
@@ -34,6 +34,7 @@ import { VEX_DEFAULT_SLIPPAGE_BPS } from "../../slippage-policy.js";
 import { canonSlippageBpsWithDefault } from "../slippage.js";
 import type { ProtocolExecutionContext } from "../../types.js";
 import type { LendDepositMatchInput, LendWithdrawMatchInput } from "./hash.js";
+import { MORPHO_VAULT_LANE } from "./lane.js";
 
 /** The direction-specific amount key. Deliberately NOT interchangeable. */
 const AMOUNT_KEY = {
@@ -88,6 +89,12 @@ export function buildMorphoLendDepositIdentity(
   const leg = resolveLendLeg(params, context, "deposit");
   return {
     kind: "lend_deposit",
+    // Named, not implied. The lane used to be carried here by OMISSION (the
+    // dispatcher reads anything that is not "market" as the vault), which left
+    // the value itself owned only by the sites that DID spell it. It is stated
+    // now, from the one owner, so a substitution of that owner moves this
+    // identity too - the drift check the description depends on.
+    lane: MORPHO_VAULT_LANE,
     sessionId,
     provider: "morpho",
     chainId: leg.chainId,
@@ -108,6 +115,8 @@ export function buildMorphoLendWithdrawIdentity(
   const leg = resolveLendLeg(params, context, "withdraw");
   return {
     kind: "lend_withdraw",
+    /** VAULT lane, from its one owner - see the deposit builder. */
+    lane: MORPHO_VAULT_LANE,
     sessionId,
     provider: "morpho",
     chainId: leg.chainId,

--- a/src/vex-agent/tools/protocols/prequote/record/bridge.ts
+++ b/src/vex-agent/tools/protocols/prequote/record/bridge.ts
@@ -17,6 +17,7 @@ import type { BridgeMatchInput } from "../identity/hash.js";
 import { buildBridgeIdentity } from "../identity/bridge.js";
 import { buildRelayBridgeIdentity, isValidRelayQuoteShape } from "../identity/relay-bridge.js";
 import { writePrequoteRow } from "./row.js";
+import { BRIDGE_QUOTE_GATE_TARGET } from "./gate-targets.js";
 import { withVexFee } from "../fee-disclosure.js";
 
 /**
@@ -81,7 +82,7 @@ export async function recordBridgePrequote(
     prequoteId: `prequote-${randomUUID()}`,
     sessionId,
     matchHash,
-    kind: "bridge",
+    kind: BRIDGE_QUOTE_GATE_TARGET.kind,
     // Bridge prequote `family` is the SOURCE family (where the signer lives) -
     // mirrors the verdict provider/family pairing the gate reads back by kind.
     family: identity.sourceFamily,

--- a/src/vex-agent/tools/protocols/prequote/record/gate-targets.ts
+++ b/src/vex-agent/tools/protocols/prequote/record/gate-targets.ts
@@ -22,9 +22,11 @@
  * identity builders keep owning the hash material. Where a table already
  * existed on that side, this module DERIVES from it rather than restating it:
  *
- *   - the Morpho MARKET map calls `morphoBorrowKindForDirection`, the same
- *     function the identity builders use, so the row, the hash and the
- *     description read one table;
+ *   - the Morpho MARKET map calls `morphoBorrowKindForDirection` and
+ *     `morphoMarketLaneForDirection`, the same functions the identity builders
+ *     use, and the VAULT map reads the same `identity/lane.ts` constant its
+ *     builders now put on the identity, so the row, the hash and the
+ *     description read one table and one lane owner;
  *   - every map is keyed by the EXTRACTOR's own direction union, so a venue
  *     that gains a direction fails to compile here until its row is declared.
  *
@@ -38,8 +40,10 @@ import type { ExtractedPendleLpQuote } from "../safety/extract/pendle-lp.js";
 import type { ExtractedPendlePyQuote } from "../safety/extract/pendle-py.js";
 import {
   morphoBorrowKindForDirection,
+  morphoMarketLaneForDirection,
   type MorphoBorrowDirection,
 } from "../identity/morpho-borrow.js";
+import { MORPHO_VAULT_LANE } from "../identity/lane.js";
 
 /** The row the four venue swap quotes record (`record/swap.ts`). */
 export const SWAP_QUOTE_GATE_TARGET = { kind: "swap" } as const satisfies PrequoteGateTarget;
@@ -85,22 +89,26 @@ export const PENDLE_LP_QUOTE_GATE_TARGETS = {
  * market", which share both kinds.
  */
 export const MORPHO_LEND_QUOTE_GATE_TARGETS = {
-  deposit: { kind: "lend_deposit", lane: "vault" },
-  withdraw: { kind: "lend_withdraw", lane: "vault" },
+  deposit: { kind: "lend_deposit", lane: MORPHO_VAULT_LANE },
+  withdraw: { kind: "lend_withdraw", lane: MORPHO_VAULT_LANE },
 } as const satisfies Readonly<Record<ExtractedMorphoLendQuote["direction"], PrequoteGateTarget>>;
 
 /**
  * The row one market direction records. The four borrower operations carry no
  * lane (their kinds belong to this lane alone); the LENDER'S two reuse the
- * vault lane's kinds, so they MUST carry `lane: "market"` - the same
- * discriminator their identity builders put in the hash
- * (`identity/morpho-borrow.ts`, `buildMorphoMarketSupplyIdentity`).
+ * vault lane's kinds, so they MUST carry the market lane.
+ *
+ * NEITHER HALF IS DECIDED HERE. The kind comes from the identity side's own
+ * table (`morphoBorrowKindForDirection`) and the lane from the same module's
+ * `morphoMarketLaneForDirection`, which is what the two market builders
+ * actually put on the identity they hash. A lane spelled as a literal here
+ * could move while the identity stood still, and the description would then
+ * publish an authorization the gate refuses.
  */
 function morphoMarketGateTarget(direction: MorphoBorrowDirection): PrequoteGateTarget {
   const kind = morphoBorrowKindForDirection(direction);
-  return kind === "lend_deposit" || kind === "lend_withdraw"
-    ? { kind, lane: "market" }
-    : { kind };
+  const lane = morphoMarketLaneForDirection(direction);
+  return lane === undefined ? { kind } : { kind, lane };
 }
 
 /**

--- a/src/vex-agent/tools/protocols/prequote/record/gate-targets.ts
+++ b/src/vex-agent/tools/protocols/prequote/record/gate-targets.ts
@@ -1,0 +1,122 @@
+/**
+ * THE GATE ROW EACH RECORDER WRITES, owned by the recorders themselves.
+ *
+ * ONE SOURCE, TWO CONSUMERS. Every `kind` (and, on the two shared lend kinds,
+ * every `lane`) a prequote recorder can write is declared here ONCE:
+ *
+ *   - the recorder reads it to build the row it persists
+ *     (`record/swap.ts`, `record/bridge.ts`, `record/pendle-*.ts`,
+ *     `record/morpho-*.ts`), and
+ *   - `prequote/registry.ts` composes `PREQUOTE_QUOTE_WRITES` out of it, which
+ *     is what `vex_ToolDescribe.quoteGate.authorizedBy` publishes.
+ *
+ * That is the whole reason this module exists. The published answer used to be
+ * a SECOND literal table in the registry and a THIRD in its test, so a recorder
+ * could change the row it writes and leave both copies green - the description
+ * would keep advertising a pairing the gate refuses, on a call that moves
+ * money. There is now nothing to drift from: change a value here and both the
+ * persisted row and the published contract change with it.
+ *
+ * NOT A GATE. Nothing here admits a prequote. The gate keeps reading
+ * `EXECUTE_GATE_TOOLS` plus the match hash (`prequote/gate.ts`), and the
+ * identity builders keep owning the hash material. Where a table already
+ * existed on that side, this module DERIVES from it rather than restating it:
+ *
+ *   - the Morpho MARKET map calls `morphoBorrowKindForDirection`, the same
+ *     function the identity builders use, so the row, the hash and the
+ *     description read one table;
+ *   - every map is keyed by the EXTRACTOR's own direction union, so a venue
+ *     that gains a direction fails to compile here until its row is declared.
+ *
+ * Pure data + pure functions. No IO.
+ */
+
+import type { PrequoteGateTarget } from "../registry.js";
+import type { ExtractedMorphoLendQuote } from "../safety/extract/morpho-lend.js";
+import type { ExtractedPendleQuote } from "../safety/extract/pendle-pt.js";
+import type { ExtractedPendleLpQuote } from "../safety/extract/pendle-lp.js";
+import type { ExtractedPendlePyQuote } from "../safety/extract/pendle-py.js";
+import {
+  morphoBorrowKindForDirection,
+  type MorphoBorrowDirection,
+} from "../identity/morpho-borrow.js";
+
+/** The row the four venue swap quotes record (`record/swap.ts`). */
+export const SWAP_QUOTE_GATE_TARGET = { kind: "swap" } as const satisfies PrequoteGateTarget;
+
+/** The row both bridge quotes record (`record/bridge.ts`). */
+export const BRIDGE_QUOTE_GATE_TARGET = { kind: "bridge" } as const satisfies PrequoteGateTarget;
+
+/**
+ * The rows `pendle.pt.quote` records, by the Convert `action` its own result
+ * echoes (`record/pendle-pt.ts`). `pendle.yt.quote` shares this recorder, but
+ * its handler FIXES `action: "swap"`, so the registry narrows it to that one
+ * action rather than inheriting both.
+ */
+export const PENDLE_PT_QUOTE_GATE_TARGETS = {
+  swap: { kind: "swap" },
+  redeem: { kind: "redeem" },
+} as const satisfies Readonly<Record<ExtractedPendleQuote["action"], PrequoteGateTarget>>;
+
+/** The action a Pendle PT/YT quote can record under. */
+export type PendlePtQuoteAction = keyof typeof PENDLE_PT_QUOTE_GATE_TARGETS;
+
+/** Every action the PT recorder can take, for the tools that are not narrowed. */
+export const PENDLE_PT_QUOTE_ACTIONS = ["swap", "redeem"] as const satisfies
+  readonly PendlePtQuoteAction[];
+
+/** The rows `pendle.py.quote` records, by the echoed direction (`record/pendle-py.ts`). */
+export const PENDLE_PY_QUOTE_GATE_TARGETS = {
+  mint: { kind: "mint" },
+  redeem: { kind: "redeem_py" },
+} as const satisfies Readonly<Record<ExtractedPendlePyQuote["direction"], PrequoteGateTarget>>;
+
+/** The rows `pendle.lp.quote` records, by the echoed direction (`record/pendle-lp.ts`). */
+export const PENDLE_LP_QUOTE_GATE_TARGETS = {
+  add: { kind: "lp_add" },
+  remove: { kind: "lp_remove" },
+} as const satisfies Readonly<Record<ExtractedPendleLpQuote["direction"], PrequoteGateTarget>>;
+
+/**
+ * The rows `morpho.vault.quote` records (`record/morpho-lend.ts`), on the VAULT
+ * lane. The lane is not decoration: it travels on the identity into
+ * `computePrequoteMatchHash` (`identity/hash/morpho-lend.ts`), and it is the
+ * only thing between "put money in a curated vault" and "lend into a Blue
+ * market", which share both kinds.
+ */
+export const MORPHO_LEND_QUOTE_GATE_TARGETS = {
+  deposit: { kind: "lend_deposit", lane: "vault" },
+  withdraw: { kind: "lend_withdraw", lane: "vault" },
+} as const satisfies Readonly<Record<ExtractedMorphoLendQuote["direction"], PrequoteGateTarget>>;
+
+/**
+ * The row one market direction records. The four borrower operations carry no
+ * lane (their kinds belong to this lane alone); the LENDER'S two reuse the
+ * vault lane's kinds, so they MUST carry `lane: "market"` - the same
+ * discriminator their identity builders put in the hash
+ * (`identity/morpho-borrow.ts`, `buildMorphoMarketSupplyIdentity`).
+ */
+function morphoMarketGateTarget(direction: MorphoBorrowDirection): PrequoteGateTarget {
+  const kind = morphoBorrowKindForDirection(direction);
+  return kind === "lend_deposit" || kind === "lend_withdraw"
+    ? { kind, lane: "market" }
+    : { kind };
+}
+
+/**
+ * The rows `morpho.market.quote` records, by the direction it priced.
+ *
+ * Every row's KIND comes from the identity side's own table rather than being
+ * restated here, and the six keys are required by the compiler, so a direction
+ * added to that lane fails to build until it declares the row it writes.
+ */
+export const MORPHO_MARKET_QUOTE_GATE_TARGETS: Readonly<
+  Record<MorphoBorrowDirection, PrequoteGateTarget>
+> = {
+  supplyCollateral: morphoMarketGateTarget("supplyCollateral"),
+  withdrawCollateral: morphoMarketGateTarget("withdrawCollateral"),
+  borrow: morphoMarketGateTarget("borrow"),
+  repay: morphoMarketGateTarget("repay"),
+  supply: morphoMarketGateTarget("supply"),
+  withdraw: morphoMarketGateTarget("withdraw"),
+};

--- a/src/vex-agent/tools/protocols/prequote/record/morpho-borrow.ts
+++ b/src/vex-agent/tools/protocols/prequote/record/morpho-borrow.ts
@@ -24,12 +24,10 @@ import type { CreatePrequoteInput, PrequoteFamily } from "@vex-agent/db/repos/sw
 
 import { PREQUOTE_MAX_AGE_MS } from "../registry.js";
 import { computePrequoteMatchHash } from "../identity/hash.js";
-import {
-  buildMorphoBorrowIdentityFor,
-  morphoBorrowKindForDirection,
-} from "../identity/morpho-borrow.js";
+import { buildMorphoBorrowIdentityFor } from "../identity/morpho-borrow.js";
 import { extractMorphoMarketQuote } from "../safety/extract/morpho-borrow.js";
 import { writePrequoteRow } from "./row.js";
+import { MORPHO_MARKET_QUOTE_GATE_TARGETS } from "./gate-targets.js";
 import { readParamSlippageBps } from "../slippage.js";
 
 export async function recordMorphoBorrowPrequote(
@@ -68,7 +66,7 @@ export async function recordMorphoBorrowPrequote(
     prequoteId: `prequote-${randomUUID()}`,
     sessionId,
     matchHash: computePrequoteMatchHash(identity),
-    kind: morphoBorrowKindForDirection(extracted.direction),
+    kind: MORPHO_MARKET_QUOTE_GATE_TARGETS[extracted.direction].kind,
     family: registered.family,
     provider: registered.provider,
     chainId: identity.chainId,

--- a/src/vex-agent/tools/protocols/prequote/record/morpho-lend.ts
+++ b/src/vex-agent/tools/protocols/prequote/record/morpho-lend.ts
@@ -25,6 +25,7 @@ import {
 } from "../identity/morpho-lend.js";
 import { extractMorphoLendQuote } from "../safety/extract/morpho-lend.js";
 import { writePrequoteRow } from "./row.js";
+import { MORPHO_LEND_QUOTE_GATE_TARGETS } from "./gate-targets.js";
 
 export async function recordMorphoLendPrequote(
   toolId: string,
@@ -59,7 +60,7 @@ export async function recordMorphoLendPrequote(
     prequoteId: `prequote-${randomUUID()}`,
     sessionId,
     matchHash: computePrequoteMatchHash(identity),
-    kind: extracted.direction === "deposit" ? "lend_deposit" : "lend_withdraw",
+    kind: MORPHO_LEND_QUOTE_GATE_TARGETS[extracted.direction].kind,
     family: registered.family,
     provider: registered.provider,
     chainId: identity.chainId,

--- a/src/vex-agent/tools/protocols/prequote/record/pendle-lp.ts
+++ b/src/vex-agent/tools/protocols/prequote/record/pendle-lp.ts
@@ -16,6 +16,7 @@ import { computePrequoteMatchHash } from "../identity/hash.js";
 import { buildPendleLpAddIdentity, buildPendleLpRemoveIdentity } from "../identity/pendle-lp.js";
 import { extractPendleLpQuote } from "../safety/extract.js";
 import { writePrequoteRow } from "./row.js";
+import { PENDLE_LP_QUOTE_GATE_TARGETS } from "./gate-targets.js";
 
 /**
  * Record a Pendle LP prequote (P5). `pendle.lp.quote` records EITHER an `lp_add`
@@ -52,7 +53,7 @@ export async function recordPendleLpPrequote(
       prequoteId: `prequote-${randomUUID()}`,
       sessionId,
       matchHash: computePrequoteMatchHash(identity),
-      kind: "lp_add",
+      kind: PENDLE_LP_QUOTE_GATE_TARGETS[extracted.direction].kind,
       family: registered.family,
       provider: registered.provider,
       chainId: identity.chainId,
@@ -87,7 +88,7 @@ export async function recordPendleLpPrequote(
     prequoteId: `prequote-${randomUUID()}`,
     sessionId,
     matchHash: computePrequoteMatchHash(identity),
-    kind: "lp_remove",
+    kind: PENDLE_LP_QUOTE_GATE_TARGETS[extracted.direction].kind,
     family: registered.family,
     provider: registered.provider,
     chainId: identity.chainId,

--- a/src/vex-agent/tools/protocols/prequote/record/pendle-pt.ts
+++ b/src/vex-agent/tools/protocols/prequote/record/pendle-pt.ts
@@ -18,6 +18,7 @@ import { buildPendleRedeemIdentity } from "../identity/pendle-redeem.js";
 import { extractPendleQuote } from "../safety/extract.js";
 import { canonSlippageBps, readParamSlippageBps } from "../slippage.js";
 import { familyToChainFamily, writePrequoteRow } from "./row.js";
+import { PENDLE_PT_QUOTE_GATE_TARGETS } from "./gate-targets.js";
 
 /**
  * Record a Pendle prequote (Wave 5). The single `pendle.pt.quote` tool records
@@ -68,7 +69,7 @@ export async function recordPendlePrequote(
       prequoteId: `prequote-${randomUUID()}`,
       sessionId,
       matchHash: computePrequoteMatchHash(identity),
-      kind: "redeem",
+      kind: PENDLE_PT_QUOTE_GATE_TARGETS[extracted.action].kind,
       family: registered.family,
       provider: registered.provider,
       chainId: identity.chainId,
@@ -91,7 +92,7 @@ export async function recordPendlePrequote(
   // Swap path (buy / early-exit sell) - same money/safety leg as the other swaps:
   // recipient defaults to self, approveExact false, slippage from the quote params.
   const matchHash = computePrequoteMatchHash({
-    kind: "swap",
+    kind: PENDLE_PT_QUOTE_GATE_TARGETS.swap.kind,
     sessionId,
     family: registered.family,
     provider: registered.provider,
@@ -108,7 +109,7 @@ export async function recordPendlePrequote(
     prequoteId: `prequote-${randomUUID()}`,
     sessionId,
     matchHash,
-    kind: "swap",
+    kind: PENDLE_PT_QUOTE_GATE_TARGETS[extracted.action].kind,
     family: registered.family,
     provider: registered.provider,
     chainId: extracted.chainId,

--- a/src/vex-agent/tools/protocols/prequote/record/pendle-py.ts
+++ b/src/vex-agent/tools/protocols/prequote/record/pendle-py.ts
@@ -16,6 +16,7 @@ import { computePrequoteMatchHash } from "../identity/hash.js";
 import { buildPendleMintIdentity, buildPendleRedeemPyIdentity } from "../identity/pendle-py.js";
 import { extractPendlePyQuote } from "../safety/extract.js";
 import { writePrequoteRow } from "./row.js";
+import { PENDLE_PY_QUOTE_GATE_TARGETS } from "./gate-targets.js";
 
 /**
  * Record a Pendle PY prequote (P4). `pendle.py.quote` records EITHER a `mint`
@@ -52,7 +53,7 @@ export async function recordPendlePyPrequote(
       prequoteId: `prequote-${randomUUID()}`,
       sessionId,
       matchHash: computePrequoteMatchHash(identity),
-      kind: "mint",
+      kind: PENDLE_PY_QUOTE_GATE_TARGETS[extracted.direction].kind,
       family: registered.family,
       provider: registered.provider,
       chainId: identity.chainId,
@@ -87,7 +88,7 @@ export async function recordPendlePyPrequote(
     prequoteId: `prequote-${randomUUID()}`,
     sessionId,
     matchHash: computePrequoteMatchHash(identity),
-    kind: "redeem_py",
+    kind: PENDLE_PY_QUOTE_GATE_TARGETS[extracted.direction].kind,
     family: registered.family,
     provider: registered.provider,
     chainId: identity.chainId,

--- a/src/vex-agent/tools/protocols/prequote/record/swap.ts
+++ b/src/vex-agent/tools/protocols/prequote/record/swap.ts
@@ -25,6 +25,7 @@ import { parseSpendabilityPreview } from "../../quote-authority/spendability.js"
 import { withVexFee } from "../fee-disclosure.js";
 import { PREQUOTE_MAX_AGE_MS } from "../registry.js";
 import { computePrequoteMatchHash } from "../identity/hash.js";
+import { SWAP_QUOTE_GATE_TARGET } from "./gate-targets.js";
 import { extractQuote } from "../safety/extract.js";
 import { canonSlippageBps, readParamSlippageBps } from "../slippage.js";
 import { familyToChainFamily, writePrequoteRow } from "./row.js";
@@ -163,7 +164,7 @@ export async function recordSwapPrequote(
   // execute params. Solana has no recipient/approveExact concept - self/false
   // are inert constants there.
   const matchHash = computePrequoteMatchHash({
-    kind: "swap",
+    kind: SWAP_QUOTE_GATE_TARGET.kind,
     sessionId,
     family: registered.family,
     // Venue binding (LOCKED #4) - the quoting provider is part of the identity.
@@ -203,7 +204,7 @@ export async function recordSwapPrequote(
     prequoteId: `prequote-${randomUUID()}`,
     sessionId,
     matchHash,
-    kind: "swap",
+    kind: SWAP_QUOTE_GATE_TARGET.kind,
     family: registered.family,
     provider: registered.provider,
     chainId: extracted.chainId,

--- a/src/vex-agent/tools/protocols/prequote/registry.ts
+++ b/src/vex-agent/tools/protocols/prequote/registry.ts
@@ -13,6 +13,7 @@
 
 import type { PrequoteFamily } from "@vex-agent/db/repos/swap-prequotes.js";
 
+import { MORPHO_MARKET_LANE, MORPHO_VAULT_LANE, type MorphoLendLane } from "./identity/lane.js";
 import {
   BRIDGE_QUOTE_GATE_TARGET,
   MORPHO_LEND_QUOTE_GATE_TARGETS,
@@ -153,15 +154,18 @@ export type ExecuteGateRegistration =
   // history. That makes the kind alone insufficient to build an identity, so
   // every registration under these two kinds MUST name its `lane`, and the same
   // discriminator travels on the match input into `computePrequoteMatchHash`.
+  // The two VALUES come from `identity/lane.ts`, the one owner every side reads
+  // (the identity builders, the recorders' gate targets, and this table), so a
+  // lane cannot move on one side and stand still on the others.
   | {
     readonly kind: "lend_deposit";
-    readonly lane: "vault" | "market";
+    readonly lane: MorphoLendLane;
     readonly family: PrequoteFamily;
     readonly provider: string;
   }
   | {
     readonly kind: "lend_withdraw";
-    readonly lane: "vault" | "market";
+    readonly lane: MorphoLendLane;
     readonly family: PrequoteFamily;
     readonly provider: string;
   }
@@ -209,8 +213,8 @@ export const EXECUTE_GATE_TOOLS: Record<string, ExecuteGateRegistration> = {
   "pendle.lp.remove": { kind: "lp_remove", family: "eip155", provider: "pendle" },
   // Morpho vault deposit / withdraw match their dedicated `lend_deposit` /
   // `lend_withdraw` prequotes from `morpho.vault.quote` (E3b-2).
-  "morpho.vault.deposit": { kind: "lend_deposit", lane: "vault", family: "eip155", provider: "morpho" },
-  "morpho.vault.withdraw": { kind: "lend_withdraw", lane: "vault", family: "eip155", provider: "morpho" },
+  "morpho.vault.deposit": { kind: "lend_deposit", lane: MORPHO_VAULT_LANE, family: "eip155", provider: "morpho" },
+  "morpho.vault.withdraw": { kind: "lend_withdraw", lane: MORPHO_VAULT_LANE, family: "eip155", provider: "morpho" },
   // Morpho Blue market operations match their dedicated borrow-lane prequotes
   // from `morpho.market.quote` (E3c). ONE kind each, and the mapping is the
   // whole safety property: the gate reads its row under the kind as a predicate,
@@ -229,8 +233,8 @@ export const EXECUTE_GATE_TOOLS: Record<string, ExecuteGateRegistration> = {
   // cannot authorize a market supply and the reverse is equally impossible: the
   // gate builds a market identity here, whose material is a different length
   // over a different anchor, so the digests cannot meet.
-  "morpho.market.supply": { kind: "lend_deposit", lane: "market", family: "eip155", provider: "morpho" },
-  "morpho.market.withdraw": { kind: "lend_withdraw", lane: "market", family: "eip155", provider: "morpho" },
+  "morpho.market.supply": { kind: "lend_deposit", lane: MORPHO_MARKET_LANE, family: "eip155", provider: "morpho" },
+  "morpho.market.withdraw": { kind: "lend_withdraw", lane: MORPHO_MARKET_LANE, family: "eip155", provider: "morpho" },
 };
 
 // ── Recorder -> gate-row mapping (derived, read-only) ─────────────────────
@@ -245,7 +249,7 @@ export const EXECUTE_GATE_TOOLS: Record<string, ExecuteGateRegistration> = {
  */
 export interface PrequoteGateTarget {
   readonly kind: ExecuteGateRegistration["kind"];
-  readonly lane?: "vault" | "market";
+  readonly lane?: MorphoLendLane;
 }
 
 /**
@@ -304,7 +308,7 @@ export const PREQUOTE_QUOTE_WRITES: Readonly<Record<string, readonly PrequoteGat
   );
 
 /** The lane a gate registration carries, or `undefined` when its kind needs none. */
-export function laneOfGateRegistration(gate: ExecuteGateRegistration): "vault" | "market" | undefined {
+export function laneOfGateRegistration(gate: ExecuteGateRegistration): MorphoLendLane | undefined {
   return "lane" in gate ? gate.lane : undefined;
 }
 

--- a/src/vex-agent/tools/protocols/prequote/registry.ts
+++ b/src/vex-agent/tools/protocols/prequote/registry.ts
@@ -5,10 +5,25 @@
  * a prequote on success and how; the execute-gate registry (`EXECUTE_GATE_TOOLS`)
  * names which execute tools are subject to the quote-before-transaction gate and
  * which prequote `kind` each must match. `PREQUOTE_MAX_AGE_MS` is the shared
- * freshness window. Pure data + types - no IO.
+ * freshness window. `PREQUOTE_QUOTE_WRITES` is composed from the recorders' own
+ * gate-target metadata (`record/gate-targets.ts`), so the published answer to
+ * "which quote authorizes this execute" reads the same table the recorder
+ * writes its row from. Pure data + pure functions - no IO.
  */
 
 import type { PrequoteFamily } from "@vex-agent/db/repos/swap-prequotes.js";
+
+import {
+  BRIDGE_QUOTE_GATE_TARGET,
+  MORPHO_LEND_QUOTE_GATE_TARGETS,
+  MORPHO_MARKET_QUOTE_GATE_TARGETS,
+  PENDLE_LP_QUOTE_GATE_TARGETS,
+  PENDLE_PT_QUOTE_ACTIONS,
+  PENDLE_PT_QUOTE_GATE_TARGETS,
+  PENDLE_PY_QUOTE_GATE_TARGETS,
+  SWAP_QUOTE_GATE_TARGET,
+  type PendlePtQuoteAction,
+} from "./record/gate-targets.js";
 
 // ── Quote-tool registry ──────────────────────────────────────────────────
 
@@ -30,7 +45,19 @@ type PrequoteQuoteRegistration =
   // sell) OR a `redeem` prequote - decided at record-time from the Convert
   // `action` (Wave 5). The recorder dispatches on this `pendle` label, then
   // writes the appropriate DB kind. `family` is always eip155 (Ethereum v1).
-  | { readonly kind: "pendle"; readonly family: PrequoteFamily; readonly provider: string }
+  | {
+    readonly kind: "pendle";
+    readonly family: PrequoteFamily;
+    readonly provider: string;
+    /**
+     * The Convert actions THIS tool's handler can produce, when it produces
+     * fewer than the recorder can write. `pendle.yt.quote` fixes
+     * `action: "swap"` (`pendle/handlers/yt/quote.ts`), so a YT quote can never
+     * record - and must never be published as authorizing - a PT redeem.
+     * Omitted means every action the recorder declares.
+     */
+    readonly actions?: readonly PendlePtQuoteAction[];
+  }
   // Pendle's PY quote records EITHER a `mint` prequote (direction "mint") OR a
   // `redeem_py` prequote (direction "redeem"), decided from the echoed
   // `direction` (P4). Each writes its dedicated DB kind + identity.
@@ -63,7 +90,7 @@ export const PREQUOTE_QUOTE_TOOLS: Record<string, PrequoteQuoteRegistration> = {
   "pendle.pt.quote": { kind: "pendle", family: "eip155", provider: "pendle" },
   // YT is ALWAYS a swap (never redeem-py); the pendle recorder records it via the
   // swap identity, so a YT quote authorizes only the matching YT buy/sell execute.
-  "pendle.yt.quote": { kind: "pendle", family: "eip155", provider: "pendle" },
+  "pendle.yt.quote": { kind: "pendle", family: "eip155", provider: "pendle", actions: ["swap"] },
   // PY quote records a `mint` or `redeem_py` prequote (P4) - decided from the
   // echoed `direction`.
   "pendle.py.quote": { kind: "pendle-py", family: "eip155", provider: "pendle" },
@@ -225,6 +252,14 @@ export interface PrequoteGateTarget {
  * WHICH GATE ROWS EACH QUOTE TOOL ACTUALLY WRITES, keyed by the same quote
  * toolId as {@link PREQUOTE_QUOTE_TOOLS}.
  *
+ * COMPOSED FROM THE RECORDERS, NOT RESTATED BESIDE THEM. Every row comes from
+ * `record/gate-targets.ts`, the same metadata the recorder itself reads when it
+ * builds the row it persists, so this projection cannot fall out of step with
+ * what actually gets written. It used to be a second literal table here and a
+ * third in the test, which meant a recorder could change the row it writes and
+ * leave both copies green - publishing an authorization the gate refuses, on a
+ * call that moves money.
+ *
  * READ-ONLY DERIVATION, NOT A SECOND GATE. The gate itself keeps reading
  * `EXECUTE_GATE_TOOLS` + the match hash; nothing here can admit a prequote the
  * gate would refuse. It exists because the published contract
@@ -235,52 +270,38 @@ export interface PrequoteGateTarget {
  * Provider is necessary and never sufficient - the gate reads its row under
  * `kind` (and `lane`) as a predicate.
  *
- * EVERY ROW IS TAKEN FROM THE RECORDER THAT WRITES IT, never from convention:
- *
- * - `swap` (`record/swap.ts:165,185`) for the four venue swap quotes.
- * - `bridge` (`record/bridge.ts:72`) for both bridge quotes.
- * - `pendle.pt.quote` writes `redeem` (`record/pendle-pt.ts:71`) or `swap`
- *   (`record/pendle-pt.ts:94,111`), decided from the Convert `action`.
- * - `pendle.yt.quote` shares that recorder but its handler FIXES
- *   `action: "swap"` (`pendle/handlers/yt/quote.ts:88`), so the redeem branch
- *   is unreachable for it and a YT quote can never authorize a PT redeem.
- * - `pendle.py.quote` writes `mint` (`record/pendle-py.ts:55`) or `redeem_py`
- *   (`record/pendle-py.ts:90`).
- * - `pendle.lp.quote` writes `lp_add` (`record/pendle-lp.ts:55`) or
- *   `lp_remove` (`record/pendle-lp.ts:90`).
- * - `morpho.vault.quote` writes `lend_deposit` or `lend_withdraw`
- *   (`record/morpho-lend.ts:62`) on the VAULT lane
- *   (`identity/hash/morpho-lend.ts:61,87`).
- * - `morpho.market.quote` writes one of the six borrow-lane kinds
- *   (`record/morpho-borrow.ts:71` through
- *   `identity/morpho-borrow.ts:61-72 KIND_FOR_DIRECTION`), and its `supply` /
- *   `withdraw` directions reuse the two lend kinds on the MARKET lane
- *   (`identity/morpho-borrow.ts:199,213`).
+ * The ONE per-tool narrowing lives on the registration rather than in the
+ * recorder, because it is not the recorder's fact: `pendle.yt.quote` shares the
+ * PT recorder, and it is its HANDLER that fixes `action: "swap"`.
  */
-export const PREQUOTE_QUOTE_WRITES: Readonly<Record<string, readonly PrequoteGateTarget[]>> = {
-  "kyberswap.swap.quote": [{ kind: "swap" }],
-  "uniswap.swap.quote": [{ kind: "swap" }],
-  "trench.trade_quote": [{ kind: "swap" }],
-  "solana.swap.quote": [{ kind: "swap" }],
-  "khalani.quote.get": [{ kind: "bridge" }],
-  "relay.quote.get": [{ kind: "bridge" }],
-  "pendle.pt.quote": [{ kind: "swap" }, { kind: "redeem" }],
-  "pendle.yt.quote": [{ kind: "swap" }],
-  "pendle.py.quote": [{ kind: "mint" }, { kind: "redeem_py" }],
-  "pendle.lp.quote": [{ kind: "lp_add" }, { kind: "lp_remove" }],
-  "morpho.vault.quote": [
-    { kind: "lend_deposit", lane: "vault" },
-    { kind: "lend_withdraw", lane: "vault" },
-  ],
-  "morpho.market.quote": [
-    { kind: "lend_supply_collateral" },
-    { kind: "lend_withdraw_collateral" },
-    { kind: "lend_borrow" },
-    { kind: "lend_repay" },
-    { kind: "lend_deposit", lane: "market" },
-    { kind: "lend_withdraw", lane: "market" },
-  ],
-};
+function gateRowsWrittenBy(registration: PrequoteQuoteRegistration): readonly PrequoteGateTarget[] {
+  switch (registration.kind) {
+    case "swap":
+      return [SWAP_QUOTE_GATE_TARGET];
+    case "bridge":
+      return [BRIDGE_QUOTE_GATE_TARGET];
+    case "pendle":
+      return (registration.actions ?? PENDLE_PT_QUOTE_ACTIONS).map(
+        (action) => PENDLE_PT_QUOTE_GATE_TARGETS[action],
+      );
+    case "pendle-py":
+      return Object.values(PENDLE_PY_QUOTE_GATE_TARGETS);
+    case "pendle-lp":
+      return Object.values(PENDLE_LP_QUOTE_GATE_TARGETS);
+    case "morpho-lend":
+      return Object.values(MORPHO_LEND_QUOTE_GATE_TARGETS);
+    case "morpho-borrow":
+      return Object.values(MORPHO_MARKET_QUOTE_GATE_TARGETS);
+  }
+}
+
+/** {@link gateRowsWrittenBy} for every registered quote tool. */
+export const PREQUOTE_QUOTE_WRITES: Readonly<Record<string, readonly PrequoteGateTarget[]>> =
+  Object.fromEntries(
+    Object.entries(PREQUOTE_QUOTE_TOOLS).map(
+      ([quoteToolId, registration]) => [quoteToolId, gateRowsWrittenBy(registration)],
+    ),
+  );
 
 /** The lane a gate registration carries, or `undefined` when its kind needs none. */
 export function laneOfGateRegistration(gate: ExecuteGateRegistration): "vault" | "market" | undefined {


### PR DESCRIPTION
## What changes

- **One owner for the authorizing-quote mapping.** `prequote/record/gate-targets.ts` declares every direction-to-kind row a recorder can write; the recorders read it and `prequote/registry.ts` composes `PREQUOTE_QUOTE_WRITES` from it, which is what `vex_ToolDescribe.quoteGate.authorizedBy` publishes. The Morpho market rows derive from the identity side's own function; every map is keyed by the extractor's direction union so a new direction fails to compile until its row exists. A substitution test flips one row and watches the persisted kind and the published authorizer move together; the registry test holds no table any more.
- **Fixed aliases described through their target.** `SwapExecuteUniswap` and `BridgeExecuteRelay` are described as gated by their resolved tool's exact quote; `SwapExecute` and `BridgeExecute` stay venue-resolved, with a test showing `SwapExecute` really reaches two venues.
- **The 2048 bound is measured in bytes too.** The cut is by characters (measured), but the hot set is not pure ASCII (a U+2192 arrow puts two descriptions at 2045 characters and 2047 bytes); the lint now asserts the UTF-8 byte length as well and the notes say so.
- **`approval-intent-preview.test.ts`** (841 lines) splits into policy-snapshot and client-name suites; assertions moved verbatim.

Generated toolsnaps and docs regenerated: byte-identical.

## Verification

- root vitest on `mcp`, toolsnaps, `engine/core`, `tools/protocols`: 325 files, 5019 tests; the toolsnap update run 30 files, 940 tests, no artifact changed; both `generate:* -- --check` up to date; root tsc clean; em-dash and unsafe-escapes gates green.
- Growth decision: `protocols/conventions.ts` 770 to 778, grown on purpose (the note sits on the constant it constrains; the file is the cohesive protocol vocabulary kernel).

Reference reading: github-mcp-server `pkg/github/tools.go` (one registration owns a tool's facts, nothing restated) and `repositories_test.go` (assert from the registration, never a second expected table).
