### PR TITLE
fix(sync): per-wallet in-flight attribution, totals independent of the bounded list, closed in-flight vocabulary

### DIFF
--- a/src/__tests__/integration/repos/snapshot-publication-gate.int.test.ts
+++ b/src/__tests__/integration/repos/snapshot-publication-gate.int.test.ts
@@ -31,6 +31,7 @@ import {
   readActivityFence,
   readInFlightMoney,
   type InFlightEntry,
+  type InFlightLedger,
 } from "@vex-agent/sync/balance-sync/publication-gate.js";
 import { publishSnapshotGroup } from "@vex-agent/sync/balance-sync/snapshot-publication.js";
 import { makeSession, resetDb } from "../setup/fixtures.js";
@@ -83,7 +84,7 @@ async function insertAgentActivity(
  * reported. `normalized_route` and `provider_order_id` are constrained to this
  * event role (migration 045), and the money lives on the OUTPUT columns.
  */
-async function insertBridgeFill(sessionId: string): Promise<number> {
+async function insertBridgeFill(sessionId: string, walletAddress: string = WALLET): Promise<number> {
   const executionId = await insertProtocolExecution(sessionId);
   const row = await queryOne<{ id: number }>(
     `INSERT INTO agent_activity
@@ -97,14 +98,20 @@ async function insertBridgeFill(sessionId: string): Promise<number> {
              'USDC', '151.0', 151.00,
              'USDC', '150.5', 150.25)
      RETURNING id`,
-    [executionId, WALLET, sessionId],
+    [executionId, walletAddress, sessionId],
   );
   return row?.id ?? 0;
 }
 
 async function insertWalletIntent(
   sessionId: string,
-  fields: { status: string; expiresInMs?: number; txHash?: string | null; activityId?: number },
+  fields: {
+    status: string;
+    expiresInMs?: number;
+    txHash?: string | null;
+    activityId?: number;
+    walletAddress?: string;
+  },
 ): Promise<string> {
   const intentId = randomUUID();
   // `wallet_intents_unconfirmed_evidence` (migration 093) requires BOTH a hash
@@ -117,7 +124,7 @@ async function insertWalletIntent(
      VALUES ($1, $2, $3, 'eip155', '0xdest', '1',
              '{"label":"send","criticalArgs":{}}'::jsonb, $4,
              NOW() + ($5::text || ' milliseconds')::interval, $6, $7)`,
-    [intentId, sessionId, WALLET, fields.status,
+    [intentId, sessionId, fields.walletAddress ?? WALLET, fields.status,
      String(fields.expiresInMs ?? 600_000), fields.txHash ?? null, fields.activityId ?? null],
   );
   return intentId;
@@ -125,7 +132,13 @@ async function insertWalletIntent(
 
 async function insertTransactionIntent(
   sessionId: string,
-  fields: { status: string; expiresInMs?: number; txHash?: string | null; createdAt?: string },
+  fields: {
+    status: string;
+    expiresInMs?: number;
+    txHash?: string | null;
+    createdAt?: string;
+    walletAddress?: string;
+  },
 ): Promise<string> {
   const intentId = randomUUID();
   await execute(
@@ -139,7 +152,7 @@ async function insertTransactionIntent(
              repeat('b', 64), 'v1', $4,
              NOW() + ($5::text || ' milliseconds')::interval, $6,
              COALESCE($7::timestamptz, NOW()))`,
-    [intentId, sessionId, WALLET, fields.status,
+    [intentId, sessionId, fields.walletAddress ?? WALLET, fields.status,
      String(fields.expiresInMs ?? 600_000), fields.txHash ?? null, fields.createdAt ?? null],
   );
   return intentId;
@@ -147,7 +160,12 @@ async function insertTransactionIntent(
 
 async function insertWrapIntent(
   sessionId: string,
-  fields: { status: string; expiresInMs?: number; txHash?: string | null },
+  fields: {
+    status: string;
+    expiresInMs?: number;
+    txHash?: string | null;
+    walletAddress?: string;
+  },
 ): Promise<string> {
   const intentId = randomUUID();
   await execute(
@@ -163,22 +181,29 @@ async function insertWrapIntent(
              '{"label":"wrap","criticalArgs":{}}'::jsonb, '{}'::jsonb,
              repeat('a', 64), 'v1', $4,
              NOW() + ($5::text || ' milliseconds')::interval, $6)`,
-    [intentId, sessionId, WALLET, fields.status,
+    [intentId, sessionId, fields.walletAddress ?? WALLET, fields.status,
      String(fields.expiresInMs ?? 600_000), fields.txHash ?? null],
   );
   return intentId;
 }
 
 /** Read the ledger the way production does: inside a transaction. */
-async function inFlightNow(): Promise<readonly InFlightEntry[]> {
+async function ledgerNow(
+  wallets: readonly string[] = WALLETS,
+  now: number = Date.now(),
+): Promise<InFlightLedger> {
   const client = await getPool().connect();
   try {
     await client.query("BEGIN");
-    return (await readInFlightMoney(client, WALLETS)).entries;
+    return await readInFlightMoney(client, wallets, now);
   } finally {
     await client.query("ROLLBACK").catch(() => undefined);
     client.release();
   }
+}
+
+async function inFlightNow(): Promise<readonly InFlightEntry[]> {
+  return (await ledgerNow()).entries;
 }
 
 const kindsNow = async () => (await inFlightNow()).map((e) => e.kind).sort();
@@ -363,6 +388,258 @@ describe("the ledger SQL against the real schema", () => {
     // `wallet_transaction_intents` is calldata-shaped: it has no amount and no
     // asset column at all, and the ledger says so.
     expect(entry).toMatchObject({ amountHuman: null, symbol: null, usdEstimate: null });
+  });
+});
+
+// ── 1b. Per-wallet attribution, against the real schema ──────────────────
+
+describe("in-flight money is attributed PER WALLET", () => {
+  const OTHER = "0xother-wallet";
+
+  it("gives a scoped read ZERO in transit and NO foreign entry when only the OTHER wallet is pending", async () => {
+    // The exact defect: wallet B is mid-bridge, the user opens a scope that
+    // holds only wallet A, and B's $150.25 lands in A's portfolio.
+    await insertBridgeFill(sessionId, OTHER);
+
+    const scopedToA = await ledgerNow([WALLET]);
+
+    expect(scopedToA.entries).toEqual([]);
+    expect(scopedToA.perWallet).toEqual([]);
+    expect(scopedToA.totalCount).toBe(0);
+
+    // And the wallet that IS mid-bridge sees exactly its own money.
+    const scopedToB = await ledgerNow([OTHER]);
+    expect(scopedToB.perWallet).toEqual([
+      { walletAddress: OTHER, entryCount: 1, unresolvedCount: 0, inTransitUsd: 150.25 },
+    ]);
+    expect(scopedToB.entries.map((entry) => entry.walletAddress)).toEqual([OTHER]);
+  });
+
+  it("splits a two-wallet scope into two rows, each carrying only its own money", async () => {
+    await insertBridgeFill(sessionId, OTHER);
+    await insertWalletIntent(sessionId, { status: "consuming" });
+
+    const both = await ledgerNow([WALLET, OTHER]);
+
+    expect(new Map(both.perWallet.map((w) => [w.walletAddress, w.inTransitUsd]))).toEqual(
+      new Map([
+        // The bridge fill's expected output, priced.
+        [OTHER, 150.25],
+        // `wallet_intents` carries no USD estimate at all: not priced is not
+        // worth zero, and it contributes nothing rather than a fabricated
+        // figure.
+        [WALLET, 0],
+      ]),
+    );
+    expect(both.totalCount).toBe(2);
+    expect(both.entries).toHaveLength(2);
+  });
+
+  it("names the owning wallet on EVERY entry, from the row's own column", async () => {
+    await insertBridgeFill(sessionId, OTHER);
+    await insertTransactionIntent(sessionId, { status: "consuming" });
+
+    const both = await ledgerNow([WALLET, OTHER]);
+
+    expect(new Set(both.entries.map((entry) => entry.walletAddress))).toEqual(
+      new Set([WALLET, OTHER]),
+    );
+  });
+});
+
+// ── 1c. Totals over ALL rows; the LIST alone is bounded ──────────────────
+
+describe("the display bound never bounds a total", () => {
+  it("counts and prices all 55 rows while listing 50, and says the list is short", async () => {
+    // 55 live transaction intents, more than the 50-row display bound.
+    for (let i = 0; i < 55; i++) {
+      await insertTransactionIntent(sessionId, { status: "consuming" });
+    }
+
+    const ledger = await ledgerNow();
+
+    // The list is bounded, and says so.
+    expect(ledger.entries).toHaveLength(50);
+    expect(ledger.truncated).toBe(true);
+    // The accounting is NOT bounded: every row was counted by the server.
+    expect(ledger.totalCount).toBe(55);
+    expect(ledger.perWallet).toEqual([
+      { walletAddress: WALLET, entryCount: 55, unresolvedCount: 0, inTransitUsd: 0 },
+    ]);
+  });
+
+  it("keeps the OLDEST rows in the bounded list", async () => {
+    const oldest = await insertTransactionIntent(sessionId, {
+      status: "consuming",
+      createdAt: new Date(Date.now() - 60 * 60_000).toISOString(),
+    });
+    for (let i = 0; i < 55; i++) {
+      await insertTransactionIntent(sessionId, { status: "consuming" });
+    }
+
+    const ledger = await ledgerNow();
+
+    expect(ledger.entries[0]?.ref).toBe(oldest);
+    expect(ledger.truncated).toBe(true);
+  });
+
+  it("reports an untruncated list as untruncated", async () => {
+    await insertTransactionIntent(sessionId, { status: "consuming" });
+    const ledger = await ledgerNow();
+    expect(ledger.totalCount).toBe(1);
+    expect(ledger.truncated).toBe(false);
+  });
+});
+
+// ── 1d. The standing, decided by the server from the bound table ─────────
+
+describe("the standing bounds, evaluated by real Postgres", () => {
+  it("calls a young same-chain leg in transit and an old one unresolved", async () => {
+    const id = await insertAgentActivity(sessionId, "pending", {
+      createdAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+    });
+    expect((await ledgerNow()).entries[0]?.standing).toBe("in_transit");
+
+    await execute("UPDATE agent_activity SET created_at = NOW() - interval '2 hours' WHERE id = $1", [id]);
+    const aged = await ledgerNow();
+    // Past the one-hour bound for a same-chain leg: listed, counted, and in NO
+    // total.
+    expect(aged.entries[0]?.standing).toBe("unresolved");
+    expect(aged.perWallet[0]?.unresolvedCount).toBe(1);
+    expect(aged.perWallet[0]?.inTransitUsd).toBe(0);
+  });
+
+  it("gives a bridge fill the two-hour bound its detail override names", async () => {
+    const id = await insertBridgeFill(sessionId);
+    await execute("UPDATE agent_activity SET created_at = NOW() - interval '90 minutes' WHERE id = $1", [id]);
+
+    const ledger = await ledgerNow();
+
+    // 90 minutes is past the same-chain hour and inside the cross-chain two,
+    // so this row proves the OVERRIDE is applied and not the kind's default.
+    expect(ledger.entries[0]?.standing).toBe("in_transit");
+    expect(ledger.perWallet[0]?.inTransitUsd).toBeCloseTo(150.25, 6);
+  });
+
+  it("uses the row's OWN expiry for a claimable proposal, not its age", async () => {
+    await insertWalletIntent(sessionId, { status: "consuming", expiresInMs: -1_000 });
+    // Seconds old, and already dead: the CAS filters on `expires_at > NOW()`.
+    expect((await ledgerNow()).entries[0]?.standing).toBe("unresolved");
+
+    await execute("DELETE FROM wallet_intents");
+    await insertWalletIntent(sessionId, { status: "consuming", expiresInMs: 600_000 });
+    expect((await ledgerNow()).entries[0]?.standing).toBe("in_transit");
+  });
+
+  it("counts an unresolved row without letting its estimate reach any total", async () => {
+    const id = await insertBridgeFill(sessionId);
+    await execute("UPDATE agent_activity SET created_at = NOW() - interval '3 hours' WHERE id = $1", [id]);
+
+    const ledger = await ledgerNow();
+
+    expect(ledger.entries[0]?.standing).toBe("unresolved");
+    // The entry keeps its estimate for the operator to read; the accounting
+    // refuses it in either direction.
+    expect(ledger.entries[0]?.usdEstimate).toBeCloseTo(150.25, 6);
+    expect(ledger.perWallet[0]).toEqual({
+      walletAddress: WALLET,
+      entryCount: 1,
+      unresolvedCount: 1,
+      inTransitUsd: 0,
+    });
+  });
+
+  it("reads a NEGATIVE estimate as not priced, in the entry AND in the total", async () => {
+    const id = await insertBridgeFill(sessionId);
+    await execute("UPDATE agent_activity SET usd_out_est = -500 WHERE id = $1", [id]);
+
+    const ledger = await ledgerNow();
+
+    // A negative estimate is a bad price, not a liability. It must not
+    // subtract from a portfolio on either path.
+    expect(ledger.entries[0]?.usdEstimate).toBeNull();
+    expect(ledger.perWallet[0]?.inTransitUsd).toBe(0);
+  });
+});
+
+// ── 1e. The documented exception: expired, unbroadcast, never in flight ──
+
+describe("an expired PENDING intent with no transaction hash", () => {
+  /**
+   * The owner's exception (2026-09-04), asserted as a table over all three
+   * intent tables: such a row is not listed at all, in either standing. The
+   * proposal can never be claimed (`expires_at > NOW()` in the consuming CAS)
+   * and nothing was ever broadcast, so no money left and there is no outcome
+   * for anyone to prove. Listing it as `unresolved` would tell a human money is
+   * unaccounted for when none ever moved.
+   */
+  const EXPIRED_PENDING: ReadonlyArray<readonly [string, () => Promise<unknown>]> = [
+    ["wallet_intents", () => insertWalletIntent(sessionId, { status: "pending", expiresInMs: -60_000 })],
+    ["wallet_transaction_intents", () => insertTransactionIntent(sessionId, { status: "pending", expiresInMs: -60_000 })],
+    ["wallet_wrap_intents", () => insertWrapIntent(sessionId, { status: "pending", expiresInMs: -60_000 })],
+  ];
+
+  it.each(EXPIRED_PENDING)("%s: is not listed, not counted, and in no total", async (_table, insert) => {
+    await insert();
+
+    const ledger = await ledgerNow();
+
+    expect(ledger.entries).toEqual([]);
+    expect(ledger.perWallet).toEqual([]);
+    expect(ledger.totalCount).toBe(0);
+  });
+
+  /**
+   * The other half of the exception, and the reason it is safe: the moment a
+   * row carries a hash, expiry stops being the relevant clock. Expiry bounds
+   * the APPROVAL; the transaction has already left.
+   */
+  const BROADCAST_PAST_EXPIRY: ReadonlyArray<readonly [string, () => Promise<unknown>, string]> = [
+    [
+      "wallet_transaction_intents",
+      () => insertTransactionIntent(sessionId, {
+        status: "broadcast_unconfirmed",
+        txHash: "0xbroadcast-tx",
+        expiresInMs: -60_000,
+      }),
+      "wallet_transaction_intent_live",
+    ],
+    [
+      "wallet_wrap_intents",
+      () => insertWrapIntent(sessionId, {
+        status: "broadcast_unconfirmed",
+        txHash: "0xbroadcast-wrap",
+        expiresInMs: -60_000,
+      }),
+      "wallet_wrap_intent_live",
+    ],
+  ];
+
+  it.each(BROADCAST_PAST_EXPIRY)(
+    "%s: a BROADCAST row past its expiry is still listed",
+    async (_table, insert, kind) => {
+      await insert();
+
+      const ledger = await ledgerNow();
+
+      expect(ledger.entries.map((entry) => entry.kind)).toEqual([kind]);
+      expect(ledger.totalCount).toBe(1);
+    },
+  );
+
+  it("wallet_intents: a broadcast row past its expiry is still listed", async () => {
+    const activityId = await insertAgentActivity(sessionId, "confirmed");
+    await insertWalletIntent(sessionId, {
+      status: "broadcast_unconfirmed",
+      txHash: "0xbroadcast-intent",
+      activityId,
+      expiresInMs: -60_000,
+    });
+
+    const ledger = await ledgerNow();
+
+    expect(ledger.entries.map((entry) => entry.kind)).toEqual(["wallet_confirmation_unknown"]);
+    expect(ledger.totalCount).toBe(1);
   });
 });
 
@@ -593,23 +870,97 @@ describe("publishSnapshotGroup against a contended table", () => {
       settled_usd: string;
       in_transit_usd: string;
       unresolved_count: number;
+      in_flight_total_count: number;
       in_flight: Array<Record<string, unknown>>;
     }>(
-      `SELECT settled_usd::text, in_transit_usd::text, unresolved_count, in_flight
+      `SELECT settled_usd::text, in_transit_usd::text, unresolved_count,
+              in_flight_total_count, in_flight
          FROM proj_portfolio_snapshot_groups WHERE snapshot_group_id = $1`,
       [groupId],
     );
     expect(Number(group?.settled_usd)).toBeCloseTo(100, 6);
     expect(Number(group?.in_transit_usd)).toBeCloseTo(150.25, 6);
     expect(group?.unresolved_count).toBe(0);
+    // The rows FOUND, beside the rows stored: a reader compares the two to
+    // know whether it holds the whole list.
+    expect(group?.in_flight_total_count).toBe(1);
     expect(group?.in_flight).toHaveLength(1);
     expect(group?.in_flight[0]).toMatchObject({
       kind: "agent_activity_pending",
+      walletAddress: WALLET,
       detail: "bridge_fill_expected",
       standing: "in_transit",
       amountHuman: "150.5",
       symbol: "USDC",
     });
+
+    // And the per-wallet attribution (migration 102), against the real table
+    // and its real CHECK constraints.
+    const perWallet = await query<{
+      wallet_address: string;
+      entry_count: number;
+      unresolved_count: number;
+      in_transit_usd: string;
+    }>(
+      `SELECT wallet_address, entry_count, unresolved_count, in_transit_usd::text
+         FROM proj_portfolio_snapshot_group_wallets WHERE snapshot_group_id = $1`,
+      [groupId],
+    );
+    expect(perWallet).toHaveLength(1);
+    expect(perWallet[0]?.wallet_address).toBe(WALLET);
+    expect(perWallet[0]?.entry_count).toBe(1);
+    expect(perWallet[0]?.unresolved_count).toBe(0);
+    expect(Number(perWallet[0]?.in_transit_usd)).toBeCloseTo(150.25, 6);
+  });
+
+  it("attributes ONE wallet's pending bridge to that wallet alone in the durable record", async () => {
+    const other = "0xother-wallet";
+    await insertBridgeFill(sessionId, other);
+    const fence = await readActivityFence(getPool(), [WALLET, other]);
+    const groupId = randomUUID();
+
+    const outcome = await publishSnapshotGroup({
+      snapshotGroupId: groupId,
+      walletAddresses: [WALLET, other],
+      fenceAtCycleStart: fence,
+      drafts: [draft(WALLET), draft(other)],
+    });
+
+    expect(outcome.published).toBe(true);
+    const perWallet = await query<{ wallet_address: string; in_transit_usd: string }>(
+      `SELECT wallet_address, in_transit_usd::text
+         FROM proj_portfolio_snapshot_group_wallets WHERE snapshot_group_id = $1`,
+      [groupId],
+    );
+    // Exactly ONE row: the wallet with nothing in flight has nothing recorded,
+    // which is what lets a scoped read for it sum to zero instead of
+    // inheriting the group figure.
+    expect(perWallet).toEqual([
+      expect.objectContaining({ wallet_address: other }),
+    ]);
+    expect(Number(perWallet[0]?.in_transit_usd)).toBeCloseTo(150.25, 6);
+  });
+
+  it("refuses a negative per-wallet in-transit total at the SCHEMA, not only in code", async () => {
+    const fence = await readActivityFence(getPool(), WALLETS);
+    const groupId = randomUUID();
+    await publishSnapshotGroup({
+      snapshotGroupId: groupId,
+      walletAddresses: WALLETS,
+      fenceAtCycleStart: fence,
+      drafts: [draft(WALLET)],
+    });
+
+    // The durable floor: money in transit is never negative, and the
+    // database is the last place that can be told otherwise.
+    await expect(
+      execute(
+        `INSERT INTO proj_portfolio_snapshot_group_wallets
+           (snapshot_group_id, wallet_address, entry_count, unresolved_count, in_transit_usd)
+         VALUES ($1::uuid, $2, 1, 0, -1)`,
+        [groupId, WALLET],
+      ),
+    ).rejects.toThrow(/in_transit_usd_check/);
   });
 
   it("writes NO group record when a per-wallet insert fails", async () => {

--- a/src/__tests__/integration/repos/snapshot-publication-indexes.int.test.ts
+++ b/src/__tests__/integration/repos/snapshot-publication-indexes.int.test.ts
@@ -18,8 +18,9 @@
  * WHERE THE SQL COMES FROM. The gate's seven-branch UNION is a private const
  * inside its own module, and re-typing 60 lines of money-path SQL into a test
  * would create a second source of truth that can drift silently. This file
- * therefore EXTRACTS the exact `IN_FLIGHT_SQL` and `MAX_IN_FLIGHT` text from the
- * owner's source file and explains that, so the plan measured here is the plan
+ * therefore EXTRACTS the exact `IN_FLIGHT_SQL` text (and the two nested
+ * templates it is assembled from) plus `MAX_IN_FLIGHT` from the owner's source
+ * files and explains that, so the plan measured here is the plan
  * production gets. A rename breaks this test loudly, which is the correct
  * failure.
  *
@@ -41,7 +42,9 @@ import pg from "pg";
 import { runMigrationsWithProgress } from "../../../lib/db/migrate-runner.js";
 import { getPackageRoot, getVexAgentMigrationsDir } from "@utils/package-assets.js";
 import {
+  boundFor,
   readInFlightMoney,
+  IN_FLIGHT_KINDS,
   type InFlightEntry,
 } from "@vex-agent/sync/balance-sync/publication-gate.js";
 
@@ -76,11 +79,20 @@ const GATE_SOURCE = readFileSync(
   "utf-8",
 );
 
-function extractTemplate(name: string): string {
-  const match = new RegExp(`const ${name} = \`([\\s\\S]*?)\`;`).exec(GATE_SOURCE);
+/**
+ * The fence moved to its own module when the gate crossed the repository's
+ * 750-line file gate; it is still the same statement, read from its new owner.
+ */
+const FENCE_SOURCE = readFileSync(
+  path.join(getPackageRoot(), "src/vex-agent/sync/balance-sync/activity-fence.ts"),
+  "utf-8",
+);
+
+function extractTemplate(source: string, name: string): string {
+  const match = new RegExp(`const ${name} = \`([\\s\\S]*?)\`;`).exec(source);
   if (match?.[1] === undefined) {
     throw new Error(
-      `publication-gate.ts no longer declares a template literal named ${name}. ` +
+      `the gate no longer declares a template literal named ${name}. ` +
         `This test explains the gate's REAL SQL; update the extraction rather than inlining a copy.`,
     );
   }
@@ -95,9 +107,49 @@ function extractNumber(name: string): number {
   return Number(match[1].replace(/_/g, ""));
 }
 
-const IN_FLIGHT_SQL = extractTemplate("IN_FLIGHT_SQL");
-const FENCE_SQL = extractTemplate("FENCE_SQL");
+/**
+ * `IN_FLIGHT_SQL` is assembled from two nested template literals, so the
+ * extraction resolves them in the same order the module does. Reading the
+ * source rather than importing the constant is deliberate and unchanged: this
+ * suite exists to EXPLAIN the gate's real statement, and an import would let a
+ * refactor quietly change what is being explained.
+ */
+function extractInFlightSql(): string {
+  const branches = extractTemplate(GATE_SOURCE, "LEDGER_BRANCHES_SQL");
+  const cte = extractTemplate(GATE_SOURCE, "LEDGER_CTE_SQL")
+    .replace("${LEDGER_BRANCHES_SQL}", branches);
+  return extractTemplate(GATE_SOURCE, "IN_FLIGHT_SQL").replace("${LEDGER_CTE_SQL}", cte);
+}
+
+const IN_FLIGHT_SQL = extractInFlightSql();
+const FENCE_SQL = extractTemplate(FENCE_SOURCE, "FENCE_SQL");
 const MAX_IN_FLIGHT = extractNumber("MAX_IN_FLIGHT");
+
+/**
+ * The bound table as the statement receives it, built from the gate's own
+ * exported table so the EXPLAIN joins a `bounds` relation of the real size
+ * rather than an empty one the planner would collapse. Only the PARAMETER is
+ * imported; the SQL is still read from source, for the reason in the header.
+ */
+const STANDING_BOUNDS_JSON = JSON.stringify(
+  IN_FLIGHT_KINDS.map((kind) => {
+    const bound = boundFor(kind, null);
+    return {
+      kind,
+      detail: null,
+      rule: bound.rule,
+      seconds: bound.rule === "max-age" ? bound.maxAgeSeconds : bound.fallbackMaxAgeSeconds,
+    };
+  }),
+);
+
+/** The four bind parameters `readInFlightMoney` sends. */
+const IN_FLIGHT_PARAMS = [
+  PROBE_WALLETS,
+  MAX_IN_FLIGHT,
+  STANDING_BOUNDS_JSON,
+  new Date().toISOString(),
+];
 
 // ── plan inspection ───────────────────────────────────────────────────────
 
@@ -366,7 +418,7 @@ describe("098 wallet-address indexes for the publication gate", () => {
     }
 
     blockersBefore = (await readInFlightMoney(pool, PROBE_WALLETS)).entries;
-    planBefore = await measure(IN_FLIGHT_SQL, [PROBE_WALLETS, MAX_IN_FLIGHT + 1]);
+    planBefore = await measure(IN_FLIGHT_SQL, IN_FLIGHT_PARAMS);
     fencePlan = await measure(FENCE_SQL, [PROBE_WALLETS]);
 
     // THE DEFECT, stated as a plan: with no wallet index, at least one branch
@@ -420,7 +472,7 @@ describe("098 wallet-address indexes for the publication gate", () => {
 
   it("plans every wallet predicate through the named index, with no sequential scan left", async () => {
     await pool.query("ANALYZE");
-    planAfter = await measure(IN_FLIGHT_SQL, [PROBE_WALLETS, MAX_IN_FLIGHT + 1]);
+    planAfter = await measure(IN_FLIGHT_SQL, IN_FLIGHT_PARAMS);
 
     for (const table of INTENT_TABLES) {
       const scans = scansOf(planAfter, table);

--- a/src/__tests__/vex-agent/sync/balance-sync-snapshot-publication.test.ts
+++ b/src/__tests__/vex-agent/sync/balance-sync-snapshot-publication.test.ts
@@ -34,7 +34,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 interface Statement { sql: string; params?: unknown[] }
 
-/** Rows the ledger query should return. Empty = nothing in flight. */
+/**
+ * Rows the ledger query should return, in the shape the real statement emits:
+ * `row_type = 'wallet'` aggregate rows (computed by the SERVER over every
+ * in-flight row) followed by `row_type = 'entry'` display rows. The helpers
+ * below build both halves from one description so a scenario cannot
+ * accidentally describe a total the entries contradict.
+ */
 let ledgerRows: Record<string, unknown>[] = [];
 /** The fence the gate reads INSIDE the transaction. */
 let fenceInTx = { max_id: "0", row_count: "0", pending_count: "0", confirmed_count: "0" };
@@ -59,6 +65,7 @@ async function fakeQuery(sql: string, params?: unknown[]): Promise<{ rows: unkno
   }
   if (sql.includes("MAX(id)")) return { rows: [fenceInTx], rowCount: 1 };
   if (sql.includes("agent_activity_pending")) return { rows: ledgerRows, rowCount: ledgerRows.length };
+  if (sql.includes("proj_portfolio_snapshot_group_wallets")) return { rows: [], rowCount: 0 };
   return { rows: [], rowCount: 0 };
 }
 
@@ -165,24 +172,121 @@ beforeEach(() => {
 
 // ── 1. In-flight money is ACCOUNTED FOR, never a veto ────────────────────
 
+/**
+ * One row as the ledger statement returns it.
+ *
+ * `standing` and `ageSeconds` are columns now: the server classifies every row
+ * so it can AGGREGATE over all of them, including the ones the bounded display
+ * list never returns. The classification itself is therefore proved against
+ * real Postgres in `__tests__/integration/repos/snapshot-publication-gate`,
+ * which is where that risk lives; what this suite owns is what the publisher
+ * does with the answer.
+ */
+interface FakeEntry {
+  kind: string;
+  walletAddress?: string;
+  ref: string;
+  detail: string | null;
+  standing: "in_transit" | "unresolved";
+  ageSeconds: number;
+  amountText?: string | null;
+  amountDecimals?: number | null;
+  symbol?: string | null;
+  usdEst?: string | null;
+}
+
+interface FakeWalletTotals {
+  walletAddress: string;
+  entryCount: number;
+  unresolvedCount: number;
+  inTransitUsd: string;
+}
+
+/**
+ * Script the ledger statement's two row types.
+ *
+ * The per-wallet aggregates default to what the server would compute if every
+ * row were also displayed. A test that wants the OVERFLOW case - more rows than
+ * the display bound - passes aggregates that deliberately exceed the entries,
+ * which is exactly the shape production produces.
+ */
+function scriptLedger(entries: readonly FakeEntry[], totals?: readonly FakeWalletTotals[]): void {
+  const perWallet = totals ?? derivedTotals(entries);
+  ledgerRows = [
+    ...perWallet.map((wallet) => ({
+      row_type: "wallet",
+      wallet_address: wallet.walletAddress,
+      entry_count: String(wallet.entryCount),
+      unresolved_count: String(wallet.unresolvedCount),
+      in_transit_usd: wallet.inTransitUsd,
+      kind: null,
+      ref: null,
+      detail: null,
+      standing: null,
+      age_seconds: null,
+      since: null,
+      amount_text: null,
+      amount_decimals: null,
+      symbol: null,
+      usd_est: null,
+    })),
+    ...entries.map((entry) => ({
+      row_type: "entry",
+      wallet_address: entry.walletAddress ?? WALLETS[0],
+      entry_count: null,
+      unresolved_count: null,
+      in_transit_usd: null,
+      kind: entry.kind,
+      ref: entry.ref,
+      detail: entry.detail,
+      standing: entry.standing,
+      age_seconds: String(entry.ageSeconds),
+      since: agedBy(entry.ageSeconds),
+      amount_text: entry.amountText ?? null,
+      amount_decimals: entry.amountDecimals ?? null,
+      symbol: entry.symbol ?? null,
+      usd_est: entry.usdEst ?? null,
+    })),
+  ];
+}
+
+function derivedTotals(entries: readonly FakeEntry[]): FakeWalletTotals[] {
+  const byWallet = new Map<string, FakeWalletTotals>();
+  for (const entry of entries) {
+    const address = entry.walletAddress ?? WALLETS[0];
+    const totals = byWallet.get(address)
+      ?? { walletAddress: address, entryCount: 0, unresolvedCount: 0, inTransitUsd: "0" };
+    totals.entryCount += 1;
+    if (entry.standing === "unresolved") totals.unresolvedCount += 1;
+    else if (entry.usdEst != null) {
+      totals.inTransitUsd = String(Number(totals.inTransitUsd) + Number(entry.usdEst));
+    }
+    byWallet.set(address, totals);
+  }
+  return [...byWallet.values()];
+}
+
 /** The owner's row: a bridge fill the provider has not conclusively reported. */
-function bridgeFill(ageSeconds: number) {
+function bridgeFill(ageSeconds: number, standing: "in_transit" | "unresolved"): FakeEntry {
   return {
     kind: "agent_activity_pending",
     ref: "132",
     detail: "bridge_fill_expected",
-    since: agedBy(ageSeconds),
-    expires_at: null,
-    amount_text: "150.5",
-    amount_decimals: null,
+    standing,
+    ageSeconds,
+    amountText: "150.5",
     symbol: "USDC",
-    usd_est: "150.25",
+    usdEst: "150.25",
   };
 }
 
+/** The statement that writes the group's per-wallet in-flight rows. */
+const groupWalletStatement = () =>
+  statements.find((s) => s.sql.includes("proj_portfolio_snapshot_group_wallets"));
+
 describe("a pending bridge fill at PUBLICATION time", () => {
   it("no longer withholds the group - the snapshot is published with it named", async () => {
-    ledgerRows = [bridgeFill(10 * 60)];
+    scriptLedger([bridgeFill(10 * 60, "in_transit")]);
 
     const outcome = await publish();
 
@@ -194,8 +298,8 @@ describe("a pending bridge fill at PUBLICATION time", () => {
     expect(indexOf("INSERT INTO proj_portfolio_snapshots")).toBeGreaterThan(-1);
   });
 
-  it("carries it in the ledger as in_transit, with its expected OUTPUT leg", async () => {
-    ledgerRows = [bridgeFill(10 * 60)];
+  it("carries it in the ledger as in_transit, named by WALLET, with its expected OUTPUT leg", async () => {
+    scriptLedger([bridgeFill(10 * 60, "in_transit")]);
 
     const outcome = await publish();
 
@@ -203,6 +307,9 @@ describe("a pending bridge fill at PUBLICATION time", () => {
     expect(outcome.ledger.entries).toEqual([
       {
         kind: "agent_activity_pending",
+        // Whose money it is, on the entry itself: without this a portfolio read
+        // for the OTHER wallet inherits this bridge.
+        walletAddress: "0xAAA",
         ref: "132",
         detail: "bridge_fill_expected",
         standing: "in_transit",
@@ -216,28 +323,109 @@ describe("a pending bridge fill at PUBLICATION time", () => {
     ]);
     expect(outcome.ledger.inTransitUsd).toBeCloseTo(150.25, 6);
     expect(outcome.ledger.unresolvedCount).toBe(0);
+    expect(outcome.ledger.perWallet).toEqual([
+      { walletAddress: "0xAAA", entryCount: 1, unresolvedCount: 0, inTransitUsd: 150.25 },
+    ]);
     // settled is what was actually inserted, not what was offered.
     expect(outcome.ledger.settledUsd).toBeCloseTo(200, 6);
   });
 
-  it("writes the group record in the SAME transaction, after the per-wallet rows", async () => {
-    ledgerRows = [bridgeFill(10 * 60)];
+  it("writes the group record and its PER-WALLET rows in the SAME transaction, after the snapshots", async () => {
+    scriptLedger([bridgeFill(10 * 60, "in_transit")]);
 
     await publish();
 
     const groupAt = indexOf("INSERT INTO proj_portfolio_snapshot_groups");
+    const walletsAt = indexOf("proj_portfolio_snapshot_group_wallets");
     expect(groupAt).toBeGreaterThan(indexOf("INSERT INTO proj_portfolio_snapshots"));
-    expect(indexOf("COMMIT")).toBeGreaterThan(groupAt);
+    // The child rows reference the group row, so they cannot precede it.
+    expect(walletsAt).toBeGreaterThan(groupAt);
+    expect(indexOf("COMMIT")).toBeGreaterThan(walletsAt);
 
     const stmt = statements[groupAt];
     expect(stmt?.params?.[0]).toBe("group-1");
     expect(stmt?.params?.[2]).toBeCloseTo(150.25, 6);
     expect(stmt?.params?.[3]).toBe(0);
     expect(JSON.parse(String(stmt?.params?.[4]))).toHaveLength(1);
+    // The rows the ledger FOUND, which is what a reader compares the stored
+    // array against to know whether it holds the whole list.
+    expect(stmt?.params?.[5]).toBe(1);
+
+    // The COLUMN vocabulary, not the domain one: `jsonb_to_recordset` matches
+    // its record definition to the JSON keys by name.
+    expect(JSON.parse(String(groupWalletStatement()?.params?.[1]))).toEqual([
+      {
+        wallet_address: "0xAAA",
+        entry_count: 1,
+        unresolved_count: 0,
+        in_transit_usd: 150.25,
+      },
+    ]);
   });
 
-  it("at three hours the SAME row is unresolved: listed, counted, in NO total", async () => {
-    ledgerRows = [bridgeFill(3 * HOUR_SECONDS)];
+  it("attributes each wallet's money to that wallet and to no other", async () => {
+    // Only 0xBBB is mid-bridge. A group total would hand 0xAAA a stranger's
+    // $150; per-wallet rows are what let a scoped read refuse to.
+    scriptLedger([
+      { ...bridgeFill(10 * 60, "in_transit"), walletAddress: "0xBBB" },
+      {
+        kind: "wallet_intent_live",
+        walletAddress: "0xAAA",
+        ref: "wi_1",
+        detail: "consuming",
+        standing: "in_transit",
+        ageSeconds: 30,
+        amountText: "12.5",
+        symbol: "USDC",
+        usdEst: "12.5",
+      },
+    ]);
+
+    const outcome = await publish();
+
+    if (!outcome.published) throw new Error("unreachable");
+    expect(outcome.ledger.perWallet).toEqual([
+      { walletAddress: "0xBBB", entryCount: 1, unresolvedCount: 0, inTransitUsd: 150.25 },
+      { walletAddress: "0xAAA", entryCount: 1, unresolvedCount: 0, inTransitUsd: 12.5 },
+    ]);
+    // The group figure is still the SUM of the parts - it is just no longer the
+    // only thing recorded.
+    expect(outcome.ledger.inTransitUsd).toBeCloseTo(162.75, 6);
+    expect(outcome.ledger.entries.map((entry) => entry.walletAddress)).toEqual(["0xBBB", "0xAAA"]);
+  });
+
+  it("takes EVERY total from the server's aggregates, never from the bounded list", async () => {
+    // THE NO-SILENT-CUTTING CASE. 51 rows exist for one wallet; the statement
+    // returns the 50 oldest. Summing the list would delete the 51st row's money
+    // from the portfolio and report a complete-looking number.
+    const shown: FakeEntry[] = Array.from({ length: 50 }, (_, i) => ({
+      kind: "agent_activity_pending",
+      ref: `row-${i}`,
+      detail: "swap",
+      standing: "in_transit",
+      ageSeconds: 60 + i,
+      usdEst: "10",
+    }));
+    scriptLedger(shown, [
+      { walletAddress: "0xAAA", entryCount: 51, unresolvedCount: 3, inTransitUsd: "480" },
+    ]);
+
+    const outcome = await publish();
+
+    if (!outcome.published) throw new Error("unreachable");
+    // 48 in-transit rows at $10 plus 3 unresolved: the aggregate, not the 50
+    // displayed rows' $500.
+    expect(outcome.ledger.inTransitUsd).toBe(480);
+    expect(outcome.ledger.unresolvedCount).toBe(3);
+    expect(outcome.ledger.totalCount).toBe(51);
+    expect(outcome.ledger.entries).toHaveLength(50);
+    // Said out loud, in the record itself: rows exist beyond this list.
+    expect(outcome.ledger.truncated).toBe(true);
+    expect(statements[indexOf("INSERT INTO proj_portfolio_snapshot_groups")]?.params?.[5]).toBe(51);
+  });
+
+  it("counts an unresolved row without adding it to any total", async () => {
+    scriptLedger([bridgeFill(3 * HOUR_SECONDS, "unresolved")]);
 
     const outcome = await publish();
 
@@ -253,7 +441,7 @@ describe("a pending bridge fill at PUBLICATION time", () => {
   });
 
   it("reports an unresolved entry by ref and kind, and never its amount", async () => {
-    ledgerRows = [bridgeFill(3 * HOUR_SECONDS)];
+    scriptLedger([bridgeFill(3 * HOUR_SECONDS, "unresolved")]);
 
     logPublicationOutcome(await publish(), "group-1");
 
@@ -270,17 +458,16 @@ describe("a pending bridge fill at PUBLICATION time", () => {
   });
 
   it("a non-bridge pending leg reports its INPUT leg instead", async () => {
-    ledgerRows = [{
+    scriptLedger([{
       kind: "agent_activity_pending",
       ref: "901",
       detail: "swap",
-      since: agedBy(60),
-      expires_at: null,
-      amount_text: "1.25",
-      amount_decimals: null,
+      standing: "in_transit",
+      ageSeconds: 60,
+      amountText: "1.25",
       symbol: "WETH",
-      usd_est: "4200",
-    }];
+      usdEst: "4200",
+    }]);
 
     const outcome = await publish();
 
@@ -294,18 +481,18 @@ describe("a pending bridge fill at PUBLICATION time", () => {
   });
 
   it("converts a base-unit amount through its decimals, never through a float", async () => {
-    ledgerRows = [{
+    scriptLedger([{
       kind: "wallet_wrap_intent_live",
       ref: "wwi_1",
       detail: "consuming",
-      since: agedBy(30),
-      expires_at: new Date(Date.now() + 600_000),
+      standing: "in_transit",
+      ageSeconds: 30,
       // 1 wei short of 1 ETH: a float64 cannot represent this, a string can.
-      amount_text: "999999999999999999",
-      amount_decimals: 18,
+      amountText: "999999999999999999",
+      amountDecimals: 18,
       symbol: "WETH",
-      usd_est: null,
-    }];
+      usdEst: null,
+    }]);
 
     const outcome = await publish();
 
@@ -316,26 +503,42 @@ describe("a pending bridge fill at PUBLICATION time", () => {
     expect(outcome.ledger.inTransitUsd).toBe(0);
   });
 
-  it("an intent past its OWN expiry is unresolved even though it is young", async () => {
-    ledgerRows = [{
-      kind: "wallet_intent_live",
-      ref: "wi_1",
-      detail: "consuming",
-      since: agedBy(120),
-      expires_at: new Date(Date.now() - 1_000),
-      amount_text: "12.5",
-      amount_decimals: null,
-      symbol: "USDC",
-      usd_est: null,
-    }];
+  it("reads a NEGATIVE estimate as not priced, so it cannot reduce the published basis", async () => {
+    // A negative USD estimate is a bad price, not a liability, and
+    // it would render as a subtraction from the user's portfolio.
+    scriptLedger(
+      [{
+        kind: "agent_activity_pending",
+        ref: "neg-1",
+        detail: "swap",
+        standing: "in_transit",
+        ageSeconds: 60,
+        amountText: "1",
+        symbol: "USDC",
+        usdEst: "-500",
+      }],
+      [{ walletAddress: "0xAAA", entryCount: 1, unresolvedCount: 0, inTransitUsd: "0" }],
+    );
 
     const outcome = await publish();
 
     if (!outcome.published) throw new Error("unreachable");
-    // The CAS filters on `expires_at > NOW()`, so this can never be claimed:
-    // it is dead, not slow, and age would have called it in transit.
-    expect(outcome.ledger.entries[0]?.standing).toBe("unresolved");
-    expect(outcome.ledger.unresolvedCount).toBe(1);
+    expect(outcome.ledger.entries[0]?.usdEstimate).toBeNull();
+    expect(outcome.ledger.inTransitUsd).toBe(0);
+    expect(outcome.ledger.settledUsd).toBeCloseTo(200, 6);
+  });
+
+  it("refuses a negative per-wallet aggregate rather than subtracting it", async () => {
+    scriptLedger(
+      [bridgeFill(10 * 60, "in_transit")],
+      [{ walletAddress: "0xAAA", entryCount: 1, unresolvedCount: 0, inTransitUsd: "-42" }],
+    );
+
+    const outcome = await publish();
+
+    if (!outcome.published) throw new Error("unreachable");
+    expect(outcome.ledger.perWallet[0]?.inTransitUsd).toBe(0);
+    expect(outcome.ledger.inTransitUsd).toBe(0);
   });
 
   it("publishes an EMPTY ledger when nothing is in flight", async () => {
@@ -343,9 +546,14 @@ describe("a pending bridge fill at PUBLICATION time", () => {
 
     if (!outcome.published) throw new Error("unreachable");
     expect(outcome.ledger.entries).toEqual([]);
+    expect(outcome.ledger.perWallet).toEqual([]);
     expect(outcome.ledger.inTransitUsd).toBe(0);
     expect(outcome.ledger.unresolvedCount).toBe(0);
+    expect(outcome.ledger.totalCount).toBe(0);
     expect(outcome.ledger.truncated).toBe(false);
+    // An empty JSON array, not a skipped statement: absence of rows is a fact
+    // the group records, not a hole.
+    expect(JSON.parse(String(groupWalletStatement()?.params?.[1]))).toEqual([]);
   });
 });
 
@@ -517,7 +725,7 @@ describe("the transition fence", () => {
     // writers touch no status and insert nothing, so every component of the
     // new fence is identical across the touch.
     fenceInTx = { max_id: "7", row_count: "3", pending_count: "1", confirmed_count: "2" };
-    ledgerRows = [bridgeFill(31 * 24 * 3600)];
+    scriptLedger([bridgeFill(31 * 24 * 3600, "unresolved")]);
 
     const outcome = await publish();
 
@@ -631,7 +839,7 @@ describe("whole group or none", () => {
 
 describe("the published-group report", () => {
   it("names the settled and in-transit halves and the unresolved count", async () => {
-    ledgerRows = [bridgeFill(10 * 60)];
+    scriptLedger([bridgeFill(10 * 60, "in_transit")]);
 
     logPublicationOutcome(await publish(), "group-1");
 
@@ -643,6 +851,8 @@ describe("the published-group report", () => {
         settledUsd: "200.00",
         inTransitUsd: "150.25",
         inFlightCount: 1,
+        inFlightShown: 1,
+        walletsWithMoneyInFlight: 1,
         unresolvedCount: 0,
       }),
     );

--- a/src/vex-agent/db/migrations/102_portfolio_snapshot_group_wallets.sql
+++ b/src/vex-agent/db/migrations/102_portfolio_snapshot_group_wallets.sql
@@ -1,0 +1,153 @@
+-- 102_portfolio_snapshot_group_wallets.sql - in-flight money is attributed PER
+-- WALLET, and the group's totals stop being a group-wide figure a subset read
+-- can inherit.
+--
+-- THE DEFECT THIS CLOSES (external review, 2026-09-04). Migration 101 records
+-- ONE in-transit total and ONE ledger for the whole inventory the sync cycle
+-- scanned. `vex-app/src/main/database/portfolio-db.ts` then attaches that whole
+-- figure to whatever address SUBSET the reader asked about. So: wallet B has a
+-- pending bridge, the user opens a project or session scoped to wallet A only,
+-- and B's in-transit amount is added to A's portfolio. The money is real, the
+-- attribution is not, and the number the user reads is a wallet's balance plus
+-- a stranger's bridge.
+--
+-- The reference is MetaMask's `bridge-status-controller`
+-- (`agents-colab/metamask-core/packages/bridge-status-controller`): its history
+-- item is written with `account: selectedAddress` at creation
+-- (`utils/history.ts` `getInitialHistoryItem`) and every scoped operation
+-- filters on `bridgeHistoryItem.account === address`, so one account's pending
+-- item can never be counted into another's. This table is that same idea in
+-- durable form.
+--
+-- WHY A CHILD TABLE AND NOT JSONB ON THE GROUP ROW. The reader's question is
+-- "sum the in-flight components of THESE wallets", which is a keyed aggregate.
+-- A child table answers it with `SUM(...) WHERE wallet_address = ANY($1)`,
+-- carries a CHECK on every component of every wallet, gets referential
+-- integrity from a real foreign key, and stays readable in psql during an
+-- incident. Per-wallet JSONB on the group row would need path extraction per
+-- key in every reader, could not be constrained per element, and would make the
+-- money columns invisible to the constraint system - on a money path that is
+-- the wrong trade for saving one table.
+--
+-- COLUMNS.
+--   snapshot_group_id  the group, cascading from `proj_portfolio_snapshot_groups`.
+--   wallet_address     the raw stored address, exactly as `proj_balances` and
+--                      `proj_portfolio_snapshots` hold it. NEVER lowercased:
+--                      the engine stores checksum/base58 forms and every join
+--                      in this schema is on the raw string.
+--   entry_count        every in-flight row this wallet had at publication,
+--                      whether or not it fitted the group's bounded ledger.
+--   unresolved_count   those whose kind's bound had passed. In NO total.
+--   in_transit_usd     sum of the USD ESTIMATES of this wallet's `in_transit`
+--                      rows. An estimate, never a settlement figure.
+--
+-- A WALLET WITH NOTHING IN FLIGHT HAS NO ROW. Absent means zero, which is also
+-- what a group written before this migration reports, so the reader needs no
+-- version branch and no backfill exists to write: pre-102 groups carry no
+-- attribution at all (their ledger entries predate the `walletAddress` field),
+-- and inventing one would be fabricating money-path data. They read as in
+-- transit 0 / unresolved 0, exactly as migration 101 already specified for
+-- groups written before IT. Snapshot groups are published every sync cycle, so
+-- the two most recent groups - the only ones the PnL basis reads - carry
+-- attribution within one cycle of this migration applying.
+--
+-- ALSO IN THIS MIGRATION, on `proj_portfolio_snapshot_groups`:
+--
+--   in_flight_total_count  the number of in-flight rows the ledger FOUND. The
+--                          `in_flight` array is bounded at 50 entries; this is
+--                          not. A reader compares the two to know whether it
+--                          holds the whole list. Without it the bound silently
+--                          removes rows from a report that claims to be
+--                          complete, which the repository's no-silent-cutting
+--                          decree forbids. DEFAULT 0 so existing rows stay
+--                          readable: a pre-102 group reports 0 found, which
+--                          beside its stored array reads as "not truncated" -
+--                          the same answer that group has always given.
+--
+--   the non-negative CHECK on in_transit_usd. A negative in-transit total is
+--   not a liability, it is a bad price estimate, and the reader would render it
+--   as a SUBTRACTION from the user's portfolio. The writer now maps a negative
+--   estimate to "not priced" (`sync/balance-sync/publication-gate.ts`), and
+--   this constraint is the durable floor under that decision.
+--
+--   REPAIR before the constraint: any existing row with a negative
+--   `in_transit_usd` is set to 0. It is idempotent, bounded to one column of
+--   one table, and it corrects a value that was never meaningful; without it a
+--   single such row would abort this migration and block application boot.
+--   `settled_usd` - the measured half - is never touched.
+--
+-- ROLLBACK CONTRACT.
+--   DROP TABLE IF EXISTS proj_portfolio_snapshot_group_wallets;
+--   ALTER TABLE proj_portfolio_snapshot_groups
+--     DROP CONSTRAINT IF EXISTS proj_portfolio_snapshot_groups_in_transit_usd_check,
+--     DROP COLUMN IF EXISTS in_flight_total_count;
+-- No data repair and no reader/writer ordering requirement: nothing references
+-- the child table, the dropped column has a default, and a reader that predates
+-- this migration never looked at either. The only loss is per-wallet
+-- attribution for groups taken while it existed; every settled row survives
+-- untouched. The clamped negative estimates are NOT restorable, which is the
+-- accepted cost of the repair above.
+--
+-- EXPAND-ONLY and readable by old code: nothing existing is altered in meaning
+-- or dropped, and `proj_portfolio_snapshot_groups` keeps every column it had.
+-- Forward-only and idempotent via IF NOT EXISTS, per the runner's contract
+-- (`src/lib/db/migrate-runner.ts` applies every file whose numeric prefix is
+-- above `MAX(schema_version.version)`, each inside its own transaction).
+
+CREATE TABLE IF NOT EXISTS proj_portfolio_snapshot_group_wallets (
+  snapshot_group_id  UUID    NOT NULL
+    REFERENCES proj_portfolio_snapshot_groups(snapshot_group_id) ON DELETE CASCADE,
+  wallet_address     TEXT    NOT NULL,
+  entry_count        INTEGER NOT NULL,
+  unresolved_count   INTEGER NOT NULL,
+  in_transit_usd     NUMERIC NOT NULL,
+  PRIMARY KEY (snapshot_group_id, wallet_address),
+  CONSTRAINT proj_portfolio_snapshot_group_wallets_entry_count_check
+    CHECK (entry_count >= 0),
+  CONSTRAINT proj_portfolio_snapshot_group_wallets_unresolved_count_check
+    CHECK (unresolved_count >= 0),
+  -- Per wallet: money in transit is money, and money in transit is
+  -- never negative. A wallet's component cannot subtract from a scoped read.
+  CONSTRAINT proj_portfolio_snapshot_group_wallets_in_transit_usd_check
+    CHECK (in_transit_usd >= 0),
+  -- Counted rows cannot exceed the rows that exist.
+  CONSTRAINT proj_portfolio_snapshot_group_wallets_unresolved_within_entries
+    CHECK (unresolved_count <= entry_count)
+);
+
+-- Every scoped read filters wallets first and then aggregates, so the address
+-- is the leading predicate and the primary key (group, address) cannot serve
+-- it.
+CREATE INDEX IF NOT EXISTS proj_portfolio_snapshot_group_wallets_wallet_idx
+  ON proj_portfolio_snapshot_group_wallets (wallet_address, snapshot_group_id);
+
+ALTER TABLE proj_portfolio_snapshot_groups
+  ADD COLUMN IF NOT EXISTS in_flight_total_count INTEGER NOT NULL DEFAULT 0;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'proj_portfolio_snapshot_groups_in_flight_total_count_check'
+  ) THEN
+    ALTER TABLE proj_portfolio_snapshot_groups
+      ADD CONSTRAINT proj_portfolio_snapshot_groups_in_flight_total_count_check
+      CHECK (in_flight_total_count >= 0);
+  END IF;
+END $$;
+
+-- The repair described in the header, before the constraint that would
+-- otherwise refuse the row and abort the migration.
+UPDATE proj_portfolio_snapshot_groups
+   SET in_transit_usd = 0
+ WHERE in_transit_usd < 0;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'proj_portfolio_snapshot_groups_in_transit_usd_check'
+  ) THEN
+    ALTER TABLE proj_portfolio_snapshot_groups
+      ADD CONSTRAINT proj_portfolio_snapshot_groups_in_transit_usd_check
+      CHECK (in_transit_usd >= 0);
+  END IF;
+END $$;

--- a/src/vex-agent/sync/balance-sync.ts
+++ b/src/vex-agent/sync/balance-sync.ts
@@ -577,6 +577,11 @@ async function runFullBalanceSync(): Promise<FullSyncResult> {
     snapshotSkippedReason: outcome.published ? null : outcome.reason,
     inTransitUsd: outcome.published ? outcome.ledger.inTransitUsd.toFixed(2) : null,
     unresolvedCount: outcome.published ? outcome.ledger.unresolvedCount : null,
+    // The rows the ledger FOUND, not the rows it displays: the list is bounded
+    // at 50 and the totals above are not, so a cycle log that reported only the
+    // list would understate the money the group accounted for.
+    inFlightCount: outcome.published ? outcome.ledger.totalCount : null,
+    inFlightTruncated: outcome.published ? outcome.ledger.truncated : null,
     totalUsd: aggregateTotalUsd.toFixed(2),
     snapshotGroupId,
   });

--- a/src/vex-agent/sync/balance-sync/activity-fence.ts
+++ b/src/vex-agent/sync/balance-sync/activity-fence.ts
@@ -1,0 +1,107 @@
+/**
+ * The ACTIVITY TRANSITION FENCE: proof that no money moved while the balance
+ * scan ran.
+ *
+ * Split out of `./publication-gate.ts` (2026-09-04) because it answers a
+ * different question at a different point in the lifecycle. The in-flight
+ * ledger asks "what is this cycle's money currently inside", once, under the
+ * publication lock. The fence is stamped at CYCLE START by
+ * `../balance-sync.ts`, minutes before the transaction exists, and compared
+ * again inside it. Two owners, two clocks, one reason to change each.
+ *
+ * `publication-gate.ts` re-exports this module's three symbols, so every
+ * existing consumer keeps its import unchanged.
+ *
+ * A transaction that BEGINS and SETTLES entirely inside the multi-wallet scan
+ * leaves nothing in flight at publication time, yet the wallets scanned before
+ * it and after it were read on opposite sides of a money movement. See
+ * `FENCE_SQL` for why the fence is keyed on MONEY and no longer on
+ * `updated_at`.
+ */
+
+import type { Executor } from "@vex-agent/db/client.js";
+
+/**
+ * The activity table's MONEY generation for one wallet set. Compared by VALUE,
+ * so every component is read back as a stable string rather than a
+ * driver-typed `Date`/`BigInt` whose equality depends on the pg type parser.
+ */
+export interface ActivityFence {
+  readonly maxId: string;
+  readonly rowCount: string;
+  readonly pendingCount: string;
+  readonly confirmedCount: string;
+}
+
+interface FenceRow {
+  max_id: string;
+  row_count: string;
+  pending_count: string;
+  confirmed_count: string;
+}
+
+/**
+ * WHY THESE FOUR COLUMNS, AND WHY `MAX(updated_at)` IS GONE.
+ *
+ * The fence must move when MONEY moves during the scan and stay still when
+ * bookkeeping touches a row. `MAX(updated_at)` failed the second half: every
+ * bridge sweep attempt stamps `updated_at = NOW()` on a still-pending row - the
+ * candidate claim (`bridge-activity-repair-production-deps.ts`), `touchLastChecked`
+ * and `clearVerificationStall` (`db/repos/agent-activity/swap-lifecycle/
+ * verification-bookkeeping.ts`) all do, and the sweep runs every five minutes
+ * forever on an old row. That is a pure re-check of something we already knew,
+ * and it was tripping `activity_transition` on cycles where nothing moved.
+ *
+ * Those same three writers set ONLY `updated_at`, `last_attempted_at`,
+ * `last_checked_at`, `verification_attempts`, `last_verification_*` and
+ * `provider_status`; every one of them is fenced with `WHERE ... status =
+ * 'pending'` and none inserts, deletes or writes `status`. So all four
+ * components below are invariant under a sweep touch, by construction rather
+ * than by hope.
+ *
+ * What each component catches:
+ *   max_id           a row INSERTED during the scan (a broadcast).
+ *   row_count        an insert or a delete.
+ *   pending_count    any transition INTO or OUT OF the in-flight state -
+ *                    which is what a settlement is.
+ *   confirmed_count  a confirmation specifically, so a settle-and-broadcast
+ *                    pair inside one scan (pending_count unchanged) is caught.
+ *
+ * The one status change invisible here is `definitively_failed` <->
+ * `superseded_unproven`: a relabelling of an already-dead row, where no balance
+ * moves and nothing enters or leaves flight. `status` has exactly four values
+ * (migration 078), so that is the complete gap.
+ */
+const FENCE_SQL = `
+  SELECT COALESCE(MAX(id), 0)::text                                  AS max_id,
+         COUNT(*)::text                                              AS row_count,
+         COUNT(*) FILTER (WHERE status = 'pending')::text            AS pending_count,
+         COUNT(*) FILTER (WHERE status = 'confirmed')::text          AS confirmed_count
+    FROM agent_activity
+   WHERE wallet_address = ANY($1::text[])`;
+
+/**
+ * Stamp the activity generation for `walletAddresses`. Call this BEFORE the
+ * scan starts; the same value is handed to the publisher so the gate can prove
+ * no money moved in between.
+ */
+export async function readActivityFence(
+  executor: Executor,
+  walletAddresses: readonly string[],
+): Promise<ActivityFence> {
+  const res = await executor.query<FenceRow>(FENCE_SQL, [[...walletAddresses]]);
+  const row = res.rows[0];
+  return {
+    maxId: row?.max_id ?? "0",
+    rowCount: row?.row_count ?? "0",
+    pendingCount: row?.pending_count ?? "0",
+    confirmedCount: row?.confirmed_count ?? "0",
+  };
+}
+
+export function fencesMatch(a: ActivityFence, b: ActivityFence): boolean {
+  return a.maxId === b.maxId
+    && a.rowCount === b.rowCount
+    && a.pendingCount === b.pendingCount
+    && a.confirmedCount === b.confirmedCount;
+}

--- a/src/vex-agent/sync/balance-sync/publication-gate.ts
+++ b/src/vex-agent/sync/balance-sync/publication-gate.ts
@@ -57,8 +57,9 @@
  * `readActivityFence` closes the second race: a transaction that BEGINS and
  * SETTLES entirely inside the multi-wallet scan leaves nothing in flight at
  * publication time, yet the wallets scanned before it and after it were read on
- * opposite sides of a money movement. See `FENCE_SQL` for why the fence is
- * keyed on MONEY and no longer on `updated_at`.
+ * opposite sides of a money movement. It is stamped at cycle start rather than
+ * here, so it lives in `./activity-fence.ts` and is re-exported below; see that
+ * module for why the fence is keyed on MONEY and no longer on `updated_at`.
  *
  * ## Known scope limit
  *
@@ -73,25 +74,47 @@ import { formatUnits } from "viem";
 import type { Executor } from "@vex-agent/db/client.js";
 
 /**
- * Bounded: the ledger is a named list a human reads, and it is persisted into
- * the group record, so it cannot be allowed to grow with the money path. More
- * rows than this is reported (`InFlightLedger.truncated`), never dropped
- * silently.
+ * Bounded: the DISPLAYED ledger is a named list a human reads, and it is
+ * persisted into the group record, so it cannot be allowed to grow with the
+ * money path.
+ *
+ * It bounds the LIST and nothing else. Every total and every count this module
+ * reports is aggregated by the SERVER over EVERY matching row, so a wallet with
+ * 400 in-flight rows still contributes all 400 to its own totals while the list
+ * shows the 50 oldest and says so (`InFlightLedger.totalCount` against
+ * `entries.length`, and `truncated`). A bound that also bounded the totals
+ * would silently remove money from the portfolio, which the repository's
+ * no-silent-cutting decree forbids.
  */
 const MAX_IN_FLIGHT = 50;
 
 const MINUTE_SECONDS = 60;
 const HOUR_SECONDS = 60 * MINUTE_SECONDS;
 
-/** One thing this cycle's money is currently inside. */
-export type InFlightKind =
-  | "agent_activity_pending"
-  | "wallet_intent_live"
-  | "wallet_confirmation_unknown"
-  | "wallet_transaction_intent_live"
-  | "wallet_transaction_confirmation_unknown"
-  | "wallet_wrap_intent_live"
-  | "wallet_wrap_confirmation_unknown";
+/**
+ * One thing this cycle's money is currently inside.
+ *
+ * DUPLICATED, deliberately, by `vex-app/src/shared/schemas/portfolio.ts`'s
+ * `snapshotInFlightKindDtoSchema`. The engine tree (`src/`) and the desktop
+ * app's `shared` tree cannot import each other: `shared` bundles into the
+ * untrusted renderer and the process-boundary gate forbids `@vex-agent` there
+ * (rule 90), while the root project's `rootDir` is `src`, so it cannot reach
+ * into `vex-app`. `vex-app/src/shared/engine-error-classification.ts` carries
+ * the same duplication for the same reason. The two lists are pinned against
+ * each other by `vex-app/src/main/database/__tests__/portfolio-snapshot-basis.test.ts`,
+ * which runs in the main process and CAN see both.
+ */
+export const IN_FLIGHT_KINDS = [
+  "agent_activity_pending",
+  "wallet_intent_live",
+  "wallet_confirmation_unknown",
+  "wallet_transaction_intent_live",
+  "wallet_transaction_confirmation_unknown",
+  "wallet_wrap_intent_live",
+  "wallet_wrap_confirmation_unknown",
+] as const;
+
+export type InFlightKind = (typeof IN_FLIGHT_KINDS)[number];
 
 /**
  * - `in_transit`  - inside the bound for its kind. Counted in the group's
@@ -106,6 +129,18 @@ export type InFlightStanding = "in_transit" | "unresolved";
 /** One row of the group's in-flight ledger. */
 export interface InFlightEntry {
   readonly kind: InFlightKind;
+  /**
+   * The wallet this money belongs to, carried on EVERY entry so a portfolio
+   * read for a SUBSET of the group's wallets can drop what is not its own.
+   *
+   * Adopted from MetaMask's `bridge-status-controller`: its history item is
+   * written with `account: selectedAddress` at creation
+   * (`utils/history.ts` `getInitialHistoryItem`) and every scoped operation
+   * filters on `bridgeHistoryItem.account === address`
+   * (`bridge-status-controller.ts` `#wipeBridgeStatusByChainId`), so one
+   * account's pending item can never be attributed to another's.
+   */
+  readonly walletAddress: string;
   /** Identifier of the row, for audit and operator diagnosis. */
   readonly ref: string;
   /** Structural label only (a status or an event role) - never provider text. */
@@ -124,12 +159,35 @@ export interface InFlightEntry {
   readonly usdEstimate: number | null;
 }
 
-export interface InFlightLedger {
-  readonly entries: readonly InFlightEntry[];
+/**
+ * One wallet's in-flight accounting, aggregated by the SERVER over EVERY row
+ * that belongs to it - never over the bounded display list.
+ */
+export interface WalletInFlightTotals {
+  readonly walletAddress: string;
+  /** Every in-flight row for this wallet, whether or not it is displayed. */
+  readonly entryCount: number;
+  /** Rows whose kind's bound has passed. In NO total, in either direction. */
+  readonly unresolvedCount: number;
   /**
-   * More than `MAX_IN_FLIGHT` rows existed; the OLDEST were kept. Reported so
-   * a consumer knows rows are missing rather than being told a short list is
-   * the whole truth.
+   * Sum of the USD ESTIMATES of this wallet's `in_transit` rows. Estimates
+   * only, never negative (a negative estimate is read as "not priced"), and 0
+   * when nothing is in flight or nothing carries a price.
+   */
+  readonly inTransitUsd: number;
+}
+
+export interface InFlightLedger {
+  /** The bounded DISPLAY list: the `MAX_IN_FLIGHT` oldest rows, all wallets. */
+  readonly entries: readonly InFlightEntry[];
+  /** Per-wallet aggregates over ALL rows. Absent wallet means nothing in flight. */
+  readonly perWallet: readonly WalletInFlightTotals[];
+  /** Every in-flight row across every requested wallet, displayed or not. */
+  readonly totalCount: number;
+  /**
+   * `totalCount` exceeded `MAX_IN_FLIGHT`; the OLDEST were kept in `entries`.
+   * Reported so a consumer knows rows are missing rather than being told a
+   * short list is the whole truth. The TOTALS are unaffected.
    */
   readonly truncated: boolean;
 }
@@ -234,108 +292,81 @@ export function boundFor(kind: InFlightKind, detail: string | null): StandingBou
   return override ?? entry.bound;
 }
 
-function standingFor(
-  kind: InFlightKind,
-  detail: string | null,
-  ageSeconds: number,
-  secondsUntilExpiry: number | null,
-): InFlightStanding {
-  const bound = boundFor(kind, detail);
-  if (bound.rule === "own-expiry") {
-    if (secondsUntilExpiry === null) {
-      return ageSeconds <= bound.fallbackMaxAgeSeconds ? "in_transit" : "unresolved";
-    }
-    return secondsUntilExpiry > 0 ? "in_transit" : "unresolved";
-  }
-  return ageSeconds <= bound.maxAgeSeconds ? "in_transit" : "unresolved";
+/**
+ * THE ONE DOCUMENTED EXCEPTION to "every in-flight row is listed and
+ * classified" (owner decision 2026-09-04, after the review finding that expired
+ * pending intents disappear from the ledger).
+ *
+ * A `pending` wallet / transaction / wrap intent that is past its own
+ * `expires_at` and carries NO transaction hash is NOT listed at all - not as
+ * `in_transit`, not as `unresolved`. It is not money in flight and never was:
+ *
+ *   - a `pending` row is a PROPOSAL the user has not spent. The consuming CAS
+ *     (`consumeIfPending` and its siblings) filters on `expires_at > NOW()`, so
+ *     past that instant the proposal can never be claimed;
+ *   - `tx_hash IS NULL` proves nothing was ever broadcast, so no balance moved
+ *     and there is no outcome for anyone to prove.
+ *
+ * Listing it as `unresolved` would tell a human that money is unaccounted for
+ * when in fact none ever left. The moment a row DOES carry a hash it is caught
+ * by its table's `*_confirmation_unknown` (or `*_intent_live`) branch, which
+ * has NO expiry predicate at all: expiry bounds the APPROVAL, and the approval
+ * stopped being the relevant clock the moment the transaction left. The
+ * integration suite pins both halves as a table over the three intent tables.
+ *
+ * This is a predicate of `IN_FLIGHT_SQL` (the `expires_at > NOW()` conjunct on
+ * each `pending` branch), not of `STANDING_BOUNDS`: a row that is excluded has
+ * no standing to compute.
+ */
+
+/**
+ * The bound table as the SERVER sees it: one row per (kind, detail), with
+ * `detail = null` meaning "the kind's default". Built ONCE from
+ * `STANDING_BOUNDS` above, which stays the single owner of the DATA; the SQL
+ * `CASE` in `LEDGER_CTE` is the single owner of the RULE.
+ *
+ * Standing moved into SQL because the totals must be aggregated over EVERY
+ * row, not over the bounded display list, and an aggregate cannot ask
+ * TypeScript how to classify a row it never returns.
+ */
+interface StandingBoundRow {
+  readonly kind: InFlightKind;
+  readonly detail: string | null;
+  readonly rule: StandingBound["rule"];
+  readonly seconds: number;
 }
+
+function secondsOf(bound: StandingBound): number {
+  return bound.rule === "max-age" ? bound.maxAgeSeconds : bound.fallbackMaxAgeSeconds;
+}
+
+function standingBoundRows(): readonly StandingBoundRow[] {
+  const rows: StandingBoundRow[] = [];
+  for (const kind of IN_FLIGHT_KINDS) {
+    const entry = STANDING_BOUNDS[kind];
+    rows.push({ kind, detail: null, rule: entry.bound.rule, seconds: secondsOf(entry.bound) });
+    for (const [detail, bound] of Object.entries(entry.byDetail ?? {})) {
+      rows.push({ kind, detail, rule: bound.rule, seconds: secondsOf(bound) });
+    }
+  }
+  return rows;
+}
+
+const STANDING_BOUND_ROWS_JSON = JSON.stringify(standingBoundRows());
 
 // ── The transition fence ─────────────────────────────────────────────────
 
 /**
- * The activity table's MONEY generation for one wallet set. Compared by VALUE,
- * so every component is read back as a stable string rather than a
- * driver-typed `Date`/`BigInt` whose equality depends on the pg type parser.
+ * The fence lives in `./activity-fence.ts`: it is stamped at cycle start, long
+ * before this module's transaction exists, and it answers a different question
+ * (did money MOVE) from the ledger below (what money IS in flight). Re-exported
+ * here so every consumer of the publication gate keeps one import.
  */
-export interface ActivityFence {
-  readonly maxId: string;
-  readonly rowCount: string;
-  readonly pendingCount: string;
-  readonly confirmedCount: string;
-}
-
-interface FenceRow {
-  max_id: string;
-  row_count: string;
-  pending_count: string;
-  confirmed_count: string;
-}
-
-/**
- * WHY THESE FOUR COLUMNS, AND WHY `MAX(updated_at)` IS GONE.
- *
- * The fence must move when MONEY moves during the scan and stay still when
- * bookkeeping touches a row. `MAX(updated_at)` failed the second half: every
- * bridge sweep attempt stamps `updated_at = NOW()` on a still-pending row - the
- * candidate claim (`bridge-activity-repair-production-deps.ts`), `touchLastChecked`
- * and `clearVerificationStall` (`db/repos/agent-activity/swap-lifecycle/
- * verification-bookkeeping.ts`) all do, and the sweep runs every five minutes
- * forever on an old row. That is a pure re-check of something we already knew,
- * and it was tripping `activity_transition` on cycles where nothing moved.
- *
- * Those same three writers set ONLY `updated_at`, `last_attempted_at`,
- * `last_checked_at`, `verification_attempts`, `last_verification_*` and
- * `provider_status`; every one of them is fenced with `WHERE ... status =
- * 'pending'` and none inserts, deletes or writes `status`. So all four
- * components below are invariant under a sweep touch, by construction rather
- * than by hope.
- *
- * What each component catches:
- *   max_id           a row INSERTED during the scan (a broadcast).
- *   row_count        an insert or a delete.
- *   pending_count    any transition INTO or OUT OF the in-flight state -
- *                    which is what a settlement is.
- *   confirmed_count  a confirmation specifically, so a settle-and-broadcast
- *                    pair inside one scan (pending_count unchanged) is caught.
- *
- * The one status change invisible here is `definitively_failed` <->
- * `superseded_unproven`: a relabelling of an already-dead row, where no balance
- * moves and nothing enters or leaves flight. `status` has exactly four values
- * (migration 078), so that is the complete gap.
- */
-const FENCE_SQL = `
-  SELECT COALESCE(MAX(id), 0)::text                                  AS max_id,
-         COUNT(*)::text                                              AS row_count,
-         COUNT(*) FILTER (WHERE status = 'pending')::text            AS pending_count,
-         COUNT(*) FILTER (WHERE status = 'confirmed')::text          AS confirmed_count
-    FROM agent_activity
-   WHERE wallet_address = ANY($1::text[])`;
-
-/**
- * Stamp the activity generation for `walletAddresses`. Call this BEFORE the
- * scan starts; the same value is handed to the publisher so the gate can prove
- * no money moved in between.
- */
-export async function readActivityFence(
-  executor: Executor,
-  walletAddresses: readonly string[],
-): Promise<ActivityFence> {
-  const res = await executor.query<FenceRow>(FENCE_SQL, [[...walletAddresses]]);
-  const row = res.rows[0];
-  return {
-    maxId: row?.max_id ?? "0",
-    rowCount: row?.row_count ?? "0",
-    pendingCount: row?.pending_count ?? "0",
-    confirmedCount: row?.confirmed_count ?? "0",
-  };
-}
-
-export function fencesMatch(a: ActivityFence, b: ActivityFence): boolean {
-  return a.maxId === b.maxId
-    && a.rowCount === b.rowCount
-    && a.pendingCount === b.pendingCount
-    && a.confirmedCount === b.confirmedCount;
-}
+export {
+  readActivityFence,
+  fencesMatch,
+  type ActivityFence,
+} from "./activity-fence.js";
 
 // ── The ledger query ─────────────────────────────────────────────────────
 
@@ -344,7 +375,7 @@ export function fencesMatch(a: ActivityFence, b: ActivityFence): boolean {
  * reading of the correspondingly named predicate in
  * `db/repos/approval-intents/money-state.ts`; which rows count as live is that
  * module's decision, deliberately not re-derived here. What is NEW is that each
- * branch also carries WHAT the money is.
+ * branch also carries WHAT the money is and WHOSE it is.
  *
  *  1. `agent_activity` PENDING - a broadcast awaiting confirmation. For a
  *     `bridge_fill_expected` row the money in transit is the EXPECTED OUTPUT
@@ -352,10 +383,12 @@ export function fencesMatch(a: ActivityFence, b: ActivityFence): boolean {
  *     already left the wallet and the balance read no longer contains it. For
  *     every other role the input leg is the amount in transit.
  *  2. `wallet_intents` `consuming`, or `pending` that has NOT expired. `amount`
- *     is the human quantity the user approved and `token` its symbol.
+ *     is the human quantity the user approved and `token` its symbol. The
+ *     expiry conjunct is the documented exception above, not an oversight.
  *  3. `wallet_intents` hash-carrying rows in a state that does not prove an
  *     outcome. A legacy `failed`-with-hash row releases ONLY when its linked
- *     activity proves a mined revert.
+ *     activity proves a mined revert. NO expiry predicate: a broadcast row is
+ *     never dropped because its approval window lapsed.
  *  4/5. `wallet_transaction_intents` (migration 087) - a GENERIC calldata
  *     proposal, so the table carries no amount or asset at all and the ledger
  *     honestly reports nulls rather than inventing a figure from the payload.
@@ -363,12 +396,16 @@ export function fencesMatch(a: ActivityFence, b: ActivityFence): boolean {
  *     (`amount_raw`) with `wrapped_native_decimals`; the conversion happens in
  *     TypeScript through viem's `formatUnits`, never in floating-point SQL.
  *
- * `expires_at` is selected wherever the table has it; `STANDING_BOUNDS` alone
+ * EVERY branch selects `wallet_address`. The predicate already filters on it,
+ * so attribution costs nothing and is exact - and without it a portfolio read
+ * for one wallet inherits another wallet's pending bridge, which is the defect
+ * this column exists to close.
+ *
+ * `expires_at` is selected wherever the table has it; the bound table alone
  * decides whether the standing rule uses it.
  */
-const IN_FLIGHT_SQL = `
-  SELECT * FROM (
-  SELECT 'agent_activity_pending'::text AS kind, a.id::text AS ref,
+const LEDGER_BRANCHES_SQL = `
+  SELECT 'agent_activity_pending'::text AS kind, a.wallet_address, a.id::text AS ref,
          a.event_role::text AS detail, a.created_at AS since,
          NULL::timestamptz AS expires_at,
          CASE WHEN a.event_role = 'bridge_fill_expected'
@@ -383,7 +420,7 @@ const IN_FLIGHT_SQL = `
 
    UNION ALL
 
-  SELECT 'wallet_intent_live', w.intent_id::text, w.status::text, w.created_at,
+  SELECT 'wallet_intent_live', w.wallet_address, w.intent_id::text, w.status::text, w.created_at,
          w.expires_at, w.amount, NULL::smallint, w.token, NULL::numeric
     FROM wallet_intents w
    WHERE w.wallet_address = ANY($1::text[])
@@ -391,7 +428,7 @@ const IN_FLIGHT_SQL = `
 
    UNION ALL
 
-  SELECT 'wallet_confirmation_unknown', w.intent_id::text, w.status::text, w.created_at,
+  SELECT 'wallet_confirmation_unknown', w.wallet_address, w.intent_id::text, w.status::text, w.created_at,
          w.expires_at, w.amount, NULL::smallint, w.token, NULL::numeric
     FROM wallet_intents w
    WHERE w.wallet_address = ANY($1::text[])
@@ -414,7 +451,7 @@ const IN_FLIGHT_SQL = `
 
    UNION ALL
 
-  SELECT 'wallet_transaction_intent_live', t.intent_id::text, t.status::text, t.created_at,
+  SELECT 'wallet_transaction_intent_live', t.wallet_address, t.intent_id::text, t.status::text, t.created_at,
          t.expires_at, NULL::text, NULL::smallint, NULL::text, NULL::numeric
     FROM wallet_transaction_intents t
    WHERE t.wallet_address = ANY($1::text[])
@@ -423,7 +460,7 @@ const IN_FLIGHT_SQL = `
 
    UNION ALL
 
-  SELECT 'wallet_transaction_confirmation_unknown', t.intent_id::text, t.status::text, t.created_at,
+  SELECT 'wallet_transaction_confirmation_unknown', t.wallet_address, t.intent_id::text, t.status::text, t.created_at,
          t.expires_at, NULL::text, NULL::smallint, NULL::text, NULL::numeric
     FROM wallet_transaction_intents t
    WHERE t.wallet_address = ANY($1::text[])
@@ -432,7 +469,7 @@ const IN_FLIGHT_SQL = `
 
    UNION ALL
 
-  SELECT 'wallet_wrap_intent_live', w2.intent_id::text, w2.status::text, w2.created_at,
+  SELECT 'wallet_wrap_intent_live', w2.wallet_address, w2.intent_id::text, w2.status::text, w2.created_at,
          w2.expires_at, w2.amount_raw, w2.wrapped_native_decimals,
          w2.wrapped_native_symbol, NULL::numeric
     FROM wallet_wrap_intents w2
@@ -442,7 +479,7 @@ const IN_FLIGHT_SQL = `
 
    UNION ALL
 
-  SELECT 'wallet_wrap_confirmation_unknown', w2.intent_id::text, w2.status::text, w2.created_at,
+  SELECT 'wallet_wrap_confirmation_unknown', w2.wallet_address, w2.intent_id::text, w2.status::text, w2.created_at,
          w2.expires_at, w2.amount_raw, w2.wrapped_native_decimals,
          w2.wrapped_native_symbol, NULL::numeric
     FROM wallet_wrap_intents w2
@@ -450,22 +487,141 @@ const IN_FLIGHT_SQL = `
      AND w2.tx_hash IS NOT NULL
      AND w2.status NOT IN (
            'executed', 'failed', 'superseded_unproven', 'broadcast_unconfirmed', 'review_required'
-         )
-  ) ledger
-   ORDER BY since ASC, ref ASC
-   LIMIT $2`;
+         )`;
+
+/**
+ * The bound table, the age and the standing, evaluated by the SERVER over
+ * EVERY in-flight row.
+ *
+ *   `bounds`      `STANDING_BOUNDS` projected through `$3::jsonb`. The data
+ *                 still has exactly one owner in TypeScript; the server is
+ *                 handed a copy per call rather than a second table to
+ *                 maintain, so the two cannot drift.
+ *   `aged`        seconds since the row was created, floored at 0, against the
+ *                 caller's clock `$4` - the same instant used for every row in
+ *                 the group, and controllable by a test.
+ *   `classified`  the effective bound for the row (its `detail` override if the
+ *                 table has one, otherwise the kind's default), then the
+ *                 standing. `own-expiry` uses the row's own `expires_at`, and
+ *                 falls back to the kind's seconds only when that column is
+ *                 NULL - which the schema forbids on all three intent tables.
+ *
+ * A NEGATIVE `usd_est` is normalized to NULL here, ONCE, so the entry a human
+ * reads and the total it feeds can never disagree. A price feed that emits a
+ * negative estimate is reporting "unknown", and unknown must not subtract from
+ * a portfolio (review finding, 2026-09-04).
+ */
+const LEDGER_CTE_SQL = `
+  bounds AS (
+    SELECT * FROM jsonb_to_recordset($3::jsonb)
+      AS b(kind text, detail text, rule text, seconds bigint)
+  ),
+  ledger AS (
+${LEDGER_BRANCHES_SQL}
+  ),
+  aged AS (
+    SELECT l.*,
+           GREATEST(
+             0,
+             FLOOR(EXTRACT(EPOCH FROM ($4::timestamptz - COALESCE(l.since, $4::timestamptz))))
+           )::bigint AS age_seconds
+      FROM ledger l
+  ),
+  classified AS (
+    SELECT a.kind, a.wallet_address, a.ref, a.detail, a.since, a.age_seconds,
+           a.amount_text, a.amount_decimals, a.symbol,
+           CASE WHEN a.usd_est >= 0 THEN a.usd_est END AS usd_est,
+           CASE
+             WHEN eff.rule = 'own-expiry' AND a.expires_at IS NOT NULL
+               THEN CASE WHEN a.expires_at > $4::timestamptz
+                         THEN 'in_transit' ELSE 'unresolved' END
+             WHEN a.age_seconds <= eff.seconds THEN 'in_transit'
+             ELSE 'unresolved'
+           END AS standing
+      FROM aged a
+      JOIN LATERAL (
+        SELECT b.rule, b.seconds
+          FROM bounds b
+         WHERE b.kind = a.kind
+           AND (b.detail IS NULL OR b.detail = a.detail)
+         ORDER BY (b.detail IS NULL) ASC
+         LIMIT 1
+      ) eff ON TRUE
+  )`;
+
+/**
+ * ONE statement, two kinds of row, because they must agree.
+ *
+ * `agent_activity` is locked by the caller, but `wallet_intents`,
+ * `wallet_transaction_intents` and `wallet_wrap_intents` are not; under READ
+ * COMMITTED two separate statements would see two snapshots, and an aggregate
+ * that counted four rows beside a list that showed five would be a worse
+ * report than either. A single statement is one snapshot by construction.
+ *
+ *   `row_type = 'wallet'`  one per wallet with anything in flight: its counts
+ *                          and its in-transit total, over ALL of its rows.
+ *   `row_type = 'entry'`   the bounded display list, oldest first.
+ */
+const IN_FLIGHT_SQL = `
+  WITH ${LEDGER_CTE_SQL},
+  per_wallet AS (
+    SELECT c.wallet_address,
+           COUNT(*)                                                  AS entry_count,
+           COUNT(*) FILTER (WHERE c.standing = 'unresolved')         AS unresolved_count,
+           COALESCE(SUM(c.usd_est) FILTER (WHERE c.standing = 'in_transit'), 0) AS in_transit_usd
+      FROM classified c
+     GROUP BY c.wallet_address
+  ),
+  shown AS (
+    SELECT * FROM classified ORDER BY since ASC, ref ASC LIMIT $2
+  )
+  SELECT 0 AS sort_group, 'wallet'::text AS row_type, w.wallet_address,
+         w.entry_count::text      AS entry_count,
+         w.unresolved_count::text AS unresolved_count,
+         w.in_transit_usd::text   AS in_transit_usd,
+         NULL::text        AS kind,
+         NULL::text        AS ref,
+         NULL::text        AS detail,
+         NULL::text        AS standing,
+         NULL::bigint      AS age_seconds,
+         NULL::timestamptz AS since,
+         NULL::text        AS amount_text,
+         NULL::int         AS amount_decimals,
+         NULL::text        AS symbol,
+         NULL::numeric     AS usd_est
+    FROM per_wallet w
+   UNION ALL
+  SELECT 1, 'entry'::text, s.wallet_address,
+         NULL::text, NULL::text, NULL::text,
+         s.kind, s.ref, s.detail, s.standing, s.age_seconds, s.since,
+         s.amount_text, s.amount_decimals::int, s.symbol, s.usd_est
+    FROM shown s
+   ORDER BY sort_group ASC, since ASC NULLS FIRST, ref ASC, wallet_address ASC`;
 
 interface LedgerRow {
-  kind: InFlightKind;
-  ref: string;
+  row_type: string;
+  wallet_address: string;
+  entry_count: string | null;
+  unresolved_count: string | null;
+  in_transit_usd: string | null;
+  kind: string | null;
+  ref: string | null;
   detail: string | null;
+  standing: string | null;
   since: Date | string | null;
-  expires_at: Date | string | null;
+  age_seconds: string | number | null;
   amount_text: string | null;
   amount_decimals: number | string | null;
   symbol: string | null;
   usd_est: string | number | null;
 }
+
+const EMPTY_LEDGER: InFlightLedger = {
+  entries: [],
+  perWallet: [],
+  totalCount: 0,
+  truncated: false,
+};
 
 /**
  * Read everything this cycle's money is currently inside, INSIDE the caller's
@@ -473,42 +629,81 @@ interface LedgerRow {
  * outside that lock the answer is stale the instant it returns - hence the
  * required `Executor`.
  *
- * `MAX_IN_FLIGHT + 1` rows are requested so an overflow is DETECTED rather than
- * inferred; the extra row is dropped and `truncated` says so.
+ * The DISPLAY list is bounded at `MAX_IN_FLIGHT`. The per-wallet totals are
+ * not: they are aggregated by the server over every matching row, so bounding
+ * the list can never remove money from a total. `truncated` compares the two.
  */
 export async function readInFlightMoney(
   executor: Executor,
   walletAddresses: readonly string[],
   now: number = Date.now(),
 ): Promise<InFlightLedger> {
-  if (walletAddresses.length === 0) return { entries: [], truncated: false };
+  if (walletAddresses.length === 0) return EMPTY_LEDGER;
   const res = await executor.query<LedgerRow>(IN_FLIGHT_SQL, [
     [...walletAddresses],
-    MAX_IN_FLIGHT + 1,
+    MAX_IN_FLIGHT,
+    STANDING_BOUND_ROWS_JSON,
+    new Date(now).toISOString(),
   ]);
-  const truncated = res.rows.length > MAX_IN_FLIGHT;
-  const kept = truncated ? res.rows.slice(0, MAX_IN_FLIGHT) : res.rows;
+
+  const entries: InFlightEntry[] = [];
+  const perWallet: WalletInFlightTotals[] = [];
+  let totalCount = 0;
+  for (const row of res.rows) {
+    if (row.row_type === "wallet") {
+      const totals = toWalletTotals(row);
+      perWallet.push(totals);
+      totalCount += totals.entryCount;
+      continue;
+    }
+    entries.push(toEntry(row));
+  }
+  return { entries, perWallet, totalCount, truncated: totalCount > entries.length };
+}
+
+function toWalletTotals(row: LedgerRow): WalletInFlightTotals {
   return {
-    entries: kept.map((row) => toEntry(row, now)),
-    truncated,
+    walletAddress: row.wallet_address,
+    entryCount: toCount(row.entry_count),
+    unresolvedCount: toCount(row.unresolved_count),
+    inTransitUsd: Math.max(0, toUsdEstimate(row.in_transit_usd) ?? 0),
   };
 }
 
-function toEntry(row: LedgerRow, now: number): InFlightEntry {
-  const ageSeconds = toAgeSeconds(row.since, now);
-  const expiresAtMs = toEpochMs(row.expires_at);
-  const secondsUntilExpiry =
-    expiresAtMs === null ? null : Math.floor((expiresAtMs - now) / 1000);
+function toEntry(row: LedgerRow): InFlightEntry {
   return {
-    kind: row.kind,
-    ref: row.ref,
+    kind: toKind(row.kind),
+    walletAddress: row.wallet_address,
+    ref: row.ref ?? "",
     detail: row.detail,
-    standing: standingFor(row.kind, row.detail, ageSeconds, secondsUntilExpiry),
-    ageSeconds,
+    standing: row.standing === "unresolved" ? "unresolved" : "in_transit",
+    ageSeconds: toCount(row.age_seconds),
     amountHuman: toHumanAmount(row.amount_text, row.amount_decimals),
     symbol: row.symbol,
     usdEstimate: toUsdEstimate(row.usd_est),
   };
+}
+
+/**
+ * The `kind` column is emitted by `LEDGER_BRANCHES_SQL` itself, one literal per
+ * branch, so it is always one of the seven. Parsed rather than asserted anyway:
+ * the value has crossed the driver, and a cast here would be the one place a
+ * future eighth branch could enter the ledger unnamed.
+ */
+function toKind(value: string | null): InFlightKind {
+  const match = IN_FLIGHT_KINDS.find((kind) => kind === value);
+  if (match === undefined) {
+    throw new Error(`in-flight ledger returned an unknown kind: ${String(value)}`);
+  }
+  return match;
+}
+
+/** A `COUNT`/`bigint` column: a non-negative integer, never a fraction. */
+function toCount(value: string | number | null): number {
+  if (value === null) return 0;
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.trunc(n));
 }
 
 /**
@@ -531,21 +726,15 @@ function toHumanAmount(text: string | null, decimals: number | string | null): s
  * estimate is a display numeric (never a token amount), so a finite `number` is
  * the right shape and an unparseable value is `null`, not zero - "we do not
  * know" and "it is worth nothing" are different facts.
+ *
+ * A NEGATIVE estimate is also `null`. The SQL already normalizes it (see
+ * `LEDGER_CTE_SQL`); this is the same decision at the driver boundary, so a
+ * negative figure cannot reach a portfolio and subtract from it whichever path
+ * it arrived on.
  */
 function toUsdEstimate(value: string | number | null): number | null {
   if (value === null) return null;
   const n = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(n) ? n : null;
-}
-
-function toEpochMs(value: Date | string | null): number | null {
-  if (value === null) return null;
-  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
-  return Number.isFinite(ms) ? ms : null;
-}
-
-function toAgeSeconds(since: Date | string | null, now: number): number {
-  const ms = toEpochMs(since);
-  if (ms === null) return 0;
-  return Math.max(0, Math.floor((now - ms) / 1000));
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
 }

--- a/src/vex-agent/sync/balance-sync/snapshot-publication.ts
+++ b/src/vex-agent/sync/balance-sync/snapshot-publication.ts
@@ -13,7 +13,8 @@
  *      can be written until we commit, which is what makes step 4 a boundary
  *      rather than a stale reading.
  *   4. the in-flight ledger + the transition fence, under the lock.
- *   5. the per-wallet rows AND the group record, still under the lock.
+ *   5. the per-wallet snapshot rows, the group record AND the group's
+ *      per-wallet in-flight rows, still under the lock.
  *   6. COMMIT.
  *
  * ## In-flight money is ACCOUNTED FOR, never a reason to withhold
@@ -38,8 +39,9 @@
  *
  * ## Whole group or none
  *
- * Every row - the per-wallet snapshots AND the group record that carries the
- * in-flight ledger - is inserted on the transaction's own client, so a failure
+ * Every row - the per-wallet snapshots, the group record that carries the
+ * in-flight ledger, and that group's per-wallet in-flight rows - is inserted on
+ * the transaction's own client, so a failure
  * at wallet three rolls back wallets one and two and the group record with
  * them. A half-populated `snapshotGroupId` would break the aggregate stitch AND
  * `pnl_vs_prev`; a group record without its rows (or rows without their record)
@@ -56,6 +58,8 @@ import {
   readInFlightMoney,
   type ActivityFence,
   type InFlightEntry,
+  type InFlightLedger,
+  type WalletInFlightTotals,
 } from "./publication-gate.js";
 
 /**
@@ -94,12 +98,26 @@ export interface PublishedSnapshot {
 export interface SnapshotGroupLedger {
   /** Sum of the per-wallet `total_usd` rows: balances actually read. */
   readonly settledUsd: number;
-  /** Sum of the `usdEstimate`s of the `in_transit` entries. Estimates only. */
+  /**
+   * Sum of the `in_transit` USD estimates across EVERY in-flight row of every
+   * wallet in the group. Estimates only, and never the sum of the bounded
+   * `entries` list - see `perWallet`.
+   */
   readonly inTransitUsd: number;
-  /** `unresolved` entries. Listed, counted, and in NO total. */
+  /** `unresolved` rows across every wallet. Listed, counted, and in NO total. */
   readonly unresolvedCount: number;
+  /**
+   * The group's in-flight accounting SPLIT BY WALLET, aggregated by the server
+   * over all rows. This is what makes a portfolio read for a SUBSET of the
+   * group's wallets honest: it sums only the rows that belong to the wallets it
+   * was asked about, instead of inheriting the group's total.
+   */
+  readonly perWallet: readonly WalletInFlightTotals[];
+  /** The bounded DISPLAY list, oldest first, each entry naming its wallet. */
   readonly entries: readonly InFlightEntry[];
-  /** The ledger hit its bound and the oldest entries were kept. */
+  /** Every in-flight row in the group, displayed or not. */
+  readonly totalCount: number;
+  /** `totalCount` exceeded the display bound; the oldest entries were kept. */
   readonly truncated: boolean;
 }
 
@@ -130,10 +148,33 @@ export interface PublishSnapshotGroupInput {
   readonly lockTimeoutMs?: number;
 }
 
+/**
+ * `in_flight_total_count` is the number of rows the ledger FOUND, which is not
+ * the length of `in_flight`: the list is bounded at 50 and the count is not.
+ * A reader compares the two to know whether it is looking at the whole list,
+ * so no consumer is ever handed a short list as if it were the truth.
+ */
 const INSERT_GROUP_SQL = `
   INSERT INTO proj_portfolio_snapshot_groups
-    (snapshot_group_id, settled_usd, in_transit_usd, unresolved_count, in_flight)
-  VALUES ($1::uuid, $2, $3, $4, $5::jsonb)`;
+    (snapshot_group_id, settled_usd, in_transit_usd, unresolved_count, in_flight,
+     in_flight_total_count)
+  VALUES ($1::uuid, $2, $3, $4, $5::jsonb, $6)`;
+
+/**
+ * One row per wallet that has anything in flight (migration 102). A wallet with
+ * no row has nothing in flight, which is the same answer a group written before
+ * this migration gives - so the reader needs no version branch.
+ *
+ * Written as ONE statement over a JSON array rather than a loop: the wallet
+ * count is bounded by the group, and a per-wallet round trip inside the
+ * activity-table lock would hold it for no reason.
+ */
+const INSERT_GROUP_WALLETS_SQL = `
+  INSERT INTO proj_portfolio_snapshot_group_wallets
+    (snapshot_group_id, wallet_address, entry_count, unresolved_count, in_transit_usd)
+  SELECT $1::uuid, w.wallet_address, w.entry_count, w.unresolved_count, w.in_transit_usd
+    FROM jsonb_to_recordset($2::jsonb)
+      AS w(wallet_address text, entry_count int, unresolved_count int, in_transit_usd numeric)`;
 
 export async function publishSnapshotGroup(
   input: PublishSnapshotGroupInput,
@@ -175,13 +216,18 @@ export async function publishSnapshotGroup(
         });
       }
 
-      const ledger = summarizeLedger(rows, inFlight.entries, inFlight.truncated);
+      const ledger = summarizeLedger(rows, inFlight);
       await client.query(INSERT_GROUP_SQL, [
         input.snapshotGroupId,
         ledger.settledUsd,
         ledger.inTransitUsd,
         ledger.unresolvedCount,
         JSON.stringify(ledger.entries),
+        ledger.totalCount,
+      ]);
+      await client.query(INSERT_GROUP_WALLETS_SQL, [
+        input.snapshotGroupId,
+        toWalletRowsJson(ledger.perWallet),
       ]);
 
       return { published: true as const, rows, ledger };
@@ -192,32 +238,55 @@ export async function publishSnapshotGroup(
 }
 
 /**
+ * The per-wallet rows in the COLUMN vocabulary of migration 102.
+ * `jsonb_to_recordset` matches its record definition to the JSON keys by name,
+ * so the mapping is written here, once and explicitly, rather than by renaming
+ * the domain type to please a SQL function.
+ */
+function toWalletRowsJson(perWallet: readonly WalletInFlightTotals[]): string {
+  return JSON.stringify(
+    perWallet.map((wallet) => ({
+      wallet_address: wallet.walletAddress,
+      entry_count: wallet.entryCount,
+      unresolved_count: wallet.unresolvedCount,
+      in_transit_usd: wallet.inTransitUsd,
+    })),
+  );
+}
+
+/**
  * `settledUsd` is the sum of what was actually inserted, not of what was
  * offered, so the record can never claim a wallet the group does not contain.
  *
- * `inTransitUsd` sums ONLY `in_transit` entries with a known estimate. An
- * `unresolved` entry contributes nothing in either direction - it is money
- * nobody can currently account for, and a portfolio must not assert it is
- * there or that it is gone.
+ * The two in-flight figures are summed from the SERVER'S PER-WALLET
+ * AGGREGATES, never from `entries`. `entries` is a bounded display list, and
+ * deriving a total from it would silently drop every row past the bound out of
+ * the portfolio - the defect this shape exists to close. An `unresolved` row
+ * contributes to no total in either direction: it is money nobody can currently
+ * account for, and a portfolio must not assert it is there or that it is gone.
  */
 function summarizeLedger(
   rows: readonly PublishedSnapshot[],
-  entries: readonly InFlightEntry[],
-  truncated: boolean,
+  inFlight: InFlightLedger,
 ): SnapshotGroupLedger {
   let settledUsd = 0;
   for (const row of rows) settledUsd += row.totalUsd;
 
   let inTransitUsd = 0;
   let unresolvedCount = 0;
-  for (const entry of entries) {
-    if (entry.standing === "unresolved") {
-      unresolvedCount += 1;
-      continue;
-    }
-    if (entry.usdEstimate !== null) inTransitUsd += entry.usdEstimate;
+  for (const wallet of inFlight.perWallet) {
+    inTransitUsd += wallet.inTransitUsd;
+    unresolvedCount += wallet.unresolvedCount;
   }
-  return { settledUsd, inTransitUsd, unresolvedCount, entries, truncated };
+  return {
+    settledUsd,
+    inTransitUsd,
+    unresolvedCount,
+    perWallet: inFlight.perWallet,
+    entries: inFlight.entries,
+    totalCount: inFlight.totalCount,
+    truncated: inFlight.truncated,
+  };
 }
 
 /**
@@ -228,6 +297,10 @@ function summarizeLedger(
  * The warn line carries the kind, the ref and the age and deliberately NOT the
  * amount or the symbol: an operator needs to know which row to open, and a warn
  * log is not the place to restate what the user holds.
+ *
+ * `unresolvedCount` counts EVERY unresolved row; `unresolved` lists only those
+ * that fit the display bound. The two are logged side by side so a shorter list
+ * beside a larger count reads as "there are more", never as the whole set.
  */
 export function logPublicationOutcome(
   outcome: PublicationOutcome,
@@ -240,7 +313,9 @@ export function logPublicationOutcome(
       wallets: outcome.rows.length,
       settledUsd: ledger.settledUsd.toFixed(2),
       inTransitUsd: ledger.inTransitUsd.toFixed(2),
-      inFlightCount: ledger.entries.length,
+      inFlightCount: ledger.totalCount,
+      inFlightShown: ledger.entries.length,
+      walletsWithMoneyInFlight: ledger.perWallet.length,
       unresolvedCount: ledger.unresolvedCount,
       inFlightTruncated: ledger.truncated,
     });

--- a/vex-app/src/main/database/__tests__/portfolio-db.test.ts
+++ b/vex-app/src/main/database/__tests__/portfolio-db.test.ts
@@ -156,6 +156,9 @@ describe("portfolio-db getPortfolio - global scope", () => {
       snapshotInTransitUsd: null,
       snapshotInFlight: null,
       snapshotUnresolvedCount: null,
+      snapshotInFlightTotalCount: null,
+      snapshotInFlightShownCount: null,
+      snapshotInFlightTruncated: null,
       pnlVsPrev: null,
       snapshotAt: null,
       tokens: [],
@@ -360,18 +363,15 @@ describe("portfolio-db getPortfolio - coercion + fallback", () => {
     );
   });
 
-  it("collapses an absent snapshot to null total/pnl/at and a null ledger", async () => {
+  it("keeps the live total readable when no snapshot cycle exists", async () => {
+    // The snapshot half of that answer - every null the absent basis produces -
+    // belongs to `portfolio-snapshot-basis.test.ts`; what this file still owns
+    // is that the live aggregation is unaffected by it.
     scriptPortfolioQueries({ live: "10", tokens: [], snapshot: null });
     const result = await getPortfolio({ scope: "global" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.data.snapshotTotalUsd).toBeNull();
-    expect(result.data.snapshotSettledUsd).toBeNull();
-    expect(result.data.snapshotInTransitUsd).toBeNull();
-    expect(result.data.snapshotInFlight).toBeNull();
-    expect(result.data.snapshotUnresolvedCount).toBeNull();
-    expect(result.data.pnlVsPrev).toBeNull();
-    expect(result.data.snapshotAt).toBeNull();
     expect(result.data.liveTotalUsd).toBe(10);
   });
 
@@ -460,239 +460,11 @@ describe("portfolio-db getPortfolio - coercion + fallback", () => {
   });
 });
 
-/** One in-flight bridge leg, in the exact shape the publisher persists. */
-const IN_FLIGHT_BRIDGE = {
-  kind: "agent_activity_pending",
-  ref: "132",
-  detail: "bridge_fill_expected",
-  standing: "in_transit" as const,
-  ageSeconds: 600,
-  amountHuman: "150.0",
-  symbol: "USDC",
-  usdEstimate: 150,
-};
-
-describe("portfolio-db getPortfolio - PnL + token cap (codex review)", () => {
+describe("portfolio-db getPortfolio - token cap (codex review)", () => {
   beforeEach(() => {
     mocks.listWallets.mockImplementation((family: string) =>
       family === "evm" ? [{ id: "1", address: WALLET_A, label: "", createdAt: "" }] : [],
     );
-  });
-
-  it("computes PnL as latest.total − previous.total over two complete cycles", async () => {
-    scriptPortfolioQueries({
-      live: "100",
-      tokens: [],
-      snapshot: { snapshot_group_id: "g1", total: "100", at: "2026-05-21T10:00:00.000Z" },
-      previousSnapshot: { snapshot_group_id: "g0", total: "80", at: "2026-05-20T10:00:00.000Z" },
-    });
-    const result = await getPortfolio({ scope: "global" });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.snapshotTotalUsd).toBeCloseTo(100, 4);
-    expect(result.data.pnlVsPrev).toBeCloseTo(20, 4);
-    // The snapshot query asks for the latest TWO groups and no longer sums
-    // per-wallet pnl_vs_prev.
-    const snapshotSql = String(mocks.query.mock.calls[3]?.[0] ?? "");
-    expect(snapshotSql).toContain("LIMIT 2");
-    expect(snapshotSql).not.toContain("pnl_vs_prev");
-  });
-
-  it("leaves PnL null when only one complete cycle exists", async () => {
-    scriptPortfolioQueries({
-      live: "100",
-      tokens: [],
-      snapshot: { snapshot_group_id: "g1", total: "100", at: "2026-05-21T10:00:00.000Z" },
-    });
-    const result = await getPortfolio({ scope: "global" });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.snapshotTotalUsd).toBeCloseTo(100, 4);
-    expect(result.data.pnlVsPrev).toBeNull();
-  });
-
-  it("SETTLED + IN TRANSIT is the basis, on both sides of the PnL", async () => {
-    scriptPortfolioQueries({
-      live: "100",
-      tokens: [],
-      snapshot: {
-        snapshot_group_id: "g1",
-        total: "50",
-        at: "2026-05-21T10:00:00.000Z",
-        in_transit: 150,
-        unresolved_count: 0,
-        in_flight: JSON.stringify([IN_FLIGHT_BRIDGE]),
-      },
-      previousSnapshot: {
-        snapshot_group_id: "g0",
-        total: "180",
-        at: "2026-05-20T10:00:00.000Z",
-        in_transit: 20,
-        unresolved_count: 0,
-        in_flight: "[]",
-      },
-    });
-    const result = await getPortfolio({ scope: "global" });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.snapshotTotalUsd).toBeCloseTo(200, 4);
-    // 200 vs 200: the previous cycle held 180 settled plus 20 on its way.
-    expect(result.data.pnlVsPrev).toBeCloseTo(0, 4);
-  });
-
-  it("THE OWNER'S SCENARIO: 200 settled, then 50 settled mid-bridge, reads 200 and 0", async () => {
-    // "I did a bridge, I have $200 and send it, a snapshot fires meanwhile and
-    // shows $50 and -$150, which causes anxiety." The previous cycle measured
-    // the whole $200 settled; the latest fires while $150 is in transit.
-    scriptPortfolioQueries({
-      live: "50",
-      tokens: [],
-      snapshot: {
-        snapshot_group_id: "mid-bridge",
-        total: "50",
-        at: "2026-05-21T10:05:00.000Z",
-        in_transit: 150,
-        unresolved_count: 0,
-        in_flight: JSON.stringify([IN_FLIGHT_BRIDGE]),
-      },
-      previousSnapshot: {
-        snapshot_group_id: "before-bridge",
-        total: "200",
-        at: "2026-05-21T10:00:00.000Z",
-        in_transit: 0,
-        unresolved_count: 0,
-        in_flight: "[]",
-      },
-    });
-    const result = await getPortfolio({ scope: "global" });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.snapshotSettledUsd).toBeCloseTo(50, 4);
-    expect(result.data.snapshotInTransitUsd).toBeCloseTo(150, 4);
-    expect(result.data.snapshotTotalUsd).toBeCloseTo(200, 4);
-    // No loss was taken, so none is reported. This is the whole point.
-    expect(result.data.pnlVsPrev).toBeCloseTo(0, 4);
-    expect(result.data.snapshotInFlight).toEqual([IN_FLIGHT_BRIDGE]);
-    expect(result.data.snapshotUnresolvedCount).toBe(0);
-  });
-
-  it("treats a group with NO record (written before migration 101) as in-transit 0", async () => {
-    scriptPortfolioQueries({
-      live: "100",
-      tokens: [],
-      snapshot: {
-        snapshot_group_id: "g1",
-        total: "100",
-        at: "2026-05-21T10:00:00.000Z",
-        in_transit: null,
-        unresolved_count: null,
-        in_flight: null,
-      },
-      previousSnapshot: {
-        snapshot_group_id: "g0",
-        total: "80",
-        at: "2026-05-20T10:00:00.000Z",
-        in_transit: null,
-        unresolved_count: null,
-        in_flight: null,
-      },
-    });
-    const result = await getPortfolio({ scope: "global" });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    // Exactly the figures the pre-101 reader produced, so the two bases stay
-    // comparable across the migration rather than reporting a phantom jump.
-    expect(result.data.snapshotSettledUsd).toBeCloseTo(100, 4);
-    expect(result.data.snapshotInTransitUsd).toBe(0);
-    expect(result.data.snapshotTotalUsd).toBeCloseTo(100, 4);
-    expect(result.data.pnlVsPrev).toBeCloseTo(20, 4);
-    expect(result.data.snapshotInFlight).toEqual([]);
-    expect(result.data.snapshotUnresolvedCount).toBe(0);
-  });
-
-  it("mixes an old previous group with a new latest one without a phantom jump", async () => {
-    scriptPortfolioQueries({
-      live: "100",
-      tokens: [],
-      snapshot: {
-        snapshot_group_id: "g1",
-        total: "100",
-        at: "2026-05-21T10:00:00.000Z",
-        in_transit: 0,
-        unresolved_count: 0,
-        in_flight: "[]",
-      },
-      previousSnapshot: {
-        snapshot_group_id: "g0",
-        total: "80",
-        at: "2026-05-20T10:00:00.000Z",
-        in_transit: null,
-        unresolved_count: null,
-        in_flight: null,
-      },
-    });
-    const result = await getPortfolio({ scope: "global" });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.pnlVsPrev).toBeCloseTo(20, 4);
-  });
-
-  it("counts an UNRESOLVED entry without adding it to any total", async () => {
-    scriptPortfolioQueries({
-      live: "50",
-      tokens: [],
-      snapshot: {
-        snapshot_group_id: "g1",
-        total: "50",
-        at: "2026-05-21T10:00:00.000Z",
-        // The publisher already excluded the unresolved estimate from
-        // `in_transit_usd`; the reader must not add it back.
-        in_transit: 0,
-        unresolved_count: 1,
-        in_flight: JSON.stringify([{ ...IN_FLIGHT_BRIDGE, standing: "unresolved" }]),
-      },
-    });
-    const result = await getPortfolio({ scope: "global" });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.snapshotTotalUsd).toBeCloseTo(50, 4);
-    expect(result.data.snapshotUnresolvedCount).toBe(1);
-    expect(result.data.snapshotInFlight?.[0]?.standing).toBe("unresolved");
-  });
-
-  it("degrades a malformed ledger to an empty one, keeping the settled total", async () => {
-    scriptPortfolioQueries({
-      live: "50",
-      tokens: [],
-      snapshot: {
-        snapshot_group_id: "g1",
-        total: "50",
-        at: "2026-05-21T10:00:00.000Z",
-        in_transit: 150,
-        unresolved_count: 0,
-        in_flight: '[{"kind":"agent_activity_pending"}]',
-      },
-    });
-    const result = await getPortfolio({ scope: "global" });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    // A durable row that has crossed serialization is external input: it is
-    // parsed, not trusted. A row that fails the schema must not take the rest
-    // of the portfolio down with it, and must not reach the DTO half-formed.
-    expect(result.data.snapshotInFlight).toEqual([]);
-    expect(result.data.snapshotTotalUsd).toBeCloseTo(200, 4);
-    expect(mocks.log.warn).toHaveBeenCalled();
-  });
-
-  it("joins the group record by snapshot_group_id, not by a second query", async () => {
-    scriptPortfolioQueries({ live: "0", tokens: [], snapshot: null });
-    await getPortfolio({ scope: "global" });
-    // Still four SELECTs: the group record is a correlated scalar subquery in
-    // the snapshot query, so a group with no record cannot drop out of it.
-    expect(mocks.query).toHaveBeenCalledTimes(4);
-    const snapshotSql = String(mocks.query.mock.calls[3]?.[0] ?? "");
-    expect(snapshotSql).toContain("proj_portfolio_snapshot_groups");
-    expect(snapshotSql).toContain("LIMIT 2");
   });
 
   it("caps token lines at 500 even if the DB returns more (no output-schema overflow)", async () => {

--- a/vex-app/src/main/database/__tests__/portfolio-snapshot-basis.test.ts
+++ b/vex-app/src/main/database/__tests__/portfolio-snapshot-basis.test.ts
@@ -1,0 +1,684 @@
+/**
+ * The PnL BASIS of a portfolio read: `main/database/portfolio/snapshot-basis.ts`,
+ * exercised through the PUBLIC `getPortfolio` entry point with no real DB.
+ *
+ * Split out of `portfolio-db.test.ts` (2026-09-04) when that file crossed the
+ * repository's 750-line gate at 1,422 lines. The scenarios did not change
+ * owner: they still drive `getPortfolio`, because the basis is only ever
+ * observable through it. What they no longer do is sit beside 900 lines of
+ * token-aggregation and address-resolution coverage that shares none of their
+ * fixtures.
+ *
+ * What is pinned here:
+ *
+ *  1. the basis is SETTLED + IN TRANSIT, on both sides of the PnL, so a
+ *     snapshot taken mid-bridge does not report a loss the user did not take;
+ *  2. in-transit money is summed PER WALLET over exactly the resolved address
+ *     set - a scope holding wallet A never inherits wallet B's pending bridge;
+ *  3. the bounded display list is never the source of a total, and the
+ *     total/shown/truncated contract says so out loud;
+ *  4. a group written before migration 102 reads as in transit 0, which is
+ *     exactly what the pre-migration reader produced;
+ *  5. the durable ledger is PARSED, not trusted: a malformed entry is dropped
+ *     and reported, an unknown kind maps to the typed fallback and stays
+ *     listed, a negative estimate is refused;
+ *  6. the closed kind vocabulary matches the engine's, which this suite can
+ *     see because it runs in the main process and both trees are importable.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IN_FLIGHT_KINDS } from "@vex-agent/sync/balance-sync/publication-gate.js";
+import {
+  SNAPSHOT_IN_FLIGHT_KINDS,
+  snapshotInFlightEntryDtoSchema,
+} from "@shared/schemas/portfolio.js";
+
+type QueryFn = (
+  text: string,
+  params?: readonly unknown[],
+) => Promise<{ rows: ReadonlyArray<Record<string, unknown>> }>;
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn() as ReturnType<typeof vi.fn> & QueryFn,
+  connect: vi.fn(),
+  end: vi.fn(),
+  buildPoolConfig: vi.fn(),
+  listWallets: vi.fn(),
+  getSessionWalletScope: vi.fn(),
+  readProjectPortfolioScope: vi.fn(),
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("pg", () => {
+  function MockClient() {
+    return { connect: mocks.connect, end: mocks.end, query: mocks.query };
+  }
+  return { Client: MockClient };
+});
+vi.mock("../db-config.js", () => ({ buildPoolConfig: mocks.buildPoolConfig }));
+vi.mock("@vex-lib/wallet.js", () => ({ listWallets: mocks.listWallets }));
+vi.mock("../sessions-db.js", () => ({ getSessionWalletScope: mocks.getSessionWalletScope }));
+vi.mock("../projects/portfolio-scope.js", () => ({
+  readProjectPortfolioScope: mocks.readProjectPortfolioScope,
+}));
+vi.mock("../../logger/index.js", () => ({ log: mocks.log }));
+
+const { getPortfolio } = await import("../portfolio-db.js");
+
+const WALLET_A = "0xAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaa";
+const WALLET_B = "0xBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbb";
+
+/** One in-flight bridge leg, in the exact shape the publisher persists. */
+const IN_FLIGHT_BRIDGE = {
+  kind: "agent_activity_pending",
+  walletAddress: WALLET_A,
+  ref: "132",
+  detail: "bridge_fill_expected",
+  standing: "in_transit" as const,
+  ageSeconds: 600,
+  amountHuman: "150.0",
+  symbol: "USDC",
+  usdEstimate: 150,
+};
+
+/**
+ * One row of the snapshot query, with the defaults a group written before
+ * migration 102 produces: no per-wallet attribution at all.
+ */
+function snapshotRow(fields: Record<string, unknown>): Record<string, unknown> {
+  return {
+    snapshot_group_id: "g1",
+    at: "2026-05-21T10:00:00.000Z",
+    in_transit: 0,
+    unresolved_count: 0,
+    in_flight_total_count: 0,
+    in_flight: null,
+    ...fields,
+  };
+}
+
+/**
+ * Script the four queries `getPortfolio` issues (live total, token lines,
+ * per-chain breakdown, snapshot) in order.
+ */
+function scriptSnapshot(
+  latest: Record<string, unknown> | null,
+  previous?: Record<string, unknown> | null,
+): void {
+  const rows = [latest, previous ?? null].filter(
+    (row): row is Record<string, unknown> => row != null,
+  );
+  mocks.query
+    .mockResolvedValueOnce({ rows: [{ live: "0" }] })
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows });
+}
+
+/** The snapshot query is the fourth. */
+const snapshotCall = () => mocks.query.mock.calls[3];
+
+async function readGlobalPortfolio() {
+  const result = await getPortfolio({ scope: "global" });
+  expect(result.ok).toBe(true);
+  if (!result.ok) throw new Error("unreachable");
+  return result.data;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.buildPoolConfig.mockResolvedValue({
+    host: "127.0.0.1",
+    port: 5777,
+    database: "vex",
+    user: "vex",
+    password: "secret",
+  });
+  mocks.connect.mockResolvedValue(undefined);
+  mocks.end.mockResolvedValue(undefined);
+  mocks.listWallets.mockImplementation((family: string) =>
+    family === "evm" ? [{ id: "1", address: WALLET_A, label: "", createdAt: "" }] : [],
+  );
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── 1. The basis is settled + in transit ─────────────────────────────────
+
+describe("the PnL basis", () => {
+  it("computes PnL as latest.total - previous.total over two complete cycles", async () => {
+    scriptSnapshot(
+      snapshotRow({ total: "100" }),
+      snapshotRow({ snapshot_group_id: "g0", total: "80", at: "2026-05-20T10:00:00.000Z" }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotTotalUsd).toBeCloseTo(100, 4);
+    expect(data.pnlVsPrev).toBeCloseTo(20, 4);
+    // The snapshot query asks for the latest TWO groups and no longer sums
+    // per-wallet pnl_vs_prev.
+    const sql = String(snapshotCall()?.[0] ?? "");
+    expect(sql).toContain("LIMIT 2");
+    expect(sql).not.toContain("pnl_vs_prev");
+  });
+
+  it("leaves PnL null when only one complete cycle exists", async () => {
+    scriptSnapshot(snapshotRow({ total: "100" }));
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotTotalUsd).toBeCloseTo(100, 4);
+    expect(data.pnlVsPrev).toBeNull();
+  });
+
+  it("uses SETTLED + IN TRANSIT on both sides of the PnL", async () => {
+    scriptSnapshot(
+      snapshotRow({
+        total: "50",
+        in_transit: 150,
+        in_flight_total_count: 1,
+        in_flight: JSON.stringify([IN_FLIGHT_BRIDGE]),
+      }),
+      snapshotRow({
+        snapshot_group_id: "g0",
+        total: "180",
+        at: "2026-05-20T10:00:00.000Z",
+        in_transit: 20,
+        in_flight: "[]",
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotTotalUsd).toBeCloseTo(200, 4);
+    // 200 vs 200: the previous cycle held 180 settled plus 20 on its way.
+    expect(data.pnlVsPrev).toBeCloseTo(0, 4);
+  });
+
+  it("THE OWNER'S SCENARIO: 200 settled, then 50 settled mid-bridge, reads 200 and 0", async () => {
+    // "I did a bridge, I have $200 and send it, a snapshot fires meanwhile and
+    // shows $50 and -$150, which causes anxiety." The previous cycle measured
+    // the whole $200 settled; the latest fires while $150 is in transit.
+    scriptSnapshot(
+      snapshotRow({
+        snapshot_group_id: "mid-bridge",
+        total: "50",
+        at: "2026-05-21T10:05:00.000Z",
+        in_transit: 150,
+        in_flight_total_count: 1,
+        in_flight: JSON.stringify([IN_FLIGHT_BRIDGE]),
+      }),
+      snapshotRow({
+        snapshot_group_id: "before-bridge",
+        total: "200",
+        at: "2026-05-21T10:00:00.000Z",
+        in_flight: "[]",
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotSettledUsd).toBeCloseTo(50, 4);
+    expect(data.snapshotInTransitUsd).toBeCloseTo(150, 4);
+    expect(data.snapshotTotalUsd).toBeCloseTo(200, 4);
+    // No loss was taken, so none is reported. This is the whole point.
+    expect(data.pnlVsPrev).toBeCloseTo(0, 4);
+    expect(data.snapshotInFlight).toEqual([IN_FLIGHT_BRIDGE]);
+    expect(data.snapshotUnresolvedCount).toBe(0);
+  });
+
+  it("treats a group with NO per-wallet attribution (before migration 102) as in-transit 0", async () => {
+    scriptSnapshot(
+      snapshotRow({ total: "100", in_transit: null, unresolved_count: null, in_flight: null }),
+      snapshotRow({
+        snapshot_group_id: "g0",
+        total: "80",
+        at: "2026-05-20T10:00:00.000Z",
+        in_transit: null,
+        unresolved_count: null,
+        in_flight: null,
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    // Exactly the figures the pre-101 reader produced, so the two bases stay
+    // comparable across the migration rather than reporting a phantom jump.
+    expect(data.snapshotSettledUsd).toBeCloseTo(100, 4);
+    expect(data.snapshotInTransitUsd).toBe(0);
+    expect(data.snapshotTotalUsd).toBeCloseTo(100, 4);
+    expect(data.pnlVsPrev).toBeCloseTo(20, 4);
+    expect(data.snapshotInFlight).toEqual([]);
+    expect(data.snapshotUnresolvedCount).toBe(0);
+  });
+
+  it("mixes an old previous group with a new latest one without a phantom jump", async () => {
+    scriptSnapshot(
+      snapshotRow({ total: "100", in_flight: "[]" }),
+      snapshotRow({
+        snapshot_group_id: "g0",
+        total: "80",
+        at: "2026-05-20T10:00:00.000Z",
+        in_transit: null,
+        unresolved_count: null,
+        in_flight: null,
+      }),
+    );
+
+    expect((await readGlobalPortfolio()).pnlVsPrev).toBeCloseTo(20, 4);
+  });
+
+  it("counts an UNRESOLVED entry without adding it to any total", async () => {
+    scriptSnapshot(
+      snapshotRow({
+        total: "50",
+        // The publisher already excluded the unresolved estimate from
+        // `in_transit_usd`; the reader must not add it back.
+        in_transit: 0,
+        unresolved_count: 1,
+        in_flight_total_count: 1,
+        in_flight: JSON.stringify([{ ...IN_FLIGHT_BRIDGE, standing: "unresolved" }]),
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotTotalUsd).toBeCloseTo(50, 4);
+    expect(data.snapshotUnresolvedCount).toBe(1);
+    expect(data.snapshotInFlight?.[0]?.standing).toBe("unresolved");
+  });
+
+  it("reads the group record through correlated subqueries, not a second query", async () => {
+    scriptSnapshot(null);
+
+    await readGlobalPortfolio();
+
+    // Still four SELECTs: the group's accounting is correlated subqueries in
+    // the snapshot query, so a group with no record cannot drop out of it.
+    expect(mocks.query).toHaveBeenCalledTimes(4);
+    const sql = String(snapshotCall()?.[0] ?? "");
+    expect(sql).toContain("proj_portfolio_snapshot_group_wallets");
+    expect(sql).toContain("LIMIT 2");
+  });
+
+  it("collapses an absent snapshot to null totals, ledger and bound contract", async () => {
+    scriptSnapshot(null);
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotTotalUsd).toBeNull();
+    expect(data.snapshotSettledUsd).toBeNull();
+    expect(data.snapshotInTransitUsd).toBeNull();
+    expect(data.snapshotInFlight).toBeNull();
+    expect(data.snapshotUnresolvedCount).toBeNull();
+    expect(data.snapshotInFlightTotalCount).toBeNull();
+    expect(data.snapshotInFlightShownCount).toBeNull();
+    expect(data.snapshotInFlightTruncated).toBeNull();
+    expect(data.pnlVsPrev).toBeNull();
+    expect(data.snapshotAt).toBeNull();
+  });
+});
+
+// ── 2. In-flight money is scoped to the wallets being asked about ────────
+
+describe("per-wallet scoping of in-flight money", () => {
+  const BRIDGE_ON_B = { ...IN_FLIGHT_BRIDGE, walletAddress: WALLET_B, ref: "b-132" };
+
+  it("sums the in-flight components of exactly the resolved addresses, in SQL", async () => {
+    scriptSnapshot(snapshotRow({ total: "100" }));
+
+    await readGlobalPortfolio();
+
+    // Every in-flight aggregate carries the SAME `$1::text[]` allow-list the
+    // rest of the read binds. A scope cannot be widened for the money half of
+    // the answer while the balances half stays narrow.
+    const sql = String(snapshotCall()?.[0] ?? "");
+    const scopedAggregates = sql.match(
+      /FROM proj_portfolio_snapshot_group_wallets w\s+WHERE w\.snapshot_group_id = s\.snapshot_group_id\s+AND w\.wallet_address = ANY\(\$1::text\[\]\)/g,
+    );
+    expect(scopedAggregates).toHaveLength(3);
+    expect(snapshotCall()?.[1]).toEqual([[WALLET_A], 1]);
+  });
+
+  it("gives a scope holding only wallet A ZERO in transit and NO entry belonging to B", async () => {
+    // THE DEFECT. Wallet B is mid-bridge; the user opens a scope that holds
+    // only wallet A. The group's own figure would hand A a stranger's $150.
+    scriptSnapshot(
+      snapshotRow({
+        total: "50",
+        // The SQL aggregate already summed only A's rows, of which there are
+        // none. The stored LIST is still the whole group's, so the reader must
+        // drop B's entry itself.
+        in_transit: 0,
+        unresolved_count: 0,
+        in_flight_total_count: 0,
+        in_flight: JSON.stringify([BRIDGE_ON_B]),
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotInTransitUsd).toBe(0);
+    expect(data.snapshotUnresolvedCount).toBe(0);
+    expect(data.snapshotInFlight).toEqual([]);
+    expect(data.snapshotTotalUsd).toBeCloseTo(50, 4);
+  });
+
+  it("gives a scope holding only wallet B its OWN pending bridge and nothing of A's", async () => {
+    mocks.listWallets.mockImplementation((family: string) =>
+      family === "evm" ? [{ id: "2", address: WALLET_B, label: "", createdAt: "" }] : [],
+    );
+    scriptSnapshot(
+      snapshotRow({
+        total: "0",
+        // The SQL aggregate summed B's rows only; the stored list still holds
+        // both wallets' entries and the reader narrows it.
+        in_transit: 150,
+        in_flight_total_count: 1,
+        in_flight: JSON.stringify([IN_FLIGHT_BRIDGE, BRIDGE_ON_B]),
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotInFlight).toEqual([BRIDGE_ON_B]);
+    expect(data.snapshotInTransitUsd).toBe(150);
+    expect(data.snapshotTotalUsd).toBeCloseTo(150, 4);
+    expect(snapshotCall()?.[1]).toEqual([[WALLET_B], 1]);
+  });
+
+  it("gives a scope holding BOTH wallets both entries and the summed total", async () => {
+    mocks.listWallets.mockImplementation((family: string) =>
+      family === "evm"
+        ? [
+            { id: "1", address: WALLET_A, label: "", createdAt: "" },
+            { id: "2", address: WALLET_B, label: "", createdAt: "" },
+          ]
+        : [],
+    );
+    scriptSnapshot(
+      snapshotRow({
+        total: "50",
+        in_transit: 300,
+        in_flight_total_count: 2,
+        in_flight: JSON.stringify([IN_FLIGHT_BRIDGE, BRIDGE_ON_B]),
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotInFlight?.map((entry) => entry.walletAddress)).toEqual([
+      WALLET_A,
+      WALLET_B,
+    ]);
+    expect(data.snapshotInTransitUsd).toBe(300);
+    expect(data.snapshotTotalUsd).toBeCloseTo(350, 4);
+    expect(snapshotCall()?.[1]).toEqual([[WALLET_A, WALLET_B], 2]);
+  });
+
+  it("drops an entry written before migration 102, which carries no attribution", async () => {
+    const { walletAddress: _omitted, ...unattributed } = IN_FLIGHT_BRIDGE;
+    scriptSnapshot(
+      snapshotRow({ total: "50", in_flight: JSON.stringify([unattributed]) }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    // "Nothing in flight for these wallets" is the conservative reading;
+    // showing an unattributed row would be showing somebody's money without
+    // knowing whose.
+    expect(data.snapshotInFlight).toEqual([]);
+  });
+});
+
+/**
+ * The owner's scenario, replayed at all three scopes.
+ *
+ * Wallet A holds $50 settled with $150 mid-bridge; wallet B holds nothing and
+ * has nothing in flight. The group's own figures are settled 50 and in transit
+ * 150, and the question every scope must answer differently is "whose $150 is
+ * that".
+ */
+describe("wallet A is 50 settled plus 150 in transit, wallet B is empty", () => {
+  const BOTH = [
+    { id: "1", address: WALLET_A, label: "", createdAt: "" },
+    { id: "2", address: WALLET_B, label: "", createdAt: "" },
+  ];
+
+  /**
+   * `total` is the settled sum the snapshot rows give for the SCOPE, and
+   * `in_transit` is what the per-wallet aggregate sums for that same scope.
+   */
+  function scriptScenario(settled: string, inTransit: number, shown: number): void {
+    scriptSnapshot(
+      snapshotRow({
+        total: settled,
+        in_transit: inTransit,
+        in_flight_total_count: shown,
+        in_flight: JSON.stringify([IN_FLIGHT_BRIDGE]),
+      }),
+    );
+  }
+
+  it("FULL scope reads 50 settled, 150 in transit, 200 total, and names A's entry", async () => {
+    mocks.listWallets.mockImplementation((family: string) => (family === "evm" ? BOTH : []));
+    scriptScenario("50", 150, 1);
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotSettledUsd).toBeCloseTo(50, 4);
+    expect(data.snapshotInTransitUsd).toBeCloseTo(150, 4);
+    expect(data.snapshotTotalUsd).toBeCloseTo(200, 4);
+    expect(data.snapshotInFlight).toEqual([IN_FLIGHT_BRIDGE]);
+    expect(data.snapshotInFlightTotalCount).toBe(1);
+    expect(data.snapshotInFlightTruncated).toBe(false);
+  });
+
+  it("A-ONLY scope reads the same 200, because the money is A's", async () => {
+    scriptScenario("50", 150, 1);
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotSettledUsd).toBeCloseTo(50, 4);
+    expect(data.snapshotInTransitUsd).toBeCloseTo(150, 4);
+    expect(data.snapshotTotalUsd).toBeCloseTo(200, 4);
+    expect(data.snapshotInFlight).toEqual([IN_FLIGHT_BRIDGE]);
+    expect(snapshotCall()?.[1]).toEqual([[WALLET_A], 1]);
+  });
+
+  it("B-ONLY scope reads 0 and 0, and is shown none of A's bridge", async () => {
+    mocks.listWallets.mockImplementation((family: string) =>
+      family === "evm" ? [{ id: "2", address: WALLET_B, label: "", createdAt: "" }] : [],
+    );
+    // The aggregate sums B's per-wallet rows, of which there are none.
+    scriptScenario("0", 0, 0);
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotSettledUsd).toBeCloseTo(0, 4);
+    expect(data.snapshotInTransitUsd).toBe(0);
+    expect(data.snapshotTotalUsd).toBeCloseTo(0, 4);
+    // Not "$150 appeared in an empty wallet": the entry is A's and is dropped.
+    expect(data.snapshotInFlight).toEqual([]);
+    expect(data.snapshotInFlightTotalCount).toBe(0);
+  });
+});
+
+// ── 3. The bounded list is a list, never a total ─────────────────────────
+
+describe("the display bound contract", () => {
+  it("reports totalCount, shownCount and truncated when rows exist beyond the list", async () => {
+    const shown = Array.from({ length: 50 }, (_, i) => ({
+      ...IN_FLIGHT_BRIDGE,
+      ref: `row-${i}`,
+    }));
+    scriptSnapshot(
+      snapshotRow({
+        total: "50",
+        // The publisher counted 55 rows and priced all of them; only 50 fitted
+        // the list. Summing the list would delete five rows' money.
+        in_transit: 8250,
+        in_flight_total_count: 55,
+        in_flight: JSON.stringify(shown),
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotInFlightTotalCount).toBe(55);
+    expect(data.snapshotInFlightShownCount).toBe(50);
+    expect(data.snapshotInFlightTruncated).toBe(true);
+    // The total came from the publisher's aggregate, not from the 50 rows.
+    expect(data.snapshotInTransitUsd).toBe(8250);
+    expect(data.snapshotTotalUsd).toBeCloseTo(8300, 4);
+  });
+
+  it("reports an untruncated list as untruncated", async () => {
+    scriptSnapshot(
+      snapshotRow({
+        total: "50",
+        in_transit: 150,
+        in_flight_total_count: 1,
+        in_flight: JSON.stringify([IN_FLIGHT_BRIDGE]),
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    expect(data.snapshotInFlightTotalCount).toBe(1);
+    expect(data.snapshotInFlightShownCount).toBe(1);
+    expect(data.snapshotInFlightTruncated).toBe(false);
+  });
+});
+
+// ── 4. The durable ledger is parsed, not trusted ─────────────────────────
+
+describe("reading the durable ledger", () => {
+  it("degrades a malformed entry to an empty list, keeping the settled total", async () => {
+    scriptSnapshot(
+      snapshotRow({
+        total: "50",
+        in_transit: 150,
+        in_flight: JSON.stringify([{ kind: "agent_activity_pending", walletAddress: WALLET_A }]),
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    // A durable row that has crossed serialization is external input: it is
+    // parsed, not trusted. A row that fails the schema must not take the rest
+    // of the portfolio down with it, and must not reach the DTO half-formed.
+    expect(data.snapshotInFlight).toEqual([]);
+    expect(data.snapshotTotalUsd).toBeCloseTo(200, 4);
+    expect(mocks.log.warn).toHaveBeenCalled();
+  });
+
+  it("keeps the readable entries when only one of several is malformed", async () => {
+    scriptSnapshot(
+      snapshotRow({
+        total: "50",
+        in_transit: 150,
+        in_flight_total_count: 2,
+        in_flight: JSON.stringify([
+          IN_FLIGHT_BRIDGE,
+          { kind: "agent_activity_pending", walletAddress: WALLET_A },
+        ]),
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    // One unreadable row must not delete a report about the user's money.
+    expect(data.snapshotInFlight).toEqual([IN_FLIGHT_BRIDGE]);
+    expect(mocks.log.warn).toHaveBeenCalled();
+  });
+
+  it("degrades unparseable JSON to an empty list and says so", async () => {
+    scriptSnapshot(snapshotRow({ total: "50", in_flight: "{not json" }));
+
+    expect((await readGlobalPortfolio()).snapshotInFlight).toEqual([]);
+    expect(mocks.log.warn).toHaveBeenCalled();
+  });
+
+  it("maps a kind this build has never heard of to the typed unknown fallback", async () => {
+    scriptSnapshot(
+      snapshotRow({
+        total: "50",
+        in_transit: 150,
+        in_flight_total_count: 1,
+        in_flight: JSON.stringify([{ ...IN_FLIGHT_BRIDGE, kind: "some_future_kind" }]),
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    // A ledger written by a NEWER build stays VISIBLE - money is in flight and
+    // a human should see it - while the closed enum still refuses to present an
+    // unnamed kind as if it were understood.
+    expect(data.snapshotInFlight).toEqual([{ ...IN_FLIGHT_BRIDGE, kind: "unknown" }]);
+    // And it contributes nothing: the total came from the publisher's
+    // aggregate, which never saw this list.
+    expect(data.snapshotInTransitUsd).toBe(150);
+  });
+
+  it("refuses a NEGATIVE usdEstimate rather than letting it subtract", async () => {
+    scriptSnapshot(
+      snapshotRow({
+        total: "50",
+        in_flight: JSON.stringify([{ ...IN_FLIGHT_BRIDGE, usdEstimate: -500 }]),
+      }),
+    );
+
+    const data = await readGlobalPortfolio();
+
+    // The DTO's own gate: a negative estimate is a bad price, not a liability,
+    // and it never reaches a surface that renders money.
+    expect(data.snapshotInFlight).toEqual([]);
+    expect(mocks.log.warn).toHaveBeenCalled();
+  });
+
+  it("clamps a negative persisted in-transit total to zero", async () => {
+    scriptSnapshot(snapshotRow({ total: "50", in_transit: -42, in_flight: "[]" }));
+
+    const data = await readGlobalPortfolio();
+
+    // Migration 102 CHECKs this at the schema; a row written before it must not
+    // subtract from the portfolio either.
+    expect(data.snapshotInTransitUsd).toBe(0);
+    expect(data.snapshotTotalUsd).toBeCloseTo(50, 4);
+  });
+});
+
+// ── 5. The closed vocabulary, pinned across the two trees ────────────────
+
+describe("the in-flight kind vocabulary", () => {
+  /**
+   * The engine's `IN_FLIGHT_KINDS` and this tree's `SNAPSHOT_IN_FLIGHT_KINDS`
+   * are duplicated on purpose: `shared` bundles into the untrusted renderer and
+   * cannot import `@vex-agent`, and the engine's project cannot reach into
+   * `vex-app`. This suite runs in the main process, which can see both, so the
+   * duplication is checked rather than trusted.
+   */
+  it("matches the engine's producer list, plus the reader's own fallback", () => {
+    expect([...SNAPSHOT_IN_FLIGHT_KINDS]).toEqual([...IN_FLIGHT_KINDS, "unknown"]);
+  });
+
+  it("rejects a kind outside the closed list at the DTO boundary", () => {
+    const parsed = snapshotInFlightEntryDtoSchema.safeParse({
+      ...IN_FLIGHT_BRIDGE,
+      kind: "some_future_kind",
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("accepts every producer kind", () => {
+    for (const kind of IN_FLIGHT_KINDS) {
+      expect(snapshotInFlightEntryDtoSchema.safeParse({ ...IN_FLIGHT_BRIDGE, kind }).success)
+        .toBe(true);
+    }
+  });
+});

--- a/vex-app/src/main/database/portfolio-db.ts
+++ b/vex-app/src/main/database/portfolio-db.ts
@@ -12,6 +12,11 @@
  *                 snapshot_group_id UUID, total_usd NUMERIC,
  *                 pnl_vs_prev NUMERIC, created_at)
  *
+ * The snapshot half of the read - the group records, their per-wallet in-flight
+ * accounting and the PnL basis - is owned by `./portfolio/snapshot-basis.ts`.
+ * It is called with the SAME server-resolved address allow-list every query
+ * here binds, and it cannot widen it.
+ *
  * SECURITY (non-negotiable):
  *  - GLOBAL is an EXPLICIT address allow-list. EVERY SELECT carries
  *    `WHERE wallet_address = ANY($1::text[])` with a bound, finite array.
@@ -56,15 +61,14 @@ import type {
   PortfolioReadInput,
   PositionChainDto,
   PositionTokenDto,
-  SnapshotInFlightEntryDto,
 } from "@shared/schemas/portfolio.js";
-import { snapshotInFlightEntryDtoSchema } from "@shared/schemas/portfolio.js";
 import { familyForChainId } from "@shared/chains/display.js";
 import { sanitizeTokenName } from "@shared/token-name-sanitizer.js";
 import { solanaRouteMintFromPersistedAddress } from "@tools/solana-ecosystem/shared/solana-asset-identity.js";
 import { listInventoryWalletEntries } from "./inventory-wallets.js";
 import { getSessionWalletScope } from "./sessions-db.js";
 import { readProjectPortfolioScope } from "./projects/portfolio-scope.js";
+import { readSnapshotBases } from "./portfolio/snapshot-basis.js";
 import { buildPoolConfig } from "./db-config.js";
 import { log } from "../logger/index.js";
 
@@ -146,16 +150,6 @@ interface TokenRow {
   readonly token_name: string | null;
   readonly usd: number | string | null;
   readonly amount: number | string | null;
-}
-
-interface SnapshotRow {
-  readonly total: number | string | null;
-  readonly at: string | Date | null;
-  /** From `proj_portfolio_snapshot_groups`; null for a group written before migration 101. */
-  readonly in_transit: number | string | null;
-  readonly unresolved_count: number | string | null;
-  /** The ledger as JSON TEXT, so it crosses the driver without a jsonb parser. */
-  readonly in_flight: string | null;
 }
 
 interface ChainBreakdownRow {
@@ -346,63 +340,6 @@ function toChainId(value: number | string | null | undefined): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function toIso(value: string | Date): string {
-  return value instanceof Date ? value.toISOString() : value;
-}
-
-/**
- * One snapshot group, read as the three facts the card needs.
- *
- * `totalUsd` is SETTLED + IN TRANSIT. A group with no record in
- * `proj_portfolio_snapshot_groups` - every group published before migration 101
- * - reads as in transit 0, unresolved 0, no ledger, so its basis is exactly the
- * settled figure the old code returned and the two bases stay comparable.
- *
- * The ledger arrives as JSON text written by this repository's own publisher,
- * and it is still PARSED rather than trusted: a durable row that has crossed
- * serialization is external input (rule 04), and it feeds a surface that shows
- * the user money. A row that fails the schema degrades to "no ledger" and is
- * logged; it never throws away the settled total beside it and never reaches
- * the DTO half-formed.
- */
-interface SnapshotBasis {
-  readonly totalUsd: number | null;
-  readonly settledUsd: number | null;
-  readonly inTransitUsd: number;
-  readonly unresolvedCount: number;
-  readonly inFlight: SnapshotInFlightEntryDto[];
-  readonly at: string | null;
-}
-
-function readSnapshotBasis(row: SnapshotRow | undefined): SnapshotBasis | null {
-  if (row === undefined) return null;
-  const settledUsd = toNumberOrNull(row.total);
-  const inTransitUsd = toNumber(row.in_transit);
-  const unresolvedCount = Math.max(0, Math.trunc(toNumber(row.unresolved_count)));
-  return {
-    totalUsd: settledUsd === null ? null : settledUsd + inTransitUsd,
-    settledUsd,
-    inTransitUsd,
-    unresolvedCount,
-    inFlight: parseInFlight(row.in_flight),
-    at: row.at !== null ? toIso(row.at) : null,
-  };
-}
-
-function parseInFlight(json: string | null): SnapshotInFlightEntryDto[] {
-  if (json === null) return [];
-  try {
-    const parsed = snapshotInFlightEntryDtoSchema.array().max(50).safeParse(JSON.parse(json));
-    if (parsed.success) return parsed.data;
-    log.warn(
-      "[portfolio-db] snapshot in-flight ledger failed its schema; reporting an empty ledger",
-    );
-  } catch {
-    log.warn("[portfolio-db] snapshot in-flight ledger is not valid JSON; reporting an empty ledger");
-  }
-  return [];
-}
-
 function emptyPortfolio(scope: PortfolioReadInput["scope"]): PortfolioDto {
   return {
     scope,
@@ -413,6 +350,9 @@ function emptyPortfolio(scope: PortfolioReadInput["scope"]): PortfolioDto {
     snapshotInTransitUsd: null,
     snapshotInFlight: null,
     snapshotUnresolvedCount: null,
+    snapshotInFlightTotalCount: null,
+    snapshotInFlightShownCount: null,
+    snapshotInFlightTruncated: null,
     pnlVsPrev: null,
     snapshotAt: null,
     tokens: [],
@@ -691,47 +631,14 @@ export async function getPortfolio(
       );
       const chains = buildChainBreakdown(breakdownResult.rows);
 
-      // (c) PnL across COMPLETE snapshot cycles: the latest TWO groups that
-      // cover EXACTLY the resolved address set (HAVING COUNT(DISTINCT)=N - a
-      // partial group for a subset of the wallets is ignored). Aggregate PnL is
+      // (c) The PnL BASIS across COMPLETE snapshot cycles, owned by
+      // `./portfolio/snapshot-basis.ts`: the latest two groups covering
+      // EXACTLY this address set, each with its in-flight accounting summed
+      // over exactly these wallets (migration 102). Aggregate PnL is
       // `latest.basis - previous.basis`, NOT SUM(pnl_vs_prev): per-wallet PnL
       // baselines don't compose into a correct set total (and miss wallets with
       // no prior row). snapshot/PnL are null when the cycle(s) are absent.
-      //
-      // THE BASIS IS SETTLED + IN TRANSIT (migration 101). `total_usd` still
-      // means exactly what it always did - balances that were read - and the
-      // group's in-flight ledger is joined on beside it. Comparing settled
-      // alone across a cycle in which money left one chain and had not yet
-      // arrived on the other reports a loss the user did not take; that
-      // "$50 and -$150" reading is the whole reason the ledger exists.
-      //
-      // The three group columns come from CORRELATED SCALAR SUBQUERIES, not a
-      // join: the group record is one row per group and the query groups by
-      // exactly that key, so this stays a lookup and a group written before 101
-      // simply yields NULL rather than dropping out of the result.
-      const snapshotResult = await client.query<SnapshotRow>(
-        `SELECT s.snapshot_group_id,
-                SUM(s.total_usd)::float8 AS total,
-                MAX(s.created_at)        AS at,
-                (SELECT g.in_transit_usd::float8
-                   FROM proj_portfolio_snapshot_groups g
-                  WHERE g.snapshot_group_id = s.snapshot_group_id) AS in_transit,
-                (SELECT g.unresolved_count
-                   FROM proj_portfolio_snapshot_groups g
-                  WHERE g.snapshot_group_id = s.snapshot_group_id) AS unresolved_count,
-                (SELECT g.in_flight::text
-                   FROM proj_portfolio_snapshot_groups g
-                  WHERE g.snapshot_group_id = s.snapshot_group_id) AS in_flight
-           FROM proj_portfolio_snapshots s
-          WHERE s.wallet_address = ANY($1::text[])
-          GROUP BY s.snapshot_group_id
-         HAVING COUNT(DISTINCT s.wallet_address) = $2
-          ORDER BY at DESC
-          LIMIT 2`,
-        [addrParam, addresses.length],
-      );
-      const latest = readSnapshotBasis(snapshotResult.rows[0]);
-      const previous = readSnapshotBasis(snapshotResult.rows[1]);
+      const { latest, previous } = await readSnapshotBases(client, addresses);
       const snapshotTotalUsd = latest?.totalUsd ?? null;
       const pnlVsPrev =
         latest?.totalUsd !== undefined && latest.totalUsd !== null
@@ -755,6 +662,9 @@ export async function getPortfolio(
         snapshotInTransitUsd: latest?.inTransitUsd ?? null,
         snapshotInFlight: latest?.inFlight ?? null,
         snapshotUnresolvedCount: latest?.unresolvedCount ?? null,
+        snapshotInFlightTotalCount: latest?.inFlightTotalCount ?? null,
+        snapshotInFlightShownCount: latest?.inFlight.length ?? null,
+        snapshotInFlightTruncated: latest?.inFlightTruncated ?? null,
         pnlVsPrev,
         snapshotAt,
         tokens,

--- a/vex-app/src/main/database/portfolio/snapshot-basis.ts
+++ b/vex-app/src/main/database/portfolio/snapshot-basis.ts
@@ -1,0 +1,276 @@
+/**
+ * The PnL BASIS of a portfolio read: what the most recent complete snapshot
+ * cycles measured, and what was in flight FOR THE WALLETS BEING ASKED ABOUT.
+ *
+ * Extracted from `../portfolio-db.ts` (2026-09-04) when that file crossed the
+ * repository's 750-line gate. `getPortfolio` keeps its public shape and its
+ * home; what moved here is one coherent responsibility with its own name: read
+ * the snapshot groups, scope their in-flight accounting, and hand back a basis.
+ * It owns the snapshot SQL, the durable-JSON parse and the basis arithmetic.
+ * It knows nothing about balances, chains, tokens or address resolution.
+ *
+ * ## The basis is SETTLED + IN TRANSIT, and IN TRANSIT is per wallet
+ *
+ * `proj_portfolio_snapshots.total_usd` still means exactly what it always did:
+ * balances that were read. Comparing that alone across a cycle in which money
+ * left one chain and had not yet arrived on the other reports a loss the user
+ * did not take - the "$50 and -$150" reading that migration 101 exists to
+ * prevent.
+ *
+ * Migration 101 answered that with ONE group-wide in-transit total, which
+ * external review then showed is wrong for any read narrower than the whole
+ * inventory: a session or project scoped to wallet A would inherit wallet B's
+ * pending bridge. Migration 102 persists the accounting PER WALLET, and every
+ * figure below is summed over exactly the resolved address set - the same
+ * `wallet_address = ANY($1::text[])` allow-list that bounds every other query
+ * in this read. There is no path here that can widen it.
+ *
+ * ## The bounded list is a list, never a total
+ *
+ * `in_flight` is the group's DISPLAY ledger, bounded at 50 entries by the
+ * publisher. Nothing here derives a total from it. `inTransitUsd`,
+ * `unresolvedCount` and `totalCount` all come from the per-wallet aggregate
+ * rows, which the publisher computed over EVERY in-flight row. `truncated`
+ * compares the two so a consumer is never handed a short list as the truth.
+ *
+ * ## The durable row is parsed, not trusted
+ *
+ * The ledger arrives as JSON text written by this repository's own publisher,
+ * and it is still PARSED (rule 04: durable data that has crossed serialization
+ * is external input), because it feeds a surface that shows the user money. A
+ * malformed entry is dropped and reported by COUNT; a kind this build has never
+ * heard of - a ledger written by a newer build - maps to the typed `unknown`
+ * fallback and stays listed rather than vanishing.
+ */
+
+import type { Client } from "pg";
+
+import {
+  SNAPSHOT_IN_FLIGHT_KINDS,
+  snapshotInFlightEntryDtoSchema,
+  type SnapshotInFlightEntryDto,
+} from "@shared/schemas/portfolio.js";
+import { log } from "../../logger/index.js";
+
+/**
+ * The latest TWO groups that cover EXACTLY the resolved address set
+ * (`HAVING COUNT(DISTINCT) = N` - a partial group for a subset of the wallets
+ * is ignored), each with its in-flight accounting scoped to those same
+ * addresses.
+ *
+ * The four in-flight figures come from CORRELATED SCALAR SUBQUERIES, not joins:
+ * the aggregate is over one group's per-wallet rows and the outer query already
+ * groups by exactly that key, so this stays a lookup, and a group written
+ * before migration 102 yields 0 rather than dropping out of the result.
+ *
+ * `COALESCE(..., 0)` on all three sums is the pre-102 contract: no per-wallet
+ * rows means no attribution exists for that group, and the conservative reading
+ * is that these wallets had nothing in flight - never that the group's own
+ * whole-inventory figure belongs to them.
+ */
+const SNAPSHOT_BASIS_SQL = `
+  SELECT s.snapshot_group_id,
+         SUM(s.total_usd)::float8 AS total,
+         MAX(s.created_at)        AS at,
+         (SELECT COALESCE(SUM(w.in_transit_usd), 0)::float8
+            FROM proj_portfolio_snapshot_group_wallets w
+           WHERE w.snapshot_group_id = s.snapshot_group_id
+             AND w.wallet_address = ANY($1::text[]))       AS in_transit,
+         (SELECT COALESCE(SUM(w.unresolved_count), 0)
+            FROM proj_portfolio_snapshot_group_wallets w
+           WHERE w.snapshot_group_id = s.snapshot_group_id
+             AND w.wallet_address = ANY($1::text[]))       AS unresolved_count,
+         (SELECT COALESCE(SUM(w.entry_count), 0)
+            FROM proj_portfolio_snapshot_group_wallets w
+           WHERE w.snapshot_group_id = s.snapshot_group_id
+             AND w.wallet_address = ANY($1::text[]))       AS in_flight_total_count,
+         (SELECT g.in_flight::text
+            FROM proj_portfolio_snapshot_groups g
+           WHERE g.snapshot_group_id = s.snapshot_group_id) AS in_flight
+    FROM proj_portfolio_snapshots s
+   WHERE s.wallet_address = ANY($1::text[])
+   GROUP BY s.snapshot_group_id
+  HAVING COUNT(DISTINCT s.wallet_address) = $2
+   ORDER BY at DESC
+   LIMIT 2`;
+
+interface SnapshotRow {
+  readonly total: number | string | null;
+  readonly at: string | Date | null;
+  /** Summed over the RESOLVED addresses only; 0 for a group written before 102. */
+  readonly in_transit: number | string | null;
+  readonly unresolved_count: number | string | null;
+  readonly in_flight_total_count: number | string | null;
+  /** The group's display ledger as JSON TEXT, so it crosses the driver whole. */
+  readonly in_flight: string | null;
+}
+
+/** One snapshot group, read as the facts the Position card needs. */
+export interface SnapshotBasis {
+  /** SETTLED + IN TRANSIT. `null` only when the group's settled sum is absent. */
+  readonly totalUsd: number | null;
+  readonly settledUsd: number | null;
+  readonly inTransitUsd: number;
+  readonly unresolvedCount: number;
+  /** The scoped entries of the bounded display list. Never a source of totals. */
+  readonly inFlight: SnapshotInFlightEntryDto[];
+  /** Every in-flight row these wallets had, displayed or not. */
+  readonly inFlightTotalCount: number;
+  /** `inFlightTotalCount > inFlight.length`: rows exist beyond the list. */
+  readonly inFlightTruncated: boolean;
+  readonly at: string | null;
+}
+
+export interface SnapshotBases {
+  readonly latest: SnapshotBasis | null;
+  readonly previous: SnapshotBasis | null;
+}
+
+/**
+ * Read the two most recent complete snapshot cycles for `addresses`.
+ *
+ * `addresses` is the server-resolved allow-list; it is bound into the ONE
+ * `$1::text[]` parameter that every predicate and every aggregate in
+ * `SNAPSHOT_BASIS_SQL` uses, and it is the same array used to filter the
+ * display ledger below. A caller cannot widen the scope of one without the
+ * other.
+ */
+export async function readSnapshotBases(
+  client: Client,
+  addresses: readonly string[],
+): Promise<SnapshotBases> {
+  const result = await client.query<SnapshotRow>(SNAPSHOT_BASIS_SQL, [
+    [...addresses],
+    addresses.length,
+  ]);
+  const scope = new Set(addresses);
+  return {
+    latest: readSnapshotBasis(result.rows[0], scope),
+    previous: readSnapshotBasis(result.rows[1], scope),
+  };
+}
+
+function readSnapshotBasis(
+  row: SnapshotRow | undefined,
+  scope: ReadonlySet<string>,
+): SnapshotBasis | null {
+  if (row === undefined) return null;
+  const settledUsd = toNullableUsd(row.total);
+  // Clamped: `in_transit_usd` is CHECKed non-negative from migration 102
+  // onward, and a pre-102 row that predates the check must not subtract from a
+  // portfolio either.
+  const inTransitUsd = Math.max(0, toUsd(row.in_transit));
+  const unresolvedCount = toCount(row.unresolved_count);
+  const inFlight = scopedInFlight(row.in_flight, scope);
+  const inFlightTotalCount = toCount(row.in_flight_total_count);
+  return {
+    totalUsd: settledUsd === null ? null : settledUsd + inTransitUsd,
+    settledUsd,
+    inTransitUsd,
+    unresolvedCount,
+    inFlight,
+    inFlightTotalCount,
+    inFlightTruncated: inFlightTotalCount > inFlight.length,
+    at: row.at !== null ? toIso(row.at) : null,
+  };
+}
+
+/**
+ * The group's bounded ledger, narrowed to the wallets this read is about.
+ *
+ * Each entry is validated on its own rather than the array as a whole: one
+ * unreadable row must not delete the rest of a report about the user's money.
+ * Drops are reported by COUNT - never silently, and never with their content,
+ * which is unvalidated durable text.
+ *
+ * An entry whose `walletAddress` is outside `scope` belongs to another wallet
+ * in the same publication cycle and is dropped BEFORE validation: it is not
+ * this portfolio's money. An entry with no `walletAddress` at all was written
+ * before migration 102, carries no attribution, and is dropped for the same
+ * reason - the pre-102 reading is "nothing in flight for these wallets", not
+ * "somebody's rows".
+ */
+function scopedInFlight(
+  json: string | null,
+  scope: ReadonlySet<string>,
+): SnapshotInFlightEntryDto[] {
+  if (json === null) return [];
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    log.warn("[portfolio-db] snapshot in-flight ledger is not valid JSON; reporting an empty ledger");
+    return [];
+  }
+  if (!Array.isArray(raw)) {
+    log.warn("[portfolio-db] snapshot in-flight ledger is not an array; reporting an empty ledger");
+    return [];
+  }
+
+  const entries: SnapshotInFlightEntryDto[] = [];
+  let rejected = 0;
+  for (const candidate of raw) {
+    if (!belongsToScope(candidate, scope)) continue;
+    const parsed = snapshotInFlightEntryDtoSchema.safeParse(withKnownKind(candidate));
+    if (parsed.success) entries.push(parsed.data);
+    else rejected += 1;
+  }
+  if (rejected > 0) {
+    log.warn(
+      `[portfolio-db] snapshot in-flight ledger dropped ${rejected} entr${
+        rejected === 1 ? "y" : "ies"
+      } that failed the entry schema`,
+    );
+  }
+  return entries;
+}
+
+function belongsToScope(candidate: unknown, scope: ReadonlySet<string>): boolean {
+  if (typeof candidate !== "object" || candidate === null) return false;
+  const address = (candidate as { walletAddress?: unknown }).walletAddress;
+  return typeof address === "string" && scope.has(address);
+}
+
+/**
+ * A durable ledger written by a NEWER build can name a kind this one has never
+ * heard of. Mapping it to the typed `unknown` fallback keeps the row VISIBLE -
+ * money is in flight and a human should see it - while the closed enum still
+ * refuses to let an unnamed kind reach a surface as if it were understood. It
+ * contributes to no total, because every total on this path comes from the
+ * publisher's aggregates rather than from this list.
+ */
+function withKnownKind(candidate: unknown): unknown {
+  if (typeof candidate !== "object" || candidate === null) return candidate;
+  const kind = (candidate as { kind?: unknown }).kind;
+  const known = SNAPSHOT_IN_FLIGHT_KINDS.some((value) => value === kind);
+  return known ? candidate : { ...candidate, kind: "unknown" };
+}
+
+/**
+ * `NUMERIC`/`float8` columns come back from `pg` as strings or numbers. These
+ * three coercions are this module's own: they read the snapshot group's money
+ * and time columns, and `portfolio-db.ts` keeps its own for the balance
+ * columns, so neither file's column contract can be changed by editing the
+ * other's helper.
+ */
+function toUsd(value: number | string | null | undefined): number {
+  const parsed = toNullableUsd(value);
+  return parsed ?? 0;
+}
+
+function toNullableUsd(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toCount(value: number | string | null | undefined): number {
+  const parsed = toNullableUsd(value);
+  if (parsed === null) return 0;
+  return Math.max(0, Math.trunc(parsed));
+}
+
+function toIso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value;
+}

--- a/vex-app/src/shared/schemas/portfolio.ts
+++ b/vex-app/src/shared/schemas/portfolio.ts
@@ -227,16 +227,66 @@ export type PositionChainDto = z.infer<typeof positionChainDtoSchema>;
  *  - `usdEstimate` - a display ESTIMATE, never a settlement figure. `null`
  *    means "not priced", which is not the same as 0.
  */
+export const SNAPSHOT_IN_FLIGHT_KINDS = [
+  "agent_activity_pending",
+  "wallet_intent_live",
+  "wallet_confirmation_unknown",
+  "wallet_transaction_intent_live",
+  "wallet_transaction_confirmation_unknown",
+  "wallet_wrap_intent_live",
+  "wallet_wrap_confirmation_unknown",
+  /**
+   * The deliberate FALLBACK, not a producer value: a durable ledger written by
+   * a NEWER build than the one reading it can name a kind this build has never
+   * heard of. Such an entry is still LISTED - the row exists and a human should
+   * see it - and it is never counted into a total, because a build that cannot
+   * name the money cannot vouch for its amount. The reader
+   * (`main/database/portfolio/snapshot-basis.ts`) maps an unrecognized kind
+   * here; nothing else ever emits it.
+   */
+  "unknown",
+] as const;
+
+/**
+ * The closed vocabulary of in-flight kinds.
+ *
+ * DUPLICATED, deliberately, from `IN_FLIGHT_KINDS` in
+ * `src/vex-agent/sync/balance-sync/publication-gate.ts`, which owns the
+ * producer side. This tree bundles into the untrusted renderer and the
+ * process-boundary gate forbids `@vex-agent` here (rule 90), while the engine's
+ * own project cannot reach into `vex-app` - so the two lists cannot share a
+ * module. `engine-error-classification.ts` carries the same duplication for the
+ * same reason. They are pinned against each other by
+ * `main/database/__tests__/portfolio-snapshot-basis.test.ts`, which runs in the
+ * main process and can see both; the extra `unknown` member is this side's
+ * alone and the pin accounts for it.
+ */
+export const snapshotInFlightKindDtoSchema = z.enum(SNAPSHOT_IN_FLIGHT_KINDS);
+export type SnapshotInFlightKindDto = z.infer<typeof snapshotInFlightKindDtoSchema>;
+
 export const snapshotInFlightEntryDtoSchema = z
   .object({
-    kind: z.string(),
+    kind: snapshotInFlightKindDtoSchema,
+    /**
+     * Whose money this is. Present on every entry so a portfolio read for a
+     * SUBSET of a group's wallets can drop what is not its own instead of
+     * showing one wallet another wallet's pending bridge. The raw stored
+     * address, never lowercased, matching every other join in this schema.
+     */
+    walletAddress: z.string(),
     ref: z.string(),
     detail: z.string().nullable(),
     standing: z.enum(["in_transit", "unresolved"]),
-    ageSeconds: z.number(),
+    ageSeconds: z.number().nonnegative(),
     amountHuman: z.string().nullable(),
     symbol: z.string().nullable(),
-    usdEstimate: z.number().nullable(),
+    /**
+     * NON-NEGATIVE or `null`. A negative estimate is a bad price, not a
+     * liability, and it would render as a subtraction from the user's
+     * portfolio; the producer already maps one to "not priced" and this is the
+     * same refusal at the contract boundary.
+     */
+    usdEstimate: z.number().nonnegative().nullable(),
   })
   .strict();
 export type SnapshotInFlightEntryDto = z.infer<typeof snapshotInFlightEntryDtoSchema>;
@@ -258,17 +308,33 @@ export type SnapshotInFlightEntryDto = z.infer<typeof snapshotInFlightEntryDtoSc
  *  - `snapshotSettledUsd`/`snapshotInTransitUsd` - the two halves of that
  *                        total, kept separate so a surface can show them
  *                        separately. Settled is measured; in transit is a sum
- *                        of ESTIMATES. `null` alongside `snapshotTotalUsd`;
- *                        in-transit is 0 for a group published before migration
- *                        101, which carries no group record.
- *  - `snapshotInFlight`  - that group's in-flight ledger, at most 50 entries
- *                        (the publisher's own bound; an overflow keeps the
- *                        oldest and is reported in the sync log). An EMPTY
- *                        array means "a group exists and nothing was in
- *                        flight"; `null` means there is no group to report on.
- *  - `snapshotUnresolvedCount` - entries in that ledger whose standing is
- *                        `unresolved`. They are in NO total; a surface showing
- *                        the total must say separately that they exist.
+ *                        of ESTIMATES, and it is summed PER WALLET over exactly
+ *                        the resolved address set (migration 102), so a
+ *                        one-wallet read never inherits another wallet's
+ *                        pending bridge. Both are `null` alongside
+ *                        `snapshotTotalUsd`; in-transit is 0 for a group
+ *                        published before migration 102, which carries no
+ *                        per-wallet attribution.
+ *  - `snapshotInFlight`  - the entries of that group's in-flight ledger THAT
+ *                        BELONG TO THE RESOLVED ADDRESS SET, at most 50 (the
+ *                        publisher's own display bound). An EMPTY array means
+ *                        "a group exists and none of these wallets had anything
+ *                        in flight"; `null` means there is no group to report
+ *                        on. It is a LIST, never the source of a total.
+ *  - `snapshotUnresolvedCount` - rows of that ledger, for these wallets, whose
+ *                        standing is `unresolved`. Counted by the publisher
+ *                        over EVERY row, so it can exceed the number of
+ *                        `unresolved` entries the bounded list shows. They are
+ *                        in NO total; a surface showing the total must say
+ *                        separately that they exist.
+ *  - `snapshotInFlightTotalCount` / `snapshotInFlightShownCount` /
+ *    `snapshotInFlightTruncated` - the explicit bound contract. `totalCount` is
+ *                        every in-flight row these wallets had, aggregated by
+ *                        the publisher independently of any list; `shownCount`
+ *                        is `snapshotInFlight.length`; `truncated` is
+ *                        `totalCount > shownCount`. A surface that renders the
+ *                        list must say that rows exist beyond it rather than
+ *                        presenting a short list as the whole truth.
  *  - `tokens`          — per-(chain,token) live lines, biggest USD first,
  *                        capped at 500 (defensive bound, never expected to hit).
  *                        `balanceUsd: null` marks an unpriced holding.
@@ -276,13 +342,15 @@ export type SnapshotInFlightEntryDto = z.infer<typeof snapshotInFlightEntryDtoSc
  *                        non-negative totals (0 = unpriced-only chain),
  *                        top-3 tokens each, bounded at 64 chains.
  *
- * The four ledger fields are OPTIONAL on the wire and REQUIRED of the producer:
- * `getPortfolio` always emits all four, so a consumer sees `null` (no complete
- * group covers the resolved address set) or a value. `undefined` exists only so
- * that a DTO literal written before these fields still type-checks, and no
- * surface may treat it as a distinct state. A group published before migration
- * 101 has no group record, so its ledger reads as settled = total, in transit
- * 0, unresolved 0, no entries.
+ * The seven ledger fields are OPTIONAL on the wire and REQUIRED of the
+ * producer: `getPortfolio` always emits all seven, so a consumer sees `null`
+ * (no complete group covers the resolved address set) or a value. `undefined`
+ * exists only so that a DTO literal written before these fields still
+ * type-checks, and no surface may treat it as a distinct state. A group
+ * published before migration 102 carries no per-wallet attribution, so its
+ * ledger reads as settled = total, in transit 0, unresolved 0, total count 0,
+ * no entries - the same conservative reading migration 101 already specified
+ * for groups published before IT.
  */
 export const portfolioDtoSchema = z
   .object({
@@ -294,6 +362,9 @@ export const portfolioDtoSchema = z
     snapshotInTransitUsd: z.number().nullable().optional(),
     snapshotInFlight: z.array(snapshotInFlightEntryDtoSchema).max(50).nullable().optional(),
     snapshotUnresolvedCount: z.number().int().nonnegative().nullable().optional(),
+    snapshotInFlightTotalCount: z.number().int().nonnegative().nullable().optional(),
+    snapshotInFlightShownCount: z.number().int().nonnegative().nullable().optional(),
+    snapshotInFlightTruncated: z.boolean().nullable().optional(),
     pnlVsPrev: z.number().nullable(),
     snapshotAt: z.string().datetime({ offset: true }).nullable(),
     tokens: z.array(positionTokenDtoSchema).max(500),


### PR DESCRIPTION
## What changes

- **Per-wallet attribution.** Every in-flight entry carries its wallet; per-wallet aggregates are computed in SQL over all rows; migration 102 (expand-only, mirror byte-identical) adds `proj_portfolio_snapshot_group_wallets` keyed by group and wallet with a CHECK per component. A scoped read (session, project, single wallet) sums only the requested wallets and lists only their entries. The owner's scenario is a named test: wallet A $50 settled + $150 in transit, wallet B $0; full scope 200, A-only 200, B-only 0 with no foreign entry.
- **Totals never depend on the bounded list.** Aggregates and counts come from SQL over all rows; the list stays bounded at 50 with a persisted `in_flight_total_count`, and the DTO carries `shownCount`, `totalCount`, `truncated`. A 55-row overflow test proves every row contributes.
- **Expired pending intents** (no transaction hash past `expires_at`) are documented as never in flight and pinned by a table test; a broadcast intent is never excluded by expiry.
- **Non-negative estimates** at the driver, the DTO and a CHECK (with a repair before the CHECK so one bad row cannot block boot).
- **Closed vocabulary** on both sides of the process boundary with a typed `unknown` fallback (listed, never counted), pinned across both trees.
- **Extractions**: `database/portfolio/snapshot-basis.ts` (portfolio-db 767 to 677, `getPortfolio` unchanged) and `balance-sync/activity-fence.ts` (publication-gate 810 to 740, re-exported).

## Renderer follow-up (not in this PR)

The Position card can now render per scope: settled and in-transit halves of the total, an "N items unaccounted for" line outside every total, and the bounded ledger with "shown of total" and an affordance when truncated. No renderer file is touched; it compiles unchanged.

## Verification

- root vitest `sync/balance-sync`: 8 files, 99 tests; Postgres integration `integration/repos`: 18 files, 240 tests on the real server with migration 102 applied by the runner; vex-app `src/main/database` and `src/shared`: 126 files, 1877 tests; root tsc, vex-app `lint:tsc`, process boundaries, em-dash and unsafe-escapes gates green.
- Growth decisions: two test files grown on purpose (one scripted-Postgres harness shared by every section; one real-schema fixture set shared by one publication lifecycle); the group-level `in_transit_usd` / `unresolved_count` columns stay as the whole-inventory audit record.

Reference reading: MetaMask `bridge-status-controller` (attribution at creation, scoped operations filter on it) and its test.
