### PR TITLE
fix(sync): DNS-pinned public egress for provider RPC URLs, a deadline per bridge leg

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "smol-toml": "1.8.0",
     "socket.io-client": "^4.8.3",
     "tweetnacl": "1.0.3",
+    "undici": "7.25.0",
     "viem": "2.54.3",
     "winston": "^3.17.0",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       tweetnacl:
         specifier: 1.0.3
         version: 1.0.3
+      undici:
+        specifier: 7.25.0
+        version: 7.25.0
       viem:
         specifier: 2.54.3
         version: 2.54.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)

--- a/src/__tests__/vex-agent/sync/bridge-activity-repair-row-deadline.test.ts
+++ b/src/__tests__/vex-agent/sync/bridge-activity-repair-row-deadline.test.ts
@@ -1,0 +1,179 @@
+/**
+ * THE LEG HAS A DEADLINE, and the deadline is what the sweep's other queues get
+ * back.
+ *
+ * The defect this pins (external review of PR #142, blocker 2): every candidate
+ * had a 15 s transport timeout AND one transport retry, and the widened
+ * candidate list made six candidates realistic, so ONE leg of ONE row could hold
+ * the shared sync worker for three minutes while balance and settlement sync
+ * waited behind the same drain. The sweep takes 25 rows per run at a 120 s
+ * cadence, so the row was the wrong unit to leave unbounded.
+ *
+ * Time is FAKE here on purpose (VS Code's `runWithFakedTimers` deadline tests,
+ * `src/vs/base/test/common/async.test.ts`, are the pattern): a deadline that can
+ * only be proven by waiting 20 real seconds would never be run.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+
+import {
+  BRIDGE_LEG_VERIFICATION_DEADLINE_MS,
+  BRIDGE_RPC_CANDIDATE_TIMEOUT_MS,
+  VERIFICATION_REASONS,
+} from "@vex-agent/sync/bridge-activity-repair-contracts.js";
+
+/** What each candidate URL does when it is probed, in candidate order. */
+type CandidateScript = { readonly hangs: true } | { readonly hangs: false; readonly receiptStatus: string };
+
+let script: CandidateScript[] = [];
+let rpcUrls: string[] = [];
+/** How long the provider registry takes to answer, in fake milliseconds. */
+let registryDelayMs = 0;
+const probed: string[] = [];
+
+vi.mock("viem", () => ({
+  http: (url: string) => url,
+  createPublicClient: ({ transport }: { transport: string }) => {
+    probed.push(transport);
+    const step = script.shift() ?? { hangs: true as const };
+    const hang = <T,>(): Promise<T> => new Promise<T>(() => undefined);
+    return {
+      getChainId: async () => (step.hangs ? hang<number>() : 42161),
+      getTransactionReceipt: async () => (step.hangs ? hang<{ status: string }>() : { status: step.receiptStatus }),
+    };
+  },
+}));
+
+vi.mock("@vex-agent/sync/solana-rpc-safety.js", () => ({
+  SOLANA_MAINNET_GENESIS: "genesis",
+  selectVerificationRpcUrls: () => rpcUrls,
+  solanaRpcCall: vi.fn(),
+}));
+
+vi.mock("@config/chain-rpc-overrides.js", () => ({ getUserRpcOverridesForChain: () => [] }));
+vi.mock("@tools/evm-chains/registry.js", () => ({
+  getLocalChain: () => null,
+  getLocalChainRpcUrl: () => "",
+}));
+vi.mock("@tools/khalani/chains.js", () => ({
+  getCachedKhalaniChains: async () => {
+    // A registry that is slow rather than broken: the old code awaited it with
+    // no budget at all, before any RPC timeout applied.
+    await new Promise<void>((resolve) => setTimeout(resolve, registryDelayMs));
+    return [];
+  },
+}));
+vi.mock("@tools/relay/client.js", () => ({ getCachedRelayChains: async () => [] }));
+
+const { verifyBridgeLegOnChain } = await import("@vex-agent/sync/bridge-activity-repair-verification.js");
+
+const HASH = `0x${"b".repeat(64)}`;
+
+function input() {
+  return {
+    txHash: HASH,
+    expectedChainId: 42161,
+    chainFamily: "eip155" as const,
+    protocol: "relay",
+    tokenOutAddress: null,
+    recipient: null,
+  };
+}
+
+/**
+ * Run one verification against the fake clock and report how much VIRTUAL time
+ * it consumed. The generous advance (three deadlines) is what makes an
+ * unbounded leg fail this test instead of hanging it.
+ */
+async function measureLegVerification(): Promise<{ elapsedMs: number; result: Awaited<ReturnType<typeof verifyBridgeLegOnChain>> }> {
+  const startedAt = Date.now();
+  let elapsedMs = -1;
+  const pending = verifyBridgeLegOnChain(input()).then((result) => {
+    elapsedMs = Date.now() - startedAt;
+    return result;
+  });
+  await vi.advanceTimersByTimeAsync(BRIDGE_LEG_VERIFICATION_DEADLINE_MS * 3);
+  return { elapsedMs, result: await pending };
+}
+
+/**
+ * Load every dynamically imported module (viem, the three registries) BEFORE the
+ * fake clock starts. A module load settles on a real I/O turn, which a fake
+ * clock does not wait for, so a cold import inside a measured run would be
+ * overtaken by the virtual deadline and measure nothing.
+ */
+beforeAll(async () => {
+  rpcUrls = ["https://warm-up"];
+  script = [{ hangs: false, receiptStatus: "success" }];
+  await verifyBridgeLegOnChain(input());
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  script = [];
+  rpcUrls = [];
+  registryDelayMs = 0;
+  probed.length = 0;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("one leg of one row cannot occupy the shared sync worker", () => {
+  it("six unresponsive candidates behind a slow registry still finish inside the leg deadline", async () => {
+    registryDelayMs = 3_000;
+    rpcUrls = ["https://a", "https://b", "https://c", "https://d", "https://e", "https://f"];
+    script = Array.from({ length: 6 }, () => ({ hangs: true as const }));
+
+    const { elapsedMs, result } = await measureLegVerification();
+
+    expect(elapsedMs).toBeGreaterThan(0);
+    expect(elapsedMs).toBeLessThanOrEqual(BRIDGE_LEG_VERIFICATION_DEADLINE_MS);
+    expect(result.verified).toBe(false);
+    // Typed, in the stored vocabulary, and terminalizes nothing: the row stays
+    // pending and is retried on the next tick.
+    expect(VERIFICATION_REASONS).toContain(result.reason);
+    expect(result.reason).toBe("rpc_unreachable");
+  });
+
+  it("abandons a hung candidate at its own timeout rather than at the leg deadline", async () => {
+    rpcUrls = ["https://a", "https://b"];
+    script = [{ hangs: true }, { hangs: false, receiptStatus: "success" }];
+
+    const { elapsedMs, result } = await measureLegVerification();
+
+    expect(result).toEqual({ verified: true });
+    expect(probed).toEqual(["https://a", "https://b"]);
+    // One candidate timeout, not one leg deadline: the second candidate got its
+    // turn with the rest of the budget intact.
+    expect(elapsedMs).toBeGreaterThanOrEqual(BRIDGE_RPC_CANDIDATE_TIMEOUT_MS);
+    expect(elapsedMs).toBeLessThan(BRIDGE_LEG_VERIFICATION_DEADLINE_MS);
+  });
+
+  it("a settlement found on candidate three still wins", async () => {
+    rpcUrls = ["https://a", "https://b", "https://c", "https://d"];
+    script = [{ hangs: true }, { hangs: true }, { hangs: false, receiptStatus: "success" }];
+
+    const { elapsedMs, result } = await measureLegVerification();
+
+    expect(result).toEqual({ verified: true });
+    expect(probed).toEqual(["https://a", "https://b", "https://c"]);
+    expect(elapsedMs).toBeLessThanOrEqual(BRIDGE_LEG_VERIFICATION_DEADLINE_MS);
+  });
+
+  it("a registry that outlasts the whole budget reports a typed reason and no candidates", async () => {
+    registryDelayMs = BRIDGE_LEG_VERIFICATION_DEADLINE_MS * 2;
+    rpcUrls = ["https://a"];
+
+    const { elapsedMs, result } = await measureLegVerification();
+
+    expect(elapsedMs).toBeLessThanOrEqual(BRIDGE_LEG_VERIFICATION_DEADLINE_MS);
+    expect(probed).toEqual([]);
+    expect(result.verified).toBe(false);
+    // Nothing was observed, so nothing more specific can honestly be claimed.
+    expect(result.reason).toBe("verification_failed");
+    expect(VERIFICATION_REASONS).toContain(result.reason);
+  });
+});

--- a/src/__tests__/vex-agent/sync/bridge-activity-repair-row-deadline.test.ts
+++ b/src/__tests__/vex-agent/sync/bridge-activity-repair-row-deadline.test.ts
@@ -1,6 +1,7 @@
 /**
  * THE LEG HAS A DEADLINE, and the deadline is what the sweep's other queues get
- * back.
+ * back. The TRANSPORT the leg builds is part of that contract, so it is asserted
+ * here too rather than assumed.
  *
  * The defect this pins (external review of PR #142, blocker 2): every candidate
  * had a 15 s transport timeout AND one transport retry, and the widened
@@ -8,6 +9,21 @@
  * the shared sync worker for three minutes while balance and settlement sync
  * waited behind the same drain. The sweep takes 25 rows per run at a 120 s
  * cadence, so the row was the wrong unit to leave unbounded.
+ *
+ * The second defect, found by the round-2 review of THIS suite: the viem mock
+ * threw the transport options away and its fake client ignored the signal
+ * entirely, so deleting `retryCount: 0`, the dispatcher or `fetchOptions.signal`
+ * left every test green. The options are now captured and asserted, and a
+ * stalled candidate settles ONLY when the signal it was handed aborts - which is
+ * what makes "the abort reaches the socket" an observation instead of a comment.
+ *
+ * PRODUCTION FACT behind that assertion (measured, viem 2.x
+ * `node_modules/viem/_esm/utils/rpc/http.js`): the fetch call passes
+ * `signal: signal_ || (timeout > 0 ? signal : null)`, where `signal_` is
+ * `fetchOptions.signal`. OUR signal therefore wins over viem's own timeout
+ * signal, so the candidate budget - not the transport option - is what actually
+ * ends a hung request, and a dropped `fetchOptions.signal` would silently hand
+ * cancellation back to viem.
  *
  * Time is FAKE here on purpose (VS Code's `runWithFakedTimers` deadline tests,
  * `src/vs/base/test/common/async.test.ts`, are the pattern): a deadline that can
@@ -25,21 +41,88 @@ import {
 /** What each candidate URL does when it is probed, in candidate order. */
 type CandidateScript = { readonly hangs: true } | { readonly hangs: false; readonly receiptStatus: string };
 
+/** The subset of viem's `http` options this verifier is contracted to build. */
+interface CapturedFetchOptions {
+  readonly redirect?: RequestRedirect;
+  readonly signal?: AbortSignal | null;
+  readonly dispatcher?: unknown;
+}
+interface CapturedTransportOptions {
+  readonly timeout?: number;
+  readonly retryCount?: number;
+  readonly fetchOptions?: CapturedFetchOptions;
+}
+interface CapturedTransport {
+  readonly url: string;
+  readonly options: CapturedTransportOptions;
+}
+
 let script: CandidateScript[] = [];
 let rpcUrls: string[] = [];
+let curatedUrls: string[] = [];
 /** How long the provider registry takes to answer, in fake milliseconds. */
 let registryDelayMs = 0;
 const probed: string[] = [];
+/** Every `http(url, options)` the verifier built, in order. */
+const transportCalls: CapturedTransport[] = [];
+/** Every candidate whose OWN handed-in signal fired: the abort reaching the transport. */
+const abortedTransports: string[] = [];
+
+/**
+ * The egress dispatcher, stubbed so its LIFECYCLE is observable. The real one
+ * holds keep-alive sockets; the contract is that the verifier closes exactly the
+ * one it opened, on every exit path.
+ */
+let egressOpened = 0;
+let egressClosed = 0;
+const fakeEgressDispatcher = {
+  close: async (): Promise<void> => {
+    egressClosed += 1;
+  },
+};
+
+vi.mock("@vex-agent/sync/rpc-egress-policy.js", () => ({
+  createPinnedPublicEgressDispatcher: () => {
+    egressOpened += 1;
+    return fakeEgressDispatcher;
+  },
+  isEgressRefusal: () => false,
+}));
 
 vi.mock("viem", () => ({
-  http: (url: string) => url,
-  createPublicClient: ({ transport }: { transport: string }) => {
-    probed.push(transport);
+  http: (url: string, options: CapturedTransportOptions) => {
+    transportCalls.push({ url, options });
+    return { url, options };
+  },
+  createPublicClient: ({ transport }: { transport: CapturedTransport }) => {
+    probed.push(transport.url);
     const step = script.shift() ?? { hangs: true as const };
-    const hang = <T,>(): Promise<T> => new Promise<T>(() => undefined);
+    /**
+     * A stalled endpoint behaves like a real one: the request settles only when
+     * the signal it was given aborts. A transport built WITHOUT a signal simply
+     * never settles, which is what the options assertions catch.
+     */
+    const respond = <T>(produce: () => T): Promise<T> =>
+      new Promise<T>((resolve, reject) => {
+        if (!step.hangs) {
+          resolve(produce());
+          return;
+        }
+        const signal = transport.options.fetchOptions?.signal;
+        if (!signal) return;
+        const onAbort = (): void => {
+          abortedTransports.push(transport.url);
+          reject(Object.assign(new Error("The operation was aborted."), { name: "AbortError" }));
+        };
+        if (signal.aborted) {
+          onAbort();
+          return;
+        }
+        signal.addEventListener("abort", onAbort, { once: true });
+      });
     return {
-      getChainId: async () => (step.hangs ? hang<number>() : 42161),
-      getTransactionReceipt: async () => (step.hangs ? hang<{ status: string }>() : { status: step.receiptStatus }),
+      getChainId: () => respond(() => 42161),
+      getTransactionReceipt: () => respond(() => ({ status: step.hangs ? "" : step.receiptStatus })),
     };
   },
 }));
@@ -50,7 +133,7 @@ vi.mock("@vex-agent/sync/solana-rpc-safety.js", () => ({
   solanaRpcCall: vi.fn(),
 }));
 
-vi.mock("@config/chain-rpc-overrides.js", () => ({ getUserRpcOverridesForChain: () => [] }));
+vi.mock("@config/chain-rpc-overrides.js", () => ({ getUserRpcOverridesForChain: () => curatedUrls }));
 vi.mock("@tools/evm-chains/registry.js", () => ({
   getLocalChain: () => null,
   getLocalChainRpcUrl: () => "",
@@ -113,8 +196,13 @@ beforeEach(() => {
   vi.setSystemTime(0);
   script = [];
   rpcUrls = [];
+  curatedUrls = [];
   registryDelayMs = 0;
   probed.length = 0;
+  transportCalls.length = 0;
+  abortedTransports.length = 0;
+  egressOpened = 0;
+  egressClosed = 0;
 });
 
 afterEach(() => {
@@ -136,6 +224,11 @@ describe("one leg of one row cannot occupy the shared sync worker", () => {
     // pending and is retried on the next tick.
     expect(VERIFICATION_REASONS).toContain(result.reason);
     expect(result.reason).toBe("rpc_unreachable");
+    // Every stalled candidate was ABANDONED THROUGH ITS OWN SIGNAL, not merely
+    // outlived by the loop: the abort reached the transport each time.
+    expect(abortedTransports).toEqual(probed);
+    // The deadline path still closes the dispatcher it opened.
+    expect({ opened: egressOpened, closed: egressClosed }).toEqual({ opened: 1, closed: 1 });
   });
 
   it("abandons a hung candidate at its own timeout rather than at the leg deadline", async () => {
@@ -150,6 +243,9 @@ describe("one leg of one row cannot occupy the shared sync worker", () => {
     // turn with the rest of the budget intact.
     expect(elapsedMs).toBeGreaterThanOrEqual(BRIDGE_RPC_CANDIDATE_TIMEOUT_MS);
     expect(elapsedMs).toBeLessThan(BRIDGE_LEG_VERIFICATION_DEADLINE_MS);
+    expect(abortedTransports).toEqual(["https://a"]);
+    // The success path closes it too.
+    expect({ opened: egressOpened, closed: egressClosed }).toEqual({ opened: 1, closed: 1 });
   });
 
   it("a settlement found on candidate three still wins", async () => {
@@ -175,5 +271,58 @@ describe("one leg of one row cannot occupy the shared sync worker", () => {
     // Nothing was observed, so nothing more specific can honestly be claimed.
     expect(result.reason).toBe("verification_failed");
     expect(VERIFICATION_REASONS).toContain(result.reason);
+    // A leg that never reached an endpoint still closes the dispatcher it opened.
+    expect({ opened: egressOpened, closed: egressClosed }).toEqual({ opened: 1, closed: 1 });
+  });
+});
+
+describe("the transport the leg builds is the transport the contract promises", () => {
+  it("no retry, a candidate timeout, redirects off, the leg signal, and the dispatcher on PROVIDER candidates only", async () => {
+    // The user's own node first (curated: fetched as configured, private
+    // addresses are supported there), then a provider-registry endpoint.
+    curatedUrls = ["https://curated.example"];
+    rpcUrls = ["https://curated.example", "https://provider.example"];
+    script = [{ hangs: true }, { hangs: false, receiptStatus: "success" }];
+
+    const { result } = await measureLegVerification();
+
+    expect(result).toEqual({ verified: true });
+    expect(transportCalls.map((call) => call.url)).toEqual(["https://curated.example", "https://provider.example"]);
+    for (const call of transportCalls) {
+      // The candidate list is the fallback, so the same endpoint is never tried
+      // twice: one retry per candidate doubled the worst case that produced the
+      // three-minute leg.
+      expect({ url: call.url, retryCount: call.options.retryCount }).toEqual({ url: call.url, retryCount: 0 });
+      expect(call.options.timeout).toBe(BRIDGE_RPC_CANDIDATE_TIMEOUT_MS);
+      // A 3xx to a re-pointed (possibly private) host is refused, not followed.
+      expect(call.options.fetchOptions?.redirect).toBe("error");
+      // The leg budget reaches the socket. viem prefers this signal over its own
+      // timeout signal, so its absence would hand cancellation back to viem.
+      expect(call.options.fetchOptions?.signal).toBeInstanceOf(AbortSignal);
+    }
+    // A curated URL is fetched AS CONFIGURED: no egress dispatcher, because a
+    // self-hosted archive node on a private address is a supported setup.
+    expect(transportCalls[0]?.options.fetchOptions?.dispatcher).toBeUndefined();
+    // A provider-registry URL gets the pinning dispatcher, and it is the one
+    // dispatcher this leg opened.
+    expect(transportCalls[1]?.options.fetchOptions?.dispatcher).toBe(fakeEgressDispatcher);
+    expect({ opened: egressOpened, closed: egressClosed }).toEqual({ opened: 1, closed: 1 });
+  });
+
+  it("the signal handed to a candidate is aborted by the LEG deadline too, not only by its own timeout", async () => {
+    // One candidate, and a registry slow enough that the leg deadline arrives
+    // before the candidate's own timeout could: the abort still reaches the
+    // transport, because both timers drive the same handed-in signal.
+    registryDelayMs = BRIDGE_LEG_VERIFICATION_DEADLINE_MS - BRIDGE_RPC_CANDIDATE_TIMEOUT_MS / 2;
+    rpcUrls = ["https://slow-start"];
+    script = [{ hangs: true }];
+
+    const { result } = await measureLegVerification();
+
+    expect(probed).toEqual(["https://slow-start"]);
+    expect(abortedTransports).toEqual(["https://slow-start"]);
+    expect(result.verified).toBe(false);
+    expect(VERIFICATION_REASONS).toContain(result.reason);
+    expect({ opened: egressOpened, closed: egressClosed }).toEqual({ opened: 1, closed: 1 });
   });
 });

--- a/src/__tests__/vex-agent/sync/bridge-activity-repair-row-deadline.test.ts
+++ b/src/__tests__/vex-agent/sync/bridge-activity-repair-row-deadline.test.ts
@@ -3,7 +3,7 @@
  * back. The TRANSPORT the leg builds is part of that contract, so it is asserted
  * here too rather than assumed.
  *
- * The defect this pins (external review of PR #142, blocker 2): every candidate
+ * The defect this pins (review finding, 2026-09-04): every candidate
  * had a 15 s transport timeout AND one transport retry, and the widened
  * candidate list made six candidates realistic, so ONE leg of ONE row could hold
  * the shared sync worker for three minutes while balance and settlement sync

--- a/src/__tests__/vex-agent/sync/rpc-egress-address-table.test.ts
+++ b/src/__tests__/vex-agent/sync/rpc-egress-address-table.test.ts
@@ -1,0 +1,207 @@
+/**
+ * THE EGRESS ADDRESS TABLE, ENUMERATED.
+ *
+ * The defect this pins (external review of PR #142, round 2): the IPv6 side of
+ * the classifier matched TEXT PREFIXES, so `fe80` stood in for `fe80::/10` and
+ * `fe90::1` - a link-local address by every RFC that names one - was classified
+ * public and would have been handed a socket. Documentation, benchmarking,
+ * discard, Teredo, 6to4 and site-local space was not considered at all.
+ *
+ * WHAT THIS TEST IS. Not a sample of interesting addresses: a CROSS-CHECK
+ * against the table the module exports. Every CIDR the policy declares must
+ * appear here with at least one address INSIDE it (refused) and one nearby
+ * address the table still clears (allowed), and the completeness assertion at
+ * the end fails if a block is ever added without a case. Deleting a block turns
+ * its inside cases red; widening one turns an allowed case red.
+ *
+ * Nesting is called out where it exists: `255.255.255.255/32` sits inside
+ * `240.0.0.0/4`, so the address next to it is not public either and the allowed
+ * sample is the nearest address outside BOTH.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  EMBEDDED_IPV4_IPV6_CIDRS,
+  NON_PUBLIC_IPV4_CIDRS,
+  NON_PUBLIC_IPV6_CIDRS,
+  isPrivateOrLoopbackHost,
+  isPublicIpAddress,
+  isSsrfSafeRpcUrl,
+} from "@vex-agent/sync/rpc-egress-policy.js";
+
+/** One declared block, with addresses that must be refused and addresses that must be cleared. */
+interface BlockCase {
+  readonly cidr: string;
+  /** Inside the block (edges included where the edge is what a prefix bug gets wrong). */
+  readonly refused: readonly string[];
+  /** Outside the block AND outside every other block: these prove the range does not overreach. */
+  readonly allowed: readonly string[];
+}
+
+const IPV4_CASES: readonly BlockCase[] = [
+  { cidr: "0.0.0.0/8", refused: ["0.0.0.0", "0.255.255.255"], allowed: ["1.0.0.1"] },
+  { cidr: "10.0.0.0/8", refused: ["10.0.0.0", "10.255.255.255"], allowed: ["9.255.255.255", "11.0.0.1"] },
+  { cidr: "100.64.0.0/10", refused: ["100.64.0.0", "100.127.255.255"], allowed: ["100.63.255.255", "100.128.0.1"] },
+  { cidr: "127.0.0.0/8", refused: ["127.0.0.1", "127.255.255.255"], allowed: ["126.255.255.255", "128.0.0.1"] },
+  { cidr: "169.254.0.0/16", refused: ["169.254.0.1", "169.254.169.254"], allowed: ["169.253.255.255", "169.255.0.1"] },
+  { cidr: "172.16.0.0/12", refused: ["172.16.0.0", "172.31.255.255"], allowed: ["172.15.255.255", "172.32.0.1"] },
+  { cidr: "192.0.0.0/24", refused: ["192.0.0.0", "192.0.0.255"], allowed: ["192.0.1.1"] },
+  { cidr: "192.0.2.0/24", refused: ["192.0.2.0", "192.0.2.255"], allowed: ["192.0.3.1"] },
+  { cidr: "192.168.0.0/16", refused: ["192.168.0.1", "192.168.255.255"], allowed: ["192.167.255.255", "192.169.0.1"] },
+  { cidr: "198.18.0.0/15", refused: ["198.18.0.0", "198.19.255.255"], allowed: ["198.17.255.255", "198.20.0.1"] },
+  { cidr: "198.51.100.0/24", refused: ["198.51.100.0", "198.51.100.255"], allowed: ["198.51.99.1", "198.51.101.1"] },
+  { cidr: "203.0.113.0/24", refused: ["203.0.113.0", "203.0.113.255"], allowed: ["203.0.112.1", "203.0.114.1"] },
+  { cidr: "224.0.0.0/4", refused: ["224.0.0.1", "239.255.255.255"], allowed: ["223.255.255.255"] },
+  // Nested: everything just below 240/4 is multicast, so the nearest cleared
+  // address is the one below 224/4 as well.
+  { cidr: "240.0.0.0/4", refused: ["240.0.0.1", "255.255.255.254"], allowed: ["223.255.255.255"] },
+  { cidr: "255.255.255.255/32", refused: ["255.255.255.255"], allowed: ["223.255.255.255"] },
+];
+
+const IPV6_CASES: readonly BlockCase[] = [
+  { cidr: "::/128", refused: ["::", "0:0:0:0:0:0:0:0"], allowed: ["::2"] },
+  { cidr: "::1/128", refused: ["::1", "0:0:0:0:0:0:0:1"], allowed: ["::2"] },
+  {
+    cidr: "64:ff9b:1::/48",
+    refused: ["64:ff9b:1::1", "64:ff9b:1:ffff:ffff:ffff:ffff:ffff"],
+    allowed: ["64:ff9b:2::1"],
+  },
+  { cidr: "100::/64", refused: ["100::", "100::ffff:ffff:ffff:ffff"], allowed: ["100:0:0:1::1"] },
+  { cidr: "2001::/32", refused: ["2001::1", "2001:0:ffff:ffff:ffff:ffff:ffff:ffff"], allowed: ["2001:1::1"] },
+  { cidr: "2001:db8::/32", refused: ["2001:db8::1", "2001:db8:ffff::1"], allowed: ["2001:db9::1"] },
+  { cidr: "fc00::/7", refused: ["fc00::1", "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"], allowed: ["fbff::1"] },
+  // The regression itself: `fe90::1` and `febf::1` are inside `fe80::/10` and a
+  // `startsWith("fe80")` classifier cleared both.
+  { cidr: "fe80::/10", refused: ["fe80::1", "fe90::1", "febf:ffff::1"], allowed: ["fe7f:ffff::1"] },
+  { cidr: "fec0::/10", refused: ["fec0::1", "feff:ffff::1"], allowed: ["fe7f:ffff::1"] },
+  // Nested neighbourhood: `feff::1` below `ff00::/8` is site-local, so the
+  // cleared sample is ordinary public space.
+  { cidr: "ff00::/8", refused: ["ff00::1", "ff02::1", "ffff::1"], allowed: ["2606:4700:4700::1111"] },
+];
+
+const EMBEDDED_CASES: readonly BlockCase[] = [
+  {
+    cidr: "::ffff:0:0/96",
+    // Both textual forms of the same mapped address: WHATWG URL parsing
+    // normalizes the dotted one to hex before a host ever reaches us.
+    refused: ["::ffff:127.0.0.1", "::ffff:7f00:1", "::ffff:10.0.0.1", "::ffff:169.254.169.254"],
+    allowed: ["::ffff:1.1.1.1", "::ffff:101:101"],
+  },
+  {
+    cidr: "64:ff9b::/96",
+    refused: ["64:ff9b::127.0.0.1", "64:ff9b::7f00:1", "64:ff9b::192.168.1.1"],
+    allowed: ["64:ff9b::1.1.1.1"],
+  },
+  {
+    cidr: "2002::/16",
+    refused: ["2002:7f00:1::1", "2002:a00:1::", "2002:a9fe:a9fe::1"],
+    allowed: ["2002:101:101::1"],
+  },
+];
+
+const ALL_CASES: readonly BlockCase[] = [...IPV4_CASES, ...IPV6_CASES, ...EMBEDDED_CASES];
+
+describe("every declared non-public block is enumerated, inside and outside", () => {
+  it.each(ALL_CASES.map((entry) => [entry.cidr, entry] as const))("%s", (_cidr, entry) => {
+    for (const address of entry.refused) {
+      expect({ address, public: isPublicIpAddress(address) }).toEqual({ address, public: false });
+      expect({ address, blocked: isPrivateOrLoopbackHost(address) }).toEqual({ address, blocked: true });
+    }
+    for (const address of entry.allowed) {
+      expect({ address, public: isPublicIpAddress(address) }).toEqual({ address, public: true });
+      expect({ address, blocked: isPrivateOrLoopbackHost(address) }).toEqual({ address, blocked: false });
+    }
+  });
+
+  it("covers the declared table exactly: a new block without a case fails here", () => {
+    const declared = [
+      ...NON_PUBLIC_IPV4_CIDRS,
+      ...NON_PUBLIC_IPV6_CIDRS,
+      ...EMBEDDED_IPV4_IPV6_CIDRS.map((entry) => entry.cidr),
+    ];
+    expect([...ALL_CASES.map((entry) => entry.cidr)].sort()).toEqual([...declared].sort());
+  });
+});
+
+describe("an address the classifier cannot parse is refused, never passed on as a name", () => {
+  // Every one of these resolves to loopback through `getaddrinfo`, and none is a
+  // hostname anybody can register: the classic SSRF bypasses.
+  it.each([
+    "010.0.0.1",
+    "0x7f.0.0.1",
+    "0177.0.0.1",
+    "2130706433",
+    "0x7f000001",
+    "127.1",
+    "1.2.3.4.5",
+    "::gg",
+    "1:::2",
+    "12345::1",
+    "fe80::1::2",
+    "1:2:3:4:5:6:7",
+    "1:2:3:4:5:6:7:8:9",
+    ":1::",
+    "not-an-address",
+  ])("%s is not cleared", (host) => {
+    expect({ host, public: isPublicIpAddress(host) }).toEqual({ host, public: false });
+  });
+
+  it.each([
+    "010.0.0.1",
+    "0x7f.0.0.1",
+    "0177.0.0.1",
+    "2130706433",
+    "0x7f000001",
+    "127.1",
+    "::gg",
+    "1:::2",
+    "fe80::1::2",
+  ])("%s is blocked as a host", (host) => {
+    expect({ host, blocked: isPrivateOrLoopbackHost(host) }).toEqual({ host, blocked: true });
+  });
+
+  it("still treats an ordinary DNS name as a name, decided later at connect time", () => {
+    expect(isPrivateOrLoopbackHost("rpc.example.com")).toBe(false);
+    expect(isPrivateOrLoopbackHost("localhost")).toBe(true);
+    expect(isPrivateOrLoopbackHost("api.localhost")).toBe(true);
+  });
+});
+
+describe("bracketed and zoned literals are classified by the address itself", () => {
+  it.each([
+    ["[fe90::1]", false],
+    ["[fe80::1%eth0]", false],
+    ["fe80::1%eth0", false],
+    ["[2606:4700:4700::1111]", true],
+  ] as const)("%s", (host, expected) => {
+    expect({ host, public: isPublicIpAddress(host) }).toEqual({ host, public: expected });
+  });
+});
+
+describe("the URL gate refuses what the table refuses", () => {
+  it.each([
+    "https://[fe90::1]/rpc",
+    "https://[fec0::1]/rpc",
+    // WHATWG URL canonicalizes every numeric host form before we see it
+    // (`2130706433`, `0x7f000001` and `0177.0.0.1` all arrive as `127.0.0.1`),
+    // so these prove the gate refuses the canonical result, not the spelling.
+    "https://2130706433/rpc",
+    "https://0x7f000001/rpc",
+    "https://0177.0.0.1/rpc",
+    "https://127.1/rpc",
+    "https://198.51.100.7/rpc",
+    "https://[64:ff9b::7f00:1]/rpc",
+    "http://rpc.example.com/",
+    "https://user:pass@rpc.example.com/",
+  ])("%s is not an SSRF-safe RPC URL", (url) => {
+    expect({ url, safe: isSsrfSafeRpcUrl(url) }).toEqual({ url, safe: false });
+  });
+
+  it.each(["https://rpc.example.com/", "https://[2606:4700:4700::1111]/", "https://1.1.1.1/"])(
+    "%s is accepted by the syntactic pass",
+    (url) => {
+      expect({ url, safe: isSsrfSafeRpcUrl(url) }).toEqual({ url, safe: true });
+    },
+  );
+});

--- a/src/__tests__/vex-agent/sync/rpc-egress-pinning.test.ts
+++ b/src/__tests__/vex-agent/sync/rpc-egress-pinning.test.ts
@@ -1,0 +1,264 @@
+/**
+ * A PROVIDER-SUPPLIED RPC URL CANNOT REACH PRIVATE SPACE, proven at the socket.
+ *
+ * The defect (external review of PR #142, blocker 1): the SSRF control was
+ * syntactic, so `https://rebound.test` was accepted on its face and whatever it
+ * resolved to received the request. The `eth_chainId` echo stops us BELIEVING a
+ * false receipt; it does not stop the POST from arriving at a local service.
+ *
+ * WHAT MAKES THIS A TRANSPORT TEST AND NOT A UNIT TEST: viem, undici, `fetch`
+ * and the verifier's own loop are all REAL here. The only scripted boundary is
+ * `node:dns`, which is exactly the boundary an attacker controls in a rebinding
+ * attack. The listener is a real socket on `127.0.0.1` that counts CONNECTIONS,
+ * so "the policy refused" is measured as "no socket was ever opened", not as a
+ * returned string.
+ *
+ * The positive control matters as much as the refusal: the same listener, named
+ * as a CURATED endpoint (the app's own configuration, where a private address is
+ * a supported setup), is reached and verifies a receipt end to end. Without it,
+ * a test that broke the transport entirely would look like a passing policy.
+ */
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { VERIFICATION_REASONS } from "@vex-agent/sync/bridge-activity-repair-contracts.js";
+
+/** Hostnames the scripted resolver knows, and the addresses it hands back. */
+const scriptedDns = new Map<string, Array<{ address: string; family: number }>>();
+
+vi.mock("node:dns", async () => {
+  const actual = await vi.importActual<typeof import("node:dns")>("node:dns");
+  return {
+    ...actual,
+    default: actual,
+    lookup: (
+      hostname: string,
+      options: unknown,
+      callback: (err: NodeJS.ErrnoException | null, address: unknown, family?: number) => void,
+    ) => {
+      const scripted = scriptedDns.get(hostname);
+      if (!scripted) {
+        callback(Object.assign(new Error(`getaddrinfo ENOTFOUND ${hostname}`), { code: "ENOTFOUND" }), "", undefined);
+        return;
+      }
+      callback(null, scripted);
+    },
+  };
+});
+
+let curated: string[] = [];
+let providerRegistryUrl: string | null = null;
+
+vi.mock("@config/chain-rpc-overrides.js", () => ({ getUserRpcOverridesForChain: () => curated }));
+vi.mock("@tools/evm-chains/registry.js", () => ({
+  getLocalChain: () => null,
+  getLocalChainRpcUrl: () => "",
+}));
+vi.mock("@tools/khalani/chains.js", () => ({
+  getCachedKhalaniChains: async () =>
+    providerRegistryUrl === null
+      ? []
+      : [{ id: LOCAL_CHAIN_ID, rpcUrls: { default: { http: [providerRegistryUrl] } } }],
+}));
+vi.mock("@tools/relay/client.js", () => ({ getCachedRelayChains: async () => [] }));
+
+const { verifyBridgeLegOnChain } = await import("@vex-agent/sync/bridge-activity-repair-verification.js");
+const { pinPublicAddress, isPublicIpAddress, RpcEgressRefusedError } = await import(
+  "@vex-agent/sync/rpc-egress-policy.js"
+);
+
+/**
+ * A chain id viem has never heard of (the app's own local chain), so the
+ * bundled-registry candidate contributes nothing and this test never reaches a
+ * real public endpoint.
+ */
+const LOCAL_CHAIN_ID = 4663;
+const HASH = `0x${"c".repeat(64)}`;
+
+/** Every JSON-RPC method the listener was asked for, so a leaked request is visible even if the socket count were not. */
+const served: string[] = [];
+let connections = 0;
+let server: Server;
+let port = 0;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk: Buffer) => {
+      body += chunk.toString("utf-8");
+    });
+    req.on("end", () => {
+      const parsed: unknown = JSON.parse(body || "{}");
+      const method = typeof parsed === "object" && parsed !== null ? (parsed as { method?: unknown }).method : null;
+      served.push(typeof method === "string" ? method : "unknown");
+      const result =
+        method === "eth_chainId"
+          ? `0x${LOCAL_CHAIN_ID.toString(16)}`
+          : {
+              status: "0x1",
+              blockNumber: "0x1",
+              transactionHash: HASH,
+              logs: [],
+            };
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ jsonrpc: "2.0", id: 1, result }));
+    });
+  });
+  server.on("connection", () => {
+    connections += 1;
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  scriptedDns.clear();
+  served.length = 0;
+  connections = 0;
+  curated = [];
+  providerRegistryUrl = null;
+});
+
+function input() {
+  return {
+    txHash: HASH,
+    expectedChainId: LOCAL_CHAIN_ID,
+    chainFamily: "eip155" as const,
+    protocol: "relay",
+    tokenOutAddress: null,
+    recipient: null,
+  };
+}
+
+describe("a provider hostname that resolves into private space never gets a socket", () => {
+  it("refuses BOTH RPC calls of the leg: the listener sees zero connections", async () => {
+    // The rebinding: a public-looking name in an untrusted registry, resolving
+    // to the loopback listener that is waiting to answer.
+    providerRegistryUrl = `https://rebound.test:${port}`;
+    scriptedDns.set("rebound.test", [{ address: "127.0.0.1", family: 4 }]);
+
+    const result = await verifyBridgeLegOnChain(input());
+
+    expect(connections).toBe(0);
+    expect(served).toEqual([]); // neither eth_chainId nor eth_getTransactionReceipt.
+    expect(result.verified).toBe(false);
+    expect(result.reason).toBe("no_safe_rpc");
+    // The refusal is a member of the stored 065 vocabulary, so it reaches the
+    // user and the agent as a named fact rather than as "unexpected error".
+    expect(VERIFICATION_REASONS).toContain(result.reason);
+  });
+
+  it("refuses when only ONE of several resolved addresses is private", async () => {
+    providerRegistryUrl = `https://split-horizon.test:${port}`;
+    scriptedDns.set("split-horizon.test", [
+      { address: "93.184.216.34", family: 4 },
+      { address: "127.0.0.1", family: 4 },
+    ]);
+
+    const result = await verifyBridgeLegOnChain(input());
+
+    expect(connections).toBe(0);
+    expect(result).toEqual({ verified: false, reason: "no_safe_rpc" });
+  });
+
+  it("refuses the cloud metadata address, which is the whole point of the control", async () => {
+    providerRegistryUrl = `https://metadata.test:${port}`;
+    scriptedDns.set("metadata.test", [{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await verifyBridgeLegOnChain(input());
+
+    expect(connections).toBe(0);
+    expect(result).toEqual({ verified: false, reason: "no_safe_rpc" });
+  });
+
+  it("a provider URL that the transport reached and simply could not resolve is NOT reported as refused", async () => {
+    // The control that keeps the refusals above honest: the same candidate path,
+    // the same real transport, a resolver failure instead of a policy refusal.
+    // `rpc_unreachable` here proves the URL DID reach the probe loop, so
+    // `no_safe_rpc` above is the egress decision and not a dropped candidate.
+    providerRegistryUrl = `https://unknown-host.test:${port}`;
+
+    const result = await verifyBridgeLegOnChain(input());
+
+    expect(connections).toBe(0);
+    expect(result).toEqual({ verified: false, reason: "rpc_unreachable" });
+  });
+
+  it("POSITIVE CONTROL: the same listener, named as a CURATED endpoint, is reached and verifies", async () => {
+    // The user's own node on a private address is supported configuration and is
+    // NOT subject to the provider egress policy. This also proves the listener
+    // would have answered the refused requests above.
+    curated = [`http://127.0.0.1:${port}`];
+
+    const result = await verifyBridgeLegOnChain(input());
+
+    expect(result).toEqual({ verified: true });
+    expect(served).toEqual(["eth_chainId", "eth_getTransactionReceipt"]);
+    expect(connections).toBeGreaterThan(0);
+  });
+});
+
+describe("the pinning lookup admits a public address and pins exactly one", () => {
+  it("passes a public address through as a single pinned entry", async () => {
+    const pinned = await new Promise<unknown>((resolve, reject) => {
+      pinPublicAddress((_hostname, _options, callback) => {
+        callback(null, [
+          { address: "1.1.1.1", family: 4 },
+          { address: "8.8.8.8", family: 4 },
+        ]);
+      })("public.example", { all: true }, (err, address) => (err ? reject(err) : resolve(address)));
+    });
+
+    // ONE address, the one that was checked: there is no second resolution for a
+    // rebinding to win.
+    expect(pinned).toEqual([{ address: "1.1.1.1", family: 4 }]);
+  });
+
+  it("refuses with a typed error the transport classifier can recognise", async () => {
+    const refusal = await new Promise<unknown>((resolve) => {
+      pinPublicAddress((_hostname, _options, callback) => {
+        callback(null, [{ address: "10.1.2.3", family: 4 }]);
+      })("rebound.test", { all: true }, (err) => resolve(err));
+    });
+
+    expect(refusal).toBeInstanceOf(RpcEgressRefusedError);
+    expect(refusal).toMatchObject({ name: "RpcEgressRefusedError", refusal: "non_public_address" });
+  });
+
+  it("classifies the address table the policy refuses", () => {
+    for (const address of [
+      "0.0.0.0",
+      "127.0.0.1",
+      "10.1.2.3",
+      "172.16.0.1",
+      "192.168.1.1",
+      "169.254.169.254",
+      "100.64.0.1",
+      "192.0.0.1",
+      "198.18.0.1",
+      "224.0.0.1",
+      "240.0.0.1",
+      "::1",
+      "::",
+      "fe80::1",
+      "fc00::1",
+      "fd12:3456::1",
+      "ff02::1",
+      "::ffff:127.0.0.1",
+      "::ffff:7f00:1",
+      "64:ff9b::7f00:1",
+      "not-an-address",
+    ]) {
+      expect({ address, public: isPublicIpAddress(address) }).toEqual({ address, public: false });
+    }
+    for (const address of ["1.1.1.1", "93.184.216.34", "172.32.0.1", "100.63.0.1", "2606:4700:4700::1111"]) {
+      expect({ address, public: isPublicIpAddress(address) }).toEqual({ address, public: true });
+    }
+  });
+});

--- a/src/__tests__/vex-agent/sync/rpc-egress-pinning.test.ts
+++ b/src/__tests__/vex-agent/sync/rpc-egress-pinning.test.ts
@@ -1,7 +1,7 @@
 /**
  * A PROVIDER-SUPPLIED RPC URL CANNOT REACH PRIVATE SPACE, proven at the socket.
  *
- * The defect (external review of PR #142, blocker 1): the SSRF control was
+ * The defect (review finding, 2026-09-04): the SSRF control was
  * syntactic, so `https://rebound.test` was accepted on its face and whatever it
  * resolved to received the request. The `eth_chainId` echo stops us BELIEVING a
  * false receipt; it does not stop the POST from arriving at a local service.

--- a/src/vex-agent/sync/bridge-activity-repair-contracts.ts
+++ b/src/vex-agent/sync/bridge-activity-repair-contracts.ts
@@ -27,6 +27,48 @@ import type {
 export const BRIDGE_SWEEP_BATCH_LIMIT = 25;
 
 /**
+ * THE BUDGET FOR VERIFYING ONE LEG OF ONE ROW, deadline-enforced by the
+ * verifier itself (`bridge-activity-repair-verification.ts`).
+ *
+ * WHAT IT REPLACES, measured against the code it replaces: each candidate had a
+ * 15 s transport timeout AND one transport retry, so six candidates could hold
+ * the shared sync worker for 6 x 15 s x 2 = 180 s on ONE leg, and the sweep
+ * takes {@link BRIDGE_SWEEP_BATCH_LIMIT} rows per run. External review measured
+ * that worst case at roughly 75 minutes of shared-worker occupancy before
+ * registry overhead, while balance and settlement sync wait behind the same
+ * drain.
+ *
+ * WHY 20 s. A row that cannot conclude blocks nothing and loses nothing: it
+ * stays pending and is retried on the next 120 s tick (`sync/seed.ts`), so the
+ * budget only has to be long enough for the CANDIDATE LIST to do its job. At
+ * {@link BRIDGE_RPC_CANDIDATE_TIMEOUT_MS} per candidate, 20 s abandons two hung
+ * endpoints and still reaches a third; a candidate that ANSWERS (a refusal, a
+ * chain-echo mismatch, a receipt) costs milliseconds, so the common path still
+ * walks all five sources. It also bounds one leg at one sixth of the sweep
+ * cadence, which is the property that matters: no single row can occupy the
+ * shared worker for a whole tick.
+ *
+ * Exactly ONE leg verification runs before a row can stay pending (the primary
+ * fill, or the refund); the additional-hash loop in
+ * `bridge-activity-repair-terminalize.ts` runs only AFTER a fill has verified,
+ * which means every endpoint just answered.
+ */
+export const BRIDGE_LEG_VERIFICATION_DEADLINE_MS = 20_000;
+
+/**
+ * Per-candidate transport bound inside the leg budget above. A healthy public
+ * endpoint answers `eth_chainId` in well under a second (live-probed
+ * 2026-09-04) and an archive receipt read in a few; 8 s is generous for both and
+ * small enough that abandoning a hung endpoint still leaves the next candidate
+ * its turn.
+ *
+ * TRANSPORT RETRY IS ZERO (viem's `retryCount`), and that is the point: the
+ * CANDIDATE LIST is the fallback. Retrying the same unresponsive endpoint spends
+ * the budget on the endpoint least likely to answer.
+ */
+export const BRIDGE_RPC_CANDIDATE_TIMEOUT_MS = 8_000;
+
+/**
  * The `last_verification_reason` vocabulary is owned by the column's own repo
  * module (`db/repos/agent-activity/types.ts`), beside the read side that derives
  * `stalledVerification` from it — this family only consumes it. Re-exported here

--- a/src/vex-agent/sync/bridge-activity-repair-verification.ts
+++ b/src/vex-agent/sync/bridge-activity-repair-verification.ts
@@ -115,7 +115,7 @@ async function verifyEvmLegOnChain(
           dispatcher: trustedAsConfigured.has(rpcUrl) ? undefined : egress,
         };
         const client = createPublicClient({
-          // Redirect-off (Blocker 10): a 3xx to a re-pointed (possibly private)
+          // Redirect-off: a 3xx to a re-pointed (possibly private)
           // host is refused, not followed. `dispatcher` is the connect-time
           // egress decision for a PROVIDER-supplied URL - resolve, refuse
           // non-public, pin the checked address - and is deliberately absent for

--- a/src/vex-agent/sync/bridge-activity-repair-verification.ts
+++ b/src/vex-agent/sync/bridge-activity-repair-verification.ts
@@ -14,7 +14,18 @@ import {
   selectVerificationRpcUrls,
   solanaRpcCall,
 } from "./solana-rpc-safety.js";
-import type { FillVerification, FillVerificationInput } from "./bridge-activity-repair-contracts.js";
+import { createPinnedPublicEgressDispatcher, isEgressRefusal } from "./rpc-egress-policy.js";
+import type { DispatchableRequestInit } from "./rpc-egress-policy.js";
+import {
+  BRIDGE_LEG_VERIFICATION_DEADLINE_MS,
+  BRIDGE_RPC_CANDIDATE_TIMEOUT_MS,
+} from "./bridge-activity-repair-contracts.js";
+import type {
+  FillVerification,
+  FillVerificationInput,
+  VerificationReason,
+} from "./bridge-activity-repair-contracts.js";
+import type { Dispatcher } from "undici";
 
 /**
  * Production B4 leg verifier (fills AND refunds). EVM: SSRF-controlled RPC
@@ -36,51 +47,118 @@ import type { FillVerification, FillVerificationInput } from "./bridge-activity-
  * against the stored token + recipient is a named follow-up, and the recipient is
  * not stored anyway — Blocker 7). Any failure → `verified:false` so the row stays
  * pending (fail-closed). All verification fetches pin redirects OFF.
+ *
+ * TWO BOUNDS THIS VERIFIER OWNS, added after external review of PR #142:
+ *
+ *   EGRESS. A provider-registry URL is fetched through the pinning dispatcher
+ *   from `rpc-egress-policy.js`: its hostname is resolved before any socket
+ *   exists, refused if ANY address is non-public, and pinned to the checked
+ *   address so a rebinding has no second resolution to win. A CURATED URL (the
+ *   user's overrides, the local registry) is fetched as configured, because a
+ *   self-hosted node on a private address is supported. A refusal is recorded as
+ *   `no_safe_rpc`, not as "the chain is unreachable".
+ *
+ *   TIME. One leg gets {@link BRIDGE_LEG_VERIFICATION_DEADLINE_MS} in total,
+ *   propagated as ONE AbortSignal through the registry reads and every RPC call,
+ *   with {@link BRIDGE_RPC_CANDIDATE_TIMEOUT_MS} per candidate and NO transport
+ *   retry (the candidate list is the fallback). Exhaustion reports the most
+ *   specific thing the endpoints established and terminalizes nothing.
  */
 export async function verifyBridgeLegOnChain(input: FillVerificationInput): Promise<FillVerification> {
-  if (input.chainFamily === "solana") {
-    return verifySolanaLegOnChain(input);
+  const budget = startLegVerificationBudget(BRIDGE_LEG_VERIFICATION_DEADLINE_MS);
+  // ONE dispatcher per leg verification, owned here and closed below: it is the
+  // egress decision for every PROVIDER-REGISTRY candidate this leg touches, and
+  // it holds keep-alive sockets, so it has exactly one lifecycle owner.
+  const egress = createPinnedPublicEgressDispatcher();
+  try {
+    return input.chainFamily === "solana"
+      ? await verifySolanaLegOnChain(input, budget, egress)
+      : await verifyEvmLegOnChain(input, budget, egress);
+  } finally {
+    budget.dispose();
+    await egress.close();
   }
+}
+
+async function verifyEvmLegOnChain(
+  input: FillVerificationInput,
+  budget: LegVerificationBudget,
+  egress: Dispatcher,
+): Promise<FillVerification> {
   if (!/^0x[0-9a-fA-F]{64}$/.test(input.txHash)) {
     return { verified: false, reason: "malformed_fill_hash" };
   }
 
-  const { curated, providerRegistry } = await resolveVerificationRpcs(input.expectedChainId, input.protocol, "eip155");
+  // The registry reads are inside the budget too: a hung provider registry used
+  // to be able to consume the whole sweep before a single RPC was tried. The
+  // registry clients own their own timeouts and keep running if abandoned; what
+  // this race owns is that WE stop waiting.
+  const resolved = await raceBudget(
+    resolveVerificationRpcs(input.expectedChainId, input.protocol, "eip155"),
+    budget,
+  );
+  if (!resolved.settled) return { verified: false, reason: reportLegDeadline(input, [], null) };
+  const { curated, providerRegistry } = resolved.value;
   const urls = selectVerificationRpcUrls({ curated, providerRegistry });
   if (urls.length === 0) return { verified: false, reason: "no_safe_rpc" };
+  const trustedAsConfigured = new Set(curated.map((url) => url.trim()));
 
   const { createPublicClient, http } = await import("viem");
-  const observations: EvmProbeObservation[] = [];
+  const observations: EvmProbeOutcome[] = [];
   for (const rpcUrl of urls) {
+    if (budget.expired()) break;
     try {
-      const client = createPublicClient({
-        // Redirect-off (Blocker 10): a 3xx to a re-pointed (possibly private) host
-        // is refused, not followed. The chain-id echo below is the second defense.
-        transport: http(rpcUrl, { timeout: 15_000, retryCount: 1, fetchOptions: { redirect: "error" } }),
+      const probe = await withinCandidateBudget(budget, async (signal) => {
+        const fetchOptions: DispatchableRequestInit = {
+          redirect: "error",
+          signal,
+          dispatcher: trustedAsConfigured.has(rpcUrl) ? undefined : egress,
+        };
+        const client = createPublicClient({
+          // Redirect-off (Blocker 10): a 3xx to a re-pointed (possibly private)
+          // host is refused, not followed. `dispatcher` is the connect-time
+          // egress decision for a PROVIDER-supplied URL - resolve, refuse
+          // non-public, pin the checked address - and is deliberately absent for
+          // a curated URL, because the user's own archive node on a private
+          // address is a supported setup. `signal` is the leg budget reaching
+          // the socket; `retryCount: 0` because the candidate list is the
+          // fallback, not the same endpoint twice.
+          transport: http(rpcUrl, { timeout: BRIDGE_RPC_CANDIDATE_TIMEOUT_MS, retryCount: 0, fetchOptions }),
+        });
+        const echo = await client.getChainId();
+        if (echo !== input.expectedChainId) {
+          return { kind: "observed", observation: "chain_echo_mismatch" } as const;
+        }
+        const status: unknown = (await client.getTransactionReceipt({ hash: input.txHash as `0x${string}` })).status;
+        // Receipt exists: only the LITERAL statuses are proof. viem's formatter
+        // maps `0x1`/`0x0` and yields a nullish value for anything else, so
+        // treating "not success" as a revert (F7) would tell the user their fill
+        // REVERTED when we merely could not read the status - a claim beyond the
+        // evidence, and the same trap the EVM sweep already avoids
+        // (`agent-activity-repair.ts`). A revert is definitive NOT-verified; an
+        // unreadable status is an inconclusive check. Neither confirms.
+        if (status === "success") return { kind: "verified" } as const;
+        if (status === "reverted") return { kind: "reverted" } as const;
+        return { kind: "observed", observation: "unreadable_receipt_status" } as const;
       });
-      const echo = await client.getChainId();
-      if (echo !== input.expectedChainId) {
-        observations.push("chain_echo_mismatch"); // wrong chain / swapped endpoint — try the next url.
+      if (!probe.settled) {
+        // The candidate ran out of its own time, or the leg did. Either way this
+        // endpoint told us nothing: no answer is `rpc_unreachable`, exactly as a
+        // socket failure is.
+        observations.push("rpc_unreachable");
         continue;
       }
-      const status: unknown = (await client.getTransactionReceipt({ hash: input.txHash as `0x${string}` })).status;
-      // Receipt exists: only the LITERAL statuses are proof. viem's formatter
-      // maps `0x1`/`0x0` and yields a nullish value for anything else, so
-      // treating "not success" as a revert (F7) would tell the user their fill
-      // REVERTED when we merely could not read the status — a claim beyond the
-      // evidence, and the same trap the EVM sweep already avoids
-      // (`agent-activity-repair.ts`). A revert is definitive NOT-verified; an
-      // unreadable status is an inconclusive check. Neither confirms.
-      if (status === "success") return { verified: true };
-      if (status === "reverted") return { verified: false, reason: "fill_reverted" };
-      observations.push("unreadable_receipt_status");
+      if (probe.value.kind === "verified") return { verified: true };
+      if (probe.value.kind === "reverted") return { verified: false, reason: "fill_reverted" };
+      observations.push(probe.value.observation);
       continue;
     } catch (err) {
-      // Not mined yet, an endpoint that ANSWERED and refused, or a transport
-      // failure. Three different facts for the user - "wait", "this endpoint
-      // will not serve us", "we cannot see this chain" - and this loop is the
-      // only place that can still tell them apart. A refusal continues to the
-      // next URL exactly as a chain mismatch does.
+      // Not mined yet, an endpoint that ANSWERED and refused, a transport
+      // failure, or OUR OWN egress policy refusing a provider URL that resolves
+      // into private space. Four different facts for the user - "wait", "this
+      // endpoint will not serve us", "we cannot see this chain", "that endpoint
+      // is not one we may reach" - and this loop is the only place that can
+      // still tell them apart. Each continues to the next URL.
       const observation = classifyEvmProbeError(err);
       observations.push(observation);
       logger.debug("bridge.repair.rpc_probe_miss", {
@@ -91,7 +169,118 @@ export async function verifyBridgeLegOnChain(input: FillVerificationInput): Prom
       continue;
     }
   }
+  if (budget.expired()) {
+    const reduced = observations.length > 0 ? resolveEvmProbeReason(observations) : null;
+    return { verified: false, reason: reportLegDeadline(input, observations, reduced) };
+  }
   return { verified: false, reason: resolveEvmProbeReason(observations) };
+}
+
+/**
+ * THE LEG BUDGET: one owner-created signal, propagated through the registry
+ * reads and every RPC call of one leg verification, and disposed by its owner.
+ *
+ * The shape follows VS Code's `createCancelablePromise`/`raceCancellation`
+ * (`src/vs/base/common/async.ts`): the owner mints ONE signal, every await gets
+ * it, and abandonment never leaves a timer behind. `setTimeout` rather than
+ * `AbortSignal.timeout` deliberately - the former is what a fake-timer test can
+ * drive, and this deadline has to be provable without waiting 20 real seconds.
+ */
+interface LegVerificationBudget {
+  readonly signal: AbortSignal;
+  /** True once the leg deadline has fired. Checked before starting more work, never assumed from a rejection. */
+  expired(): boolean;
+  dispose(): void;
+}
+
+function startLegVerificationBudget(ms: number): LegVerificationBudget {
+  const controller = new AbortController();
+  const handle = setTimeout(() => controller.abort(new Error("bridge leg verification deadline")), ms);
+  return {
+    signal: controller.signal,
+    expired: () => controller.signal.aborted,
+    dispose: () => clearTimeout(handle),
+  };
+}
+
+/** Settled by the work, or abandoned because a deadline fired first. */
+type BudgetedOutcome<T> = { readonly settled: true; readonly value: T } | { readonly settled: false };
+
+/**
+ * Race owned work against an abort signal. Abandoning does NOT prove the work
+ * stopped (rule 05: abort requests cancellation, it does not prove quiescence);
+ * it proves this owner stopped waiting. The rejection handler stays attached so
+ * a late failure of abandoned work is swallowed rather than surfacing as an
+ * unhandled rejection.
+ */
+function raceAbort<T>(work: Promise<T>, signal: AbortSignal): Promise<BudgetedOutcome<T>> {
+  return new Promise<BudgetedOutcome<T>>((resolve, reject) => {
+    if (signal.aborted) {
+      void work.catch(() => undefined);
+      resolve({ settled: false });
+      return;
+    }
+    const onAbort = (): void => resolve({ settled: false });
+    signal.addEventListener("abort", onAbort, { once: true });
+    work
+      .then(
+        (value) => resolve({ settled: true, value }),
+        (err: unknown) => reject(err instanceof Error ? err : new Error(String(err))),
+      )
+      .finally(() => signal.removeEventListener("abort", onAbort));
+  });
+}
+
+function raceBudget<T>(work: Promise<T>, budget: LegVerificationBudget): Promise<BudgetedOutcome<T>> {
+  return raceAbort(work, budget.signal);
+}
+
+/**
+ * Run ONE candidate under its own timeout, linked to the leg budget: whichever
+ * fires first aborts the transport and returns the loop its turn. The
+ * per-candidate timer is always cleared and the link always removed, so an
+ * abandoned candidate leaves no timer and no listener behind.
+ */
+async function withinCandidateBudget<T>(
+  budget: LegVerificationBudget,
+  run: (signal: AbortSignal) => Promise<T>,
+): Promise<BudgetedOutcome<T>> {
+  if (budget.expired()) return { settled: false };
+  const controller = new AbortController();
+  const onLegDeadline = (): void => controller.abort(budget.signal.reason);
+  budget.signal.addEventListener("abort", onLegDeadline, { once: true });
+  const handle = setTimeout(() => controller.abort(new Error("bridge rpc candidate timeout")), BRIDGE_RPC_CANDIDATE_TIMEOUT_MS);
+  try {
+    return await raceAbort(run(controller.signal), controller.signal);
+  } finally {
+    clearTimeout(handle);
+    budget.signal.removeEventListener("abort", onLegDeadline);
+  }
+}
+
+/**
+ * What a leg that ran out of time reports. It TERMINALIZES NOTHING: the row
+ * stays pending and is retried on the next tick.
+ *
+ * Whatever the endpoints did manage to establish still wins (`reduced`),
+ * because "an endpoint refused us" remains the more specific fact even when the
+ * clock ended the search. A leg that learned nothing at all - a registry read
+ * that outlasted the budget - falls back to the vocabulary's generic
+ * `verification_failed`: the 065 vocabulary has no member for "we ran out of
+ * budget", and that column's owner is another module
+ * (`db/repos/agent-activity/types/verification.ts`).
+ */
+function reportLegDeadline(
+  input: FillVerificationInput,
+  observations: readonly string[],
+  reduced: VerificationReason | null,
+): VerificationReason {
+  logger.debug("bridge.repair.leg_deadline_exceeded", {
+    chainId: input.expectedChainId,
+    chainFamily: input.chainFamily,
+    observations: [...observations],
+  });
+  return reduced ?? "verification_failed";
 }
 
 /** What ONE endpoint established about the fill hash, when it did not settle the question. */
@@ -101,6 +290,20 @@ export type EvmProbeObservation =
   | "unreadable_receipt_status"
   | "rpc_refused_request"
   | "rpc_unreachable";
+
+/**
+ * What one endpoint established, PLUS the one outcome that is about us rather
+ * than about the endpoint: `no_safe_rpc`, recorded when our own egress policy
+ * refused to open the socket because the provider's hostname resolved into
+ * private space.
+ *
+ * It is deliberately the 065 vocabulary's EXISTING member rather than a new
+ * one: the column means "why the last check could not conclude", and "we had no
+ * endpoint we were allowed to reach" is exactly what `no_safe_rpc` already says
+ * for the syntactic refusals. The vocabulary itself is owned by
+ * `db/repos/agent-activity/types/verification.ts`, not by this family.
+ */
+export type EvmProbeOutcome = EvmProbeObservation | "no_safe_rpc";
 
 /**
  * Reduce what several endpoints said into the single most specific fact the loop
@@ -126,13 +329,14 @@ export type EvmProbeObservation =
  * see this chain" is what let one row re-probe the same refusing endpoint 1227
  * times over 31 days.
  */
-export function resolveEvmProbeReason(observations: readonly EvmProbeObservation[]): EvmProbeObservation | "no_safe_rpc" {
+export function resolveEvmProbeReason(observations: readonly EvmProbeOutcome[]): EvmProbeOutcome {
   for (const candidate of [
     "unreadable_receipt_status",
     "fill_not_mined",
     "chain_echo_mismatch",
     "rpc_refused_request",
     "rpc_unreachable",
+    "no_safe_rpc",
   ] as const) {
     if (observations.includes(candidate)) return candidate;
   }
@@ -160,8 +364,15 @@ const ERROR_CAUSE_MAX_DEPTH = 5;
  */
 const VIEM_UNKNOWN_RPC_CODE = -1;
 
-/** What ONE failed probe of a single endpoint established. */
-function classifyEvmProbeError(err: unknown): EvmProbeObservation {
+/**
+ * What ONE failed probe of a single endpoint established.
+ *
+ * OUR OWN REFUSAL IS CHECKED FIRST. An egress refusal never reached a socket, so
+ * reporting it as `rpc_unreachable` ("no endpoint answered") would describe the
+ * chain when the fact is about the endpoint we declined to reach.
+ */
+function classifyEvmProbeError(err: unknown): EvmProbeOutcome {
+  if (isEgressRefusal(err)) return "no_safe_rpc";
   if (isReceiptNotFound(err)) return "fill_not_mined";
   return isJsonRpcErrorResponse(err) ? "rpc_refused_request" : "rpc_unreachable";
 }
@@ -207,32 +418,59 @@ function isJsonRpcErrorResponse(err: unknown): boolean {
  * definitively NOT verified (the fill tx failed). Any transient/unavailable case
  * ⇒ not verified, row stays pending. Redirects are pinned OFF.
  */
-async function verifySolanaLegOnChain(input: FillVerificationInput): Promise<FillVerification> {
-  // Base58 Solana signatures are ~87–88 chars; reject an EVM-shaped hash outright.
+async function verifySolanaLegOnChain(
+  input: FillVerificationInput,
+  budget: LegVerificationBudget,
+  egress: Dispatcher,
+): Promise<FillVerification> {
+  // Base58 Solana signatures are ~87-88 chars; reject an EVM-shaped hash outright.
   if (!/^[1-9A-HJ-NP-Za-km-z]{43,90}$/.test(input.txHash)) {
     return { verified: false, reason: "malformed_fill_signature" };
   }
-  const { providerRegistry } = await resolveVerificationRpcs(input.expectedChainId, input.protocol, "solana");
-  // Solana has no curated/local EVM RPC — only the SSRF-validated provider registry.
-  const urls = selectVerificationRpcUrls({ curated: [], providerRegistry });
+  const resolved = await raceBudget(
+    resolveVerificationRpcs(input.expectedChainId, input.protocol, "solana"),
+    budget,
+  );
+  if (!resolved.settled) return { verified: false, reason: reportLegDeadline(input, [], null) };
+  // Solana has no curated/local EVM RPC - only the SSRF-validated provider
+  // registry, which means EVERY candidate here goes through the pinning
+  // dispatcher, with no as-configured bucket to exempt.
+  const urls = selectVerificationRpcUrls({ curated: [], providerRegistry: resolved.value.providerRegistry });
   if (urls.length === 0) return { verified: false, reason: "no_safe_rpc" };
 
-  const observations: SolanaProbeObservation[] = [];
+  const observations: SolanaProbeOutcome[] = [];
   for (const rpcUrl of urls) {
+    if (budget.expired()) break;
     try {
-      const genesis = await solanaRpcCall(rpcUrl, "getGenesisHash", []);
-      if (typeof genesis !== "string" || genesis !== SOLANA_MAINNET_GENESIS) {
-        observations.push("chain_echo_mismatch"); // wrong cluster — try next.
+      const probe = await withinCandidateBudget(budget, async (signal) => {
+        const call = (method: string, params: unknown[]): Promise<unknown> =>
+          solanaRpcCall(rpcUrl, method, params, {
+            signal,
+            dispatcher: egress,
+            timeoutMs: BRIDGE_RPC_CANDIDATE_TIMEOUT_MS,
+          });
+        const genesis = await call("getGenesisHash", []);
+        if (typeof genesis !== "string" || genesis !== SOLANA_MAINNET_GENESIS) {
+          return { kind: "observed", observation: "chain_echo_mismatch" } as const;
+        }
+        return {
+          kind: "statuses",
+          result: await call("getSignatureStatuses", [[input.txHash], { searchTransactionHistory: true }]),
+        } as const;
+      });
+      if (!probe.settled) {
+        observations.push("rpc_unreachable");
         continue;
       }
-      const result = await solanaRpcCall(rpcUrl, "getSignatureStatuses", [
-        [input.txHash],
-        { searchTransactionHistory: true },
-      ]);
+      if (probe.value.kind === "observed") {
+        observations.push(probe.value.observation); // wrong cluster - try next.
+        continue;
+      }
+      const result = probe.value.result;
       const value = typeof result === "object" && result !== null ? (result as Record<string, unknown>).value : undefined;
       const entry = Array.isArray(value) ? value[0] : null;
       if (entry === null || entry === undefined || typeof entry !== "object") {
-        observations.push("signature_status_unavailable"); // unknown on this node — try next.
+        observations.push("signature_status_unavailable"); // unknown on this node - try next.
         continue;
       }
       const record = entry as Record<string, unknown>;
@@ -245,13 +483,19 @@ async function verifySolanaLegOnChain(input: FillVerificationInput): Promise<Fil
       }
       return { verified: false, reason: "not_yet_confirmed" };
     } catch (err) {
-      observations.push("rpc_unreachable");
+      const observation: SolanaProbeOutcome = isEgressRefusal(err) ? "no_safe_rpc" : "rpc_unreachable";
+      observations.push(observation);
       logger.debug("bridge.repair.solana_probe_miss", {
         chainId: input.expectedChainId,
+        observation,
         error: summarizeProtocolError(err).message,
       });
       continue;
     }
+  }
+  if (budget.expired()) {
+    const reduced = observations.length > 0 ? resolveSolanaProbeReason(observations) : null;
+    return { verified: false, reason: reportLegDeadline(input, observations, reduced) };
   }
   return { verified: false, reason: resolveSolanaProbeReason(observations) };
 }
@@ -259,16 +503,22 @@ async function verifySolanaLegOnChain(input: FillVerificationInput): Promise<Fil
 /** What ONE Solana endpoint established, when it did not settle the question. */
 export type SolanaProbeObservation = "chain_echo_mismatch" | "signature_status_unavailable" | "rpc_unreachable";
 
+/** The Solana analog of {@link EvmProbeOutcome}: what an endpoint said, plus our own egress refusal. */
+export type SolanaProbeOutcome = SolanaProbeObservation | "no_safe_rpc";
+
 /**
  * Same rule as the EVM reducer: "a node answered and did not know this
  * signature" is a different fact from "no node answered at all", and reporting
  * both as `signature_status_unavailable` told the user we had looked when we had
  * not. Most-specific-wins, fixed order.
  */
-export function resolveSolanaProbeReason(
-  observations: readonly SolanaProbeObservation[],
-): SolanaProbeObservation | "no_safe_rpc" {
-  for (const candidate of ["signature_status_unavailable", "chain_echo_mismatch", "rpc_unreachable"] as const) {
+export function resolveSolanaProbeReason(observations: readonly SolanaProbeOutcome[]): SolanaProbeOutcome {
+  for (const candidate of [
+    "signature_status_unavailable",
+    "chain_echo_mismatch",
+    "rpc_unreachable",
+    "no_safe_rpc",
+  ] as const) {
     if (observations.includes(candidate)) return candidate;
   }
   return "no_safe_rpc";

--- a/src/vex-agent/sync/rpc-egress-policy.ts
+++ b/src/vex-agent/sync/rpc-egress-policy.ts
@@ -3,7 +3,7 @@
  * request is allowed to end up, decided at CONNECT time and pinned for the
  * socket.
  *
- * WHY THIS MODULE EXISTS (external review of PR #142, blocker 1). The previous
+ * WHY THIS MODULE EXISTS (review finding, 2026-09-04). The previous
  * control was syntactic only: `isSsrfSafeRpcUrl` classified an IP LITERAL and
  * accepted every DNS name on its face, so a provider registry could name
  * `rpc.example.com`, have it resolve to `127.0.0.1` or `169.254.169.254`, and

--- a/src/vex-agent/sync/rpc-egress-policy.ts
+++ b/src/vex-agent/sync/rpc-egress-policy.ts
@@ -1,0 +1,306 @@
+/**
+ * The egress policy for PROVIDER-SUPPLIED RPC URLs: where a verification
+ * request is allowed to end up, decided at CONNECT time and pinned for the
+ * socket.
+ *
+ * WHY THIS MODULE EXISTS (external review of PR #142, blocker 1). The previous
+ * control was syntactic only: `isSsrfSafeRpcUrl` classified an IP LITERAL and
+ * accepted every DNS name on its face, so a provider registry could name
+ * `rpc.example.com`, have it resolve to `127.0.0.1` or `169.254.169.254`, and
+ * the request reached that target. The `eth_chainId` / genesis echo prevents
+ * BELIEVING the answer; it does not prevent the request. A local service that
+ * acts on a POST body has already been reached by then.
+ *
+ * WHAT IS ENFORCED, and where. `createPinnedPublicEgressDispatcher` builds an
+ * undici `Agent` whose `connect.lookup` runs before any socket exists:
+ *
+ *   1. resolve the hostname to ALL its addresses (`all: true`);
+ *   2. refuse the connection outright if ANY of them is non-public
+ *      (`isPublicIpAddress` below is the closed table, fail-closed on anything
+ *      it cannot parse) - refusing on ANY, not on the first, is what removes
+ *      the "resolver returns a public and a private address" split;
+ *   3. hand exactly ONE validated address back, so the socket connects to the
+ *      address we checked. A second resolution between check and connect (the
+ *      DNS-rebinding window) cannot happen because there is no second
+ *      resolution.
+ *
+ * TLS IDENTITY IS UNCHANGED BY THE PIN. undici's connector calls
+ * `tls.connect({ ...options, servername, host: hostname })` (verified in
+ * `node_modules/undici/lib/core/connect.js`, undici 7.25.0): `servername` stays
+ * the ORIGINAL hostname, so SNI and certificate verification still run against
+ * the name the provider gave us, while `lookup` decides the address. Pinning
+ * therefore costs nothing in TLS strength.
+ *
+ * REDIRECTS ARE NOT FOLLOWED. Every caller pins `redirect: "error"`; a 3xx to a
+ * re-pointed host is refused rather than re-validated. These are credential-free
+ * reads, so there is nothing a redirect could buy us that is worth the second
+ * egress decision.
+ *
+ * NOT APPLIED TO CURATED URLS. The user's own RPC overrides and the local chain
+ * registry are the app's own configuration - a self-hosted archive node on
+ * `127.0.0.1` is a supported setup (`@config/chain-rpc-overrides.js`). This
+ * policy guards the UNTRUSTED bucket: the Khalani, Relay and viem-bundled
+ * registries.
+ */
+
+import { lookup as dnsLookup } from "node:dns";
+import type { LookupAddress } from "node:dns";
+import type { LookupFunction } from "node:net";
+import { Agent } from "undici";
+import type { Dispatcher } from "undici";
+
+/**
+ * The refusal an egress decision produces. It travels out of `fetch` as the
+ * `cause` of a `TypeError: fetch failed` (measured against undici 7.25.0), so
+ * callers classify it with {@link isEgressRefusal}, which walks the cause chain
+ * and matches the stable `name` - never message text.
+ */
+export class RpcEgressRefusedError extends Error {
+  /** Stable across bundling and across the cause chain; the classifier matches on it. */
+  override readonly name = "RpcEgressRefusedError";
+  readonly hostname: string;
+  /** The address class that caused the refusal, or the resolver's own failure. */
+  readonly refusal: EgressRefusal;
+
+  constructor(hostname: string, refusal: EgressRefusal) {
+    super(`rpc egress refused for ${hostname}: ${refusal}`);
+    this.hostname = hostname;
+    this.refusal = refusal;
+  }
+}
+
+/**
+ * `RequestInit` plus undici's `dispatcher`, which Node's global `fetch` honours
+ * at runtime (measured: Node 24.15.0 + undici 7.25.0) while the global DOM-style
+ * `RequestInit` type does not declare it. Named here rather than asserted away
+ * at each call site.
+ */
+export interface DispatchableRequestInit extends RequestInit {
+  readonly dispatcher?: Dispatcher | undefined;
+}
+
+/** Why an egress decision refused. Named so a log line says which control fired. */
+export type EgressRefusal = "non_public_address" | "no_address";
+
+/** How far down an error's `cause` chain the egress classifier looks. undici nests one level; four is slack. */
+const EGRESS_CAUSE_MAX_DEPTH = 4;
+
+/**
+ * True iff this failure is OUR egress refusal rather than an ordinary transport
+ * error. Matched by class name through the cause chain, because `fetch` wraps it
+ * in a bare `TypeError` whose message is always "fetch failed".
+ */
+export function isEgressRefusal(err: unknown): boolean {
+  let node: unknown = err;
+  for (let depth = 0; depth < EGRESS_CAUSE_MAX_DEPTH && node instanceof Error; depth += 1) {
+    if (node.name === "RpcEgressRefusedError") return true;
+    node = node.cause;
+  }
+  return false;
+}
+
+/**
+ * A dispatcher for `fetch` (viem's `fetchOptions.dispatcher`, and our own raw
+ * Solana POST) that can only reach PUBLIC addresses, at the address it checked.
+ *
+ * OWNERSHIP: the caller owns the returned dispatcher and MUST `close()` it when
+ * its verification finishes - it holds keep-alive sockets. `lookup` is injected
+ * only by tests (the DNS-rebinding transport test scripts it); production uses
+ * `node:dns`.
+ *
+ * `connectTimeoutMs` bounds the connect phase alone; the per-call deadline the
+ * caller owns still bounds the whole request.
+ */
+export function createPinnedPublicEgressDispatcher(options?: {
+  readonly lookup?: LookupFunction;
+  readonly connectTimeoutMs?: number;
+}): Dispatcher {
+  const resolve = options?.lookup ?? dnsLookup;
+  return new Agent({
+    connect: {
+      timeout: options?.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
+      lookup: pinPublicAddress(resolve),
+    },
+  });
+}
+
+/** Connect-phase bound. Shorter than any per-call deadline so a black-holed address fails fast. */
+const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
+
+/**
+ * The lookup that decides and pins. Exported for the transport test, which
+ * drives it directly for the positive control (a public address is admitted and
+ * exactly one address is returned).
+ */
+export function pinPublicAddress(resolve: LookupFunction): LookupFunction {
+  return (hostname, lookupOptions, callback) => {
+    resolve(hostname, { ...lookupOptions, all: true }, (err, resolved) => {
+      if (err) {
+        callback(err, "", undefined);
+        return;
+      }
+      const addresses = toLookupAddresses(resolved);
+      if (addresses.length === 0) {
+        callback(new RpcEgressRefusedError(hostname, "no_address"), "", undefined);
+        return;
+      }
+      for (const entry of addresses) {
+        if (!isPublicIpAddress(entry.address)) {
+          callback(new RpcEgressRefusedError(hostname, "non_public_address"), "", undefined);
+          return;
+        }
+      }
+      // PIN: one validated address, so the socket goes exactly where the check
+      // ran. `options.all` is `true` for every undici call (measured), but the
+      // single-address shape is honoured too rather than assumed away.
+      const pinned = addresses[0];
+      if (!pinned) {
+        callback(new RpcEgressRefusedError(hostname, "no_address"), "", undefined);
+        return;
+      }
+      if (lookupOptions.all === true) {
+        callback(null, [pinned]);
+        return;
+      }
+      callback(null, pinned.address, pinned.family);
+    });
+  };
+}
+
+/** Normalize both `dns.lookup` shapes into one list, dropping entries we cannot read. */
+function toLookupAddresses(resolved: string | readonly LookupAddress[]): LookupAddress[] {
+  if (typeof resolved === "string") {
+    return resolved.length > 0 ? [{ address: resolved, family: resolved.includes(":") ? 6 : 4 }] : [];
+  }
+  return resolved.filter((entry): entry is LookupAddress => typeof entry?.address === "string");
+}
+
+/**
+ * THE ADDRESS TABLE. `true` only for an address that parses AND falls outside
+ * every non-public range below; anything unparsable is refused, because an
+ * address we cannot classify is an address we cannot clear.
+ *
+ * Refused: unspecified (`0.0.0.0`, `::`), loopback (`127/8`, `::1`), RFC 1918
+ * private (`10/8`, `172.16/12`, `192.168/16`), link-local INCLUDING the cloud
+ * metadata address (`169.254/16`, `fe80::/10`), CGNAT (`100.64/10`),
+ * IETF protocol assignments (`192.0.0/24`), benchmarking (`198.18/15`),
+ * multicast and every reserved range above it (`224/4`, `240/4`, `ff00::/8`),
+ * IPv6 unique-local (`fc00::/7`), and the IPv4-mapped / NAT64-embedded forms of
+ * all of the above.
+ */
+export function isPublicIpAddress(address: string): boolean {
+  const host = address.startsWith("[") && address.endsWith("]") ? address.slice(1, -1) : address;
+  // A scoped IPv6 literal (`fe80::1%eth0`) is classified by its address part.
+  const bare = host.split("%")[0] ?? "";
+  const ipv4 = parseIpv4(bare);
+  if (ipv4) return !isNonPublicIpv4(ipv4);
+  if (bare.includes(":")) return !isNonPublicIpv6(bare);
+  return false; // not an IP literal at all: this function only clears addresses.
+}
+
+/**
+ * True iff `rawUrl` is a public HTTPS endpoint safe to use for provider-registry
+ * RPC verification. Rejects (fail-closed): non-HTTPS schemes, credentials in the
+ * URL, and loopback / private / link-local / unique-local / unspecified hosts
+ * (the SSRF surface - a provider registry is untrusted input). Curated/local RPCs
+ * bypass this (they are trusted), so this guards ONLY the provider-registry
+ * fallback.
+ *
+ * SYNTACTIC, AND NO LONGER ALONE. This is the cheap first pass: it settles IP
+ * literals and obvious scheme/credential abuse before any resolver is asked. The
+ * DNS name it cannot settle is settled at connect time by
+ * {@link createPinnedPublicEgressDispatcher}, which is where the rebinding
+ * window actually closes.
+ */
+export function isSsrfSafeRpcUrl(rawUrl: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  if (url.username.length > 0 || url.password.length > 0) return false;
+  const host = url.hostname.toLowerCase();
+  if (host.length === 0) return false;
+  return !isPrivateOrLoopbackHost(host);
+}
+
+/**
+ * Classify a hostname/IP literal as private/loopback/link-local (blocked) vs
+ * public (allowed). Pure, NO DNS resolution: an IP literal is classified exactly
+ * by the table in {@link isPublicIpAddress}; a DNS name is accepted here and
+ * decided at connect time by the pinning dispatcher.
+ */
+export function isPrivateOrLoopbackHost(host: string): boolean {
+  const h = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+
+  const ipv4 = parseIpv4(h);
+  if (ipv4) return isNonPublicIpv4(ipv4);
+
+  if (h.includes(":")) return isNonPublicIpv6(h);
+
+  // A public DNS name (not an IP literal): allowed on its face by this
+  // syntactic pass, and resolved + pinned before any socket is opened.
+  return false;
+}
+
+function parseIpv4(host: string): readonly number[] | null {
+  const parts = host.split(".");
+  if (parts.length !== 4) return null;
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n > 255) return null;
+    octets.push(n);
+  }
+  return octets;
+}
+
+function isNonPublicIpv4(octets: readonly number[]): boolean {
+  const a = octets[0] ?? 0;
+  const b = octets[1] ?? 0;
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 127) return true; // loopback
+  if (a === 0) return true; // unspecified / this-network
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 169 && b === 254) return true; // link-local (incl. 169.254.169.254 metadata)
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  if (a === 192 && b === 0 && (octets[2] ?? 0) === 0) return true; // 192.0.0.0/24 IETF protocol assignments
+  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmarking
+  if (a >= 224) return true; // multicast / reserved
+  return false;
+}
+
+function isNonPublicIpv6(host: string): boolean {
+  const h = host.toLowerCase();
+  if (h === "::1" || h === "::") return true; // loopback / unspecified
+  if (h.startsWith("fe80")) return true; // link-local
+  if (h.startsWith("fc") || h.startsWith("fd")) return true; // unique-local fc00::/7
+  if (h.startsWith("ff")) return true; // multicast ff00::/8
+  // IPv4-mapped (::ffff:a.b.c.d) and NAT64 (64:ff9b::a.b.c.d): classify the embedded v4.
+  const embedded = h.match(/:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (embedded?.[1] && (h.startsWith("::ffff:") || h.startsWith("64:ff9b:"))) {
+    const v4 = parseIpv4(embedded[1]);
+    return v4 ? isNonPublicIpv4(v4) : true;
+  }
+  // WHATWG URL NORMALIZES mapped addresses to the HEX form before we ever see
+  // them (`[::ffff:127.0.0.1]` becomes hostname `[::ffff:7f00:1]`), so the
+  // dotted match above never fires for URL-sourced hosts - decode the embedded
+  // v4 from the last two 16-bit groups.
+  const hexMapped = h.match(/^(?:::ffff:|64:ff9b::)([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hexMapped) {
+    const hi = Number.parseInt(hexMapped[1] ?? "", 16);
+    const lo = Number.parseInt(hexMapped[2] ?? "", 16);
+    if (!Number.isFinite(hi) || !Number.isFinite(lo)) return true;
+    return isNonPublicIpv4([hi >> 8, hi & 0xff, lo >> 8, lo & 0xff]);
+  }
+  // Any other ::ffff:- or NAT64-prefixed shape (or the deprecated ::ffff:0:a.b.c.d
+  // SIIT form) - fail closed rather than risk a mis-parse reaching a local target.
+  if (h.startsWith("::ffff:") || h.startsWith("64:ff9b:")) return true;
+  return false;
+}

--- a/src/vex-agent/sync/rpc-egress-policy.ts
+++ b/src/vex-agent/sync/rpc-egress-policy.ts
@@ -176,25 +176,129 @@ function toLookupAddresses(resolved: string | readonly LookupAddress[]): LookupA
 }
 
 /**
- * THE ADDRESS TABLE. `true` only for an address that parses AND falls outside
- * every non-public range below; anything unparsable is refused, because an
- * address we cannot classify is an address we cannot clear.
+ * THE ADDRESS TABLE, as CIDR blocks rather than string prefixes.
  *
- * Refused: unspecified (`0.0.0.0`, `::`), loopback (`127/8`, `::1`), RFC 1918
- * private (`10/8`, `172.16/12`, `192.168/16`), link-local INCLUDING the cloud
- * metadata address (`169.254/16`, `fe80::/10`), CGNAT (`100.64/10`),
- * IETF protocol assignments (`192.0.0/24`), benchmarking (`198.18/15`),
- * multicast and every reserved range above it (`224/4`, `240/4`, `ff00::/8`),
- * IPv6 unique-local (`fc00::/7`), and the IPv4-mapped / NAT64-embedded forms of
- * all of the above.
+ * WHY CIDR AND NOT `startsWith` (external review of PR #142 round 2): the
+ * previous IPv6 classifier matched `fe80` as TEXT, but link-local is
+ * `fe80::/10`, which runs through `febf:ffff:...`, so `fe90::1` was classified
+ * public (and `fec0::1`, deprecated site-local, was never considered at all). A
+ * prefix expressed in BITS cannot drift from the range it names, so every block
+ * below is written as its RFC CIDR and matched numerically against the parsed
+ * address.
+ *
+ * IPv4, refused (RFC 1122, 1918, 2544, 5735, 5737, 6598, 6890):
+ * "this network", loopback, CGNAT, link-local (which is where the cloud
+ * metadata address lives), the three private ranges, the IETF protocol
+ * assignments, the three documentation ranges, benchmarking, multicast,
+ * reserved, and broadcast.
+ */
+export const NON_PUBLIC_IPV4_CIDRS = [
+  "0.0.0.0/8", // "this network" / unspecified
+  "10.0.0.0/8", // RFC 1918 private
+  "100.64.0.0/10", // RFC 6598 CGNAT
+  "127.0.0.0/8", // loopback
+  "169.254.0.0/16", // link-local, incl. 169.254.169.254 cloud metadata
+  "172.16.0.0/12", // RFC 1918 private
+  "192.0.0.0/24", // IETF protocol assignments
+  "192.0.2.0/24", // TEST-NET-1 documentation
+  "192.168.0.0/16", // RFC 1918 private
+  "198.18.0.0/15", // RFC 2544 benchmarking
+  "198.51.100.0/24", // TEST-NET-2 documentation
+  "203.0.113.0/24", // TEST-NET-3 documentation
+  "224.0.0.0/4", // multicast
+  "240.0.0.0/4", // reserved
+  "255.255.255.255/32", // limited broadcast (inside 240/4, named for the table's own sake)
+] as const;
+
+/**
+ * IPv6, refused outright (RFC 4193, 4291, 6666, 3849, 4380, 8215).
+ *
+ * `2001::/32` (Teredo) and `64:ff9b:1::/48` (RFC 8215 local-use translation)
+ * are refused WHOLE rather than decoded: Teredo tunnels an arbitrary IPv4
+ * destination inside the address, and the local-use NAT64 prefix splits its
+ * embedded IPv4 around the reserved u-octet at /48. Neither is a destination a
+ * provider registry has any honest reason to name, so the conservative
+ * classification costs us nothing and guessing at the embedded address could
+ * cost us a socket into private space.
+ */
+export const NON_PUBLIC_IPV6_CIDRS = [
+  "::/128", // unspecified
+  "::1/128", // loopback
+  "64:ff9b:1::/48", // RFC 8215 local-use IPv4/IPv6 translation
+  "100::/64", // RFC 6666 discard-only
+  "2001::/32", // Teredo
+  "2001:db8::/32", // documentation
+  "fc00::/7", // unique-local
+  "fe80::/10", // link-local (through febf:ffff:...)
+  "fec0::/10", // deprecated site-local (RFC 3879), still routed by some stacks
+  "ff00::/8", // multicast
+] as const;
+
+/**
+ * IPv6 blocks that CARRY an IPv4 address: the verdict is the verdict on the
+ * embedded IPv4, because that is where the packet ends up. `::ffff:1.1.1.1` is
+ * a public destination; `::ffff:127.0.0.1` is loopback wearing a v6 costume,
+ * which is the classic bypass this table exists to close.
+ *
+ * `embeddedAt` is the byte offset of the IPv4 address inside the 16-byte form.
+ */
+export const EMBEDDED_IPV4_IPV6_CIDRS = [
+  { cidr: "::ffff:0:0/96", embeddedAt: 12 }, // IPv4-mapped
+  { cidr: "64:ff9b::/96", embeddedAt: 12 }, // RFC 6052 well-known NAT64
+  { cidr: "2002::/16", embeddedAt: 2 }, // RFC 3056 6to4
+] as const;
+
+/** A CIDR block compiled once into the bytes and bit-length the matcher needs. */
+interface AddressBlock {
+  readonly cidr: string;
+  readonly bytes: readonly number[];
+  readonly prefixBits: number;
+}
+
+/**
+ * Compile a CIDR constant. A malformed constant is a programming error in the
+ * table above, not runtime input, so it throws at module load rather than
+ * silently classifying nothing.
+ */
+function compileCidr(cidr: string): AddressBlock {
+  const [network, prefix] = cidr.split("/");
+  const prefixBits = Number(prefix);
+  const bytes = network === undefined ? null : (parseIpv4(network) ?? parseIpv6(network));
+  if (!bytes || !Number.isInteger(prefixBits) || prefixBits < 0 || prefixBits > bytes.length * 8) {
+    throw new Error(`malformed egress CIDR constant: ${cidr}`);
+  }
+  return { cidr, bytes, prefixBits };
+}
+
+const IPV4_BLOCKS: readonly AddressBlock[] = NON_PUBLIC_IPV4_CIDRS.map(compileCidr);
+const IPV6_BLOCKS: readonly AddressBlock[] = NON_PUBLIC_IPV6_CIDRS.map(compileCidr);
+const EMBEDDED_BLOCKS: readonly { readonly block: AddressBlock; readonly embeddedAt: number }[] =
+  EMBEDDED_IPV4_IPV6_CIDRS.map((entry) => ({ block: compileCidr(entry.cidr), embeddedAt: entry.embeddedAt }));
+
+/** True iff `address` (4 or 16 bytes) falls inside `block`, compared bit by bit. */
+function withinBlock(address: readonly number[], block: AddressBlock): boolean {
+  if (address.length !== block.bytes.length) return false;
+  const wholeBytes = block.prefixBits >> 3;
+  for (let i = 0; i < wholeBytes; i += 1) {
+    if (address[i] !== block.bytes[i]) return false;
+  }
+  const remainingBits = block.prefixBits & 7;
+  if (remainingBits === 0) return true;
+  const mask = (0xff << (8 - remainingBits)) & 0xff;
+  return ((address[wholeBytes] ?? 0) & mask) === ((block.bytes[wholeBytes] ?? 0) & mask);
+}
+
+/**
+ * THE CLASSIFIER. `true` only for an address that PARSES and falls outside every
+ * block above; anything unparsable is refused, because an address we cannot
+ * classify is an address we cannot clear.
  */
 export function isPublicIpAddress(address: string): boolean {
-  const host = address.startsWith("[") && address.endsWith("]") ? address.slice(1, -1) : address;
-  // A scoped IPv6 literal (`fe80::1%eth0`) is classified by its address part.
-  const bare = host.split("%")[0] ?? "";
+  const bare = bareHost(address);
   const ipv4 = parseIpv4(bare);
   if (ipv4) return !isNonPublicIpv4(ipv4);
-  if (bare.includes(":")) return !isNonPublicIpv6(bare);
+  const ipv6 = parseIpv6(bare);
+  if (ipv6) return !isNonPublicIpv6(ipv6);
   return false; // not an IP literal at all: this function only clears addresses.
 }
 
@@ -231,28 +335,49 @@ export function isSsrfSafeRpcUrl(rawUrl: string): boolean {
  * public (allowed). Pure, NO DNS resolution: an IP literal is classified exactly
  * by the table in {@link isPublicIpAddress}; a DNS name is accepted here and
  * decided at connect time by the pinning dispatcher.
+ *
+ * AN ADDRESS-SHAPED HOST THAT DOES NOT PARSE IS REFUSED, not passed on as a
+ * name. `010.0.0.1`, `0x7f.1` and `2130706433` are all loopback to `getaddrinfo`
+ * and none of them is a hostname anybody registers, so they fail closed here
+ * instead of being handed to the resolver as if they were DNS names.
  */
 export function isPrivateOrLoopbackHost(host: string): boolean {
-  const h = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+  const h = bareHost(host).toLowerCase();
 
   if (h === "localhost" || h.endsWith(".localhost")) return true;
 
   const ipv4 = parseIpv4(h);
   if (ipv4) return isNonPublicIpv4(ipv4);
 
-  if (h.includes(":")) return isNonPublicIpv6(h);
+  const ipv6 = parseIpv6(h);
+  if (ipv6) return isNonPublicIpv6(ipv6);
+
+  if (h.includes(":") || isNumericHostShape(h)) return true; // address-shaped and unparsable: fail closed.
 
   // A public DNS name (not an IP literal): allowed on its face by this
   // syntactic pass, and resolved + pinned before any socket is opened.
   return false;
 }
 
+/** Strip an IPv6 URL bracket pair and a zone id (`[fe80::1%eth0]`), leaving the address itself. */
+function bareHost(host: string): string {
+  const unbracketed = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+  return unbracketed.split("%")[0] ?? "";
+}
+
+/** A host whose every label is decimal, octal or hex digits: an address form, never a registrable name. */
+function isNumericHostShape(host: string): boolean {
+  if (host.length === 0) return false;
+  return host.split(".").every((label) => /^(?:0x[0-9a-f]+|\d+)$/i.test(label));
+}
+
+/** Strict dotted quad: four decimal octets, no leading zeros (octal ambiguity), each 0-255. */
 function parseIpv4(host: string): readonly number[] | null {
   const parts = host.split(".");
   if (parts.length !== 4) return null;
   const octets: number[] = [];
   for (const part of parts) {
-    if (!/^\d{1,3}$/.test(part)) return null;
+    if (!/^(?:0|[1-9]\d{0,2})$/.test(part)) return null;
     const n = Number(part);
     if (n > 255) return null;
     octets.push(n);
@@ -260,47 +385,68 @@ function parseIpv4(host: string): readonly number[] | null {
   return octets;
 }
 
-function isNonPublicIpv4(octets: readonly number[]): boolean {
-  const a = octets[0] ?? 0;
-  const b = octets[1] ?? 0;
-  if (a === 10) return true; // 10.0.0.0/8
-  if (a === 127) return true; // loopback
-  if (a === 0) return true; // unspecified / this-network
-  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
-  if (a === 192 && b === 168) return true; // 192.168.0.0/16
-  if (a === 169 && b === 254) return true; // link-local (incl. 169.254.169.254 metadata)
-  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
-  if (a === 192 && b === 0 && (octets[2] ?? 0) === 0) return true; // 192.0.0.0/24 IETF protocol assignments
-  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmarking
-  if (a >= 224) return true; // multicast / reserved
-  return false;
+/**
+ * Parse an IPv6 literal into its 16 bytes, or `null` when it is not one.
+ *
+ * Handles the whole textual form RFC 4291 defines - full, `::`-compressed, and
+ * the dotted-quad tail (`::ffff:127.0.0.1`) - because the classifier has to see
+ * the same address the kernel will connect to. A single `::` is allowed once and
+ * must stand for at least one group, group values are 1-4 hex digits, and
+ * anything else returns `null` so the caller can fail closed.
+ */
+function parseIpv6(host: string): readonly number[] | null {
+  if (!host.includes(":")) return null;
+  let text = host.toLowerCase();
+
+  // A dotted-quad tail becomes the two hex groups it stands for, so the rest of
+  // the parse deals with one notation only.
+  const lastColon = text.lastIndexOf(":");
+  const tail = text.slice(lastColon + 1);
+  if (tail.includes(".")) {
+    const embedded = parseIpv4(tail);
+    if (!embedded) return null;
+    const hi = ((embedded[0] ?? 0) << 8) | (embedded[1] ?? 0);
+    const lo = ((embedded[2] ?? 0) << 8) | (embedded[3] ?? 0);
+    text = `${text.slice(0, lastColon + 1)}${hi.toString(16)}:${lo.toString(16)}`;
+  }
+
+  const sides = text.split("::");
+  if (sides.length > 2) return null;
+  const head = sides[0] ?? "";
+  const tailSide = sides.length === 2 ? (sides[1] ?? "") : "";
+  const headGroups = head.length > 0 ? head.split(":") : [];
+  const tailGroups = tailSide.length > 0 ? tailSide.split(":") : [];
+
+  let groups: string[];
+  if (sides.length === 1) {
+    if (headGroups.length !== 8) return null;
+    groups = headGroups;
+  } else {
+    // `::` stands for AT LEAST one zero group, so a compressed address can carry
+    // at most seven written groups.
+    if (headGroups.length + tailGroups.length > 7) return null;
+    const zeros = Array.from({ length: 8 - headGroups.length - tailGroups.length }, () => "0");
+    groups = [...headGroups, ...zeros, ...tailGroups];
+  }
+
+  const bytes: number[] = [];
+  for (const group of groups) {
+    if (!/^[0-9a-f]{1,4}$/.test(group)) return null;
+    const value = Number.parseInt(group, 16);
+    bytes.push(value >> 8, value & 0xff);
+  }
+  return bytes;
 }
 
-function isNonPublicIpv6(host: string): boolean {
-  const h = host.toLowerCase();
-  if (h === "::1" || h === "::") return true; // loopback / unspecified
-  if (h.startsWith("fe80")) return true; // link-local
-  if (h.startsWith("fc") || h.startsWith("fd")) return true; // unique-local fc00::/7
-  if (h.startsWith("ff")) return true; // multicast ff00::/8
-  // IPv4-mapped (::ffff:a.b.c.d) and NAT64 (64:ff9b::a.b.c.d): classify the embedded v4.
-  const embedded = h.match(/:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (embedded?.[1] && (h.startsWith("::ffff:") || h.startsWith("64:ff9b:"))) {
-    const v4 = parseIpv4(embedded[1]);
-    return v4 ? isNonPublicIpv4(v4) : true;
+function isNonPublicIpv4(octets: readonly number[]): boolean {
+  return IPV4_BLOCKS.some((block) => withinBlock(octets, block));
+}
+
+function isNonPublicIpv6(bytes: readonly number[]): boolean {
+  for (const { block, embeddedAt } of EMBEDDED_BLOCKS) {
+    if (!withinBlock(bytes, block)) continue;
+    // The packet ends up at the embedded IPv4, so that address is the verdict.
+    return isNonPublicIpv4(bytes.slice(embeddedAt, embeddedAt + 4));
   }
-  // WHATWG URL NORMALIZES mapped addresses to the HEX form before we ever see
-  // them (`[::ffff:127.0.0.1]` becomes hostname `[::ffff:7f00:1]`), so the
-  // dotted match above never fires for URL-sourced hosts - decode the embedded
-  // v4 from the last two 16-bit groups.
-  const hexMapped = h.match(/^(?:::ffff:|64:ff9b::)([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-  if (hexMapped) {
-    const hi = Number.parseInt(hexMapped[1] ?? "", 16);
-    const lo = Number.parseInt(hexMapped[2] ?? "", 16);
-    if (!Number.isFinite(hi) || !Number.isFinite(lo)) return true;
-    return isNonPublicIpv4([hi >> 8, hi & 0xff, lo >> 8, lo & 0xff]);
-  }
-  // Any other ::ffff:- or NAT64-prefixed shape (or the deprecated ::ffff:0:a.b.c.d
-  // SIIT form) - fail closed rather than risk a mis-parse reaching a local target.
-  if (h.startsWith("::ffff:") || h.startsWith("64:ff9b:")) return true;
-  return false;
+  return IPV6_BLOCKS.some((block) => withinBlock(bytes, block));
 }

--- a/src/vex-agent/sync/solana-rpc-safety.ts
+++ b/src/vex-agent/sync/solana-rpc-safety.ts
@@ -41,7 +41,7 @@ export const SOLANA_MAINNET_GENESIS = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2
 /**
  * THE SSRF CLASSIFIERS LIVE IN `rpc-egress-policy.ts` NOW, beside the connect-time
  * pin that closes the DNS-rebinding hole they could never close on their own
- * (external review of PR #142, blocker 1). They are re-exported here unchanged
+ * (review finding, 2026-09-04). They are re-exported here unchanged
  * so every existing import path - this module, `bridge-activity-repair.ts`'s own
  * re-export, and their tests - keeps working: this is a MOVE, not a behavior
  * change.

--- a/src/vex-agent/sync/solana-rpc-safety.ts
+++ b/src/vex-agent/sync/solana-rpc-safety.ts
@@ -12,13 +12,11 @@
  * same module path — this is a MOVE, not a behavior change.
  *
  * SSRF (Blocker 10, Phase-2 W4): a provider-supplied RPC URL is untrusted
- * input. `isSsrfSafeRpcUrl` rejects (fail-closed): non-HTTPS schemes,
- * credentials embedded in the URL, and loopback/private/link-local/
- * unique-local/unspecified hosts. It is SYNTACTIC ONLY — no DNS resolution,
- * no redirect re-validation — so every caller must ALSO pin
- * `redirect: "error"` on the actual fetch (closes DNS-rebinding /
- * redirect-to-private-host) and verify the endpoint's cluster identity via
- * the genesis-hash echo below (closes "wrong/malicious cluster").
+ * input. The classifiers that decide it now live in `rpc-egress-policy.js`
+ * (re-exported below, unchanged) beside the connect-time DNS pin that closes
+ * the rebinding window a syntactic check never could. This module keeps the
+ * SELECTION order (`selectVerificationRpcUrls`) and the raw POST, which pins
+ * `redirect: "error"` and takes the caller's dispatcher and deadline.
  *
  * GENESIS VERIFICATION: the Solana analog of an EVM `eth_chainId` echo —
  * before trusting an RPC's answer (a signature status, a transaction, a
@@ -27,8 +25,13 @@
  * re-pointed endpoint cannot fake this echo.
  */
 
+import type { Dispatcher } from "undici";
+
 import logger from "@utils/logger.js";
 import { summarizeProtocolError } from "@vex-agent/tools/protocols/runtime/errors.js";
+
+import { isSsrfSafeRpcUrl } from "./rpc-egress-policy.js";
+import type { DispatchableRequestInit } from "./rpc-egress-policy.js";
 
 /**
  * Solana mainnet-beta genesis hash — an immutable cluster identity constant.
@@ -36,112 +39,14 @@ import { summarizeProtocolError } from "@vex-agent/tools/protocols/runtime/error
 export const SOLANA_MAINNET_GENESIS = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d";
 
 /**
- * True iff `rawUrl` is a public HTTPS endpoint safe to use for provider-registry
- * RPC verification. Rejects (fail-closed): non-HTTPS schemes, credentials in the
- * URL, and loopback / private / link-local / unique-local / unspecified hosts
- * (the SSRF surface — a provider registry is untrusted input). Curated/local RPCs
- * bypass this (they are trusted), so this guards ONLY the provider-registry
- * fallback.
- *
- * NAMED LIMITATION (Blocker 10): this check is SYNTACTIC. It does NOT resolve DNS
- * and does NOT re-validate on HTTP redirects — a public-looking DNS name that
- * resolves to a private address (DNS rebinding), or a 3xx that re-points at a
- * private host, is NOT caught here. Two compensating controls close the gap: (a)
- * every verification fetch pins `redirect: "error"`/`fetchOptions.redirect:"error"`
- * so a redirect to a private host is refused, not followed; and (b) the
- * `eth_chainId` (EVM) / genesis-hash (Solana) echo means a re-pointed endpoint
- * cannot fake a confirmation for the expected chain.
+ * THE SSRF CLASSIFIERS LIVE IN `rpc-egress-policy.ts` NOW, beside the connect-time
+ * pin that closes the DNS-rebinding hole they could never close on their own
+ * (external review of PR #142, blocker 1). They are re-exported here unchanged
+ * so every existing import path - this module, `bridge-activity-repair.ts`'s own
+ * re-export, and their tests - keeps working: this is a MOVE, not a behavior
+ * change.
  */
-export function isSsrfSafeRpcUrl(rawUrl: string): boolean {
-  let url: URL;
-  try {
-    url = new URL(rawUrl);
-  } catch {
-    return false;
-  }
-  if (url.protocol !== "https:") return false;
-  if (url.username.length > 0 || url.password.length > 0) return false;
-  const host = url.hostname.toLowerCase();
-  if (host.length === 0) return false;
-  return !isPrivateOrLoopbackHost(host);
-}
-
-/**
- * Classify a hostname/IP literal as private/loopback/link-local (blocked) vs
- * public (allowed). Pure, NO DNS resolution (see `isSsrfSafeRpcUrl`'s named
- * limitation): an IP literal is classified exactly; a DNS name is accepted on its
- * face and defended downstream by redirect-off fetches + the chain-id echo.
- */
-export function isPrivateOrLoopbackHost(host: string): boolean {
-  // Strip an IPv6 literal's brackets if a caller passed them through.
-  const h = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
-
-  if (h === "localhost" || h.endsWith(".localhost")) return true;
-
-  const ipv4 = parseIpv4(h);
-  if (ipv4) return isPrivateIpv4(ipv4);
-
-  if (h.includes(":")) return isPrivateIpv6(h);
-
-  // A public DNS name (not an IP literal) — allowed on its face. No resolution is
-  // performed here; DNS-rebinding to a private address is out of scope for this
-  // syntactic check and is compensated by redirect-off fetches + the chain echo.
-  return false;
-}
-
-function parseIpv4(host: string): readonly number[] | null {
-  const parts = host.split(".");
-  if (parts.length !== 4) return null;
-  const octets: number[] = [];
-  for (const part of parts) {
-    if (!/^\d{1,3}$/.test(part)) return null;
-    const n = Number(part);
-    if (n > 255) return null;
-    octets.push(n);
-  }
-  return octets;
-}
-
-function isPrivateIpv4(octets: readonly number[]): boolean {
-  const a = octets[0] ?? 0;
-  const b = octets[1] ?? 0;
-  if (a === 10) return true; // 10.0.0.0/8
-  if (a === 127) return true; // loopback
-  if (a === 0) return true; // unspecified / this-network
-  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
-  if (a === 192 && b === 168) return true; // 192.168.0.0/16
-  if (a === 169 && b === 254) return true; // link-local (incl. 169.254.169.254 metadata)
-  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
-  if (a >= 224) return true; // multicast / reserved
-  return false;
-}
-
-function isPrivateIpv6(host: string): boolean {
-  const h = host.toLowerCase();
-  if (h === "::1" || h === "::") return true; // loopback / unspecified
-  if (h.startsWith("fe80")) return true; // link-local
-  if (h.startsWith("fc") || h.startsWith("fd")) return true; // unique-local fc00::/7
-  // IPv4-mapped (::ffff:a.b.c.d) — classify the embedded v4.
-  const mapped = h.match(/::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (mapped?.[1]) {
-    const v4 = parseIpv4(mapped[1]);
-    return v4 ? isPrivateIpv4(v4) : true;
-  }
-  // WHATWG URL NORMALIZES mapped addresses to the HEX form before we ever see
-  // them (`[::ffff:127.0.0.1]` → hostname `[::ffff:7f00:1]`), so the dotted
-  // regex above never fires for URL-sourced hosts — decode the embedded v4
-  // from the last two 16-bit groups.
-  const hexMapped = h.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-  if (hexMapped) {
-    const hi = Number.parseInt(hexMapped[1]!, 16);
-    const lo = Number.parseInt(hexMapped[2]!, 16);
-    return isPrivateIpv4([hi >> 8, hi & 0xff, lo >> 8, lo & 0xff]);
-  }
-  // Any other ::ffff:-prefixed shape (or the deprecated ::ffff:0:a.b.c.d SIIT
-  // form) — fail closed rather than risk a mis-parse reaching a local target.
-  if (h.startsWith("::ffff:")) return true;
-  return false;
-}
+export { isSsrfSafeRpcUrl, isPrivateOrLoopbackHost } from "./rpc-egress-policy.js";
 
 /**
  * Choose the ordered RPC endpoints to verify against: curated/local
@@ -175,20 +80,44 @@ export function selectVerificationRpcUrls(input: {
   return ordered;
 }
 
-/** Minimal JSON-RPC POST for Solana verification: redirect OFF (SSRF), 15s timeout, no auth headers. Returns `result`. */
-export async function solanaRpcCall(rpcUrl: string, method: string, params: unknown[]): Promise<unknown> {
-  const res = await fetch(rpcUrl, {
+/**
+ * Minimal JSON-RPC POST for Solana verification: redirect OFF (SSRF), no auth
+ * headers, a bounded per-call timeout. Returns `result`.
+ *
+ * `egress` is the CALLER's decision, because the two callers stand on different
+ * ground: the Solana activity sweep uses the app's own configured endpoint
+ * (`cfg.solana.rpcUrl`, the same one that signs and broadcasts) and must keep
+ * working when that endpoint is a self-hosted node, while the bridge verifier
+ * reads a PROVIDER REGISTRY and passes the pinning dispatcher from
+ * `rpc-egress-policy.js`. Default: no dispatcher, i.e. as configured.
+ *
+ * `signal` lets the caller's own deadline cut the request; it is combined with
+ * the per-call timeout rather than replacing it.
+ */
+export async function solanaRpcCall(
+  rpcUrl: string,
+  method: string,
+  params: unknown[],
+  options?: { readonly signal?: AbortSignal; readonly dispatcher?: Dispatcher; readonly timeoutMs?: number },
+): Promise<unknown> {
+  const timeout = AbortSignal.timeout(options?.timeoutMs ?? SOLANA_RPC_CALL_TIMEOUT_MS);
+  const init: DispatchableRequestInit = {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
     redirect: "error",
-    signal: AbortSignal.timeout(15_000),
-  });
+    signal: options?.signal ? AbortSignal.any([options.signal, timeout]) : timeout,
+    dispatcher: options?.dispatcher,
+  };
+  const res = await fetch(rpcUrl, init);
   if (!res.ok) throw new Error(`solana rpc ${method}: http ${res.status}`);
   const body = (await res.json()) as { result?: unknown; error?: unknown };
   if (body.error !== null && body.error !== undefined) throw new Error(`solana rpc ${method}: rpc error`);
   return body.result;
 }
+
+/** Per-call bound for a Solana JSON-RPC read. Unchanged from the value this helper shipped with. */
+const SOLANA_RPC_CALL_TIMEOUT_MS = 15_000;
 
 /**
  * The genesis-hash cluster echo (the Solana analog of an EVM `eth_chainId`


### PR DESCRIPTION
## What changes

- **DNS-rebinding-safe egress for provider-supplied RPC URLs.** The filter matched literal addresses only. `rpc-egress-policy.ts` now resolves every address at connect time (undici `Agent` with a custom `connect.lookup`), refuses if ANY address is loopback, private, link-local, CGNAT, multicast, reserved, benchmarking, unspecified, the metadata address, or an IPv4-mapped / NAT64 form of those, and pins one validated public address for the socket while TLS still verifies the original hostname. `solana-rpc-safety.ts` re-exports the classifiers (facade) and lets the bridge verifier pass a dispatcher and a signal. A real transport test proves a public-looking hostname resolving to a waiting loopback listener produces zero connections for both RPC methods, with split-horizon, metadata and resolver-failure controls and a positive control through the pin.
- **Dependency (rule 07 evaluation in the report):** `undici@7.25.0`, first-party Node.js, zero transitive dependencies, already in the lockfile at that version; `request-filtering-agent` and `ssrf-req-filter` were evaluated and rejected because they are `http.Agent`-only and cannot supply a dispatcher to the `fetch` viem uses. Contained in one module.
- **A leg deadline.** Transport retry 0 (the candidate list is the fallback), 8 s per candidate, one 20 s leg deadline propagated as an `AbortSignal` through registry reads and every RPC call; exhaustion terminalizes nothing. Six failing candidates cost at most 20 s per leg instead of 180 s.

## Deviations, named

- The deadline is per leg, not per row: exactly one leg verification runs before a row can stay pending, so the row bound is the same 20 s; a row that verifies a fill and then walks extra provider hashes pays 20 s per hash, only after every endpoint just answered. A sweep-level budget belongs to the sweep owner (follow-up).
- The verification-reason vocabulary (migration 065, a durable column) has no member for "ran out of budget"; exhaustion reports the most specific endpoint observation and `verification_failed` only when nothing was observed, and always logs `bridge.repair.leg_deadline_exceeded`. A dedicated reason is a follow-up on that column's owner.

## Verification

- root vitest `src/__tests__/vex-agent/sync`: 79 files, 1071 tests (the two new suites included); root tsc clean; em-dash and unsafe-escapes gates green; the deadline test rerun three times, stable.
- Live (rule 10, read-only): the archived row-132 shape verified in 1.9 s through the pinned egress over real TLS (`arb1.arbitrum.io` success in block 490770285; publicnode -32602 classified `rpc_refused_request`); archive under the session scratchpad.
- Note for packaging: the lockfile was updated with `--lockfile-only`; a normal install must run before packaging (it resolves to the already-present hoisted copy).

Reference reading: VS Code `async.ts` (`createCancelablePromise`, `raceCancellation`, `timeout`: one owner-created signal through every await) and `async.test.ts` (fake-clock deadline tests); undici connector documentation and the installed `lib/core/connect.js` for the TLS `servername` behaviour under a pinned address.
