### PR TITLE
fix(studio): per-connection MCP lifecycle lines, visible peer half-close, a bounded Windows dial

### DIFF
--- a/bridge/cmd/vex-mcp/dial_unix.go
+++ b/bridge/cmd/vex-mcp/dial_unix.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 
@@ -16,7 +17,7 @@ import (
 // syntax on a unix target by name (`override_pipe_on_unix`), dialEndpoint
 // re-checks runtime.GOOS at the dial site, and this build-tagged stub means a
 // unix binary contains no code that could open one at all.
-func dialPipe(path string) (handshake.Conn, error) {
+func dialPipe(_ context.Context, path string) (handshake.Conn, error) {
 	return nil, fmt.Errorf("named pipes do not exist on %s; refusing to open %s",
 		runtime.GOOS, path)
 }

--- a/bridge/cmd/vex-mcp/dial_windows.go
+++ b/bridge/cmd/vex-mcp/dial_windows.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -37,6 +38,12 @@ import (
 // one sentence. The ERROR_PIPE_BUSY loop is the documented way to wait for an
 // instance of a pipe that IS there, which is what go-winio's tryDialPipe
 // (agents-colab/go-winio/pipe.go) does under its own context deadline.
+//
+// THE DEADLINE IS NOT THE ONLY WAY OUT. The wait runs under the caller's
+// context, which carries this process's SIGINT/SIGTERM/SIGHUP registration as
+// well as this bound, so a user who interrupts the bridge while its front is
+// saturated gets the teardown this program owns rather than four seconds of a
+// loop that observes nothing.
 const WindowsDialTimeout = 4 * time.Second
 
 // pipeBusyRetryInterval is the pause between ERROR_PIPE_BUSY attempts, the
@@ -150,20 +157,26 @@ const errorPipeBusy = syscall.Errno(231)
 // (run 33646484002) drives this exact path against a pipe served by a temporary
 // SECOND local account the job creates, where the host authentication below
 // refuses with `windows_host_not_current_user` and no byte is written.
-func dialPipe(path string) (handshake.Conn, error) {
-	return dialPipeWith(path, resolveServerUserSID, resolveCurrentUserSID)
+func dialPipe(ctx context.Context, path string) (handshake.Conn, error) {
+	return dialPipeWith(ctx, path, resolveServerUserSID, resolveCurrentUserSID)
 }
 
 // dialPipeWith is dialPipe with its identity sources injected, so the refusal
 // branches can be driven deterministically on a single-account runner. The
 // production call above is the only non-test caller.
-func dialPipeWith(path string, server serverSIDResolver, current userSIDResolver) (handshake.Conn, error) {
-	return dialPipeWithin(path, WindowsDialTimeout, server, current)
+func dialPipeWith(
+	ctx context.Context,
+	path string,
+	server serverSIDResolver,
+	current userSIDResolver,
+) (handshake.Conn, error) {
+	return dialPipeWithin(ctx, path, WindowsDialTimeout, server, current)
 }
 
 // dialPipeWithin is dialPipeWith with the bound injected, so the deadline
 // branch is driven in milliseconds rather than in four real seconds.
 func dialPipeWithin(
+	ctx context.Context,
 	path string,
 	budget time.Duration,
 	server serverSIDResolver,
@@ -173,9 +186,17 @@ func dialPipeWithin(
 	if err != nil {
 		return nil, &os.PathError{Op: "open", Path: path, Err: err}
 	}
-	handle, err := createPipeHandleWithin(name, budget)
+	// THE BOUND IS APPLIED HERE, on top of whatever the caller already
+	// carries: the deadline belongs to this transport and the cancellation
+	// belongs to the process, and a derived context is how both hold at once.
+	bounded, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+	handle, err := createPipeHandleWithin(bounded, name, budget)
 	if err != nil {
 		if _, busy := asDialTimeout(err); busy {
+			return nil, err
+		}
+		if _, interrupted := asDialInterrupted(err); interrupted {
 			return nil, err
 		}
 		return nil, &os.PathError{Op: "open", Path: path, Err: err}
@@ -191,22 +212,33 @@ func dialPipeWithin(
 }
 
 // createPipeHandleWithin opens the pipe, waiting out ERROR_PIPE_BUSY until the
-// deadline.
+// context is done.
 //
 // THE SHAPE IS go-winio's tryDialPipe (agents-colab/go-winio/pipe.go line
 // 207), written against the standard library because this binary links nothing
-// else: attempt, return on success, return on any error that is not
-// ERROR_PIPE_BUSY, otherwise sleep a fixed interval and attempt again while
-// there is budget left. The deadline is checked BEFORE each attempt and after
-// each sleep, so the loop cannot overrun it by a whole interval.
+// else: check the context, attempt, return on success, return on any error
+// that is not ERROR_PIPE_BUSY, otherwise wait a fixed interval and attempt
+// again. It differs from go-winio's loop in ONE way, deliberately: go-winio
+// waits with `time.Sleep`, so a cancellation that lands mid-wait is not seen
+// until the sleep is over. Here the wait is a select on the context and the
+// timer, so the loop leaves within a scheduling quantum of the cancel rather
+// than within an interval of it. The context is checked BEFORE every attempt
+// and it is the only thing the wait can lose to, so the loop can neither
+// overrun its deadline nor outlive an interrupted process.
 //
-// Exhaustion is a dialTimeout, which carries its own sentence; every other
-// failure is the operating system's and keeps its errno so dialSentence can
-// name ENOENT and the rest.
-func createPipeHandleWithin(name *uint16, budget time.Duration) (syscall.Handle, error) {
-	deadline := time.Now().Add(budget)
+// Exhaustion is a dialTimeout and interruption is a dialInterrupted; each
+// carries its own sentence. Every other failure is the operating system's and
+// keeps its errno so dialSentence can name ENOENT and the rest.
+func createPipeHandleWithin(
+	ctx context.Context,
+	name *uint16,
+	budget time.Duration,
+) (syscall.Handle, error) {
 	attempts := 0
 	for {
+		if err := ctx.Err(); err != nil {
+			return syscall.InvalidHandle, dialGaveUp(err, budget, attempts)
+		}
 		handle, err := syscall.CreateFile(
 			name,
 			syscall.GENERIC_READ|syscall.GENERIC_WRITE,
@@ -223,15 +255,33 @@ func createPipeHandleWithin(name *uint16, budget time.Duration) (syscall.Handle,
 		if !errors.Is(err, errorPipeBusy) {
 			return syscall.InvalidHandle, err
 		}
-		if !time.Now().Add(pipeBusyRetryInterval).Before(deadline) {
-			return syscall.InvalidHandle, &dialTimeout{message: fmt.Sprintf(
-				"%s: every instance of the Vex Studio named pipe was busy for %s "+
-					"(%d attempts), so the Vex Studio bridge stopped without sending "+
-					"anything. Vex is running but its pipe front is not accepting new "+
-					"connections; close some Vex Studio MCP connections, or restart Vex, "+
-					"and connect again.",
-				dialTimeoutRefusalCode, budget, attempts)}
+		wait := time.NewTimer(pipeBusyRetryInterval)
+		select {
+		case <-ctx.Done():
+			wait.Stop()
+			return syscall.InvalidHandle, dialGaveUp(ctx.Err(), budget, attempts)
+		case <-wait.C:
 		}
-		time.Sleep(pipeBusyRetryInterval)
 	}
+}
+
+// dialGaveUp turns the context's reason for being done into the sentence the
+// user is shown, keeping "the pipe stayed busy for its whole budget" and "this
+// process was asked to stop" apart: the first is an endpoint state that asking
+// again can change, the second is not about the endpoint at all.
+func dialGaveUp(reason error, budget time.Duration, attempts int) error {
+	if errors.Is(reason, context.Canceled) {
+		return &dialInterrupted{message: fmt.Sprintf(
+			"%s: the Vex Studio bridge was asked to stop while it was waiting for a free "+
+				"instance of the Vex Studio named pipe (%d attempts), so it stopped without "+
+				"sending anything.",
+			dialInterruptedRefusalCode, attempts)}
+	}
+	return &dialTimeout{message: fmt.Sprintf(
+		"%s: every instance of the Vex Studio named pipe was busy for %s "+
+			"(%d attempts), so the Vex Studio bridge stopped without sending "+
+			"anything. Vex is running but its pipe front is not accepting new "+
+			"connections; close some Vex Studio MCP connections, or restart Vex, "+
+			"and connect again.",
+		dialTimeoutRefusalCode, budget, attempts)}
 }

--- a/bridge/cmd/vex-mcp/dial_windows.go
+++ b/bridge/cmd/vex-mcp/dial_windows.go
@@ -3,11 +3,51 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"syscall"
+	"time"
 
 	"github.com/Vex-Foundation/vex/bridge/internal/handshake"
 )
+
+// WindowsDialTimeout bounds the whole CreateFile attempt, including every
+// ERROR_PIPE_BUSY retry below.
+//
+// WHY A BOUND EXISTS AT ALL. CreateFile against a named pipe whose every
+// instance is busy returns ERROR_PIPE_BUSY immediately, so a client that wants
+// to wait must loop - and a loop without a deadline is an unbounded wait
+// inside somebody else's budget. Claude Code kills an MCP server that has not
+// come up within MCP_TIMEOUT (default 30 s), and a bridge that spent that
+// budget inside an open() reports nothing at all: the user sees "connection
+// timeout" with no cause, which is exactly the 2026-09-04 incident's shape.
+//
+// WHY FOUR SECONDS. The unix side bounds its connect at endpoint.DialTimeout
+// = 2 s. Windows is given twice that for one measured reason: the server here
+// is not a kernel socket backlog but the vex-pipe-front CHILD PROCESS, which
+// must post a fresh pipe instance through its accept loop after each
+// connection, so a burst of clients can find every instance busy for a
+// scheduling quantum that unix never spends. Four seconds is far longer than
+// that and still leaves at least 20 s of a default 30 s client budget for the
+// 5 s handshake ack and the first tools/list, which is the request this
+// connection actually exists to answer.
+//
+// It is NOT a retry (main.go's "NO RETRY, anywhere"): one dial, one deadline,
+// one sentence. The ERROR_PIPE_BUSY loop is the documented way to wait for an
+// instance of a pipe that IS there, which is what go-winio's tryDialPipe
+// (agents-colab/go-winio/pipe.go) does under its own context deadline.
+const WindowsDialTimeout = 4 * time.Second
+
+// pipeBusyRetryInterval is the pause between ERROR_PIPE_BUSY attempts, the
+// same 10 ms go-winio's tryDialPipe uses. It is a poll rather than
+// WaitNamedPipe because the standard library exposes no WaitNamedPipe and this
+// binary links nothing beyond it (cmd/vex-pipe-front/imports_test.go).
+const pipeBusyRetryInterval = 10 * time.Millisecond
+
+// dialTimeoutRefusalCode names the bound in the sentence, so a support
+// transcript can match the message back to this rule.
+const dialTimeoutRefusalCode = "windows_pipe_busy_timeout"
 
 // Impersonation-level flags for CreateFile, absent from stdlib `syscall`.
 // Values and spelling match golang.org/x/sys/windows and WinBase.h.
@@ -15,6 +55,17 @@ const (
 	securitySQOSPresent    = 0x00100000 // SECURITY_SQOS_PRESENT
 	securityIdentification = 0x00010000 // SECURITY_IDENTIFICATION (SecurityIdentification << 16)
 )
+
+// errorPipeBusy is ERROR_PIPE_BUSY (winerror.h, 231): "All pipe instances are
+// busy." CreateFile returns it when the pipe NAME exists and every instance
+// the server has posted is already connected, which is the one dial failure a
+// client is meant to wait out rather than report.
+//
+// DEFINED LOCALLY for the same reason the SQOS flags above are: stdlib
+// `syscall` does not export it on windows (verified against the installed
+// go1.27.0 tree), and this binary deliberately links no third-party package.
+// The value is the one golang.org/x/sys/windows and go-winio carry.
+const errorPipeBusy = syscall.Errno(231)
 
 // dialPipe opens the Vex Studio named pipe for OVERLAPPED (asynchronous) I/O.
 //
@@ -107,20 +158,26 @@ func dialPipe(path string) (handshake.Conn, error) {
 // branches can be driven deterministically on a single-account runner. The
 // production call above is the only non-test caller.
 func dialPipeWith(path string, server serverSIDResolver, current userSIDResolver) (handshake.Conn, error) {
+	return dialPipeWithin(path, WindowsDialTimeout, server, current)
+}
+
+// dialPipeWithin is dialPipeWith with the bound injected, so the deadline
+// branch is driven in milliseconds rather than in four real seconds.
+func dialPipeWithin(
+	path string,
+	budget time.Duration,
+	server serverSIDResolver,
+	current userSIDResolver,
+) (handshake.Conn, error) {
 	name, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
 		return nil, &os.PathError{Op: "open", Path: path, Err: err}
 	}
-	handle, err := syscall.CreateFile(
-		name,
-		syscall.GENERIC_READ|syscall.GENERIC_WRITE,
-		0,   // no sharing: this is a client handle to one pipe instance
-		nil, // default security attributes; the handle is not inherited
-		syscall.OPEN_EXISTING,
-		syscall.FILE_FLAG_OVERLAPPED|securitySQOSPresent|securityIdentification,
-		0,
-	)
+	handle, err := createPipeHandleWithin(name, budget)
 	if err != nil {
+		if _, busy := asDialTimeout(err); busy {
+			return nil, err
+		}
 		return nil, &os.PathError{Op: "open", Path: path, Err: err}
 	}
 	// BEFORE os.NewFile, therefore before any caller can hold something
@@ -131,4 +188,50 @@ func dialPipeWith(path string, server serverSIDResolver, current userSIDResolver
 		return nil, refusal
 	}
 	return os.NewFile(uintptr(handle), path), nil
+}
+
+// createPipeHandleWithin opens the pipe, waiting out ERROR_PIPE_BUSY until the
+// deadline.
+//
+// THE SHAPE IS go-winio's tryDialPipe (agents-colab/go-winio/pipe.go line
+// 207), written against the standard library because this binary links nothing
+// else: attempt, return on success, return on any error that is not
+// ERROR_PIPE_BUSY, otherwise sleep a fixed interval and attempt again while
+// there is budget left. The deadline is checked BEFORE each attempt and after
+// each sleep, so the loop cannot overrun it by a whole interval.
+//
+// Exhaustion is a dialTimeout, which carries its own sentence; every other
+// failure is the operating system's and keeps its errno so dialSentence can
+// name ENOENT and the rest.
+func createPipeHandleWithin(name *uint16, budget time.Duration) (syscall.Handle, error) {
+	deadline := time.Now().Add(budget)
+	attempts := 0
+	for {
+		handle, err := syscall.CreateFile(
+			name,
+			syscall.GENERIC_READ|syscall.GENERIC_WRITE,
+			0,   // no sharing: this is a client handle to one pipe instance
+			nil, // default security attributes; the handle is not inherited
+			syscall.OPEN_EXISTING,
+			syscall.FILE_FLAG_OVERLAPPED|securitySQOSPresent|securityIdentification,
+			0,
+		)
+		attempts++
+		if err == nil {
+			return handle, nil
+		}
+		if !errors.Is(err, errorPipeBusy) {
+			return syscall.InvalidHandle, err
+		}
+		if !time.Now().Add(pipeBusyRetryInterval).Before(deadline) {
+			return syscall.InvalidHandle, &dialTimeout{message: fmt.Sprintf(
+				"%s: every instance of the Vex Studio named pipe was busy for %s "+
+					"(%d attempts), so the Vex Studio bridge stopped without sending "+
+					"anything. Vex is running but its pipe front is not accepting new "+
+					"connections; close some Vex Studio MCP connections, or restart Vex, "+
+					"and connect again.",
+				dialTimeoutRefusalCode, budget, attempts)}
+		}
+		time.Sleep(pipeBusyRetryInterval)
+	}
 }

--- a/bridge/cmd/vex-mcp/dial_windows_test.go
+++ b/bridge/cmd/vex-mcp/dial_windows_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -429,5 +430,87 @@ func TestClosingThePipeCancelsABlockedRead(t *testing.T) {
 	if !errors.Is(cancelled.err, os.ErrClosed) && !errors.Is(cancelled.err, errorOperationAborted) {
 		t.Fatalf("the blocked read ended with %v, which is neither os.ErrClosed nor "+
 			"ERROR_OPERATION_ABORTED; the close is not what returned it", cancelled.err)
+	}
+}
+
+// THE DIAL HAS A BOUND, AND EXHAUSTION HAS A NAME.
+//
+// The defect this pins: CreateFile against a named pipe whose every instance
+// is busy returns ERROR_PIPE_BUSY at once, and the client that wants to wait
+// must loop. Before this change there was no loop and no deadline of any kind
+// on this path, so a saturated front spent an MCP client's whole startup
+// budget (Claude Code's MCP_TIMEOUT, 30 s by default) inside the open and the
+// user was shown "connection timeout" with no cause at all.
+//
+// The endpoint is REAL: a single-instance pipe served by this process, with
+// its one instance already taken by a client handle this test holds open, so
+// the dial under test meets the genuine ERROR_PIPE_BUSY the loop exists for.
+// The budget is milliseconds because the subject is the deadline being
+// honoured, not its production value.
+func TestDialPipeGivesUpOnABusyPipeWithANamedSentence(t *testing.T) {
+	name := testPipeName(t)
+	newTestPipeServer(t, name)
+
+	// TAKE THE ONE INSTANCE. From here every further CreateFile on this name
+	// answers ERROR_PIPE_BUSY.
+	occupier, err := dialPipeWith(name, resolveServerUserSID, resolveCurrentUserSID)
+	if err != nil {
+		t.Fatalf("occupying the pipe's single instance: %v", err)
+	}
+	defer occupier.Close()
+
+	const budget = 60 * time.Millisecond
+	started := time.Now()
+	conn, err := dialPipeWithin(name, budget, resolveServerUserSID, resolveCurrentUserSID)
+	elapsed := time.Since(started)
+	if conn != nil {
+		_ = conn.Close()
+		t.Fatal("a busy pipe must not yield a connection")
+	}
+	timeout, ok := asDialTimeout(err)
+	if !ok {
+		t.Fatalf("a busy pipe must give up as a bounded dial, got %T: %v", err, err)
+	}
+	if !strings.Contains(timeout.Error(), dialTimeoutRefusalCode) {
+		t.Fatalf("the sentence does not carry its code: %q", timeout.Error())
+	}
+	// The whole diagnostic is what the user sees, so the exit sentence must be
+	// this sentence rather than a generic dial line.
+	if dialSentence(name, err) != timeout.Error() {
+		t.Fatalf("dialSentence rewrote the bounded dial's own sentence: %q",
+			dialSentence(name, err))
+	}
+	// THE BOUND IS HONOURED IN BOTH DIRECTIONS. It waited (so it is a wait,
+	// not a single failed attempt) and it stopped (so it is bounded). The
+	// upper edge is generous because a scheduling hiccup is not the subject.
+	if elapsed < budget/2 {
+		t.Fatalf("the dial gave up after %s, well inside its %s budget", elapsed, budget)
+	}
+	if elapsed > 10*budget {
+		t.Fatalf("the dial overran its %s budget by far, taking %s", budget, elapsed)
+	}
+}
+
+// A pipe that is not there at all still fails IMMEDIATELY and keeps its errno,
+// so `dialSentence` can still say "no Vex Studio host is listening". The busy
+// loop must not swallow every open failure into its own sentence.
+func TestDialPipeDoesNotWaitOutAnAbsentPipe(t *testing.T) {
+	name := testPipeName(t)
+
+	started := time.Now()
+	conn, err := dialPipeWithin(name, WindowsDialTimeout, resolveServerUserSID, resolveCurrentUserSID)
+	elapsed := time.Since(started)
+	if conn != nil {
+		_ = conn.Close()
+		t.Fatal("a pipe that does not exist must not yield a connection")
+	}
+	if _, busy := asDialTimeout(err); busy {
+		t.Fatalf("an absent pipe is not a busy one: %v", err)
+	}
+	if !errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
+		t.Fatalf("the operating system's errno must survive, got %v", err)
+	}
+	if elapsed > WindowsDialTimeout/2 {
+		t.Fatalf("an absent pipe took %s; it must fail without waiting", elapsed)
 	}
 }

--- a/bridge/cmd/vex-mcp/dial_windows_test.go
+++ b/bridge/cmd/vex-mcp/dial_windows_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -124,7 +125,7 @@ func TestPipeDialSupportsConcurrentDuplex(t *testing.T) {
 	name := testPipeName(t)
 	server := newTestPipeServer(t, name)
 
-	client, err := dialPipe(name)
+	client, err := dialPipe(context.Background(), name)
 	if err != nil {
 		t.Fatalf("dialing this process's own pipe server was refused: %v", err)
 	}
@@ -230,7 +231,7 @@ func TestPipeHandleTakesARealDeadline(t *testing.T) {
 	name := testPipeName(t)
 	newTestPipeServer(t, name)
 
-	client, err := dialPipe(name)
+	client, err := dialPipe(context.Background(), name)
 	if err != nil {
 		t.Fatalf("dialing this process's own pipe server was refused: %v", err)
 	}
@@ -281,7 +282,7 @@ func TestPipeAckDeadlineFiresOnASilentHost(t *testing.T) {
 	name := testPipeName(t)
 	server := newTestPipeServer(t, name)
 
-	conn, err := dialPipe(name)
+	conn, err := dialPipe(context.Background(), name)
 	if err != nil {
 		t.Fatalf("dialing this process's own pipe server was refused: %v", err)
 	}
@@ -331,7 +332,7 @@ func TestPipeDrainDeadlineFiresOnASilentHost(t *testing.T) {
 	name := testPipeName(t)
 	newTestPipeServer(t, name)
 
-	conn, err := dialPipe(name)
+	conn, err := dialPipe(context.Background(), name)
 	if err != nil {
 		t.Fatalf("dialing this process's own pipe server was refused: %v", err)
 	}
@@ -376,7 +377,7 @@ func TestClosingThePipeCancelsABlockedRead(t *testing.T) {
 	name := testPipeName(t)
 	server := newTestPipeServer(t, name)
 
-	client, err := dialPipe(name)
+	client, err := dialPipe(context.Background(), name)
 	if err != nil {
 		t.Fatalf("dialing this process's own pipe server was refused: %v", err)
 	}
@@ -453,7 +454,7 @@ func TestDialPipeGivesUpOnABusyPipeWithANamedSentence(t *testing.T) {
 
 	// TAKE THE ONE INSTANCE. From here every further CreateFile on this name
 	// answers ERROR_PIPE_BUSY.
-	occupier, err := dialPipeWith(name, resolveServerUserSID, resolveCurrentUserSID)
+	occupier, err := dialPipeWith(context.Background(), name, resolveServerUserSID, resolveCurrentUserSID)
 	if err != nil {
 		t.Fatalf("occupying the pipe's single instance: %v", err)
 	}
@@ -461,7 +462,7 @@ func TestDialPipeGivesUpOnABusyPipeWithANamedSentence(t *testing.T) {
 
 	const budget = 60 * time.Millisecond
 	started := time.Now()
-	conn, err := dialPipeWithin(name, budget, resolveServerUserSID, resolveCurrentUserSID)
+	conn, err := dialPipeWithin(context.Background(), name, budget, resolveServerUserSID, resolveCurrentUserSID)
 	elapsed := time.Since(started)
 	if conn != nil {
 		_ = conn.Close()
@@ -498,7 +499,7 @@ func TestDialPipeDoesNotWaitOutAnAbsentPipe(t *testing.T) {
 	name := testPipeName(t)
 
 	started := time.Now()
-	conn, err := dialPipeWithin(name, WindowsDialTimeout, resolveServerUserSID, resolveCurrentUserSID)
+	conn, err := dialPipeWithin(context.Background(), name, WindowsDialTimeout, resolveServerUserSID, resolveCurrentUserSID)
 	elapsed := time.Since(started)
 	if conn != nil {
 		_ = conn.Close()
@@ -512,5 +513,79 @@ func TestDialPipeDoesNotWaitOutAnAbsentPipe(t *testing.T) {
 	}
 	if elapsed > WindowsDialTimeout/2 {
 		t.Fatalf("an absent pipe took %s; it must fail without waiting", elapsed)
+	}
+}
+
+// THE WAIT OBSERVES CANCELLATION, WHICH IS THE DIFFERENCE FROM go-winio.
+//
+// The defect this pins: a bound is not the only way a wait must be able to
+// end. `WindowsDialTimeout` is four seconds, and a user who interrupts the
+// bridge while the front is saturated used to be held for all four of them,
+// because the loop only ever looked at its own deadline. go-winio's
+// `tryDialPipe` (agents-colab/go-winio/pipe.go line 207) checks its context
+// before each attempt but waits with `time.Sleep`, so it inherits the same
+// blind spot for the length of one interval; the loop here selects on the
+// context and the timer together, so a cancel that lands MID-WAIT is what
+// returns.
+//
+// The endpoint is real and genuinely busy - the same single-instance pipe with
+// its one instance taken as the deadline test above - so the loop under test
+// is the ERROR_PIPE_BUSY loop and not a lucky first attempt. The budget is a
+// long one on purpose: the assertion is that the dial ends far inside it, and
+// it can only do that by observing the cancel.
+func TestDialPipeStopsWaitingWhenItsContextIsCancelled(t *testing.T) {
+	name := testPipeName(t)
+	newTestPipeServer(t, name)
+
+	occupier, err := dialPipeWith(context.Background(), name, resolveServerUserSID, resolveCurrentUserSID)
+	if err != nil {
+		t.Fatalf("occupying the pipe's single instance: %v", err)
+	}
+	defer occupier.Close()
+
+	const budget = 30 * time.Second
+	const cancelAfter = 50 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// CANCELLED MID-WAIT, not before the first attempt: the loop has to be
+	// inside its 10 ms wait by the time this fires.
+	timer := time.AfterFunc(cancelAfter, cancel)
+	defer timer.Stop()
+
+	started := time.Now()
+	conn, err := dialPipeWithin(ctx, name, budget, resolveServerUserSID, resolveCurrentUserSID)
+	elapsed := time.Since(started)
+	if conn != nil {
+		_ = conn.Close()
+		t.Fatal("a cancelled dial must not yield a connection")
+	}
+	interrupted, ok := asDialInterrupted(err)
+	if !ok {
+		t.Fatalf("a cancelled dial must give up as an interrupted dial, got %T: %v", err, err)
+	}
+	// AN INTERRUPTION IS NOT A BUSY ENDPOINT. The two exits differ in what
+	// they tell the user to do, so the vocabulary may not blur them.
+	if _, busy := asDialTimeout(err); busy {
+		t.Fatalf("an interrupted dial was reported as a bounded one: %v", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("an interrupted dial must unwrap to context.Canceled, got %v", err)
+	}
+	if !strings.Contains(interrupted.Error(), dialInterruptedRefusalCode) {
+		t.Fatalf("the sentence does not carry its code: %q", interrupted.Error())
+	}
+	if dialSentence(name, err) != interrupted.Error() {
+		t.Fatalf("dialSentence rewrote the interrupted dial's own sentence: %q",
+			dialSentence(name, err))
+	}
+	// IT WAITED, AND IT LEFT LONG BEFORE THE BOUND. The lower edge proves the
+	// cancel arrived mid-wait rather than before the loop began; the upper one
+	// proves the deadline is not what ended it.
+	if elapsed < cancelAfter {
+		t.Fatalf("the dial returned after %s, before its cancel at %s", elapsed, cancelAfter)
+	}
+	if elapsed > budget/10 {
+		t.Fatalf("the dial took %s of its %s budget; the cancel is not what ended it",
+			elapsed, budget)
 	}
 }

--- a/bridge/cmd/vex-mcp/hostauth_foreign_windows_test.go
+++ b/bridge/cmd/vex-mcp/hostauth_foreign_windows_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strings"
@@ -41,7 +42,7 @@ func TestHostAuthRefusesAForeignUsersServer(t *testing.T) {
 			"1.6 item 7 stays unproven by this run.", foreignPipeEnv)
 	}
 
-	conn, err := dialPipe(path)
+	conn, err := dialPipe(context.Background(), path)
 	if conn != nil {
 		_ = conn.Close()
 	}

--- a/bridge/cmd/vex-mcp/hostauth_windows_test.go
+++ b/bridge/cmd/vex-mcp/hostauth_windows_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -168,7 +169,7 @@ func TestDialPipeAcceptsThisUsersPipeServer(t *testing.T) {
 	name := testPipeName(t)
 	server := newTestPipeServer(t, name)
 
-	conn, err := dialPipe(name)
+	conn, err := dialPipe(context.Background(), name)
 	if err != nil {
 		t.Fatalf("dialing this process's own pipe server was refused: %v", err)
 	}
@@ -203,7 +204,7 @@ func TestResolveServerUserSIDIdentifiesThisProcess(t *testing.T) {
 		return pid, sid, err
 	}
 
-	conn, err := dialPipeWith(name, recording, resolveCurrentUserSID)
+	conn, err := dialPipeWith(context.Background(), name, recording, resolveCurrentUserSID)
 	if err != nil {
 		t.Fatalf("dialing this process's own pipe server was refused: %v", err)
 	}
@@ -232,7 +233,7 @@ func TestDialPipeRefusesAForeignUsersPipeServer(t *testing.T) {
 	server := newTestPipeServer(t, name)
 
 	const foreign = "S-1-5-21-1111111111-2222222222-3333333333-1001"
-	conn, err := dialPipeWith(name,
+	conn, err := dialPipeWith(context.Background(), name,
 		func(syscall.Handle) (uint32, string, error) { return 4242, foreign, nil },
 		func() (string, error) { return "S-1-5-21-9-9-9-500", nil })
 	refusal := mustRefuse(t, conn, err)
@@ -283,7 +284,7 @@ func TestDialPipeRefusesWhenIdentityCannotBeEstablished(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			name := testPipeName(t)
 			server := newTestPipeServer(t, name)
-			conn, err := dialPipeWith(name, testCase.server, testCase.current)
+			conn, err := dialPipeWith(context.Background(), name, testCase.server, testCase.current)
 			mustRefuse(t, conn, err)
 			assertNothingWasWritten(t, server)
 		})

--- a/bridge/cmd/vex-mcp/main.go
+++ b/bridge/cmd/vex-mcp/main.go
@@ -202,6 +202,21 @@ func resolveProjectID() (string, error) {
 	return value, nil
 }
 
+// isDialTimeout reports whether the dial gave up on its own bound.
+func isDialTimeout(err error) bool {
+	_, ok := asDialTimeout(err)
+	return ok
+}
+
+// dialTimeoutSentence is the bounded dial's own message, verbatim.
+func dialTimeoutSentence(err error) string {
+	timeout, ok := asDialTimeout(err)
+	if !ok {
+		return err.Error()
+	}
+	return timeout.Error()
+}
+
 // dialEndpoint opens the planned endpoint, on either transport.
 //
 // UNIX: an ordinary dial with the contract's connect bound.
@@ -213,11 +228,13 @@ func resolveProjectID() (string, error) {
 // copy of that gate stood here and went with it, because with
 // endpoint.WindowsTransportProven true it could refuse nothing.
 //
-// The connect bound does NOT apply on Windows. CreateFile has no timeout
-// parameter and stdlib exposes no WaitNamedPipe, so a pipe that exists but is
-// saturated blocks in the open rather than failing fast. That difference is
-// named in the contract's Windows section rather than papered over with a
-// goroutine that would leak a blocked open.
+// THE CONNECT BOUND IS DIFFERENT ON WINDOWS, not absent. CreateFile has no
+// timeout parameter and stdlib exposes no WaitNamedPipe, so `dialPipe` bounds
+// itself: it waits out ERROR_PIPE_BUSY under `WindowsDialTimeout` in the shape
+// go-winio's tryDialPipe uses, and gives up with its own named sentence rather
+// than spending an MCP client's whole startup budget inside an open. It is
+// still one attempt with one deadline - not a retry - and no goroutine is left
+// holding a blocked open.
 func dialEndpoint(plan endpoint.Plan) (handshake.Conn, error) {
 	if plan.Kind == endpoint.KindPipe {
 		// DEFENSIVE, at the dial site itself: a pipe plan must never be
@@ -267,6 +284,11 @@ func derivePlan() (endpoint.Plan, error) {
 // rest honest rather than guessing.
 func dialSentence(path string, err error) string {
 	switch {
+	// THE BOUND THIS PROCESS OWNS, and it already wrote its own sentence. It
+	// is first because it is the only case here that is a decision rather
+	// than an errno, and its message names the pipe, the budget and the code.
+	case isDialTimeout(err):
+		return dialTimeoutSentence(err)
 	// NEITHER OF THESE MEANS "LOCKED". A locked Vex keeps its listener up and
 	// answers the handshake with the typed `locked` refusal, which leaves this
 	// program at exit 7 with the host's own sentence. Attributing a lock here

--- a/bridge/cmd/vex-mcp/main.go
+++ b/bridge/cmd/vex-mcp/main.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -116,7 +117,17 @@ func run() int {
 		}
 	}
 
-	conn, err := dialEndpoint(plan)
+	// THE DIAL'S CANCELLATION CHANNEL. `signals` above is the relay's, and a
+	// second Notify registration receives its OWN copy of every signal rather
+	// than stealing from the first, so this context can end a dial that is
+	// waiting on a busy pipe without taking the interrupt away from the relay
+	// teardown that runs later. Stopped as soon as the dial is over: from
+	// there on the relay owns the interrupt.
+	dialCtx, stopDialSignals := signal.NotifyContext(
+		context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP,
+	)
+	conn, err := dialEndpoint(dialCtx, plan)
+	stopDialSignals()
 	if err != nil {
 		// A LOCAL REFUSAL IS NOT A DIAL FAILURE. Windows host authentication
 		// runs after the pipe opened and before anything was written; the
@@ -228,6 +239,11 @@ func dialTimeoutSentence(err error) string {
 // copy of that gate stood here and went with it, because with
 // endpoint.WindowsTransportProven true it could refuse nothing.
 //
+// BOTH TRANSPORTS DIAL UNDER THE CALLER'S CONTEXT, which carries this
+// process's signal registration. Unix keeps its `endpoint.DialTimeout` as the
+// dialer's own bound and gains the interrupt; Windows derives its deadline
+// inside `dialPipe`, because the bound is that transport's own.
+//
 // THE CONNECT BOUND IS DIFFERENT ON WINDOWS, not absent. CreateFile has no
 // timeout parameter and stdlib exposes no WaitNamedPipe, so `dialPipe` bounds
 // itself: it waits out ERROR_PIPE_BUSY under `WindowsDialTimeout` in the shape
@@ -235,7 +251,7 @@ func dialTimeoutSentence(err error) string {
 // than spending an MCP client's whole startup budget inside an open. It is
 // still one attempt with one deadline - not a retry - and no goroutine is left
 // holding a blocked open.
-func dialEndpoint(plan endpoint.Plan) (handshake.Conn, error) {
+func dialEndpoint(ctx context.Context, plan endpoint.Plan) (handshake.Conn, error) {
 	if plan.Kind == endpoint.KindPipe {
 		// DEFENSIVE, at the dial site itself: a pipe plan must never be
 		// opened on a unix target. planOverride refuses pipe syntax off
@@ -245,9 +261,10 @@ func dialEndpoint(plan endpoint.Plan) (handshake.Conn, error) {
 			return nil, fmt.Errorf("refusing to open the named pipe %s on %s: "+
 				"named pipes exist on Windows only", plan.Path, runtime.GOOS)
 		}
-		return dialPipe(plan.Path)
+		return dialPipe(ctx, plan.Path)
 	}
-	conn, err := net.DialTimeout("unix", plan.Path, endpoint.DialTimeout)
+	dialer := net.Dialer{Timeout: endpoint.DialTimeout}
+	conn, err := dialer.DialContext(ctx, "unix", plan.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -289,6 +306,15 @@ func dialSentence(path string, err error) string {
 	// than an errno, and its message names the pipe, the budget and the code.
 	case isDialTimeout(err):
 		return dialTimeoutSentence(err)
+	// AN INTERRUPTED DIAL IS NOT A BROKEN ENDPOINT. The user (or the client
+	// supervising this process) asked it to stop while it was still opening,
+	// and saying "cannot connect" would blame a host that was never asked.
+	case errors.Is(err, context.Canceled):
+		if interrupted, ok := asDialInterrupted(err); ok {
+			return interrupted.Error()
+		}
+		return fmt.Sprintf("the connection to the Vex Studio host at %s was interrupted "+
+			"before it opened.", path)
 	// NEITHER OF THESE MEANS "LOCKED". A locked Vex keeps its listener up and
 	// answers the handshake with the typed `locked` refusal, which leaves this
 	// program at exit 7 with the host's own sentence. Attributing a lock here

--- a/bridge/cmd/vex-mcp/refusal.go
+++ b/bridge/cmd/vex-mcp/refusal.go
@@ -1,6 +1,9 @@
 package main
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 // localRefusal is a decision THIS process made about the endpoint, as opposed
 // to a transport failure the operating system reported.
@@ -59,6 +62,42 @@ func asDialTimeout(err error) (*dialTimeout, bool) {
 	var timeout *dialTimeout
 	if errors.As(err, &timeout) {
 		return timeout, true
+	}
+	return nil, false
+}
+
+// dialInterruptedRefusalCode names the interruption in the sentence, so a
+// support transcript can match the message back to this rule.
+const dialInterruptedRefusalCode = "windows_pipe_dial_interrupted"
+
+// dialInterrupted is the dial giving up because THIS PROCESS was asked to
+// stop, as opposed to the endpoint being busy or absent.
+//
+// It is not a dialTimeout and it is not a localRefusal: nothing was learned
+// about the endpoint at all. A client that supervises this process sees the
+// same exit 3 a dial failure gets, and the sentence says which of the two it
+// was. It unwraps to context.Canceled so a caller can ask the question in the
+// standard vocabulary.
+//
+// NOTHING WAS WRITTEN when this error is returned: the wait happens inside the
+// open, before there is a handle a project id could travel over.
+type dialInterrupted struct {
+	message string
+}
+
+func (interrupted *dialInterrupted) Error() string {
+	return interrupted.message
+}
+
+func (interrupted *dialInterrupted) Unwrap() error {
+	return context.Canceled
+}
+
+// asDialInterrupted reports whether err is (or wraps) an interrupted dial.
+func asDialInterrupted(err error) (*dialInterrupted, bool) {
+	var interrupted *dialInterrupted
+	if errors.As(err, &interrupted) {
+		return interrupted, true
 	}
 	return nil, false
 }

--- a/bridge/cmd/vex-mcp/refusal.go
+++ b/bridge/cmd/vex-mcp/refusal.go
@@ -32,3 +32,33 @@ func asLocalRefusal(err error) (*localRefusal, bool) {
 	}
 	return nil, false
 }
+
+// dialTimeout is THIS PROCESS giving up on a dial it bounded, as opposed to
+// the operating system reporting that the endpoint is not there.
+//
+// It is not a localRefusal, and the difference is the exit code. A local
+// refusal is a decision about the endpoint itself - "that pipe is served by
+// another user" - which asking again cannot change, and it exits 2. A busy
+// pipe is the endpoint being REACHABLE AND OCCUPIED, which is exit 3's
+// documented meaning ("the endpoint did not open, retrying later may work").
+// The sentence still carries its own code, exactly as a local refusal's does,
+// so a support transcript can match it back to the rule that produced it.
+//
+// NOTHING WAS WRITTEN when this error is returned: the failure happens inside
+// the open, before there is a handle a project id could travel over.
+type dialTimeout struct {
+	message string
+}
+
+func (timeout *dialTimeout) Error() string {
+	return timeout.message
+}
+
+// asDialTimeout reports whether err is (or wraps) a bounded dial giving up.
+func asDialTimeout(err error) (*dialTimeout, bool) {
+	var timeout *dialTimeout
+	if errors.As(err, &timeout) {
+		return timeout, true
+	}
+	return nil, false
+}

--- a/bridge/internal/front/control/dispatch.go
+++ b/bridge/internal/front/control/dispatch.go
@@ -337,6 +337,14 @@ func (s *Supervisor) handleConnRead(ev connRead) {
 		// A MESSAGE-mode pipe delivers the peer's CloseWrite as EOF, and that
 		// is a HALF-close: the writable side stays open so the last response of
 		// a one-shot session can still be written (section 7.1).
+		//
+		// NAMED, and named BEFORE the END goes up. A peer that was KILLED - a
+		// client that gave up on its startup budget and reaped the bridge -
+		// arrives here and nowhere else, and until this line the only trace was
+		// main's own teardown a few milliseconds later, which reads exactly
+		// like main deciding to close. It is not a `PeerClosedReason`: nothing
+		// closed, and the connection may still answer.
+		s.log.Event("peer_half_closed", lifecycle.Num("connection", uint64(ev.id)))
 		if err := conn.PeerEnded(); err != nil {
 			s.failFlow(err)
 		}

--- a/bridge/internal/front/control/supervisor_test.go
+++ b/bridge/internal/front/control/supervisor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -576,6 +577,17 @@ func TestPeerHalfCloseRaisesEndAndTheWritableSideSurvives(t *testing.T) {
 	end := h.expectUpData()
 	if _, ok := end.Payload.(frames.End); !ok {
 		t.Fatalf("a peer FIN must raise END on plane 6, got %s", end.Type().Name())
+	}
+
+	// AND THE LOG NAMES IT. A killed client and main deciding to close were
+	// indistinguishable in the structural log before this line existed: both
+	// ended as a CLOSE from main with reason commanded_close, and the read EOF
+	// that actually started it left no trace at all. It is a NUMBER, like every
+	// other field: the connection id, never a byte the peer chose.
+	want := fmt.Sprintf("vex-pipe-front peer_half_closed connection=%d", id)
+	if logged := h.logs.String(); !strings.Contains(logged, want) {
+		t.Fatalf("the structural log does not name the peer half-close as %q:\n%s",
+			want, logged)
 	}
 
 	// The writable side is still there.

--- a/src/__tests__/vex-agent/mcp/socket-transport-framing.test.ts
+++ b/src/__tests__/vex-agent/mcp/socket-transport-framing.test.ts
@@ -20,6 +20,7 @@
 import { describe, expect, it } from "vitest";
 
 import { FakeDuplexTransport } from "@vex-agent/mcp/duplex-transport-fake.js";
+import type { StudioWriteOutcome } from "@vex-agent/mcp/duplex-transport.js";
 import {
   StudioSocketTransport,
   progressCoalesceKey,
@@ -38,7 +39,10 @@ function stalledWire(): FakeDuplexTransport {
 function makeTransport(
   socket: FakeDuplexTransport,
   options: {
-    readonly writeLine?: (line: string, progressKey: string | null) => Promise<void>;
+    readonly writeLine?: (
+      line: string,
+      progressKey: string | null,
+    ) => Promise<StudioWriteOutcome>;
     readonly shutdownDeadlineMs?: number;
   } = {},
 ): {
@@ -86,9 +90,9 @@ describe("a framing failure behind a blocked writable side", () => {
     const lines: { line: string; key: string | null }[] = [];
     // The owner's writer, blocked exactly like the real queue behind a peer
     // that stopped reading: it accepts the frame and never settles.
-    const writeLine = (line: string, key: string | null): Promise<void> => {
+    const writeLine = (line: string, key: string | null): Promise<StudioWriteOutcome> => {
       lines.push({ line, key });
-      return new Promise<void>(() => {
+      return new Promise<StudioWriteOutcome>(() => {
         // Never settles. The deadline is what must save the connection.
       });
     };
@@ -115,7 +119,7 @@ describe("a framing failure behind a blocked writable side", () => {
   it("destroys the connection within the deadline and announces onclose once", async () => {
     const socket = stalledWire();
     const harness = makeTransport(socket, {
-      writeLine: () => new Promise<void>(() => {
+      writeLine: () => new Promise<StudioWriteOutcome>(() => {
         // Never settles.
       }),
       shutdownDeadlineMs: 60,
@@ -139,7 +143,7 @@ describe("a framing failure behind a blocked writable side", () => {
   it("does not buffer the frames that arrive after the failure", async () => {
     const socket = stalledWire();
     const harness = makeTransport(socket, {
-      writeLine: () => new Promise<void>(() => undefined),
+      writeLine: () => new Promise<StudioWriteOutcome>(() => undefined),
       shutdownDeadlineMs: 40,
     });
     const delivered: unknown[] = [];

--- a/src/__tests__/vex-agent/mcp/socket-transport-lifecycle.test.ts
+++ b/src/__tests__/vex-agent/mcp/socket-transport-lifecycle.test.ts
@@ -197,6 +197,97 @@ describe("the first outbound line", () => {
         kind: "first_response",
         id: "0",
         bytes: Buffer.byteLength(`${JSON.stringify(response)}\n`, "utf8"),
+        outbound: "response",
+      },
+    ]);
+  });
+
+  it("is published only after the writer accepted the line, never at the hand-off", async () => {
+    // THE DEFECT THIS PINS. The milestone used to be written the moment the
+    // frame was handed to the outbound writer, so a queue that was closing, or
+    // a write that never completed, still produced a `first response` line -
+    // the log claimed main's answer had left main while the bytes were still
+    // in main. The one question this line exists to answer was the one it
+    // could get wrong.
+    const parked: Array<() => void> = [];
+    const wire = new FakeDuplexTransport("accept_sync");
+    const events: SocketTransportLifecycleEvent[] = [];
+    const transport = new StudioSocketTransport(wire, {
+      onLifecycle: (event) => events.push(event),
+      writeLine: () =>
+        new Promise<void>((resolve) => {
+          parked.push(resolve);
+        }),
+    });
+    await transport.start();
+
+    const sent = transport.send({ jsonrpc: "2.0", id: 0, result: { ok: true } });
+    await Promise.resolve();
+    expect(events.some((event) => event.kind === "first_response")).toBe(false);
+
+    const [accept] = parked;
+    if (accept === undefined) throw new Error("the writer was never called");
+    accept();
+    await sent;
+
+    expect(events.filter((event) => event.kind === "first_response")).toHaveLength(1);
+  });
+
+  it("is not published at all when the writer refuses the line", async () => {
+    const wire = new FakeDuplexTransport("accept_sync");
+    const events: SocketTransportLifecycleEvent[] = [];
+    const transport = new StudioSocketTransport(wire, {
+      onLifecycle: (event) => events.push(event),
+      writeLine: () => Promise.reject(new Error("the outbound queue is closed")),
+    });
+    await transport.start();
+
+    await expect(
+      transport.send({ jsonrpc: "2.0", id: 0, result: { ok: true } }),
+    ).rejects.toThrow("the outbound queue is closed");
+    await transport.close();
+
+    expect(events.some((event) => event.kind === "first_response")).toBe(false);
+    // And it counted nothing either: a refused write is not a response.
+    expect(events.filter((event) => event.kind === "closed")).toEqual([
+      {
+        kind: "closed",
+        requests: 0,
+        responses: 0,
+        notifications: 0,
+        serverRequests: 0,
+        otherOutbound: 0,
+      },
+    ]);
+  });
+
+  it("names a notification as a notification rather than as this connection's answer", async () => {
+    // A progress notification can leave before the response it belongs to.
+    // Counting it as a response made `responses` a total of frames rather than
+    // of answers, and named the milestone after something it was not.
+    const test = harness();
+    await test.transport.start();
+
+    await test.transport.send({
+      jsonrpc: "2.0",
+      method: "notifications/progress",
+      params: { progressToken: 1, progress: 1 },
+    });
+    await test.transport.send({ jsonrpc: "2.0", id: 4, result: { ok: true } });
+    await test.transport.send({ jsonrpc: "2.0", id: 5, method: "sampling/createMessage" });
+    await test.transport.close();
+
+    const first = test.events.filter((event) => event.kind === "first_response");
+    expect(first).toHaveLength(1);
+    expect(first[0]).toMatchObject({ id: null, outbound: "notification" });
+    expect(test.events.filter((event) => event.kind === "closed")).toEqual([
+      {
+        kind: "closed",
+        requests: 0,
+        responses: 1,
+        notifications: 1,
+        serverRequests: 1,
+        otherOutbound: 0,
       },
     ]);
   });
@@ -230,7 +321,14 @@ describe("the peer half-close and the final counters", () => {
 
     const kinds = test.events.map((event) => event.kind);
     expect(kinds).toEqual(["first_request", "first_response", "peer_end", "closed"]);
-    expect(test.events[3]).toEqual({ kind: "closed", requests: 1, responses: 1 });
+    expect(test.events[3]).toEqual({
+      kind: "closed",
+      requests: 1,
+      responses: 1,
+      notifications: 0,
+      serverRequests: 0,
+      otherOutbound: 0,
+    });
   });
 
   it("reports closed exactly once even when the owner and the wire both tear down", async () => {
@@ -242,7 +340,14 @@ describe("the peer half-close and the final counters", () => {
     await test.transport.close();
 
     expect(test.events.filter((event) => event.kind === "closed")).toEqual([
-      { kind: "closed", requests: 0, responses: 0 },
+      {
+        kind: "closed",
+        requests: 0,
+        responses: 0,
+        notifications: 0,
+        serverRequests: 0,
+        otherOutbound: 0,
+      },
     ]);
   });
 

--- a/src/__tests__/vex-agent/mcp/socket-transport-lifecycle.test.ts
+++ b/src/__tests__/vex-agent/mcp/socket-transport-lifecycle.test.ts
@@ -1,0 +1,297 @@
+/**
+ * WHAT HAPPENED ON THIS CONNECTION, as the transport is able to report it.
+ *
+ * The defect these cases pin is an ABSENCE. On 2026-09-04 a Windows client
+ * failed its first connect and the app log could not answer either of the two
+ * questions that would have located the fault: did the client's `initialize`
+ * reach main's transport at all, and did main's answer leave main. The host
+ * emitted no per-connection line of any kind, so a connection that was
+ * accepted, admitted and then starved looked exactly like one that was served
+ * perfectly and then abandoned.
+ *
+ * The transport is the OWNER of those two transitions, because it is the only
+ * object that sees an envelope reach the queue and a line reach the wire. It
+ * does not log - it is engine code with no logger and no connection id - so it
+ * reports, and `StudioConnection` owns the line. Every case here is about the
+ * report: that it fires once, that it carries the fields the log needs, and
+ * that a hostile peer cannot author a log line through it.
+ *
+ * The wire is the shared `FakeDuplexTransport`, so `pause` / `resume` and the
+ * remainder feed are the same contract the real socket and the Windows pipe
+ * front both implement.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { FakeDuplexTransport } from "@vex-agent/mcp/duplex-transport-fake.js";
+import {
+  loggableMcpMethod,
+  StudioSocketTransport,
+  safeWireTag,
+  STUDIO_KNOWN_MCP_METHODS,
+  STUDIO_WIRE_TAG_MAX_CHARS,
+  type SocketTransportLifecycleEvent,
+} from "@vex-agent/mcp/socket-transport.js";
+
+interface Harness {
+  readonly transport: StudioSocketTransport;
+  readonly wire: FakeDuplexTransport;
+  readonly events: SocketTransportLifecycleEvent[];
+  readonly delivered: unknown[];
+}
+
+function harness(remainder?: Buffer): Harness {
+  const wire = new FakeDuplexTransport("accept_sync");
+  const events: SocketTransportLifecycleEvent[] = [];
+  const delivered: unknown[] = [];
+  const transport = new StudioSocketTransport(wire, {
+    ...(remainder === undefined ? {} : { remainder }),
+    onLifecycle: (event) => events.push(event),
+  });
+  transport.onmessage = (message: never): void => {
+    delivered.push(message);
+  };
+  return { transport, wire, events, delivered };
+}
+
+function line(message: Record<string, unknown>): Buffer {
+  return Buffer.from(`${JSON.stringify(message)}\n`);
+}
+
+/** The 2026-07-28 `initialize` a real client sends, params and all. */
+function initializeLine(): Buffer {
+  return line({
+    jsonrpc: "2.0",
+    id: 0,
+    method: "initialize",
+    params: {
+      protocolVersion: "2026-07-28",
+      clientInfo: { name: "claude-code", version: "2.1.260" },
+      capabilities: {},
+    },
+  });
+}
+
+/** Let the transport's `setImmediate` drain run. */
+function macrotask(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+describe("the first inbound envelope", () => {
+  it("is reported once, with the client and protocol version initialize carried", async () => {
+    const test = harness(initializeLine());
+    await test.transport.start();
+    await macrotask();
+
+    expect(test.events).toEqual([
+      {
+        kind: "first_request",
+        method: "initialize",
+        client: "claude-code/2.1.260",
+        protocolVersion: "2026-07-28",
+      },
+    ]);
+    // The envelope was delivered whole; the report is beside the delivery, not
+    // instead of it.
+    expect(test.delivered).toHaveLength(1);
+  });
+
+  it("is reported when the segment ALSO carried the handshake and a pause/resume split it", async () => {
+    // THE COALESCED SEGMENT, which is the incident's own shape: a bridge that
+    // wrote `handshake\ninitialize\n` in one write, the host parsing the
+    // handshake, PAUSING the wire, and the transport being constructed with
+    // the remainder afterwards. The pause happens before this transport
+    // exists, so `start()` is what must resume it and admit the remainder.
+    const test = harness(initializeLine());
+    test.wire.pause();
+    expect(test.wire.paused).toBe(true);
+
+    await test.transport.start();
+    await macrotask();
+
+    expect(test.wire.paused).toBe(false);
+    expect(test.delivered).toHaveLength(1);
+    expect(test.events.filter((event) => event.kind === "first_request")).toHaveLength(1);
+
+    // A SECOND frame does not produce a second first-request report, and it is
+    // still delivered.
+    test.wire.deliver(line({ jsonrpc: "2.0", id: 1, method: "tools/list" }));
+    await macrotask();
+    expect(test.delivered).toHaveLength(2);
+    expect(test.events.filter((event) => event.kind === "first_request")).toHaveLength(1);
+  });
+
+  it("carries no client fields for a method that is not initialize", async () => {
+    const test = harness(line({ jsonrpc: "2.0", id: 7, method: "tools/list" }));
+    await test.transport.start();
+    await macrotask();
+
+    expect(test.events[0]).toEqual({
+      kind: "first_request",
+      method: "tools/list",
+      client: null,
+      protocolVersion: null,
+    });
+  });
+
+  it("never carries the peer's own spelling of a method it does not know", async () => {
+    // THE REDACTION RULE, at its sharpest. A client may call
+    // `tools/<whatever it likes>`, and a line that echoed that name would leak
+    // whatever the client put there - which is exactly what
+    // `mcp-wire-error-redaction.test.ts` holds this host to. The method is
+    // reported out of this repository's own closed set or not at all.
+    const test = harness(
+      line({ jsonrpc: "2.0", id: 7, method: "tools/SECRET_SENTINEL_XYZ" }),
+    );
+    await test.transport.start();
+    await macrotask();
+
+    expect(test.events[0]).toEqual({
+      kind: "first_request",
+      method: "other",
+      client: null,
+      protocolVersion: null,
+    });
+  });
+
+  it("refuses to carry a client name or version that could author a log line", async () => {
+    const test = harness(
+      line({
+        jsonrpc: "2.0",
+        id: 0,
+        method: "initialize",
+        params: {
+          protocolVersion: "2026-07-28 id=1 cause=peer_end",
+          clientInfo: { name: "evil\nvex-pipe-front admitted connection=99", version: "1" },
+        },
+      }),
+    );
+    await test.transport.start();
+    await macrotask();
+
+    // Every peer-authored token that is not a plain tag is REPLACED by the
+    // absence, never carried and never cut.
+    expect(test.events[0]).toEqual({
+      kind: "first_request",
+      method: "initialize",
+      client: null,
+      protocolVersion: null,
+    });
+  });
+});
+
+describe("the first outbound line", () => {
+  it("is reported once, with the JSON-RPC id and the byte length that left main", async () => {
+    const test = harness();
+    await test.transport.start();
+
+    const response = { jsonrpc: "2.0", id: 0, result: { ok: true } };
+    await test.transport.send(response);
+    await test.transport.send({ jsonrpc: "2.0", id: 1, result: { ok: true } });
+
+    const first = test.events.filter((event) => event.kind === "first_response");
+    expect(first).toEqual([
+      {
+        kind: "first_response",
+        id: "0",
+        bytes: Buffer.byteLength(`${JSON.stringify(response)}\n`, "utf8"),
+      },
+    ]);
+  });
+
+  it("is not reported for a send the wire can no longer carry", async () => {
+    const test = harness();
+    await test.transport.start();
+    test.wire.destroy();
+
+    await test.transport.send({ jsonrpc: "2.0", id: 0, result: { ok: true } });
+
+    // Nothing was handed to the wire, so nothing may claim it was: the
+    // question this line answers is "did main's answer leave main".
+    expect(test.events.some((event) => event.kind === "first_response")).toBe(false);
+  });
+});
+
+describe("the peer half-close and the final counters", () => {
+  it("reports peer_end once and then closed with what the connection actually carried", async () => {
+    const test = harness();
+    await test.transport.start();
+
+    test.wire.deliver(line({ jsonrpc: "2.0", id: 0, method: "initialize", params: {} }));
+    await macrotask();
+    await test.transport.send({ jsonrpc: "2.0", id: 0, result: { ok: true } });
+
+    test.wire.peerEnd();
+    // Idempotent: the host replays `readableEnded` after its dynamic import.
+    test.transport.notifyPeerEnd();
+    await macrotask();
+
+    const kinds = test.events.map((event) => event.kind);
+    expect(kinds).toEqual(["first_request", "first_response", "peer_end", "closed"]);
+    expect(test.events[3]).toEqual({ kind: "closed", requests: 1, responses: 1 });
+  });
+
+  it("reports closed exactly once even when the owner and the wire both tear down", async () => {
+    const test = harness();
+    await test.transport.start();
+
+    await test.transport.close();
+    test.wire.destroy();
+    await test.transport.close();
+
+    expect(test.events.filter((event) => event.kind === "closed")).toEqual([
+      { kind: "closed", requests: 0, responses: 0 },
+    ]);
+  });
+
+  it("does not let a reporting callback that throws become a second failure path", async () => {
+    const wire = new FakeDuplexTransport("accept_sync");
+    const transport = new StudioSocketTransport(wire, {
+      onLifecycle: () => {
+        throw new Error("the owner's logger failed");
+      },
+    });
+    const closed = vi.fn();
+    transport.onclose = closed;
+    await transport.start();
+
+    wire.peerEnd();
+    await macrotask();
+
+    expect(closed).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("loggableMcpMethod", () => {
+  it("passes the spelled set and answers other for everything else", () => {
+    for (const method of STUDIO_KNOWN_MCP_METHODS) {
+      expect(loggableMcpMethod(method)).toBe(method);
+    }
+    expect(loggableMcpMethod("tools/list ")).toBe("other");
+    expect(loggableMcpMethod("Tools/List")).toBe("other");
+    expect(loggableMcpMethod("")).toBe("other");
+    expect(loggableMcpMethod(7)).toBe("other");
+  });
+});
+
+describe("safeWireTag", () => {
+  it("passes the tokens MCP actually spells and refuses everything else", () => {
+    expect(safeWireTag("tools/list")).toBe("tools/list");
+    expect(safeWireTag("2026-07-28")).toBe("2026-07-28");
+    expect(safeWireTag("claude-code")).toBe("claude-code");
+    expect(safeWireTag("a".repeat(STUDIO_WIRE_TAG_MAX_CHARS))).toHaveLength(
+      STUDIO_WIRE_TAG_MAX_CHARS,
+    );
+
+    // A value past the bound is ABSENT, not shortened: a cut tag would be a
+    // different tag wearing a real one's name.
+    expect(safeWireTag("a".repeat(STUDIO_WIRE_TAG_MAX_CHARS + 1))).toBeNull();
+    expect(safeWireTag("has space")).toBeNull();
+    expect(safeWireTag("has\nnewline")).toBeNull();
+    expect(safeWireTag("")).toBeNull();
+    expect(safeWireTag(7)).toBeNull();
+    expect(safeWireTag(null)).toBeNull();
+  });
+});

--- a/src/__tests__/vex-agent/mcp/socket-transport-lifecycle.test.ts
+++ b/src/__tests__/vex-agent/mcp/socket-transport-lifecycle.test.ts
@@ -24,6 +24,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { FakeDuplexTransport } from "@vex-agent/mcp/duplex-transport-fake.js";
+import type { StudioWriteOutcome } from "@vex-agent/mcp/duplex-transport.js";
 import {
   loggableMcpMethod,
   StudioSocketTransport,
@@ -209,13 +210,13 @@ describe("the first outbound line", () => {
     // the log claimed main's answer had left main while the bytes were still
     // in main. The one question this line exists to answer was the one it
     // could get wrong.
-    const parked: Array<() => void> = [];
+    const parked: Array<(outcome: StudioWriteOutcome) => void> = [];
     const wire = new FakeDuplexTransport("accept_sync");
     const events: SocketTransportLifecycleEvent[] = [];
     const transport = new StudioSocketTransport(wire, {
       onLifecycle: (event) => events.push(event),
       writeLine: () =>
-        new Promise<void>((resolve) => {
+        new Promise<StudioWriteOutcome>((resolve) => {
           parked.push(resolve);
         }),
     });
@@ -227,7 +228,7 @@ describe("the first outbound line", () => {
 
     const [accept] = parked;
     if (accept === undefined) throw new Error("the writer was never called");
-    accept();
+    accept("accepted");
     await sent;
 
     expect(events.filter((event) => event.kind === "first_response")).toHaveLength(1);

--- a/src/vex-agent/mcp/duplex-transport-fake.ts
+++ b/src/vex-agent/mcp/duplex-transport-fake.ts
@@ -57,14 +57,14 @@ export class FakeDuplexTransport extends EventEmitter implements StudioDuplexTra
   refusedWrites = 0;
 
   private policy: FakeWritePolicy;
-  private readonly heldCallbacks: (() => void)[] = [];
+  private readonly heldCallbacks: ((error?: Error | null) => void)[] = [];
 
   constructor(policy: FakeWritePolicy = "accept_deferred") {
     super();
     this.policy = policy;
   }
 
-  write(line: string, callback?: () => void): boolean {
+  write(line: string, callback?: (error?: Error | null) => void): boolean {
     this.written.push(line);
     switch (this.policy) {
       case "accept_sync":

--- a/src/vex-agent/mcp/duplex-transport.ts
+++ b/src/vex-agent/mcp/duplex-transport.ts
@@ -71,6 +71,32 @@ export interface StudioDuplexTransportEvents {
 
 export type StudioDuplexTransportEvent = keyof StudioDuplexTransportEvents;
 
+/**
+ * WHAT HAPPENED TO ONE OUTBOUND LINE, as the writer knows it.
+ *
+ * A promise that merely RESOLVES says nothing: the Studio outbound queue
+ * settles every outstanding frame on close, on coalesce and at the pending
+ * bound, precisely so an ordinary disconnect does not surface as an unhandled
+ * rejection in the SDK's write path. VS Code's `NodeSocket.drain()`
+ * (`agents-colab/vscode/src/vs/base/parts/ipc/node/ipc.net.ts`) resolves the
+ * same way on `close`, `end`, `error`, `timeout` and `drain` alike - it is a
+ * QUIESCENCE signal, and VS Code can afford not to distinguish because nothing
+ * downstream claims the bytes left the process. Ours does: the `first_response`
+ * milestone and the outbound counters exist to answer "did main's answer leave
+ * main" in the one log an incident is read from, so the writer must say WHICH
+ * of the five settle edges it took.
+ *
+ *   `accepted`  the wire reported the peer-side write complete. The only
+ *               outcome that may publish a milestone or move a counter.
+ *   `coalesced` a newer progress frame replaced a queued one for the same
+ *               request. The content is delivered under the EARLIER frame's
+ *               obligation, so this caller's frame is not its own event.
+ *   `dropped`   refused at the pending bound and never queued.
+ *   `closed`    the queue was closed, or the wire went away, before the bytes
+ *               were the peer's problem.
+ */
+export type StudioWriteOutcome = "accepted" | "coalesced" | "dropped" | "closed";
+
 export interface StudioDuplexTransport {
   /** Attach a listener for every occurrence of `event`. */
   on<E extends StudioDuplexTransportEvent>(
@@ -98,13 +124,16 @@ export interface StudioDuplexTransport {
    * frame into a scheduled turn.
    *
    * `callback` means THE PEER-SIDE WRITE COMPLETED - the bytes left this
-   * process for the peer, as `net.Socket`'s own write callback means. It does
-   * NOT mean "queued internally". An implementation that relays through another
-   * process (the Windows pipe-front) may only run it once that process has
-   * reported the pipe write complete; running it on hand-off to the relay would
-   * make the outbound queue believe a frame is delivered while it sits in
-   * somebody else's buffer, and the queue's bound would stop bounding anything
-   * real.
+   * process for the peer, as `net.Socket`'s own write callback means - and its
+   * argument is `net.Socket`'s own: an `Error` (or any non-null value) means
+   * the write FAILED and the frame is not the peer's. A caller that reads the
+   * callback as unconditional acceptance would count a frame the socket threw
+   * away. It does NOT mean "queued internally". An implementation that relays
+   * through another process (the Windows pipe-front) may only run it once that
+   * process has reported the pipe write complete; running it on hand-off to
+   * the relay would make the outbound queue believe a frame is delivered while
+   * it sits in somebody else's buffer, and the queue's bound would stop
+   * bounding anything real.
    *
    * It may be invoked SYNCHRONOUSLY or on a later turn - both orders occur in
    * practice, and a caller that assumed one of them once stranded the outbound
@@ -115,7 +144,7 @@ export interface StudioDuplexTransport {
    * than none: it tells the one writer to send the next frame into a buffer
    * that is still full, which is how a bounded queue becomes an unbounded one.
    */
-  write(line: string, callback?: () => void): boolean;
+  write(line: string, callback?: (error?: Error | null) => void): boolean;
 
   /**
    * Half-close: the WRITABLE side is closed, the peer observes `end`, and the

--- a/src/vex-agent/mcp/socket-transport.ts
+++ b/src/vex-agent/mcp/socket-transport.ts
@@ -62,7 +62,10 @@
  * a typed over-limit error and a closed connection.
  */
 
-import type { StudioDuplexTransport } from "./duplex-transport.js";
+import type {
+  StudioDuplexTransport,
+  StudioWriteOutcome,
+} from "./duplex-transport.js";
 
 import type { InvalidJsonReason } from "./wire-errors.js";
 
@@ -272,8 +275,17 @@ export interface SocketTransportOptions {
    * queue, `send()` frames the message and hands the line to it rather than
    * writing. `progressKey` is non-null for a `notifications/progress` frame,
    * which is the only class the queue may coalesce.
+   *
+   * The writer ANSWERS WITH AN OUTCOME rather than a bare resolution, because
+   * its promise settles on five different edges and only one of them is the
+   * bytes leaving this process (`StudioWriteOutcome`). A milestone or a counter
+   * built on the resolution alone would claim an answer left main while it sat
+   * in a closed queue.
    */
-  readonly writeLine?: (line: string, progressKey: string | null) => Promise<void>;
+  readonly writeLine?: (
+    line: string,
+    progressKey: string | null,
+  ) => Promise<StudioWriteOutcome>;
   /**
    * The connection lifecycle transitions, for the OWNER'S structural log.
    *
@@ -308,7 +320,7 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
   private readonly shutdownDeadlineMs: number;
   private readonly onFailure: ((failure: SocketTransportFailure) => void) | undefined;
   private readonly writeLine:
-    | ((line: string, progressKey: string | null) => Promise<void>)
+    | ((line: string, progressKey: string | null) => Promise<StudioWriteOutcome>)
     | undefined;
   private readonly onLifecycle:
     | ((event: SocketTransportLifecycleEvent) => void)
@@ -419,15 +431,17 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
       return Promise.resolve();
     }
     const line = `${JSON.stringify(message)}\n`;
-    // COUNTED AND REPORTED ON ACCEPTANCE, not here.
+    // COUNTED AND REPORTED ON ACCEPTANCE, not here, and not on resolution.
     //
     // "Did main's answer leave main" is the exact question the log could not
     // answer, and a milestone written at the hand-off answers a weaker one: a
-    // frame handed to an outbound queue that is already closed, or to a write
-    // that rejects, never reached the peer at all, and a `first response` line
-    // for it is a false witness in the one log an incident is read from. The
-    // wire's completion callback and the writer's resolution are the two
-    // points at which the bytes are somebody else's; both run `accepted`.
+    // frame handed to an outbound queue that is already closed never reached
+    // the peer at all, and a `first response` line for it is a false witness
+    // in the one log an incident is read from. Nor is the writer's RESOLUTION
+    // the answer: the host's queue settles every frame it closed, coalesced or
+    // dropped at its bound, deliberately, so a disconnect is not an unhandled
+    // rejection. Only the `accepted` outcome means the bytes are somebody
+    // else's problem now.
     const outbound = classifyOutboundFrame(message);
     const accepted = (): void => {
       this.countOutbound(outbound);
@@ -440,18 +454,56 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
         outbound,
       });
     };
+    const settle = (outcome: StudioWriteOutcome): void => {
+      // ONE OUTCOME OUT OF FOUR. The owner's queue resolves for a frame it
+      // coalesced, dropped at its bound, or swallowed on close, and it says
+      // which; a milestone written on any of those is a false witness in the
+      // log an incident is read from.
+      if (outcome === "accepted") accepted();
+    };
+    // The DRAIN accounting settles on EVERY edge, acceptance or not, and a
+    // writer that rejects discharges this frame's hold too: leaving it
+    // outstanding would hold a finished connection open to its deadline for a
+    // frame nobody is waiting for any more.
+    const settleDrain = (): void => {
+      this.settleIfDrained();
+    };
     if (this.writeLine !== undefined) {
       return this.writeLine(line, progressCoalesceKey(message))
-        .then(accepted)
-        .finally(() => {
-          this.settleIfDrained();
-        });
+        .then(settle)
+        .finally(settleDrain);
     }
-    return new Promise<void>((resolve) => {
-      this.wire.write(line, () => {
-        accepted();
-        this.settleIfDrained();
-        resolve();
+    return this.writeToWire(line).then(settle).finally(settleDrain);
+  }
+
+  /**
+   * Write one line straight to the wire, with the SAME outcome vocabulary the
+   * owner's queue answers in.
+   *
+   * The standalone path (no host queue) still has to distinguish the bytes
+   * leaving from the wire going away underneath them: `close` and `error`
+   * settle it so a teardown cannot strand `send`, and neither of them is
+   * acceptance. Ordering is the queue's, not this module's, so there is no
+   * `drain` parking here - a refused write's callback still runs when Node
+   * flushes it.
+   */
+  private writeToWire(line: string): Promise<StudioWriteOutcome> {
+    return new Promise<StudioWriteOutcome>((resolve) => {
+      let settled = false;
+      const done = (outcome: StudioWriteOutcome): void => {
+        if (settled) return;
+        settled = true;
+        this.wire.off("close", gone);
+        this.wire.off("error", gone);
+        resolve(outcome);
+      };
+      const gone = (): void => {
+        done("closed");
+      };
+      this.wire.once("close", gone);
+      this.wire.once("error", gone);
+      this.wire.write(line, (error) => {
+        done(error === undefined || error === null ? "accepted" : "closed");
       });
     });
   }
@@ -762,13 +814,9 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
   }
 
   /** The framing error line, through the owner's serialized writer when set. */
-  private writeFramingLine(line: string): Promise<void> {
+  private writeFramingLine(line: string): Promise<StudioWriteOutcome> {
     if (this.writeLine !== undefined) return this.writeLine(line, null);
-    return new Promise<void>((resolve) => {
-      this.wire.write(line, () => {
-        resolve();
-      });
-    });
+    return this.writeToWire(line);
   }
 
   /** The contract's shutdown deadline, as a promise that cleans up its timer. */

--- a/src/vex-agent/mcp/socket-transport.ts
+++ b/src/vex-agent/mcp/socket-transport.ts
@@ -125,16 +125,54 @@ export type SocketTransportLifecycleEvent =
       readonly client: string | null;
       readonly protocolVersion: string | null;
     }
-  /** The FIRST outbound line handed to the wire. One per transport. */
-  | { readonly kind: "first_response"; readonly id: string | null; readonly bytes: number }
+  /**
+   * The FIRST outbound line the WIRE ACCEPTED. One per transport.
+   *
+   * Reported from the write's completion, not from the hand-off: the question
+   * this milestone exists to answer is "did main's answer leave main", and a
+   * line published before the writer took it answers a different one. A write
+   * that fails or lands on a closed queue therefore reports nothing, which is
+   * the honest reading of that log's silence.
+   */
+  | {
+      readonly kind: "first_response";
+      readonly id: string | null;
+      readonly bytes: number;
+      /** What the frame actually was. A notification is not an answer. */
+      readonly outbound: OutboundFrameKind;
+    }
   /** The peer half-closed. Latched, so it fires at most once. */
   | { readonly kind: "peer_end" }
   /** The `onclose` latch, with this connection's final counters. */
   | {
       readonly kind: "closed";
       readonly requests: number;
+      /** Answers to inbound requests. The counter the incident needed. */
       readonly responses: number;
+      /** Outbound frames that oblige nobody: progress, logging, cancelled. */
+      readonly notifications: number;
+      /** Frames this server sent that expect the PEER to answer. */
+      readonly serverRequests: number;
+      /** Outbound frames that are none of the three. Always zero in practice. */
+      readonly otherOutbound: number;
     };
+
+/**
+ * WHAT AN OUTBOUND FRAME IS, in JSON-RPC's own terms.
+ *
+ * The counters and the first-outbound milestone used to call every line a
+ * "response", so a progress notification leaving first was logged as this
+ * connection's first answer and a `responses` total silently included frames
+ * nobody had asked for. The classification is structural and matches the one
+ * `jsonRpcResponseKey` already makes for the drain accounting:
+ *
+ *   `response`       no `method`, an `id`, and exactly one of `result`/`error`
+ *   `server_request` a `method` AND an `id`: this server asking the peer
+ *   `notification`   a `method` and no `id`
+ *   `other`          none of the above. Our own defect if it ever appears,
+ *                    which is why it is counted rather than folded away.
+ */
+export type OutboundFrameKind = "response" | "notification" | "server_request" | "other";
 
 /**
  * The MCP methods this host will NAME in a log line, and nothing else.
@@ -278,8 +316,14 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
 
   /** Inbound envelopes this transport queued. Reported on close. */
   private requestCount = 0;
-  /** Outbound lines this transport handed to the wire. Reported on close. */
+  /** Answers to inbound requests the wire ACCEPTED. Reported on close. */
   private responseCount = 0;
+  /** Outbound notifications the wire accepted. Reported on close. */
+  private notificationCount = 0;
+  /** Server-initiated requests the wire accepted. Reported on close. */
+  private serverRequestCount = 0;
+  /** Outbound frames that were none of the three. Reported on close. */
+  private otherOutboundCount = 0;
   /** The `first_request` one-shot latch. */
   private firstRequestReported = false;
   /** The `first_response` one-shot latch. */
@@ -375,29 +419,59 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
       return Promise.resolve();
     }
     const line = `${JSON.stringify(message)}\n`;
-    // COUNTED AND REPORTED HERE, at the hand-off to the wire: this is the
-    // point after which the bytes are somebody else's, and "did main's answer
-    // leave main" is the exact question the log could not answer before.
-    this.responseCount += 1;
-    if (!this.firstResponseReported) {
+    // COUNTED AND REPORTED ON ACCEPTANCE, not here.
+    //
+    // "Did main's answer leave main" is the exact question the log could not
+    // answer, and a milestone written at the hand-off answers a weaker one: a
+    // frame handed to an outbound queue that is already closed, or to a write
+    // that rejects, never reached the peer at all, and a `first response` line
+    // for it is a false witness in the one log an incident is read from. The
+    // wire's completion callback and the writer's resolution are the two
+    // points at which the bytes are somebody else's; both run `accepted`.
+    const outbound = classifyOutboundFrame(message);
+    const accepted = (): void => {
+      this.countOutbound(outbound);
+      if (this.firstResponseReported) return;
       this.firstResponseReported = true;
       this.reportLifecycle({
         kind: "first_response",
         id: jsonRpcIdTag(readRecordField(message, "id")),
         bytes: Buffer.byteLength(line, "utf8"),
+        outbound,
       });
-    }
+    };
     if (this.writeLine !== undefined) {
-      return this.writeLine(line, progressCoalesceKey(message)).finally(() => {
-        this.settleIfDrained();
-      });
+      return this.writeLine(line, progressCoalesceKey(message))
+        .then(accepted)
+        .finally(() => {
+          this.settleIfDrained();
+        });
     }
     return new Promise<void>((resolve) => {
       this.wire.write(line, () => {
+        accepted();
         this.settleIfDrained();
         resolve();
       });
     });
+  }
+
+  /** One accepted outbound frame, on its own counter. */
+  private countOutbound(outbound: OutboundFrameKind): void {
+    switch (outbound) {
+      case "response":
+        this.responseCount += 1;
+        return;
+      case "notification":
+        this.notificationCount += 1;
+        return;
+      case "server_request":
+        this.serverRequestCount += 1;
+        return;
+      case "other":
+        this.otherOutboundCount += 1;
+        return;
+    }
   }
 
   /**
@@ -740,6 +814,9 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
       kind: "closed",
       requests: this.requestCount,
       responses: this.responseCount,
+      notifications: this.notificationCount,
+      serverRequests: this.serverRequestCount,
+      otherOutbound: this.otherOutboundCount,
     });
     try {
       this.onclose?.();
@@ -787,6 +864,24 @@ function jsonRpcResponseKey(message: unknown): string | null {
   const record = message as Record<string, unknown>;
   if (typeof record["method"] === "string") return null;
   return requestIdKey(record["id"]);
+}
+
+/**
+ * What an outbound frame IS, structurally. See `OutboundFrameKind`.
+ *
+ * `result` and `error` are read as PRESENCE, not as content: a response whose
+ * `result` is `null` is still a response, and a frame carrying both is
+ * malformed rather than an answer.
+ */
+function classifyOutboundFrame(message: unknown): OutboundFrameKind {
+  if (typeof message !== "object" || message === null) return "other";
+  const record = message as Record<string, unknown>;
+  const hasId = "id" in record && record["id"] !== undefined;
+  if (typeof record["method"] === "string") return hasId ? "server_request" : "notification";
+  if (!hasId) return "other";
+  const hasResult = "result" in record && record["result"] !== undefined;
+  const hasError = "error" in record && record["error"] !== undefined;
+  return hasResult !== hasError ? "response" : "other";
 }
 
 /**

--- a/src/vex-agent/mcp/socket-transport.ts
+++ b/src/vex-agent/mcp/socket-transport.ts
@@ -106,6 +106,114 @@ export type SocketTransportFailure =
   | { readonly kind: "queue_overflow"; readonly queued: number }
   | { readonly kind: "socket_error"; readonly message: string };
 
+/**
+ * What a connection's OWNER needs in its structural log, and nothing else.
+ *
+ * The transport is the only place that sees an inbound envelope reach the
+ * queue and an outbound line reach the wire, so it is the owner of those two
+ * transitions (rule 05). It does not log: this module is engine code with no
+ * logger, and the host owns the line vocabulary. Every string here is
+ * SANITISED peer content or `null` - see `safeWireTag`.
+ */
+export type SocketTransportLifecycleEvent =
+  /** The FIRST inbound envelope this transport queued. One per transport. */
+  | {
+      readonly kind: "first_request";
+      /** A member of `STUDIO_KNOWN_MCP_METHODS`, or `"other"`. NEVER the peer's. */
+      readonly method: StudioLoggableMethod;
+      /** `name/version` from `initialize`, else `null`. */
+      readonly client: string | null;
+      readonly protocolVersion: string | null;
+    }
+  /** The FIRST outbound line handed to the wire. One per transport. */
+  | { readonly kind: "first_response"; readonly id: string | null; readonly bytes: number }
+  /** The peer half-closed. Latched, so it fires at most once. */
+  | { readonly kind: "peer_end" }
+  /** The `onclose` latch, with this connection's final counters. */
+  | {
+      readonly kind: "closed";
+      readonly requests: number;
+      readonly responses: number;
+    };
+
+/**
+ * The MCP methods this host will NAME in a log line, and nothing else.
+ *
+ * A method name arrives from the peer, and `mcp-wire-error-redaction.test.ts`
+ * holds the whole host to "no byte the peer chose reaches the log": a client
+ * is free to call `tools/<a secret it just leaked>` and the line that reported
+ * it would leak it too. A closed set authored HERE answers the only question
+ * the log actually needs - was this `initialize`, a call, a listing, or
+ * something else - out of this repository's own vocabulary.
+ *
+ * The members are the client-to-server requests and notifications of the MCP
+ * specification the pinned SDK serves. An addition is an intentional change to
+ * this vocabulary, which is why the set is spelled rather than derived.
+ */
+export const STUDIO_KNOWN_MCP_METHODS = [
+  "initialize",
+  "ping",
+  "completion/complete",
+  "logging/setLevel",
+  "prompts/list",
+  "prompts/get",
+  "resources/list",
+  "resources/templates/list",
+  "resources/read",
+  "resources/subscribe",
+  "resources/unsubscribe",
+  "tools/list",
+  "tools/call",
+  "notifications/initialized",
+  "notifications/cancelled",
+  "notifications/progress",
+  "notifications/roots/list_changed",
+] as const;
+
+/** A method the log may name, or the honest `other` for everything else. */
+export type StudioLoggableMethod = (typeof STUDIO_KNOWN_MCP_METHODS)[number] | "other";
+
+const KNOWN_MCP_METHODS: ReadonlySet<string> = new Set(STUDIO_KNOWN_MCP_METHODS);
+
+/**
+ * The loggable name of an inbound method.
+ *
+ * `other` is not a failure and not an error: an unknown method is answered in
+ * band by the SDK with a JSON-RPC error, and the log's job here is only to say
+ * that the frame arrived and was not one of the calls that matter.
+ */
+export function loggableMcpMethod(value: unknown): StudioLoggableMethod {
+  if (typeof value !== "string" || !KNOWN_MCP_METHODS.has(value)) return "other";
+  // The narrowing is the set membership above: every member of the set is a
+  // member of the union by construction.
+  return value as StudioLoggableMethod;
+}
+
+/**
+ * The bound on any peer-authored token that may reach a log line.
+ *
+ * A method name, a client name or a protocol version is the PEER'S string. A
+ * log line is a shape a human and a support transcript read, so a value that
+ * could carry a newline, a control character or a kilobyte of text is not
+ * carried at all: `safeWireTag` answers `null` and the owner logs the absence.
+ * Nothing is cut - an oversized or unusual value is REPLACED, never truncated.
+ */
+export const STUDIO_WIRE_TAG_MAX_CHARS = 64;
+
+/**
+ * One peer-authored token, or `null` when it may not reach a log.
+ *
+ * The accepted set is what MCP method names, client names and protocol
+ * versions are actually spelled with. Anything else - a space, a quote, a
+ * newline, a non-ASCII byte, a value past the bound - answers `null`.
+ */
+export function safeWireTag(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  if (value.length === 0 || value.length > STUDIO_WIRE_TAG_MAX_CHARS) return null;
+  if (!/^[A-Za-z0-9._:@/+-]+$/.test(value)) return null;
+  return value;
+}
+
 export interface SocketTransportOptions {
   /** Bytes already read past the handshake newline. Fed before any socket data. */
   readonly remainder?: Buffer;
@@ -128,6 +236,14 @@ export interface SocketTransportOptions {
    * which is the only class the queue may coalesce.
    */
   readonly writeLine?: (line: string, progressKey: string | null) => Promise<void>;
+  /**
+   * The connection lifecycle transitions, for the OWNER'S structural log.
+   *
+   * Reporting only, exactly like `onFailure`: nothing here decides anything,
+   * and a callback that throws is swallowed rather than becoming a second
+   * failure path.
+   */
+  readonly onLifecycle?: (event: SocketTransportLifecycleEvent) => void;
 }
 
 /**
@@ -156,6 +272,18 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
   private readonly writeLine:
     | ((line: string, progressKey: string | null) => Promise<void>)
     | undefined;
+  private readonly onLifecycle:
+    | ((event: SocketTransportLifecycleEvent) => void)
+    | undefined;
+
+  /** Inbound envelopes this transport queued. Reported on close. */
+  private requestCount = 0;
+  /** Outbound lines this transport handed to the wire. Reported on close. */
+  private responseCount = 0;
+  /** The `first_request` one-shot latch. */
+  private firstRequestReported = false;
+  /** The `first_response` one-shot latch. */
+  private firstResponseReported = false;
 
   /** Bytes read but not yet terminated by a newline. Bounded by `maxLineBytes`. */
   private inbound: Buffer;
@@ -189,6 +317,7 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
     this.shutdownDeadlineMs = options.shutdownDeadlineMs ?? STUDIO_SHUTDOWN_DEADLINE_MS;
     this.onFailure = options.onFailure;
     this.writeLine = options.writeLine;
+    this.onLifecycle = options.onLifecycle;
     this.inbound = options.remainder === undefined
       ? Buffer.alloc(0)
       : Buffer.from(options.remainder);
@@ -246,6 +375,18 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
       return Promise.resolve();
     }
     const line = `${JSON.stringify(message)}\n`;
+    // COUNTED AND REPORTED HERE, at the hand-off to the wire: this is the
+    // point after which the bytes are somebody else's, and "did main's answer
+    // leave main" is the exact question the log could not answer before.
+    this.responseCount += 1;
+    if (!this.firstResponseReported) {
+      this.firstResponseReported = true;
+      this.reportLifecycle({
+        kind: "first_response",
+        id: jsonRpcIdTag(readRecordField(message, "id")),
+        bytes: Buffer.byteLength(line, "utf8"),
+      });
+    }
     if (this.writeLine !== undefined) {
       return this.writeLine(line, progressCoalesceKey(message)).finally(() => {
         this.settleIfDrained();
@@ -346,6 +487,7 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
   readonly notifyPeerEnd = (): void => {
     if (this.peerEnded) return;
     this.peerEnded = true;
+    this.reportLifecycle({ kind: "peer_end" });
     // A socket whose writable side is already finished cannot carry an answer,
     // so there is nothing to drain FOR. Happens when the listener was built
     // without `allowHalfOpen`, where Node ends the writable side on FIN.
@@ -434,6 +576,14 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
         return;
       }
       this.queue.push(decoded);
+      // QUEUED, not delivered: the question the incident could not answer is
+      // whether the frame reached this transport at all, and it did so here,
+      // before the consumer had any say in it.
+      this.requestCount += 1;
+      if (!this.firstRequestReported) {
+        this.firstRequestReported = true;
+        this.reportLifecycle(describeFirstRequest(decoded));
+      }
       if (this.queue.length >= this.maxQueuedMessages) this.pauseReading();
       this.scheduleDrain();
     }
@@ -555,6 +705,14 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
     });
   }
 
+  private reportLifecycle(event: SocketTransportLifecycleEvent): void {
+    try {
+      this.onLifecycle?.(event);
+    } catch {
+      // Reporting must never become a second failure path.
+    }
+  }
+
   private reportFailure(failure: SocketTransportFailure): void {
     try {
       this.onFailure?.(failure);
@@ -576,6 +734,13 @@ export class StudioSocketTransport implements JsonRpcWireTransport {
     if (this.closeAnnounced) return;
     this.closeAnnounced = true;
     this.queue.length = 0;
+    // BEFORE `onclose`, so the owner's `closed` line carries settled counters
+    // whichever of the six teardown causes ran.
+    this.reportLifecycle({
+      kind: "closed",
+      requests: this.requestCount,
+      responses: this.responseCount,
+    });
     try {
       this.onclose?.();
     } catch {
@@ -622,6 +787,64 @@ function jsonRpcResponseKey(message: unknown): string | null {
   const record = message as Record<string, unknown>;
   if (typeof record["method"] === "string") return null;
   return requestIdKey(record["id"]);
+}
+
+/**
+ * A JSON-RPC id as a log tag, or `null`.
+ *
+ * A numeric id is its own decimal; a STRING id is peer content and passes
+ * `safeWireTag` like every other peer-authored token.
+ */
+function jsonRpcIdTag(id: unknown): string | null {
+  if (typeof id === "number" && Number.isFinite(id)) return String(id);
+  return safeWireTag(id);
+}
+
+/** One field of a decoded envelope, or `undefined`. Never throws on a non-object. */
+function readRecordField(value: unknown, field: string): unknown {
+  if (typeof value !== "object" || value === null) return undefined;
+  return (value as Record<string, unknown>)[field];
+}
+
+/**
+ * The `first_request` event for one decoded envelope.
+ *
+ * The method is a member of this repository's own closed set or `other`; the
+ * peer's spelling never survives. `initialize` is the only method whose params
+ * are read, and only for the two fields the 2026-07-28 era carries in either
+ * place: `clientInfo` and `protocolVersion`. NOTHING else from params is looked
+ * at, and both survivors pass `safeWireTag`, so neither can author a log line.
+ *
+ * WHY THESE TWO ARE CARRIED AT ALL, when a method name is not. A client's
+ * `clientInfo.name` is not payload the user typed: it is the identifier the
+ * client process declares for itself, and this repository already puts it in
+ * front of a human on a durable surface - the approval card's
+ * `requestedByClient` (`approval-service.ts`) - so treating it as unloggable
+ * here would be inconsistent with a decision already taken. `protocolVersion`
+ * is a dated string from a published specification. Both are still bounded and
+ * character-restricted, because "not payload" is not the same as "trusted".
+ */
+function describeFirstRequest(message: unknown): SocketTransportLifecycleEvent {
+  const method = loggableMcpMethod(readRecordField(message, "method"));
+  if (method !== "initialize") {
+    return { kind: "first_request", method, client: null, protocolVersion: null };
+  }
+  const params = readRecordField(message, "params");
+  const meta = readRecordField(params, "_meta");
+  const info = readRecordField(params, "clientInfo")
+    ?? readRecordField(meta, "io.modelcontextprotocol/clientInfo");
+  const name = safeWireTag(readRecordField(info, "name"));
+  const version = safeWireTag(readRecordField(info, "version"));
+  const protocolVersion = safeWireTag(
+    readRecordField(params, "protocolVersion")
+      ?? readRecordField(meta, "io.modelcontextprotocol/protocolVersion"),
+  );
+  return {
+    kind: "first_request",
+    method,
+    client: name === null ? null : `${name}/${version ?? "unknown"}`,
+    protocolVersion,
+  };
 }
 
 /** The typed encoding of a JSON-RPC id, or `null` when there is no usable id. */

--- a/vex-app/src/main/studio/__tests__/front-relay.test.ts
+++ b/vex-app/src/main/studio/__tests__/front-relay.test.ts
@@ -19,10 +19,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { StudioDuplexTransport } from "@vex-agent/mcp/duplex-transport.js";
 
 vi.mock("../../logger/index.js", () => ({
-  log: { info: () => {}, warn: () => {}, error: () => {} },
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+const { log } = await import("../../logger/index.js");
+
 const { FrontSupervisor } = await import("../mcp-host/front-supervisor.js");
+const { FRONT_CREDIT_STALL_WARN_MS, FrontRelayTransport } = await import(
+  "../mcp-host/front-relay-transport.js"
+);
 const { FRONT_CHUNK_BYTES, FRONT_CREDIT_BYTES } = await import(
   "../mcp-host/front-handshake.js"
 );
@@ -106,7 +111,18 @@ async function microtasks(): Promise<void> {
   await Promise.resolve();
 }
 
+/** Every `log.warn` line this case produced. */
+function warnings(): readonly string[] {
+  return vi.mocked(log.warn).mock.calls.map((call) => String(call[0]));
+}
+
+/** Every `log.info` line this case produced. */
+function infoLines(): readonly string[] {
+  return vi.mocked(log.info).mock.calls.map((call) => String(call[0]));
+}
+
 beforeEach(() => {
+  vi.clearAllMocks();
   fronts = [];
   admitted = [];
   built = [];
@@ -121,7 +137,16 @@ beforeEach(() => {
 afterEach(() => {
   for (const supervisor of built) supervisor.dispose();
   built = [];
+  vi.useRealTimers();
 });
+
+/** One admitted wire as the relay transport it is, so its counters are readable. */
+function relayWire(wire: StudioDuplexTransport): InstanceType<typeof FrontRelayTransport> {
+  if (!(wire instanceof FrontRelayTransport)) {
+    throw new Error("the relay admitted something that is not a relay transport");
+  }
+  return wire;
+}
 
 describe("admission, before a byte is read", () => {
   it("ADMITs with the captured epoch and grants the first credit window", () => {
@@ -416,5 +441,154 @@ describe("close, and the edge that must not overtake the last response", () => {
     front().sendPeerClosed(1, "commanded_close", 0n);
     await microtasks();
     expect(closed).toBe(1);
+  });
+});
+
+/**
+ * THE DOWN-PATH UNDER A MESSAGE THAT DOES NOT FIT ITS WINDOW, and the log that
+ * says so when the front stops acknowledging.
+ *
+ * A `tools/list` for the Studio surface is on the order of 700 KB - about
+ * eleven 64 KiB credit windows and twenty-odd 32 KiB chunks - and it is the
+ * FIRST heavy exercise of this path on every connection. Before these cases
+ * the relay had no test that pushed a message past one window, and a
+ * connection whose acknowledgements stopped arriving produced no evidence of
+ * any kind: main sat with bytes it could not send and said nothing for as long
+ * as it lived, which is exactly the 2026-09-04 incident's silent 25 seconds.
+ */
+describe("a response that spans several credit windows", () => {
+  it("arrives complete and in order when the front acknowledges normally", () => {
+    build();
+    front().completeHandshake();
+    const wire = openConnection(1);
+
+    // 200 KiB of distinguishable bytes: a repeating 16-byte counter, so a
+    // reordered or dropped chunk changes the reassembled string rather than
+    // being hidden by a run of identical characters.
+    const blocks: string[] = [];
+    for (let index = 0; index < 200 * 1024 / 16; index += 1) {
+      blocks.push(String(index % 10).repeat(16));
+    }
+    const line = `${blocks.join("")}\n`;
+    let settled = 0;
+    const accepted = wire.write(line, () => (settled += 1));
+
+    // It cannot fit: the window is 64 KiB and the message is over three of
+    // them, so the writer is told to park.
+    expect(accepted).toBe(false);
+
+    // SCRIPTED ACKNOWLEDGEMENTS, one window at a time, exactly as a front that
+    // is draining its pipe would send them. The loop is bounded so a relay
+    // that stops making progress fails here instead of spinning.
+    for (let round = 0; round < 64 && settled === 0; round += 1) {
+      const written = front().dataOfType("DATA");
+      const last = written[written.length - 1];
+      if (last === undefined) break;
+      front().sendWriteDone(1, last.sequence);
+    }
+
+    expect(settled).toBe(1);
+    const reassembled = front()
+      .dataOfType("DATA")
+      .map((frame) => Buffer.from(frame.payload).toString("utf8"))
+      .join("");
+    expect(reassembled).toBe(line);
+    // Every chunk respected the plane's own bound.
+    for (const frame of front().dataOfType("DATA")) {
+      expect(frame.payload.length).toBeLessThanOrEqual(FRONT_CHUNK_BYTES);
+    }
+  });
+
+  it("warns ONCE when the credit never comes back, and never for a connection that recovers", () => {
+    vi.useFakeTimers();
+    build();
+    front().completeHandshake();
+    const wire = openConnection(1);
+
+    wire.write("a".repeat(FRONT_CHUNK_BYTES * 8));
+    // Two chunks fill the window; the rest is main's to hold.
+    expect(front().dataOfType("DATA")).toHaveLength(2);
+    expect(warnings()).toHaveLength(0);
+
+    // A moment before the bound, nothing has been said: this is pacing, and
+    // pacing is not a fault.
+    vi.advanceTimersByTime(FRONT_CREDIT_STALL_WARN_MS - 1);
+    expect(warnings()).toHaveLength(0);
+
+    vi.advanceTimersByTime(1);
+    expect(warnings()).toEqual([
+      "[studio:front] write blocked on credit connection=1 "
+        + `waitedMs=${String(FRONT_CREDIT_STALL_WARN_MS)} `
+        + `queuedBytes=${String(FRONT_CHUNK_BYTES * 6)}`,
+    ]);
+
+    // ONE PER CONNECTION, EVER. A genuinely wedged connection repeating this
+    // line every five seconds is a log that has stopped being evidence.
+    vi.advanceTimersByTime(FRONT_CREDIT_STALL_WARN_MS * 10);
+    expect(warnings()).toHaveLength(1);
+  });
+
+  it("says nothing when an acknowledgement releases the window before the bound", () => {
+    vi.useFakeTimers();
+    build();
+    front().completeHandshake();
+    const wire = openConnection(1);
+
+    wire.write("a".repeat(FRONT_CHUNK_BYTES * 8));
+    vi.advanceTimersByTime(FRONT_CREDIT_STALL_WARN_MS - 1);
+    front().sendWriteDone(1, dataSequence(0));
+    // The watch is cleared and re-armed from zero by the pump's next block, so
+    // the remaining millisecond of the old window proves nothing.
+    vi.advanceTimersByTime(1);
+    expect(warnings()).toHaveLength(0);
+
+    // And it is still ARMED: this is a clear, not a disarm.
+    vi.advanceTimersByTime(FRONT_CREDIT_STALL_WARN_MS);
+    expect(warnings()).toHaveLength(1);
+  });
+
+  it("leaves no timer behind when the connection closes while it is blocked", () => {
+    vi.useFakeTimers();
+    build();
+    front().completeHandshake();
+    const wire = openConnection(1);
+
+    wire.write("a".repeat(FRONT_CHUNK_BYTES * 8));
+    wire.destroy();
+    vi.advanceTimersByTime(FRONT_CREDIT_STALL_WARN_MS * 3);
+
+    // A warn about a connection that is gone is noise, and the timer that
+    // would have produced it is a handle with no owner.
+    expect(warnings()).toHaveLength(0);
+  });
+});
+
+describe("what the connection lost, and what the peer did", () => {
+  it("attributes a dropped frame to the connection it named", async () => {
+    build();
+    front().completeHandshake();
+    const wire = relayWire(openConnection(1));
+    expect(wire.droppedFrames).toBe(0);
+
+    wire.destroy();
+    await microtasks();
+    // A frame the front wrote a microsecond before main decided to close. It
+    // is not a fault, but the connection that lost it must be able to report
+    // it on its own closed line.
+    front().sendData(1, Buffer.from("late"));
+    front().sendWriteDone(1, 1n);
+
+    expect(wire.droppedFrames).toBe(2);
+  });
+
+  it("names a peer half-close in the log, which nothing did before", () => {
+    build();
+    front().completeHandshake();
+    const wire = openConnection(1);
+
+    front().sendPeerEnd(1);
+
+    expect(wire.readableEnded).toBe(true);
+    expect(infoLines()).toContain("[studio:front] peer half-closed connection=1");
   });
 });

--- a/vex-app/src/main/studio/__tests__/mcp-connection-lifecycle-log.test.ts
+++ b/vex-app/src/main/studio/__tests__/mcp-connection-lifecycle-log.test.ts
@@ -50,18 +50,29 @@ interface Harness {
   readonly wireLifecycle: (event: SocketTransportLifecycleEvent) => void;
   readonly failWire: () => void;
   readonly infoLines: () => readonly string[];
+  /**
+   * Let a held `serveConnection().close()` finish.
+   *
+   * Only meaningful with `holdEntryClose`, and the point of the seam: the
+   * teardown's own await is where a late peer edge lands in production, so a
+   * test that wants to script that edge has to be able to stand inside it.
+   */
+  readonly releaseEntryClose: () => void;
 }
 
 interface HarnessOptions {
   readonly transportKind?: "front" | "socket";
   readonly droppedFrames?: (() => number) | null;
   readonly isStale?: () => boolean;
+  /** Park the served entry's `close()` until `releaseEntryClose` is called. */
+  readonly holdEntryClose?: boolean;
 }
 
 function harness(options: HarnessOptions = {}): Harness {
   const wire = new FakeDuplexTransport("accept_sync");
   let onLifecycle: ((event: SocketTransportLifecycleEvent) => void) | null = null;
   let onWireFailure: ((code: "invalid_json") => void) | null = null;
+  let releaseEntryClose: (() => void) | null = null;
   const connection = new StudioConnection("c-test", wire, {
     runCall: async () => ({ kind: "completed", result: { success: true, output: "ok" } }),
     acquireCallSlot: () => ({ ok: true, release: (): void => undefined }),
@@ -71,7 +82,15 @@ function harness(options: HarnessOptions = {}): Harness {
     serveConnection: (input): StudioConnectionHandle => {
       onLifecycle = input.onWireLifecycle;
       onWireFailure = input.onWireFailure;
-      return { close: async (): Promise<void> => undefined };
+      if (options.holdEntryClose !== true) {
+        return { close: async (): Promise<void> => undefined };
+      }
+      return {
+        close: (): Promise<void> =>
+          new Promise<void>((resolve) => {
+            releaseEntryClose = resolve;
+          }),
+      };
     },
     onClosed: (): void => undefined,
     transportKind: options.transportKind ?? "socket",
@@ -90,6 +109,10 @@ function harness(options: HarnessOptions = {}): Harness {
     },
     infoLines: () =>
       vi.mocked(log.info).mock.calls.map((call) => String(call[0])),
+    releaseEntryClose: () => {
+      if (releaseEntryClose === null) throw new Error("no entry close is held");
+      releaseEntryClose();
+    },
   };
 }
 
@@ -133,10 +156,22 @@ describe("a served connection whose peer half-closes", () => {
       client: "claude-code/2.1.260",
       protocolVersion: "2026-07-28",
     });
-    test.wireLifecycle({ kind: "first_response", id: "0", bytes: 733_120 });
+    test.wireLifecycle({
+      kind: "first_response",
+      id: "0",
+      bytes: 733_120,
+      outbound: "response",
+    });
     // THE INCIDENT'S OWN EDGE: the peer went away, main did not decide to.
     test.wireLifecycle({ kind: "peer_end" });
-    test.wireLifecycle({ kind: "closed", requests: 3, responses: 3 });
+    test.wireLifecycle({
+      kind: "closed",
+      requests: 3,
+      responses: 3,
+      notifications: 0,
+      serverRequests: 0,
+      otherOutbound: 0,
+    });
     await test.connection.dispose("disconnect");
 
     const lines = test.infoLines();
@@ -148,7 +183,9 @@ describe("a served connection whose peer half-closes", () => {
       "[studio:mcp] first request id=c-test method=initialize "
         + "client=claude-code/2.1.260 protocolVersion=2026-07-28",
     );
-    expect(lines[2]).toBe("[studio:mcp] first response id=c-test rpcId=0 bytes=733120");
+    expect(lines[2]).toBe(
+      "[studio:mcp] first response id=c-test rpcId=0 bytes=733120 outbound=response",
+    );
     expect(lines[3]).toMatch(
       /^\[studio:mcp\] closed id=c-test cause=peer_end servedMs=\d+ requests=3 responses=3$/,
     );
@@ -161,12 +198,59 @@ describe("a served connection whose peer half-closes", () => {
 
     expect(test.infoLines()[0]).toContain("transport=front");
 
-    test.wireLifecycle({ kind: "closed", requests: 1, responses: 1 });
+    test.wireLifecycle({
+      kind: "closed",
+      requests: 1,
+      responses: 1,
+      notifications: 0,
+      serverRequests: 0,
+      otherOutbound: 0,
+    });
     await test.connection.dispose("disconnect");
 
     expect(closedLine(test)).toMatch(
       /cause=owner_close servedMs=\d+ requests=1 responses=1 droppedFrames=2$/,
     );
+  });
+});
+
+describe("the closed line counts answers apart from everything else main sent", () => {
+  it("names notifications and server requests when there were any, and stays quiet when there were not", async () => {
+    // The counter used to be one total of outbound LINES called `responses`,
+    // so a connection that answered once and emitted eleven progress
+    // notifications reported twelve answers. `responses` is answers now, and
+    // the rest have their own names - printed only when they are non-zero, so
+    // the ordinary line stays the line a reader knows.
+    const busy = harness();
+    busy.wire.deliver(handshakeLine());
+    await settle();
+    busy.wireLifecycle({
+      kind: "closed",
+      requests: 4,
+      responses: 4,
+      notifications: 11,
+      serverRequests: 1,
+      otherOutbound: 0,
+    });
+    await busy.connection.dispose("disconnect");
+    expect(closedLine(busy)).toContain("responses=4 notifications=11 serverRequests=1");
+    expect(closedLine(busy)).not.toContain("otherOutbound");
+
+    vi.clearAllMocks();
+
+    const quiet = harness();
+    quiet.wire.deliver(handshakeLine());
+    await settle();
+    quiet.wireLifecycle({
+      kind: "closed",
+      requests: 1,
+      responses: 1,
+      notifications: 0,
+      serverRequests: 0,
+      otherOutbound: 0,
+    });
+    await quiet.connection.dispose("disconnect");
+    expect(closedLine(quiet)).toMatch(/requests=1 responses=1$/);
   });
 });
 
@@ -177,7 +261,14 @@ describe("the cause separates the peer from main's own decisions", () => {
     await settle();
 
     test.failWire();
-    test.wireLifecycle({ kind: "closed", requests: 1, responses: 0 });
+    test.wireLifecycle({
+      kind: "closed",
+      requests: 1,
+      responses: 0,
+      notifications: 0,
+      serverRequests: 0,
+      otherOutbound: 0,
+    });
     await test.connection.dispose("disconnect");
 
     expect(closedLine(test)).toContain("cause=wire_failure");
@@ -230,13 +321,75 @@ describe("the cause separates the peer from main's own decisions", () => {
     expect(closedLine(test)).toContain("cause=stale");
   });
 
+  it("a peer EOF arriving inside main's own teardown cannot rename it", async () => {
+    // THE RACE, SCRIPTED. `runDispose` awaits the served entry's close, and a
+    // killed or exiting peer's FIN lands inside that await often enough that
+    // the incident of 2026-09-04 could not be attributed at all: main decided
+    // to close (a serve failure, an outbound overflow), the transport reported
+    // `peer_end` while the teardown was still running, and the log named the
+    // peer. Here the entry's close is HELD open, the peer's edge is delivered
+    // while it is held, and the cause must still be main's.
+    const test = harness({ holdEntryClose: true });
+    test.wire.deliver(handshakeLine());
+    await settle();
+
+    const closing = test.connection.dispose("disconnect");
+    // Inside the await, exactly where the real edge arrives.
+    test.wireLifecycle({ kind: "peer_end" });
+    test.wireLifecycle({
+      kind: "closed",
+      requests: 2,
+      responses: 1,
+      notifications: 0,
+      serverRequests: 0,
+      otherOutbound: 0,
+    });
+    test.releaseEntryClose();
+    await closing;
+
+    expect(closedLine(test)).toMatch(
+      /^\[studio:mcp\] closed id=c-test cause=owner_close servedMs=\d+ requests=2 responses=1/,
+    );
+  });
+
+  it("a peer EOF decided BEFORE main's teardown still owns the cause", async () => {
+    // The other direction of the same latch, so the fix above cannot be a
+    // blanket relabel: when the peer left first, main's teardown is the
+    // consequence and must not overwrite it.
+    const test = harness({ holdEntryClose: true });
+    test.wire.deliver(handshakeLine());
+    await settle();
+
+    test.wireLifecycle({ kind: "peer_end" });
+    const closing = test.connection.dispose("disconnect");
+    test.wireLifecycle({
+      kind: "closed",
+      requests: 1,
+      responses: 1,
+      notifications: 0,
+      serverRequests: 0,
+      otherOutbound: 0,
+    });
+    test.releaseEntryClose();
+    await closing;
+
+    expect(closedLine(test)).toContain("cause=peer_end");
+  });
+
   it("a wire error closes with cause=peer_error", async () => {
     const test = harness();
     test.wire.deliver(handshakeLine());
     await settle();
 
     test.wire.emit("error", new Error("ECONNRESET"));
-    test.wireLifecycle({ kind: "closed", requests: 0, responses: 0 });
+    test.wireLifecycle({
+      kind: "closed",
+      requests: 0,
+      responses: 0,
+      notifications: 0,
+      serverRequests: 0,
+      otherOutbound: 0,
+    });
     await test.connection.dispose("disconnect");
 
     expect(closedLine(test)).toContain("cause=peer_error");

--- a/vex-app/src/main/studio/__tests__/mcp-connection-lifecycle-log.test.ts
+++ b/vex-app/src/main/studio/__tests__/mcp-connection-lifecycle-log.test.ts
@@ -1,0 +1,276 @@
+/**
+ * THE PER-CONNECTION LOG, and the vocabulary that separates the peer leaving
+ * from main deciding.
+ *
+ * The defect these cases pin is an absence with a measured cost. On
+ * 2026-09-04 a Windows MCP client failed its first connect; the app log showed
+ * the pipe front accepting, admitting, pausing and resuming a connection, then
+ * twenty-five seconds of nothing, then a close. The MCP host had emitted no
+ * info line at all, so none of the three questions a reader needs could be
+ * answered: was this connection ever served, did a request reach it, did an
+ * answer leave it. And the close itself was ambiguous by construction - a
+ * killed client and main's own teardown were the same `reason=destroy`.
+ *
+ * So this suite asserts a VOCABULARY, not a format: `serving`, `first
+ * request`, `first response` and one `closed` carrying a cause from a closed
+ * set, in that order and once each. `StudioConnection` is the owner of every
+ * one of them, which is why it is the subject here rather than the transport
+ * (whose reporting side is proven in
+ * `src/__tests__/vex-agent/mcp/socket-transport-lifecycle.test.ts`).
+ *
+ * The wire is the shared `FakeDuplexTransport` and `serveConnection` is
+ * injected, exactly as in `mcp-connection-refusal.test.ts`: the serve chain is
+ * a dynamic import of the whole MCP SDK and is not the subject. What IS real
+ * is the connection's phase machine, its handshake parser, its outbound queue
+ * and its teardown, because that is where the cause is decided.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FakeDuplexTransport } from "@vex-agent/mcp/duplex-transport-fake.js";
+import type { StudioConnectionHandle } from "@vex-agent/mcp/server.js";
+import type { SocketTransportLifecycleEvent } from "@vex-agent/mcp/socket-transport.js";
+
+vi.mock("../../logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { log } = await import("../../logger/index.js");
+const { StudioConnection } = await import("../mcp-host/connection.js");
+const { atCapacityRefusal } = await import("../mcp-host/handshake.js");
+
+type Connection = InstanceType<typeof StudioConnection>;
+
+const PROJECT_ID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+
+interface Harness {
+  readonly connection: Connection;
+  readonly wire: FakeDuplexTransport;
+  /** Drive the transport's reports, as the real transport would. */
+  readonly wireLifecycle: (event: SocketTransportLifecycleEvent) => void;
+  readonly failWire: () => void;
+  readonly infoLines: () => readonly string[];
+}
+
+interface HarnessOptions {
+  readonly transportKind?: "front" | "socket";
+  readonly droppedFrames?: (() => number) | null;
+  readonly isStale?: () => boolean;
+}
+
+function harness(options: HarnessOptions = {}): Harness {
+  const wire = new FakeDuplexTransport("accept_sync");
+  let onLifecycle: ((event: SocketTransportLifecycleEvent) => void) | null = null;
+  let onWireFailure: ((code: "invalid_json") => void) | null = null;
+  const connection = new StudioConnection("c-test", wire, {
+    runCall: async () => ({ kind: "completed", result: { success: true, output: "ok" } }),
+    acquireCallSlot: () => ({ ok: true, release: (): void => undefined }),
+    reserveConnectionSlot: () => ({ ok: true, release: (): void => undefined }),
+    isStale: options.isStale ?? ((): boolean => false),
+    checkProject: async () => null,
+    serveConnection: (input): StudioConnectionHandle => {
+      onLifecycle = input.onWireLifecycle;
+      onWireFailure = input.onWireFailure;
+      return { close: async (): Promise<void> => undefined };
+    },
+    onClosed: (): void => undefined,
+    transportKind: options.transportKind ?? "socket",
+    droppedFrames: options.droppedFrames ?? null,
+  });
+  return {
+    connection,
+    wire,
+    wireLifecycle: (event) => {
+      if (onLifecycle === null) throw new Error("the connection never served");
+      onLifecycle(event);
+    },
+    failWire: () => {
+      if (onWireFailure === null) throw new Error("the connection never served");
+      onWireFailure("invalid_json");
+    },
+    infoLines: () =>
+      vi.mocked(log.info).mock.calls.map((call) => String(call[0])),
+  };
+}
+
+function handshakeLine(): Buffer {
+  return Buffer.from(`${JSON.stringify({ v: 1, projectId: PROJECT_ID })}\n`);
+}
+
+/** Let `establish`'s awaits settle. */
+async function settle(): Promise<void> {
+  for (let turn = 0; turn < 6; turn += 1) await Promise.resolve();
+}
+
+/** The one `closed` line, or a failure naming what was logged instead. */
+function closedLine(test: Harness): string {
+  const found = test.infoLines().filter((line) => line.includes("[studio:mcp] closed "));
+  const [only] = found;
+  if (found.length !== 1 || only === undefined) {
+    throw new Error(
+      `expected exactly one closed line, got ${String(found.length)}: ${test
+        .infoLines()
+        .join(" | ")}`,
+    );
+  }
+  return only;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("a served connection whose peer half-closes", () => {
+  it("names every transition once, in order, and closes with cause=peer_end", async () => {
+    const test = harness();
+    test.wire.deliver(handshakeLine());
+    await settle();
+
+    test.wireLifecycle({
+      kind: "first_request",
+      method: "initialize",
+      client: "claude-code/2.1.260",
+      protocolVersion: "2026-07-28",
+    });
+    test.wireLifecycle({ kind: "first_response", id: "0", bytes: 733_120 });
+    // THE INCIDENT'S OWN EDGE: the peer went away, main did not decide to.
+    test.wireLifecycle({ kind: "peer_end" });
+    test.wireLifecycle({ kind: "closed", requests: 3, responses: 3 });
+    await test.connection.dispose("disconnect");
+
+    const lines = test.infoLines();
+    expect(lines).toHaveLength(4);
+    expect(lines[0]).toBe(
+      `[studio:mcp] serving id=c-test project=${PROJECT_ID} transport=socket`,
+    );
+    expect(lines[1]).toBe(
+      "[studio:mcp] first request id=c-test method=initialize "
+        + "client=claude-code/2.1.260 protocolVersion=2026-07-28",
+    );
+    expect(lines[2]).toBe("[studio:mcp] first response id=c-test rpcId=0 bytes=733120");
+    expect(lines[3]).toMatch(
+      /^\[studio:mcp\] closed id=c-test cause=peer_end servedMs=\d+ requests=3 responses=3$/,
+    );
+  });
+
+  it("reports the front relay's dropped frames, which nothing logged before", async () => {
+    const test = harness({ transportKind: "front", droppedFrames: () => 2 });
+    test.wire.deliver(handshakeLine());
+    await settle();
+
+    expect(test.infoLines()[0]).toContain("transport=front");
+
+    test.wireLifecycle({ kind: "closed", requests: 1, responses: 1 });
+    await test.connection.dispose("disconnect");
+
+    expect(closedLine(test)).toMatch(
+      /cause=owner_close servedMs=\d+ requests=1 responses=1 droppedFrames=2$/,
+    );
+  });
+});
+
+describe("the cause separates the peer from main's own decisions", () => {
+  it("a framing failure closes with cause=wire_failure", async () => {
+    const test = harness();
+    test.wire.deliver(handshakeLine());
+    await settle();
+
+    test.failWire();
+    test.wireLifecycle({ kind: "closed", requests: 1, responses: 0 });
+    await test.connection.dispose("disconnect");
+
+    expect(closedLine(test)).toContain("cause=wire_failure");
+  });
+
+  it("a typed handshake refusal closes with cause=refused and never says serving", async () => {
+    const test = harness();
+
+    await test.connection.refuse(atCapacityRefusal(16, "MCP connections"));
+
+    const lines = test.infoLines();
+    expect(lines.filter((line) => line.includes("serving"))).toHaveLength(0);
+    expect(closedLine(test)).toMatch(
+      /^\[studio:mcp\] closed id=c-test cause=refused servedMs=0 requests=0 responses=0$/,
+    );
+  });
+
+  it("the secret-session lock closes with cause=locked, and quit with cause=quit", async () => {
+    const locked = harness();
+    locked.wire.deliver(handshakeLine());
+    await settle();
+    locked.connection.destroyNow("lock");
+    await locked.connection.dispose("lock");
+    expect(closedLine(locked)).toContain("cause=locked");
+
+    vi.clearAllMocks();
+
+    const quit = harness();
+    quit.wire.deliver(handshakeLine());
+    await settle();
+    quit.connection.destroyNow("vex_quit");
+    await quit.connection.dispose("vex_quit");
+    expect(closedLine(quit)).toContain("cause=quit");
+  });
+
+  it("an admission epoch that moved on mid-establish closes with cause=stale", async () => {
+    let stale = false;
+    const test = harness({ isStale: (): boolean => stale });
+    test.wire.deliver(handshakeLine());
+    // The lock lands while `checkProject` is still resolving.
+    stale = true;
+    await settle();
+
+    // `establish` RETURNS at the stale check rather than tearing down - the
+    // host's own lock sequence owns the destroy - so the cause is latched here
+    // and spent by whichever teardown arrives. That is the point of latching:
+    // the later `disconnect` must not rewrite what actually ended this.
+    expect(test.infoLines().filter((line) => line.includes("serving"))).toHaveLength(0);
+    await test.connection.dispose("disconnect");
+    expect(closedLine(test)).toContain("cause=stale");
+  });
+
+  it("a wire error closes with cause=peer_error", async () => {
+    const test = harness();
+    test.wire.deliver(handshakeLine());
+    await settle();
+
+    test.wire.emit("error", new Error("ECONNRESET"));
+    test.wireLifecycle({ kind: "closed", requests: 0, responses: 0 });
+    await test.connection.dispose("disconnect");
+
+    expect(closedLine(test)).toContain("cause=peer_error");
+  });
+});
+
+describe("a peer cannot author a log line through the fields it supplies", () => {
+  it("reports an unusable project id as absent rather than carrying it", async () => {
+    const test = harness();
+    test.wire.deliver(
+      Buffer.from(`${JSON.stringify({ v: 1, projectId: "a b\nc" })}\n`),
+    );
+    await settle();
+
+    const serving = test.infoLines().filter((line) => line.includes("serving"));
+    // The handshake parser may refuse the id outright; if it does not, the log
+    // must still not carry it.
+    for (const line of serving) {
+      expect(line).toContain("project=unknown");
+    }
+  });
+
+  it("names an unknown method as other rather than echoing what the peer sent", async () => {
+    const test = harness();
+    test.wire.deliver(handshakeLine());
+    await settle();
+
+    test.wireLifecycle({
+      kind: "first_request",
+      method: "other",
+      client: null,
+      protocolVersion: null,
+    });
+
+    expect(test.infoLines()[1]).toBe("[studio:mcp] first request id=c-test method=other");
+  });
+});

--- a/vex-app/src/main/studio/__tests__/mcp-connection-refusal.test.ts
+++ b/vex-app/src/main/studio/__tests__/mcp-connection-refusal.test.ts
@@ -83,6 +83,8 @@ function harness(options: HarnessOptions = {}): Harness {
       return options.serveHandle ?? { close: async (): Promise<void> => undefined };
     },
     onClosed: (): void => undefined,
+    transportKind: "socket",
+    droppedFrames: null,
   };
   const connection = new StudioConnection("c-test", socket, deps);
   return {

--- a/vex-app/src/main/studio/__tests__/mcp-host-serve-peer-end.test.ts
+++ b/vex-app/src/main/studio/__tests__/mcp-host-serve-peer-end.test.ts
@@ -20,6 +20,7 @@ import { createServer, connect, type AddressInfo, type Socket } from "node:net";
 
 import { describe, expect, it, vi } from "vitest";
 
+import type { StudioWriteOutcome } from "@vex-agent/mcp/duplex-transport.js";
 import type { SocketTransportLifecycleEvent } from "@vex-agent/mcp/socket-transport.js";
 
 import { serveOverSocket } from "../mcp-host/serve.js";
@@ -68,7 +69,7 @@ describe("serveOverSocket peer EOF replay", () => {
           result: { success: true, output: "ok" },
         }),
         cancelCause: () => "disconnect",
-        writeLine: async () => undefined,
+        writeLine: async (): Promise<StudioWriteOutcome> => "accepted",
         onWireFailure: vi.fn(),
         onWireLifecycle: (event: SocketTransportLifecycleEvent): void => {
           events.push(event);

--- a/vex-app/src/main/studio/__tests__/mcp-host-serve-peer-end.test.ts
+++ b/vex-app/src/main/studio/__tests__/mcp-host-serve-peer-end.test.ts
@@ -20,6 +20,8 @@ import { createServer, connect, type AddressInfo, type Socket } from "node:net";
 
 import { describe, expect, it, vi } from "vitest";
 
+import type { SocketTransportLifecycleEvent } from "@vex-agent/mcp/socket-transport.js";
+
 import { serveOverSocket } from "../mcp-host/serve.js";
 import { NodeSocketTransport } from "../mcp-host/node-socket-transport.js";
 
@@ -52,6 +54,10 @@ describe("serveOverSocket peer EOF replay", () => {
     expect(socket.destroyed).toBe(false);
 
     const closed = once(socket, "close");
+    // The transport's own reports, over a REAL kernel stream. The fake wire
+    // proves the reporting logic; this proves the edges it reports are the
+    // ones a socket actually raises.
+    const events: SocketTransportLifecycleEvent[] = [];
     const handle = serveOverSocket(
       {
         wire: new NodeSocketTransport(socket),
@@ -64,6 +70,9 @@ describe("serveOverSocket peer EOF replay", () => {
         cancelCause: () => "disconnect",
         writeLine: async () => undefined,
         onWireFailure: vi.fn(),
+        onWireLifecycle: (event: SocketTransportLifecycleEvent): void => {
+          events.push(event);
+        },
         onServeFailure: vi.fn(),
       },
       { epoch: 1, currentEpoch: () => 1, version: "test" },
@@ -71,6 +80,12 @@ describe("serveOverSocket peer EOF replay", () => {
 
     await closed;
     expect(socket.destroyed).toBe(true);
+    // A HALF-CLOSE THAT IS NAMED. Before this, the only trace of a peer that
+    // left was main's own teardown, which reads exactly like main deciding to
+    // close - the ambiguity the 2026-09-04 incident could not be attributed
+    // through. The counters are zero because this peer sent no frame at all.
+    expect(events.map((event) => event.kind)).toEqual(["peer_end", "closed"]);
+    expect(events[1]).toEqual({ kind: "closed", requests: 0, responses: 0 });
     await handle.close();
     client.destroy();
     await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/vex-app/src/main/studio/__tests__/mcp-host-serve-peer-end.test.ts
+++ b/vex-app/src/main/studio/__tests__/mcp-host-serve-peer-end.test.ts
@@ -85,7 +85,14 @@ describe("serveOverSocket peer EOF replay", () => {
     // close - the ambiguity the 2026-09-04 incident could not be attributed
     // through. The counters are zero because this peer sent no frame at all.
     expect(events.map((event) => event.kind)).toEqual(["peer_end", "closed"]);
-    expect(events[1]).toEqual({ kind: "closed", requests: 0, responses: 0 });
+    expect(events[1]).toEqual({
+      kind: "closed",
+      requests: 0,
+      responses: 0,
+      notifications: 0,
+      serverRequests: 0,
+      otherOutbound: 0,
+    });
     await handle.close();
     client.destroy();
     await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/vex-app/src/main/studio/__tests__/mcp-outbound-acceptance.test.ts
+++ b/vex-app/src/main/studio/__tests__/mcp-outbound-acceptance.test.ts
@@ -1,0 +1,318 @@
+/**
+ * WHAT THE `first response` LINE AND THE OUTBOUND COUNTERS ARE ALLOWED TO CLAIM.
+ *
+ * The milestone exists to answer one question from the 2026-09-04 incident log:
+ * did main's answer leave main. The transport publishes it when its writer
+ * reports acceptance - and in production the writer is `StudioOutboundQueue`,
+ * which RESOLVES for five different reasons on purpose (a closed queue, a
+ * coalesced progress frame, a frame refused at the pending bound, a wire that
+ * went away, and a completed write), so that an ordinary disconnect is not an
+ * unhandled rejection in the SDK's write path. Reading that resolution as
+ * acceptance made four of those five a false witness.
+ *
+ * So this suite is deliberately PRODUCTION-CONNECTED: a real `StudioConnection`
+ * builds the real outbound queue, and the injected serve step builds a real
+ * `StudioSocketTransport` over the SAME wire with the connection's own
+ * `writeLine`, exactly as `serve.ts` does. Only the MCP SDK is absent, which is
+ * the one piece that decides nothing here. `mcp-connection-lifecycle-log.test.ts`
+ * remains the suite for the log's wording; this one is about which frames may
+ * reach it at all.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { FakeDuplexTransport } from "@vex-agent/mcp/duplex-transport-fake.js";
+import type { StudioConnectionHandle } from "@vex-agent/mcp/server.js";
+import {
+  StudioSocketTransport,
+  type SocketTransportLifecycleEvent,
+} from "@vex-agent/mcp/socket-transport.js";
+
+vi.mock("../../logger/index.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { StudioConnection } = await import("../mcp-host/connection.js");
+const { STUDIO_MAX_PENDING_OUTBOUND } = await import("../mcp-host/outbound-queue.js");
+
+const PROJECT_ID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+
+/**
+ * The transport's shutdown deadline, shortened for the double.
+ *
+ * The real one is five seconds of flush time for a peer that is still reading.
+ * This wire never raises `close` from `end()` (nothing is listening on the
+ * other side of a fake), so the deadline is the edge that finishes every
+ * teardown here and it may not be the thing the suite spends its time on.
+ */
+const TEST_SHUTDOWN_MS = 20;
+
+/**
+ * The shared fake, with the block edge these cases need MID-CONNECTION.
+ *
+ * The handshake ack goes through the same outbound queue, so a wire that
+ * refuses from birth never reaches `serving` at all. These scenarios all start
+ * from an established connection and block the wire afterwards, exactly as a
+ * peer that stops reading does, so the block is a state this double can enter
+ * rather than one it is constructed in. `hold` semantics are the base fake's:
+ * `write` answers `false` and the completion callback is kept until a release.
+ */
+class BlockableWire extends FakeDuplexTransport {
+  private blocked = false;
+  private readonly held: ((error?: Error | null) => void)[] = [];
+
+  /** From here on the wire buffers and nothing completes until `release`. */
+  block(): void {
+    this.blocked = true;
+  }
+
+  override write(line: string, callback?: (error?: Error | null) => void): boolean {
+    if (!this.blocked) return super.write(line, callback);
+    this.written.push(line);
+    this.refusedWrites += 1;
+    if (callback !== undefined) this.held.push(callback);
+    return false;
+  }
+
+  /** Complete every held write, announce `drain`, and accept again. */
+  override unblock(): void {
+    this.blocked = false;
+    const callbacks = this.held.splice(0, this.held.length);
+    for (const callback of callbacks) callback();
+    this.emit("drain");
+  }
+}
+
+interface Harness {
+  readonly connection: InstanceType<typeof StudioConnection>;
+  readonly wire: BlockableWire;
+  /** The REAL transport the serve step built, once the handshake is through. */
+  readonly transport: () => StudioSocketTransport;
+  readonly events: readonly SocketTransportLifecycleEvent[];
+  /** Let a held entry close finish. Only meaningful with `holdEntryClose`. */
+  readonly releaseEntryClose: () => void;
+}
+
+/**
+ * A connection whose serve step is the real transport over the real queue.
+ *
+ * `holdEntryClose` parks the served entry's `close()`, which is the window a
+ * teardown actually has: `dispose` closes the outbound queue BEFORE it awaits
+ * that close, so a response produced inside the window meets a closed queue
+ * with the wire still alive. That is the reviewer's scenario, reproduced rather
+ * than simulated.
+ */
+function harness(options: { readonly holdEntryClose?: boolean } = {}): Harness {
+  const wire = new BlockableWire("accept_deferred");
+  const events: SocketTransportLifecycleEvent[] = [];
+  let transport: StudioSocketTransport | null = null;
+  let releaseEntryClose: (() => void) | null = null;
+  const connection = new StudioConnection("c-outbound", wire, {
+    runCall: async () => ({ kind: "completed", result: { success: true, output: "ok" } }),
+    acquireCallSlot: () => ({ ok: true, release: (): void => undefined }),
+    reserveConnectionSlot: () => ({ ok: true, release: (): void => undefined }),
+    isStale: (): boolean => false,
+    checkProject: async () => null,
+    serveConnection: (input): StudioConnectionHandle => {
+      const built = new StudioSocketTransport(input.wire, {
+        remainder: input.remainder,
+        shutdownDeadlineMs: TEST_SHUTDOWN_MS,
+        writeLine: input.writeLine,
+        onLifecycle: (event) => {
+          events.push(event);
+          input.onWireLifecycle(event);
+        },
+      });
+      transport = built;
+      void built.start();
+      if (options.holdEntryClose !== true) {
+        return { close: (): Promise<void> => built.close() };
+      }
+      return {
+        close: (): Promise<void> =>
+          new Promise<void>((resolve) => {
+            releaseEntryClose = (): void => {
+              void built.close().then(resolve);
+            };
+          }),
+      };
+    },
+    onClosed: (): void => undefined,
+    transportKind: "socket",
+    droppedFrames: null,
+  });
+  return {
+    connection,
+    wire,
+    transport: () => {
+      if (transport === null) throw new Error("the connection never served");
+      return transport;
+    },
+    events,
+    releaseEntryClose: () => {
+      if (releaseEntryClose === null) throw new Error("no entry close is held");
+      releaseEntryClose();
+    },
+  };
+}
+
+function handshakeLine(): Buffer {
+  return Buffer.from(`${JSON.stringify({ v: 1, projectId: PROJECT_ID })}\n`);
+}
+
+/** One event-loop turn, so the queue's own writer can run. */
+function tick(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+/**
+ * Let `establish` finish, ack and all.
+ *
+ * The handshake ack goes through the outbound queue and its write completes on
+ * a macrotask, so microtask turns alone never reach `serving`.
+ */
+async function settle(): Promise<void> {
+  for (let turn = 0; turn < 4; turn += 1) {
+    await tick();
+    await Promise.resolve();
+  }
+}
+
+function response(id: number): Record<string, unknown> {
+  return { jsonrpc: "2.0", id, result: { ok: true } };
+}
+
+function progress(token: string, value: number): Record<string, unknown> {
+  return {
+    jsonrpc: "2.0",
+    method: "notifications/progress",
+    params: { progressToken: token, progress: value },
+  };
+}
+
+function firstResponses(test: Harness): readonly SocketTransportLifecycleEvent[] {
+  return test.events.filter((event) => event.kind === "first_response");
+}
+
+/** The transport's own final counters, from the `closed` event it reports. */
+function closedCounters(test: Harness): {
+  readonly responses: number;
+  readonly notifications: number;
+} {
+  const closed = test.events.find((event) => event.kind === "closed");
+  if (closed === undefined || closed.kind !== "closed") {
+    throw new Error("the transport never reported its close");
+  }
+  return { responses: closed.responses, notifications: closed.notifications };
+}
+
+describe("a response handed to an outbound queue that is already closed", () => {
+  it("is neither the first response nor a counted answer", async () => {
+    const test = harness({ holdEntryClose: true });
+    test.wire.deliver(handshakeLine());
+    await settle();
+    test.wire.block();
+
+    // The teardown is UNDER WAY and parked exactly where production parks it:
+    // the queue is closed, the wire is not destroyed yet.
+    const disposed = test.connection.dispose("disconnect");
+    await settle();
+    expect(test.wire.destroyed).toBe(false);
+
+    // The SDK answers a call that was already in flight. The frame never
+    // reaches the peer - the queue that owns the wire is not admitting - and
+    // the queue resolves anyway, which is what used to look like acceptance.
+    await test.transport().send(response(0));
+
+    expect(firstResponses(test)).toHaveLength(0);
+    test.releaseEntryClose();
+    await disposed;
+    expect(closedCounters(test).responses).toBe(0);
+  });
+});
+
+describe("frames the outbound queue refuses at its pending bound", () => {
+  it("are not counted and do not publish the milestone", async () => {
+    const test = harness();
+    test.wire.deliver(handshakeLine());
+    await settle();
+    test.wire.block();
+
+    // The wire is blocked, so the writer parks on the first frame and the rest
+    // queue behind it. Past the bound the queue refuses - and RESOLVES.
+    const overflow = STUDIO_MAX_PENDING_OUTBOUND + 3;
+    const sends: Promise<void>[] = [];
+    for (let index = 0; index < overflow; index += 1) {
+      sends.push(test.transport().send(response(index)));
+    }
+    await tick();
+    await tick();
+
+    // The premise, asserted rather than assumed: the wire refused, and the
+    // frames past the bound have already settled while NOTHING was accepted.
+    expect(test.wire.refusedWrites).toBe(1);
+    await Promise.all(sends.slice(STUDIO_MAX_PENDING_OUTBOUND + 1));
+    expect(firstResponses(test)).toHaveLength(0);
+
+    await test.connection.dispose("disconnect");
+    expect(closedCounters(test).responses).toBe(0);
+  });
+});
+
+describe("a progress frame that coalesced into a queued one", () => {
+  it("is not a second accepted notification", async () => {
+    const test = harness();
+    test.wire.deliver(handshakeLine());
+    await settle();
+    test.wire.block();
+
+    // One frame is taken by the blocked writer, one queues behind it, and the
+    // third REPLACES the queued one: two lines will ever reach the wire.
+    void test.transport().send(progress("PT1", 1));
+    await tick();
+    void test.transport().send(progress("PT1", 2));
+    await test.transport().send(progress("PT1", 3));
+
+    // The coalesced frame settled at once, with nothing on the wire yet.
+    expect(firstResponses(test)).toHaveLength(0);
+
+    test.wire.unblock();
+    await tick();
+    await tick();
+    await test.connection.dispose("disconnect");
+
+    const wrote = test.wire.written.filter((line) => line.includes("notifications/progress"));
+    expect(wrote).toHaveLength(2);
+    expect(wrote[1]).toContain("\"progress\":3");
+    // Two lines left main, so two notifications are counted - not the three
+    // frames the SDK handed over.
+    expect(closedCounters(test).notifications).toBe(2);
+    expect(firstResponses(test)).toHaveLength(1);
+  });
+});
+
+describe("a frame still in flight when the wire goes away", () => {
+  it("is never reported as an answer that left main", async () => {
+    const test = harness();
+    test.wire.deliver(handshakeLine());
+    await settle();
+    test.wire.block();
+
+    // Blocked in the queue's own `writeLine`, parked on a `drain` that will
+    // never come, which is where a response sits when a peer stops reading.
+    const sent = test.transport().send(response(0));
+    await tick();
+    expect(test.wire.refusedWrites).toBe(1);
+
+    // The wire is gone. The write settles - it must, or the SDK's write path
+    // and the teardown behind it would hang - but the bytes are still in main.
+    test.wire.destroy();
+    await sent;
+
+    expect(firstResponses(test)).toHaveLength(0);
+    await test.connection.dispose("disconnect");
+    expect(closedCounters(test).responses).toBe(0);
+  });
+});

--- a/vex-app/src/main/studio/__tests__/outbound-queue-blocked.test.ts
+++ b/vex-app/src/main/studio/__tests__/outbound-queue-blocked.test.ts
@@ -152,6 +152,42 @@ describe("the outbound queue behind a writer that returned false", () => {
   });
 
   /**
+   * THE FOUR ANSWERS, at the seam that gives them.
+   *
+   * Every `enqueue` resolves, deliberately, so an ordinary disconnect is not an
+   * unhandled rejection in the SDK's write path. The consumer above turns
+   * acceptance into a `first response` line and a counter, so resolution alone
+   * is not an answer it can use: the outcome is the answer, and each of the
+   * four is produced here by the state that actually causes it.
+   */
+  it("names WHICH of its five settle edges each frame took", async () => {
+    const socket = blockedWire();
+    const queue = makeQueue(socket, { maxPending: 2 });
+
+    // Taken by the writer and parked on a `drain` that has not come.
+    const inFlight = queue.enqueue('{"id":0}\n');
+    await tick();
+    const queued = queue.enqueue('{"progress":1}\n', "progress:PT1");
+    // A newer frame for the same request REPLACES the queued one.
+    await expect(queue.enqueue('{"progress":2}\n', "progress:PT1")).resolves.toBe(
+      "coalesced",
+    );
+    void queue.enqueue('{"id":1}\n');
+    // At the bound, and expendable.
+    await expect(queue.enqueue('{"progress":9}\n', "progress:PT9")).resolves.toBe(
+      "dropped",
+    );
+
+    socket.unblock();
+    await expect(inFlight).resolves.toBe("accepted");
+    await expect(queued).resolves.toBe("accepted");
+
+    queue.close();
+    // Admission is closed: the frame never reaches the wire and says so.
+    await expect(queue.enqueue('{"id":2}\n')).resolves.toBe("closed");
+  });
+
+  /**
    * THE CASE WITH NO DRAIN IN IT AT ALL.
    *
    * `write` refused, `drain` never fires, and then the connection closes. Every
@@ -180,9 +216,10 @@ describe("the outbound queue behind a writer that returned false", () => {
     queue.close();
     // The queued one settles at once; the in-flight one settles when the socket
     // announces its close, which is the connection teardown it is waiting on.
-    await queued;
+    // NEITHER is acceptance: the bytes are still in this process.
+    await expect(queued).resolves.toBe("closed");
     socket.destroy();
-    await inFlight;
+    await expect(inFlight).resolves.toBe("closed");
     expect(queue.pendingCount()).toBe(0);
 
     // Admission is closed: a frame produced by a teardown handler resolves and

--- a/vex-app/src/main/studio/mcp-host.ts
+++ b/vex-app/src/main/studio/mcp-host.ts
@@ -98,6 +98,7 @@ import {
   type StudioHandshakeRefused,
 } from "./mcp-host/handshake.js";
 import { serveOverSocket } from "./mcp-host/serve.js";
+import { FrontRelayTransport } from "./mcp-host/front-relay-transport.js";
 import {
   lockStudioFrontEndpoint,
   studioFrontCause,
@@ -344,6 +345,14 @@ function handleConnection(wire: StudioDuplexTransport): void {
       connections.delete(closed);
       emitHostStatus();
     },
+    // WHICH WIRE THIS IS, decided by the one place that knows: the host built
+    // it. `instanceof` rather than a flag on the contract, because
+    // `StudioDuplexTransport` deliberately has no member that distinguishes
+    // the two implementations and adding one would put a diagnostic concern
+    // into the wire contract every consumer speaks.
+    transportKind: wire instanceof FrontRelayTransport ? "front" : "socket",
+    droppedFrames:
+      wire instanceof FrontRelayTransport ? (): number => wire.droppedFrames : null,
   });
   connections.add(connection);
   emitHostStatus();

--- a/vex-app/src/main/studio/mcp-host/connection.ts
+++ b/vex-app/src/main/studio/mcp-host/connection.ts
@@ -89,6 +89,21 @@ export type StudioCloseCause =
   | "stale"
   | "owner_close";
 
+/**
+ * The close cause of a teardown MAIN decided, from the cancel cause it used.
+ *
+ * `cancelled` and `disconnect` are not causes of their own: they are what a
+ * running tool call is told, and the connection-level reason behind them is
+ * main deciding (a serve failure, an outbound overflow, the host tearing
+ * down). Their honest name is `owner_close`, which is why it is the default
+ * the `closed` line has always fallen back to.
+ */
+function ownerCloseCause(cause: StudioCancelCause): StudioCloseCause {
+  if (cause === "lock") return "locked";
+  if (cause === "vex_quit") return "quit";
+  return "owner_close";
+}
+
 /** Which of the two wire implementations carries this connection. */
 export type StudioTransportKind = "front" | "socket";
 
@@ -240,6 +255,18 @@ export class StudioConnection {
   private servingSince: number | null = null;
   private requestCount = 0;
   private responseCount = 0;
+  /**
+   * The outbound frames that were NOT answers, kept apart from `responses`.
+   *
+   * They are logged only when they are non-zero: on an ordinary connection all
+   * three are zero and the `closed` line stays the line a reader knows, while
+   * a connection that did send them never hides it. `otherOutbound` is our own
+   * defect if it is ever anything but zero, which is why it has a name here
+   * rather than being folded into a neighbour.
+   */
+  private notificationCount = 0;
+  private serverRequestCount = 0;
+  private otherOutboundCount = 0;
 
   constructor(id: string, wire: StudioDuplexTransport, deps: StudioConnectionDeps) {
     this.id = id;
@@ -352,6 +379,20 @@ export class StudioConnection {
     this.closedLatch = true;
     this.cause = cause;
     this.phase = "closed";
+    // THE CAUSE IS LATCHED HERE, BEFORE THE FIRST AWAIT BELOW.
+    //
+    // `runDispose` awaits the served entry's close, and the peer's FIN can
+    // land inside that await: the transport then reports `peer_end` and, with
+    // nothing latched yet, WON the cause. An outbound overflow or a serve
+    // failure - main's own decisions, both of which reach here through
+    // `dispose` - would then be logged as the peer walking away, which is the
+    // one distinction this whole vocabulary exists to make.
+    //
+    // `noteCloseCause` still never overwrites, so every cause decided EARLIER
+    // (refused, wire_failure, peer_error, peer_end, stale, and the lock and
+    // quit latched by `destroyNow`) survives this line untouched. It only
+    // fills the gap that used to be filled by whatever arrived next.
+    this.noteCloseCause(ownerCloseCause(cause));
 
     this.releaseConnectionSlot();
     this.clearHandshakeTimer();
@@ -387,9 +428,7 @@ export class StudioConnection {
   destroyNow(cause: StudioCancelCause): void {
     // LATCHED FIRST, synchronously: an establish continuation that resumes
     // after this tick must see a closed connection, not a live one.
-    this.noteCloseCause(
-      cause === "lock" ? "locked" : cause === "vex_quit" ? "quit" : "owner_close",
-    );
+    this.noteCloseCause(ownerCloseCause(cause));
     this.closedLatch = true;
     this.cause = cause;
     this.releaseConnectionSlot();
@@ -524,9 +563,14 @@ export class StudioConnection {
         );
         return;
       case "first_response":
+        // NAMED FOR WHAT IT WAS. The milestone fires on the first outbound
+        // line the wire ACCEPTED, and that line is not always an answer: a
+        // progress notification can precede the response it belongs to, and
+        // logging it as this connection's first answer would misreport the one
+        // fact an incident is read for. `outbound` carries the difference.
         log.info(
           `[studio:mcp] first response id=${this.id} rpcId=${event.id ?? "none"} `
-            + `bytes=${String(event.bytes)}`,
+            + `bytes=${String(event.bytes)} outbound=${event.outbound}`,
         );
         return;
       case "peer_end":
@@ -535,6 +579,9 @@ export class StudioConnection {
       case "closed":
         this.requestCount = event.requests;
         this.responseCount = event.responses;
+        this.notificationCount = event.notifications;
+        this.serverRequestCount = event.serverRequests;
+        this.otherOutboundCount = event.otherOutbound;
         return;
     }
   };
@@ -554,6 +601,15 @@ export class StudioConnection {
           this.servingSince === null ? 0 : Date.now() - this.servingSince,
         )} `
         + `requests=${String(this.requestCount)} responses=${String(this.responseCount)}`
+        + (this.notificationCount === 0
+          ? ""
+          : ` notifications=${String(this.notificationCount)}`)
+        + (this.serverRequestCount === 0
+          ? ""
+          : ` serverRequests=${String(this.serverRequestCount)}`)
+        + (this.otherOutboundCount === 0
+          ? ""
+          : ` otherOutbound=${String(this.otherOutboundCount)}`)
         + (dropped === null ? "" : ` droppedFrames=${String(dropped())}`),
     );
   }

--- a/vex-app/src/main/studio/mcp-host/connection.ts
+++ b/vex-app/src/main/studio/mcp-host/connection.ts
@@ -40,7 +40,10 @@
  */
 
 import type { StudioToolCall } from "@vex-agent/mcp/admission.js";
-import type { StudioDuplexTransport } from "@vex-agent/mcp/duplex-transport.js";
+import type {
+  StudioDuplexTransport,
+  StudioWriteOutcome,
+} from "@vex-agent/mcp/duplex-transport.js";
 import type {
   RunStudioCallOptions,
   StudioCallOutcome,
@@ -178,7 +181,15 @@ export interface ServeConnectionInput {
   readonly projectId: string;
   readonly runCall: StudioRunCall;
   readonly cancelCause: () => StudioCancelCause;
-  readonly writeLine: (line: string, progressKey: string | null) => Promise<void>;
+  /**
+   * The connection's ONE outbound writer, answering with the outcome its queue
+   * actually took. `accepted` is the only one the transport may count or turn
+   * into this connection's `first response` line.
+   */
+  readonly writeLine: (
+    line: string,
+    progressKey: string | null,
+  ) => Promise<StudioWriteOutcome>;
   readonly onWireFailure: (code: StudioWireErrorCode) => void;
   /** The transport's own lifecycle transitions, for this connection's log. */
   readonly onWireLifecycle: (event: SocketTransportLifecycleEvent) => void;

--- a/vex-app/src/main/studio/mcp-host/connection.ts
+++ b/vex-app/src/main/studio/mcp-host/connection.ts
@@ -47,6 +47,7 @@ import type {
   StudioCancelCause,
 } from "@vex-agent/mcp/outcome.js";
 import type { StudioConnectionHandle } from "@vex-agent/mcp/server.js";
+import { safeWireTag, type SocketTransportLifecycleEvent } from "@vex-agent/mcp/socket-transport.js";
 import type { StudioWireErrorCode } from "@vex-agent/mcp/wire-errors.js";
 
 import { log } from "../../logger/index.js";
@@ -58,6 +59,38 @@ import {
   type StudioHandshakeRefused,
 } from "./handshake.js";
 import { StudioOutboundQueue } from "./outbound-queue.js";
+
+/**
+ * WHY THIS CONNECTION ENDED, as a closed vocabulary the log can be read by.
+ *
+ * The vocabulary exists to separate THE PEER LEAVING from MAIN DECIDING, which
+ * the structural log could not distinguish at all: a killed bridge and a lock
+ * both arrived as a destroyed wire, and the incident of 2026-09-04 could not be
+ * attributed from the log for exactly that reason.
+ *
+ *   `peer_end`    the peer half-closed and the transport drained (a killed
+ *                 client and an ordinary one-shot session both land here)
+ *   `peer_error`  the wire raised `error`
+ *   `wire_failure` framing: over-long line, unparseable JSON, queue overflow
+ *   `refused`     a typed handshake refusal was written
+ *   `locked`      the secret-session lock destroyed this connection
+ *   `quit`        application quit destroyed this connection
+ *   `stale`       the host's admission epoch moved on mid-establish
+ *   `owner_close` main closed for its own reason (serve failure, outbound
+ *                 overflow, host teardown). The honest default.
+ */
+export type StudioCloseCause =
+  | "peer_end"
+  | "peer_error"
+  | "wire_failure"
+  | "refused"
+  | "locked"
+  | "quit"
+  | "stale"
+  | "owner_close";
+
+/** Which of the two wire implementations carries this connection. */
+export type StudioTransportKind = "front" | "socket";
 
 /** The contract's per-connection in-flight bound. */
 export const STUDIO_MAX_INFLIGHT_PER_CONNECTION = 8;
@@ -109,6 +142,19 @@ export interface StudioConnectionDeps {
   readonly serveConnection: (input: ServeConnectionInput) => StudioConnectionHandle;
   /** Called exactly once when this connection is fully torn down. */
   readonly onClosed: (connection: StudioConnection) => void;
+  /**
+   * Which wire implementation the host accepted this connection on.
+   *
+   * The connection cannot ask the wire: the whole point of
+   * `StudioDuplexTransport` is that nothing below the host knows which of the
+   * two it is holding. The HOST knows, because it built it, so it says.
+   */
+  readonly transportKind: StudioTransportKind;
+  /**
+   * Frames the relay dropped for this connection, for the front wire only, or
+   * `null` on a wire that has no such class of event.
+   */
+  readonly droppedFrames: (() => number) | null;
 }
 
 export interface ServeConnectionInput {
@@ -119,11 +165,25 @@ export interface ServeConnectionInput {
   readonly cancelCause: () => StudioCancelCause;
   readonly writeLine: (line: string, progressKey: string | null) => Promise<void>;
   readonly onWireFailure: (code: StudioWireErrorCode) => void;
+  /** The transport's own lifecycle transitions, for this connection's log. */
+  readonly onWireLifecycle: (event: SocketTransportLifecycleEvent) => void;
   /**
    * The serve path could not be built or has failed terminally. The OWNER
    * closes; the server builder never destroys a socket it does not own.
    */
   readonly onServeFailure: (message: string) => void;
+}
+
+/**
+ * A project id as a log tag, or `unknown`.
+ *
+ * The id is the PEER'S string, and it reaches a log line, so it passes the
+ * same gate every other peer-authored token does. A real Studio project id is
+ * a UUID and clears it; anything that does not is reported as absent rather
+ * than carried or cut.
+ */
+function projectTag(projectId: string): string {
+  return safeWireTag(projectId) ?? "unknown";
 }
 
 export class StudioConnection {
@@ -168,6 +228,18 @@ export class StudioConnection {
    * "the connection is torn down". Every caller now awaits the same run.
    */
   private disposal: Promise<void> | null = null;
+  /**
+   * THE FIRST DECISION WINS.
+   *
+   * A close has one cause: whatever decided it. Everything after that decision
+   * - the wire's `close` edge, a late framing error, the host's own teardown -
+   * is consequence, so `noteCloseCause` latches and never overwrites.
+   */
+  private closeCause: StudioCloseCause | null = null;
+  /** `Date.now()` when the phase became serving, or `null` if it never did. */
+  private servingSince: number | null = null;
+  private requestCount = 0;
+  private responseCount = 0;
 
   constructor(id: string, wire: StudioDuplexTransport, deps: StudioConnectionDeps) {
     this.id = id;
@@ -238,6 +310,7 @@ export class StudioConnection {
     // makes "no handshake is parsed after this point" a property rather than a
     // race with the kernel.
     this.phase = "refusing";
+    this.noteCloseCause("refused");
     this.clearHandshakeTimer();
     this.wire.off("data", this.handleHandshakeData);
     if (!this.wire.destroyed) this.wire.pause();
@@ -295,6 +368,10 @@ export class StudioConnection {
       });
     }
     if (!this.wire.destroyed) this.wire.destroy();
+    // AFTER the entry's close, so the transport has announced its own `closed`
+    // and the counters below are final rather than a snapshot of a teardown in
+    // progress.
+    this.logClosed();
     this.deps.onClosed(this);
   }
 
@@ -310,6 +387,9 @@ export class StudioConnection {
   destroyNow(cause: StudioCancelCause): void {
     // LATCHED FIRST, synchronously: an establish continuation that resumes
     // after this tick must see a closed connection, not a live one.
+    this.noteCloseCause(
+      cause === "lock" ? "locked" : cause === "vex_quit" ? "quit" : "owner_close",
+    );
     this.closedLatch = true;
     this.cause = cause;
     this.releaseConnectionSlot();
@@ -319,6 +399,7 @@ export class StudioConnection {
   }
 
   private readonly handleSocketError = (error: Error): void => {
+    this.noteCloseCause("peer_error");
     log.warn(`[studio:mcp] socket error id=${this.id}: ${error.message}`);
   };
 
@@ -388,6 +469,14 @@ export class StudioConnection {
     }
 
     this.phase = "serving";
+    this.servingSince = Date.now();
+    // THE FIRST INFO LINE THIS HOST HAS EVER EMITTED PER CONNECTION. Before
+    // it, a connection that was accepted, admitted and then silently starved
+    // was indistinguishable in the log from one that never got this far.
+    log.info(
+      `[studio:mcp] serving id=${this.id} project=${projectTag(projectId)} `
+        + `transport=${this.deps.transportKind}`,
+    );
     this.served = this.deps.serveConnection({
       wire: this.wire,
       remainder,
@@ -397,8 +486,10 @@ export class StudioConnection {
       writeLine: (line, progressKey) =>
         this.outbound.enqueue(line, progressKey ?? undefined),
       onWireFailure: (message) => {
+        this.noteCloseCause("wire_failure");
         log.warn(`[studio:mcp] wire failure id=${this.id}: ${message}`);
       },
+      onWireLifecycle: this.handleWireLifecycle,
       onServeFailure: (message) => {
         log.error(`[studio:mcp] serve failure id=${this.id}: ${message}`);
         void this.dispose(this.cause);
@@ -411,16 +502,79 @@ export class StudioConnection {
   }
 
   /**
+   * The transport's transitions, as this connection's structural log.
+   *
+   * The OWNER of the line is here rather than in the transport because the
+   * transport is engine code with no logger and no connection id, and because
+   * one owner emitting each transition once is what rule 05 asks for. The
+   * counters are carried from the transport's own `closed` event, which fires
+   * before this connection finishes tearing down on every teardown path.
+   */
+  private readonly handleWireLifecycle = (
+    event: SocketTransportLifecycleEvent,
+  ): void => {
+    switch (event.kind) {
+      case "first_request":
+        log.info(
+          `[studio:mcp] first request id=${this.id} method=${event.method}`
+            + (event.client === null ? "" : ` client=${event.client}`)
+            + (event.protocolVersion === null
+              ? ""
+              : ` protocolVersion=${event.protocolVersion}`),
+        );
+        return;
+      case "first_response":
+        log.info(
+          `[studio:mcp] first response id=${this.id} rpcId=${event.id ?? "none"} `
+            + `bytes=${String(event.bytes)}`,
+        );
+        return;
+      case "peer_end":
+        this.noteCloseCause("peer_end");
+        return;
+      case "closed":
+        this.requestCount = event.requests;
+        this.responseCount = event.responses;
+        return;
+    }
+  };
+
+  /** Latch the first decided cause. Later events are consequence, not cause. */
+  private noteCloseCause(cause: StudioCloseCause): void {
+    if (this.closeCause !== null) return;
+    this.closeCause = cause;
+  }
+
+  /** The one `closed` line, emitted by `runDispose` once the counters settled. */
+  private logClosed(): void {
+    const dropped = this.deps.droppedFrames;
+    log.info(
+      `[studio:mcp] closed id=${this.id} cause=${this.closeCause ?? "owner_close"} `
+        + `servedMs=${String(
+          this.servingSince === null ? 0 : Date.now() - this.servingSince,
+        )} `
+        + `requests=${String(this.requestCount)} responses=${String(this.responseCount)}`
+        + (dropped === null ? "" : ` droppedFrames=${String(dropped())}`),
+    );
+  }
+
+  /**
    * Is this connection finished, for any reason an establish continuation
    * cares about? Its own teardown, or the host's lifecycle moving on.
    */
   private isOver(): boolean {
     if (this.closedLatch || this.disposed) return true;
+    let stale: boolean;
     try {
-      return this.deps.isStale();
+      stale = this.deps.isStale();
     } catch {
-      return true;
+      stale = true;
     }
+    // The host's lifecycle moved on under an establish that had not published
+    // yet. It is neither the peer leaving nor a decision about THIS connection,
+    // so it gets its own name rather than the `owner_close` default.
+    if (stale) this.noteCloseCause("stale");
+    return stale;
   }
 
   /** Give the established-connection reservation back. Idempotent. */

--- a/vex-app/src/main/studio/mcp-host/front-relay-transport.ts
+++ b/vex-app/src/main/studio/mcp-host/front-relay-transport.ts
@@ -76,6 +76,23 @@ import type { FrontPlanes } from "./front-planes.js";
  */
 export const FRONT_MAX_PENDING_WRITES = 8;
 
+/**
+ * How long a connection may sit with bytes to send and no credit before main
+ * says so, ONCE.
+ *
+ * The number is VS Code's `ProtocolConstants.TimeoutTime` reasoning at a
+ * shorter scale: 5 s is `KeepAliveSendTime`, the interval at which a healthy
+ * peer is expected to have done something. A `tools/list` for the Studio
+ * surface is on the order of eleven 64 KiB windows, so a front that
+ * acknowledges normally passes through this state many times for a few
+ * milliseconds each; five seconds inside it is not pacing, it is a stall.
+ *
+ * It WARNS and does nothing else. The connection is not torn down: an
+ * acknowledgement that arrives at six seconds is still a working connection,
+ * and this is diagnostics, not policy.
+ */
+export const FRONT_CREDIT_STALL_WARN_MS = 5_000;
+
 /** One logical `write()`, and where its chunks have got to. */
 interface PendingWrite {
   readonly kind: "data";
@@ -126,6 +143,16 @@ interface RelayConnection {
   /** The write whose `write()` returned `false`. `drain` waits on it. */
   blocking: PendingWrite | null;
 
+  /* ---- diagnostics ---- */
+  /**
+   * The credit-stall watch, owned by this record and cleared on the first
+   * acknowledgement that releases window bytes, and on close. ONE warn per
+   * connection, ever: `warned` is never reset.
+   */
+  stallTimer: NodeJS.Timeout | null;
+  stallSince: number;
+  stallWarned: boolean;
+
   /* ---- lifecycle ---- */
   destroyed: boolean;
   closeRaised: boolean;
@@ -174,15 +201,9 @@ export class FrontRelay {
   private closed = false;
 
   /** Frames naming a connection this relay no longer has. Counted, never dispatched. */
-  private droppedFrames = 0;
 
   constructor(deps: FrontRelayDeps) {
     this.deps = deps;
-  }
-
-  /** Frames dropped for an unknown or closed connection. Exposed for the tests. */
-  get droppedFrameCount(): number {
-    return this.droppedFrames;
   }
 
   /** Logical connections the relay still holds. Exposed for the bound tests. */
@@ -318,6 +339,9 @@ export class FrontRelay {
       lastAck: 0n,
       awaitingAck: [],
       blocking: null,
+      stallTimer: null,
+      stallSince: 0,
+      stallWarned: false,
       destroyed: false,
       closeRaised: false,
       pendingClose: null,
@@ -356,6 +380,7 @@ export class FrontRelay {
     }
     connection.lastAck = ack;
 
+    const outstandingBefore = connection.outstanding;
     // CUMULATIVE RELEASE, popping while the head is covered - VS Code's
     // `_outgoingUnackMsg` shape.
     while (connection.unacked.length > 0) {
@@ -364,6 +389,12 @@ export class FrontRelay {
       connection.unacked.shift();
       connection.outstanding -= head.bytes;
     }
+
+    // WINDOW BYTES CAME BACK, so whatever was blocked is not stalled. A
+    // repeated acknowledgement that released nothing leaves the watch armed,
+    // because it is not progress. `pump()` below re-arms if the connection is
+    // still blocked after this release.
+    if (connection.outstanding < outstandingBefore) this.clearStallWatch(connection);
 
     // A logical write settles only when the acknowledgement covers its FINAL
     // sequence. An earlier ack releases window bytes and settles nothing.
@@ -382,9 +413,9 @@ export class FrontRelay {
   private handlePeerClosed(id: number, through: bigint): void {
     const connection = this.connections.get(id);
     if (connection === undefined) {
-      this.droppedFrames += 1;
       return;
     }
+
     connection.pendingClose = { through };
     // THE CLOSE EDGE IS DELAYED until plane 6 has delivered through that
     // sequence (protocol 6.3). Control and data are different pipes with no
@@ -443,6 +474,11 @@ export class FrontRelay {
     }
     connection.readEnded = true;
     connection.transport.readableEnded = true;
+    // THE PEER LEFT, AND THE LOG NOW SAYS SO. A killed `vex-mcp.exe` reaches
+    // the front as a read `io.EOF`, which is a HALF-close and produced no
+    // event at all: main's own teardown four milliseconds later was the only
+    // trace, and it read exactly like main deciding to close.
+    log.info(`[studio:front] peer half-closed connection=${String(id)}`);
     // The WRITABLE side is preserved. A peer that half-closes is saying "no
     // more requests", not "no more answers" (protocol 7.1).
     connection.transport.emit("end");
@@ -460,7 +496,7 @@ export class FrontRelay {
       // The host guards every write on `destroyed` and `writableEnded`, so
       // this is a defensive branch. It is COUNTED rather than silent: a caller
       // that reaches it has a bug worth seeing in the structural log.
-      this.droppedFrames += 1;
+      connection.transport.droppedFrames += 1;
       return false;
     }
 
@@ -610,7 +646,14 @@ export class FrontRelay {
 
     const chunk = head.chunks[head.sent];
     if (chunk === undefined) return false;
-    if (connection.outstanding + chunk.length > FRONT_CREDIT_BYTES) return false;
+    if (connection.outstanding + chunk.length > FRONT_CREDIT_BYTES) {
+      // THE ONE PLACE CREDIT BLOCKS A WRITE. Everything else that stops the
+      // pump is main's own state (destroyed, nothing pending, no plane), so
+      // this is the only edge that means "the front owes us an
+      // acknowledgement".
+      this.armStallWatch(connection);
+      return false;
+    }
 
     const sequence = this.deps.planes.writeData({
       connection: connection.id,
@@ -679,6 +722,10 @@ export class FrontRelay {
   private raiseClose(connection: RelayConnection, reason: string): void {
     if (connection.closeRaised) return;
     connection.closeRaised = true;
+    // THE ONE CLEANUP POINT for this connection's watch: `destroy`,
+    // `finishClose` and `closeAll` all arrive here, and none of them may leave
+    // a timer that would warn about a connection that is gone.
+    this.clearStallWatch(connection);
     connection.transport.destroyed = true;
     log.info(`[studio:front] connection closed reason=${reason}`);
     // ASYNCHRONOUS, as a socket's own `close` is. `StudioConnection.runDispose`
@@ -689,6 +736,42 @@ export class FrontRelay {
     });
   }
 
+  /**
+   * Start this connection's credit-stall watch, if it is not already running
+   * and has not already warned.
+   *
+   * ONE WARN PER CONNECTION, EVER. A connection that is genuinely stuck would
+   * otherwise repeat the line every five seconds for as long as it lived,
+   * which is a log that has stopped being evidence. The pattern is VS Code's
+   * heartbeat ladder: a bounded, one-shot statement about a peer that stopped
+   * doing what it is expected to do.
+   */
+  private armStallWatch(connection: RelayConnection): void {
+    if (connection.stallWarned || connection.stallTimer !== null) return;
+    if (connection.destroyed || connection.closeRaised) return;
+    connection.stallSince = Date.now();
+    const timer = setTimeout(() => {
+      connection.stallTimer = null;
+      if (connection.destroyed || connection.closeRaised) return;
+      if (connection.stallWarned) return;
+      connection.stallWarned = true;
+      log.warn(
+        `[studio:front] write blocked on credit connection=${String(connection.id)} `
+          + `waitedMs=${String(Date.now() - connection.stallSince)} `
+          + `queuedBytes=${String(unsentBytes(connection))}`,
+      );
+    }, FRONT_CREDIT_STALL_WARN_MS);
+    timer.unref?.();
+    connection.stallTimer = timer;
+  }
+
+  /** Stop the watch. `stallWarned` survives, because the bound is per connection. */
+  private clearStallWatch(connection: RelayConnection): void {
+    if (connection.stallTimer === null) return;
+    clearTimeout(connection.stallTimer);
+    connection.stallTimer = null;
+  }
+
   private live(id: number): RelayConnection | null {
     const connection = this.connections.get(id);
     if (connection === undefined || connection.destroyed) {
@@ -697,11 +780,35 @@ export class FrontRelay {
       // may well have written a `WRITE_DONE` a microsecond before main decided
       // to close. Dropped and counted, exactly as the front does with main's
       // late frames.
-      this.droppedFrames += 1;
+      // ATTRIBUTED to the connection as well when the record survives, so its
+      // own `closed` line can report what it lost. A frame for an id the relay
+      // has forgotten entirely has nobody to attribute it to.
+      if (connection !== undefined) connection.transport.droppedFrames += 1;
       return null;
     }
     return connection;
   }
+}
+
+/**
+ * Bytes this connection has accepted for plane 5 and not yet written.
+ *
+ * The chunks already on the wire and awaiting an acknowledgement are NOT
+ * counted: they left main, and the number is meant to answer "how much is main
+ * still holding for this peer".
+ */
+function unsentBytes(connection: RelayConnection): number {
+  let total = 0;
+  for (const item of connection.pending) {
+    if (item.kind !== "data") continue;
+    for (let index = item.sent; index < item.chunks.length; index += 1) {
+      // The index is inside the array by construction; reading it through a
+      // guard is what keeps that construction checked rather than asserted.
+      const chunk = item.chunks[index];
+      if (chunk !== undefined) total += chunk.length;
+    }
+  }
+  return total;
 }
 
 /**
@@ -732,6 +839,12 @@ export class FrontRelayTransport
   destroyed = false;
   writableEnded = false;
   readableEnded = false;
+  /**
+   * Frames the relay dropped naming THIS connection, for the host's `closed`
+   * line. A public field written by the relay, exactly as the three latches
+   * above are: the relay is the one writer.
+   */
+  droppedFrames = 0;
 
   constructor(relay: FrontRelay, id: number) {
     super();

--- a/vex-app/src/main/studio/mcp-host/outbound-queue.ts
+++ b/vex-app/src/main/studio/mcp-host/outbound-queue.ts
@@ -24,7 +24,7 @@
  *   already taken is never mutated, so a coalesce can never overlap a blocked
  *   send.
  *
- * ## Everything settles on close
+ * ## Everything settles on close, and SAYS SO
  *
  * Each enqueue returns a promise. On close every outstanding one RESOLVES
  * rather than rejecting: the frame did not reach the peer, and the caller
@@ -32,9 +32,20 @@
  * rejection would surface as an unhandled error during a normal disconnect.
  * The connection's own teardown is the event that matters, and it has already
  * fired by then.
+ *
+ * But resolution is NOT acceptance, and this queue resolves on five different
+ * edges: a closed queue, a coalesce, the pending bound, a wire that has gone
+ * away, and a real completed write. The promise therefore carries a
+ * `StudioWriteOutcome` naming which one it took. The transport above turns
+ * `accepted` - and only `accepted` - into the `first_response` milestone and
+ * the outbound counters, so a frame this queue swallowed can never be logged
+ * as main's answer leaving main.
  */
 
-import type { StudioDuplexTransport } from "@vex-agent/mcp/duplex-transport.js";
+import type {
+  StudioDuplexTransport,
+  StudioWriteOutcome,
+} from "@vex-agent/mcp/duplex-transport.js";
 
 /** The contract's pending-frame bound for one connection. */
 export const STUDIO_MAX_PENDING_OUTBOUND = 64;
@@ -55,7 +66,7 @@ interface OutboundEntry {
   /** Present for progress only: the request this frame reports on. */
   readonly key: string | null;
   line: string;
-  readonly settle: () => void;
+  readonly settle: (outcome: StudioWriteOutcome) => void;
 }
 
 export class StudioOutboundQueue {
@@ -87,30 +98,30 @@ export class StudioOutboundQueue {
    * `progressKey` marks the frame as coalescable progress for that request.
    * Anything without a key is a response and is queued unconditionally.
    */
-  enqueue(line: string, progressKey?: string): Promise<void> {
-    if (this.closed) return Promise.resolve();
+  enqueue(line: string, progressKey?: string): Promise<StudioWriteOutcome> {
+    if (this.closed) return Promise.resolve("closed");
 
     if (progressKey !== undefined) {
       const queued = this.queuedProgress.get(progressKey);
       if (queued !== undefined) {
         // COALESCE: replace the line of an entry the writer has not taken.
         queued.line = line;
-        return Promise.resolve();
+        return Promise.resolve("coalesced");
       }
     }
 
     if (this.queue.length >= this.maxPending) {
       // Progress is expendable at the bound; a response is not, and a peer
       // that has stopped reading its own answers has failed.
-      if (progressKey !== undefined) return Promise.resolve();
+      if (progressKey !== undefined) return Promise.resolve("dropped");
       if (!this.overflowed) {
         this.overflowed = true;
         this.onOverflow?.("pending_limit", this.queue.length);
       }
-      return Promise.resolve();
+      return Promise.resolve("dropped");
     }
 
-    return new Promise<void>((resolve) => {
+    return new Promise<StudioWriteOutcome>((resolve) => {
       const entry: OutboundEntry = {
         kind: progressKey === undefined ? "response" : "progress",
         key: progressKey ?? null,
@@ -134,7 +145,7 @@ export class StudioOutboundQueue {
     this.closed = true;
     const outstanding = this.queue.splice(0, this.queue.length);
     this.queuedProgress.clear();
-    for (const entry of outstanding) entry.settle();
+    for (const entry of outstanding) entry.settle("closed");
   }
 
   /** The ONE writer. Serialized by `writing`; re-entered only by itself. */
@@ -149,11 +160,10 @@ export class StudioOutboundQueue {
         // coalesce cannot rewrite a frame that is already on the wire.
         if (entry.key !== null) this.queuedProgress.delete(entry.key);
         if (this.closed || this.wire.destroyed || this.wire.writableEnded) {
-          entry.settle();
+          entry.settle("closed");
           continue;
         }
-        await this.writeLine(entry.line);
-        entry.settle();
+        entry.settle(await this.writeLine(entry.line));
       }
     } finally {
       this.writing = false;
@@ -173,34 +183,69 @@ export class StudioOutboundQueue {
    * queue's `writing` latch stuck and the connection silently mute. It is now
    * a hoisted binding plus a post-write settle, so neither order can strand a
    * frame or throw.
+   *
+   * THE OUTCOME IS THE POINT. `close` and `error` settle this promise so a
+   * teardown can never strand the one writer, and a `drain` after a refused
+   * write means the buffer actually emptied - but only the completed write and
+   * that drain are `accepted`. Everything else is `closed`: the frame is still
+   * in this process, or gone with the wire.
    */
-  private writeLine(line: string): Promise<void> {
-    return new Promise<void>((resolve) => {
+  private writeLine(line: string): Promise<StudioWriteOutcome> {
+    return new Promise<StudioWriteOutcome>((resolve) => {
       let settled = false;
       let accepted = false;
-      const done = (): void => {
+      const done = (outcome: StudioWriteOutcome): void => {
         if (settled) return;
         settled = true;
-        this.wire.off("close", done);
-        this.wire.off("error", done);
-        resolve();
+        this.wire.off("close", gone);
+        this.wire.off("error", gone);
+        this.wire.off("drain", drained);
+        resolve(outcome);
       };
-      this.wire.once("close", done);
-      this.wire.once("error", done);
+      const gone = (): void => {
+        done("closed");
+      };
+      const drained = (): void => {
+        done("accepted");
+      };
+      this.wire.once("close", gone);
+      this.wire.once("error", gone);
       let callbackFired = false;
-      accepted = this.wire.write(line, () => {
+      let writeFailed = false;
+      let returned = false;
+      const completed = (): void => {
+        done(writeFailed ? "closed" : "accepted");
+      };
+      accepted = this.wire.write(line, (error) => {
         callbackFired = true;
-        // Only the accepted path settles here, and only when `accepted` is
-        // already known. A callback invoked synchronously runs before the
-        // assignment below, so the post-write branch settles that case.
-        if (accepted) done();
+        // `net.Socket` reports a failed write through this argument, and the
+        // `error` event that follows it is not guaranteed to arrive first. A
+        // frame the socket threw away is not the peer's, whether the write was
+        // accepted or refused.
+        if (error !== undefined && error !== null) writeFailed = true;
+        // A callback invoked SYNCHRONOUSLY runs before `write` has returned, so
+        // `accepted` is not known yet; the post-write branch settles that case.
+        if (returned) completed();
       });
-      if (accepted) {
-        if (callbackFired) done();
+      returned = true;
+      // The callback is the authoritative edge on both branches: Node runs it
+      // when the chunk is actually flushed, which is the same fact `drain`
+      // reports and arrives no later.
+      if (callbackFired) {
+        completed();
         return;
       }
-      // Refused: `drain` is the edge that says the buffer actually emptied.
-      this.wire.once("drain", done);
+      if (accepted) return;
+      // Refused, with no callback yet. A wire that is already gone will never
+      // raise `drain`, and the Windows relay refuses exactly that way without
+      // ever running the callback, so the frame is named lost here rather than
+      // parked for ever.
+      if (this.wire.destroyed || this.wire.writableEnded) {
+        done("closed");
+        return;
+      }
+      // `drain` is the edge that says the buffer emptied without the callback.
+      this.wire.once("drain", drained);
     });
   }
 }

--- a/vex-app/src/main/studio/mcp-host/serve.ts
+++ b/vex-app/src/main/studio/mcp-host/serve.ts
@@ -45,6 +45,11 @@ export function serveOverSocket(
       onFailure: (failure) => {
         input.onWireFailure(failure.kind);
       },
+      // The transport is the OWNER of the two transitions only it can see - an
+      // inbound envelope reaching the queue and an outbound line reaching the
+      // wire - and the connection is the owner of the LINE. This is the wire
+      // between them; nothing here decides anything.
+      onLifecycle: input.onWireLifecycle,
     });
     // The dynamic import is the widest await in the whole establish chain.
     // A lock inside it must not be overtaken into a serving connection.


### PR DESCRIPTION
## What this makes visible

The owner's first MCP connection from Claude Code on Windows died after 25 s with nothing in the log between the front's `resumed` and `connection closed reason=destroy`. The teardown fingerprint (END on plane 5, CLOSE on plane 4 four milliseconds later) identified `finishAfterDrain` reacting to the PEER: Claude Code killed `vex-mcp.exe` at its default 30 s `MCP_TIMEOUT`. Whether `initialize` reached the transport and whether main answered was unknowable, because the host logged nothing per connection and a peer's read EOF became a silent half-close.

- **Per-connection lifecycle lines** (`[studio:mcp]`): `serving` (id, project, transport), `first request` (method from a closed set; for `initialize` the client name, version and protocol version), `first response` (rpc id, bytes), `closed` with a latched cause (`peer_end`, `peer_error`, `wire_failure`, `refused`, `locked`, `quit`, `owner_close`, `stale`), `servedMs`, `requests`, `responses`, `droppedFrames`. Peer-authored strings pass a closed set or a strict tag filter and are replaced by absence, never truncated.
- **Peer half-close is named**: the front emits `peer_half_closed` before the END goes up; main logs `[studio:front] peer half-closed connection=<id>` once.
- **Credit stall warns once per connection** after 5 s blocked (`waitedMs`, `queuedBytes`), timer owned by the connection record.
- **Windows dial bound**: go-winio's `tryDialPipe` loop shape under a 4 s deadline against stdlib syscalls; exhaustion is a typed `dialTimeout` (exit 3, "retrying later may work") so `/mcp` shows a named cause.
- The relay-wide dropped-frame counter had no consumer and is deleted.

The incident replayed against this code would read: admitted, serving, first request initialize, first response, peer half-closed, closed cause=peer_end. Absence is evidence too: no `first request` means `initialize` never arrived; no `first response` means main never answered; both present with a credit-stall warn means the answer could not leave.

## Not in this PR (owner decisions)

A main-side PING liveness probe for the front (VS Code's 5 s keep-alive / 20 s timeout is the reference), a bound on the client's pre-accept spend (where the recon says most of the 30 s budget went), chunking of `tools/list`.

## Verification

- root vitest `src/__tests__/vex-agent/mcp`: 17 files, 392 tests; vex-app `src/main/studio`: 60 files, 1022 passed / 8 skipped (the three load-sensitive socket suites passed at load 1); Go vet and `go test -race` on all 15 packages; `GOOS=windows` build and vet; root tsc, vex-app `lint:tsc` and `lint:tsc:ratchet`, process boundaries, em-dash and unsafe-escapes gates green.
- Not run: the Windows dial test (`//go:build windows`, compiled and vetted only) and the `peer_half_closed` event on a real Windows pipe.
- Growth decision: `front-relay-transport.ts` 761 to about 880 lines, grown on purpose (the stall watch lives in the private methods that own the credit window).
- Finding for follow-up: `scripts/check-test-unsafe-escapes.mjs` is diff-based and does not see untracked new files (measured: a non-null assertion in a new test passed the gate); the assertion was removed by review.

Reference reading: go-winio `pipe.go` (`tryDialPipe`, `DialPipeContext`) and `pipe_test.go`; VS Code `ipc.net.ts` (three socket edges, keep-alive constants) and `heartbeatService.ts` (bounded one-shot warning).
