### PR TITLE
fix(bridge): a provider approve step is bound to the plan before anything signs

### DIFF
--- a/src/__tests__/khalani/khalani-bridge-executor.test.ts
+++ b/src/__tests__/khalani/khalani-bridge-executor.test.ts
@@ -58,6 +58,17 @@ const SOL_CHAIN: KhalaniChain = {
 const TOKEN = "0x4444444444444444444444444444444444444444";
 const DEPOSIT_ADDR = "0x3333333333333333333333333333333333333333";
 
+/**
+ * The origin binding the planner needs. No plan in this suite carries an
+ * approval leg, so it is never the subject; it names the token and the amount
+ * the TRANSFER plans below move.
+ */
+const ORIGIN = {
+  fromToken: TOKEN,
+  wallet: "0x33eF6673BD80cB11fcC41b82Bc2181E65cC4d2fA",
+  bridgedAmountRaw: "1000000",
+};
+
 /** Assert a synchronous `planKhalaniDepositLegs` call throws a `VexError` with `code`. */
 function expectPlanThrowsCode(fn: () => unknown, code: string): void {
   let caught: unknown;
@@ -113,7 +124,7 @@ describe("planKhalaniDepositLegs — planner-level guards (staged rewrite)", () 
         },
       ],
     };
-    expectPlanThrowsCode(() => planKhalaniDepositLegs(plan, ETH_CHAIN), ErrorCodes.CHAIN_MISMATCH);
+    expectPlanThrowsCode(() => planKhalaniDepositLegs(plan, ETH_CHAIN, null, ORIGIN), ErrorCodes.CHAIN_MISMATCH);
   });
 
   it("rejects an unsupported EVM approval method", () => {
@@ -126,7 +137,7 @@ describe("planKhalaniDepositLegs — planner-level guards (staged rewrite)", () 
         },
       ],
     };
-    expectPlanThrowsCode(() => planKhalaniDepositLegs(plan, ETH_CHAIN), ErrorCodes.KHALANI_DEPOSIT_FAILED);
+    expectPlanThrowsCode(() => planKhalaniDepositLegs(plan, ETH_CHAIN, null, ORIGIN), ErrorCodes.KHALANI_DEPOSIT_FAILED);
   });
 
   it("plans an EVM ERC20 TRANSFER as a single bridge_deposit leg with transfer calldata", () => {
@@ -137,7 +148,7 @@ describe("planKhalaniDepositLegs — planner-level guards (staged rewrite)", () 
       token: TOKEN,
       chainId: 1,
     };
-    const legs = planKhalaniDepositLegs(plan, ETH_CHAIN);
+    const legs = planKhalaniDepositLegs(plan, ETH_CHAIN, null, ORIGIN);
     expect(legs).toHaveLength(1);
     const leg = legs[0]!;
     expect(leg.role).toBe("bridge_deposit");
@@ -158,7 +169,7 @@ describe("planKhalaniDepositLegs — planner-level guards (staged rewrite)", () 
       token: "0x0000000000000000000000000000000000000000",
       chainId: 1,
     };
-    const legs = planKhalaniDepositLegs(plan, ETH_CHAIN);
+    const legs = planKhalaniDepositLegs(plan, ETH_CHAIN, null, ORIGIN);
     expect(legs).toHaveLength(1);
     const leg = legs[0]!;
     expect(leg.role).toBe("bridge_deposit");
@@ -177,7 +188,7 @@ describe("planKhalaniDepositLegs — planner-level guards (staged rewrite)", () 
       token: "native",
       chainId: 20011000000,
     };
-    expectPlanThrowsCode(() => planKhalaniDepositLegs(plan, SOL_CHAIN), ErrorCodes.KHALANI_DEPOSIT_FAILED);
+    expectPlanThrowsCode(() => planKhalaniDepositLegs(plan, SOL_CHAIN, null, ORIGIN), ErrorCodes.KHALANI_DEPOSIT_FAILED);
   });
 });
 

--- a/src/__tests__/khalani/khalani-bridge-fee-plan.test.ts
+++ b/src/__tests__/khalani/khalani-bridge-fee-plan.test.ts
@@ -38,6 +38,14 @@ function evmSend(to: string, data: string, deposit: boolean) {
  */
 const NET_AMOUNT = 1_496_250n;
 
+/**
+ * Vex's own view of the bridge, which the planner binds the approval to
+ * (`@tools/evm-chains/erc20-approve-step-guard.ts` rule 2). The plans here
+ * approve exactly `NET_AMOUNT` of `USDC_BASE` from `WALLET`, which is what a
+ * live plan does, so the fee-leg cases stay about ORDERING.
+ */
+const ORIGIN = { fromToken: USDC_BASE, wallet: WALLET, bridgedAmountRaw: NET_AMOUNT.toString() };
+
 /** `approve(address,uint256)`. `ERC20_ABI` carries only the transfer surface. */
 const APPROVE_ABI = [{
   type: "function", name: "approve", stateMutability: "nonpayable",
@@ -77,7 +85,7 @@ function solanaPlan(): DepositPlan {
 
 describe("planKhalaniDepositLegs — fee leg ordering (EVM)", () => {
   it("APPENDS the fee transfer AFTER the deposit, never before it", () => {
-    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: USDC_BASE, feeRaw: FEE });
+    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: USDC_BASE, feeRaw: FEE }, ORIGIN);
 
     expect(legs.map((l) => l.purpose)).toEqual(["bridge", "bridge", "vex_fee"]);
     const depositIndex = legs.findIndex((l) => l.isDeposit);
@@ -89,7 +97,7 @@ describe("planKhalaniDepositLegs — fee leg ordering (EVM)", () => {
   });
 
   it("the fee leg is a plain ERC-20 transfer to the pinned treasury — no approval involved", () => {
-    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: USDC_BASE, feeRaw: FEE });
+    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: USDC_BASE, feeRaw: FEE }, ORIGIN);
     const feeLeg = legs.at(-1)!;
     if (feeLeg.kind !== "evm") throw new Error("expected an evm fee leg");
 
@@ -102,7 +110,7 @@ describe("planKhalaniDepositLegs — fee leg ordering (EVM)", () => {
   });
 
   it("a NATIVE input fee leg is a value transfer, not an ERC-20 call", () => {
-    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: "native", feeRaw: FEE });
+    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: "native", feeRaw: FEE }, ORIGIN);
     const feeLeg = legs.at(-1)!;
     if (feeLeg.kind !== "evm") throw new Error("expected an evm fee leg");
 
@@ -112,7 +120,7 @@ describe("planKhalaniDepositLegs — fee leg ordering (EVM)", () => {
   });
 
   it("records the fee leg under its own `bridge_fee` event_role", () => {
-    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: USDC_BASE, feeRaw: FEE });
+    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: USDC_BASE, feeRaw: FEE }, ORIGIN);
     const feeLeg = legs.at(-1)!;
     // Migration 050 added the role. Before it the leg was labelled `allowance`,
     // which was untrue in the durable record the agent reads back.
@@ -124,7 +132,7 @@ describe("planKhalaniDepositLegs — fee leg ordering (EVM)", () => {
     // `sync/bridge-activity-repair-production-deps.ts` correlates the provider
     // order by selecting the sibling row with `event_role='bridge_deposit'`. A
     // second such row would hand the sweep the FEE hash as the deposit hash.
-    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: USDC_BASE, feeRaw: FEE });
+    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: USDC_BASE, feeRaw: FEE }, ORIGIN);
     const depositRoles = legs.filter((l) => l.role === "bridge_deposit");
     expect(depositRoles).toHaveLength(1);
     expect(depositRoles[0]!.purpose).toBe("bridge");
@@ -133,21 +141,23 @@ describe("planKhalaniDepositLegs — fee leg ordering (EVM)", () => {
 
 describe("planKhalaniDepositLegs — fee of zero is SKIPPED entirely", () => {
   it("plans no fee leg at all rather than a zero-value transfer", () => {
-    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: USDC_BASE, feeRaw: 0n });
+    const legs = planKhalaniDepositLegs(evmPlan(), BASE, { tokenAddress: USDC_BASE, feeRaw: 0n }, ORIGIN);
     expect(legs.map((l) => l.purpose)).toEqual(["bridge", "bridge"]);
     expect(legs.some((l) => l.purpose === "vex_fee")).toBe(false);
   });
 
   it("plans no fee leg when the caller passes null (dust / declined token)", () => {
-    expect(planKhalaniDepositLegs(evmPlan(), BASE, null)).toHaveLength(2);
-    // Omitted argument behaves identically — the pre-fee call sites are unchanged.
-    expect(planKhalaniDepositLegs(evmPlan(), BASE)).toHaveLength(2);
+    // `null` is now spelled at every call site: the fee argument lost its
+    // default when the origin binding became a required fourth parameter, so a
+    // caller can no longer omit the binding the approve rules are checked
+    // against (`@tools/evm-chains/erc20-approve-step-guard.ts`).
+    expect(planKhalaniDepositLegs(evmPlan(), BASE, null, ORIGIN)).toHaveLength(2);
   });
 });
 
 describe("planKhalaniDepositLegs — Solana fee leg", () => {
   it("appends an UNBUILT descriptor after the deposit (the planner stays network-free)", () => {
-    const legs = planKhalaniDepositLegs(solanaPlan(), SOLANA, { tokenAddress: "SoMeMint", feeRaw: FEE });
+    const legs = planKhalaniDepositLegs(solanaPlan(), SOLANA, { tokenAddress: "SoMeMint", feeRaw: FEE }, ORIGIN);
 
     expect(legs).toHaveLength(2);
     expect(legs[0]!.isDeposit).toBe(true);
@@ -166,12 +176,12 @@ describe("planKhalaniDepositLegs — the deposit invariant survives the extra le
       kind: "CONTRACT_CALL",
       approvals: [evmSend(ROUTER, "0xaa", true), evmSend(ROUTER, "0xbb", true)],
     } as unknown as DepositPlan;
-    expect(() => planKhalaniDepositLegs(twoDeposits, BASE, { tokenAddress: USDC_BASE, feeRaw: FEE })).toThrow();
+    expect(() => planKhalaniDepositLegs(twoDeposits, BASE, { tokenAddress: USDC_BASE, feeRaw: FEE }, ORIGIN)).toThrow();
 
     const noDeposit = {
       kind: "CONTRACT_CALL",
       approvals: [evmSend(USDC_BASE, "0x095ea7b3", false)],
     } as unknown as DepositPlan;
-    expect(() => planKhalaniDepositLegs(noDeposit, BASE, { tokenAddress: USDC_BASE, feeRaw: FEE })).toThrow();
+    expect(() => planKhalaniDepositLegs(noDeposit, BASE, { tokenAddress: USDC_BASE, feeRaw: FEE }, ORIGIN)).toThrow();
   });
 });

--- a/src/__tests__/khalani/khalani-bridge-fee-plan.test.ts
+++ b/src/__tests__/khalani/khalani-bridge-fee-plan.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { decodeFunctionData, getAddress } from "viem";
+import { decodeFunctionData, encodeFunctionData, getAddress } from "viem";
 
 import { ERC20_ABI } from "../../constants/chain.js";
 import { VEX_TREASURY_EVM } from "../../lib/vex-treasury.js";
@@ -32,12 +32,37 @@ function evmSend(to: string, data: string, deposit: boolean) {
   };
 }
 
-/** approve(router, netAmount) then the deposit call — the shape Khalani returns. */
+/**
+ * The net amount the deposit call moves, and therefore the allowance the
+ * approval grants. Live Khalani `CONTRACT_CALL` plans approve EXACTLY this.
+ */
+const NET_AMOUNT = 1_496_250n;
+
+/** `approve(address,uint256)`. `ERC20_ABI` carries only the transfer surface. */
+const APPROVE_ABI = [{
+  type: "function", name: "approve", stateMutability: "nonpayable",
+  inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+  outputs: [{ name: "", type: "bool" }],
+}] as const;
+
+/**
+ * approve(router, netAmount) then the deposit call, the shape Khalani returns.
+ *
+ * The approval carries REAL `approve` calldata naming the deposit target,
+ * because the planner now refuses an approval it cannot bind to the deposit
+ * (`@tools/evm-chains/erc20-approve-step-guard.ts`). The previous bare selector
+ * `0x095ea7b3` was never a decodable call, so it can no longer stand in for one.
+ */
 function evmPlan(): DepositPlan {
+  const approveData = encodeFunctionData({
+    abi: APPROVE_ABI,
+    functionName: "approve",
+    args: [getAddress(ROUTER), NET_AMOUNT],
+  });
   return {
     kind: "CONTRACT_CALL",
     approvals: [
-      evmSend(USDC_BASE, "0x095ea7b3", false),
+      evmSend(USDC_BASE, approveData, false),
       evmSend(ROUTER, "0xdeadbeef", true),
     ],
   } as unknown as DepositPlan;

--- a/src/__tests__/khalani/khalani-native-value-gate.test.ts
+++ b/src/__tests__/khalani/khalani-native-value-gate.test.ts
@@ -88,6 +88,18 @@ const BASE_CHAIN = {
 const DEPOSIT_TARGET: Address = getAddress("0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa");
 const UNDISCLOSED_NATIVE_CHARGE = 1_000_000_000_000_000n; // the live 1e15 wei
 
+/**
+ * The origin binding the planner needs for the approve rules. Every plan in
+ * this suite is native-origin and carries no approval leg, so the binding is
+ * never the subject here - it names the native asset, which is exactly what an
+ * approval-free plan bridges.
+ */
+const ORIGIN = {
+  fromToken: "0x0000000000000000000000000000000000000000",
+  wallet: getAddress("0x33eF6673BD80cB11fcC41b82Bc2181E65cC4d2fA"),
+  bridgedAmountRaw: "3000000000000000",
+};
+
 const noopHooks = {
   onNonceReserved: vi.fn(async (request: { nodePendingNonce: number }) => request.nodePendingNonce),
   onHashStaged: vi.fn(async () => {}),
@@ -216,6 +228,8 @@ describe("legitimate legs still sign", () => {
         chainId: 8453,
       },
       BASE_CHAIN,
+      null,
+      ORIGIN,
     );
 
     expect(legs).toHaveLength(1);
@@ -251,6 +265,8 @@ describe("legitimate legs still sign", () => {
         ],
       },
       BASE_CHAIN,
+      null,
+      ORIGIN,
     );
 
     const leg = legs[0]!;
@@ -276,6 +292,8 @@ describe("legitimate legs still sign", () => {
         ],
       },
       BASE_CHAIN,
+      null,
+      ORIGIN,
     );
 
     const leg = legs[0]!;

--- a/src/__tests__/tools/evm-chains/bridge-deposit-calldata.test.ts
+++ b/src/__tests__/tools/evm-chains/bridge-deposit-calldata.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The deposit binding itself: what `bound: true` is allowed to mean, and what
+ * the unverified-selector report is allowed to remember.
+ *
+ * TWO RULES ARE PINNED HERE.
+ *
+ * 1. A CONFIRMED SIGNATURE IS NOT AUTOMATICALLY A BOUND. `0x5a1ee3ac`
+ *    (`depositErc20(address,address,bytes32)`) appears in the same verified
+ *    `RelayDepository` source as the four-argument overload, but it encodes no
+ *    amount and carries no native value: the depository pulls the whole
+ *    EFFECTIVE allowance. The approve guard binds a grant this plan CONTAINS,
+ *    and Relay legitimately omits the approve step when an allowance already
+ *    exists, so nothing on this path proves that allowance equals `bridgedRaw`.
+ *    Reporting it `bound: true` would tell the caller the principal was proven
+ *    when it was not, so it is refused until an exact allowance read exists.
+ *
+ * 2. THE UNVERIFIED-SELECTOR DEDUP IS BOUNDED. Half of every dedup key (the
+ *    selector) is provider-controlled, and the map used to grow for the life of
+ *    the process. It is now a fixed-capacity LRU whose evictions are counted in
+ *    the log line, so a reader can tell a shape may be reported twice rather
+ *    than believing the dedup was exact.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { encodeAbiParameters, getAddress } from "viem";
+
+const info = vi.fn();
+vi.mock("@utils/logger.js", () => ({
+  default: { info: (...args: unknown[]) => info(...args), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+const { verifyBridgeDepositCalldata, logUnverifiedDepositSelector } = await import(
+  "@tools/evm-chains/bridge-deposit-calldata.js"
+);
+
+const WALLET = getAddress("0x33eF6673BD80cB11fcC41b82Bc2181E65cC4d2fA");
+const USDC = getAddress("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+const DEPOSITORY = getAddress("0x4cD00E387622C35bDDB9b4c962C136462338BC31");
+const PRINCIPAL = 5_000_000n;
+
+/** `depositErc20(depositor, token, id)` - the three-argument, amount-free overload. */
+function allowancePullData(): string {
+  const body = encodeAbiParameters(
+    [{ type: "address" }, { type: "address" }, { type: "bytes32" }],
+    [WALLET, USDC, `0x${"11".repeat(32)}`],
+  );
+  return `0x5a1ee3ac${body.slice(2)}`;
+}
+
+/** `depositErc20(depositor, token, amount, id)` - the bindable overload. */
+function boundDepositData(amount: bigint = PRINCIPAL): string {
+  const body = encodeAbiParameters(
+    [{ type: "address" }, { type: "address" }, { type: "uint256" }, { type: "bytes32" }],
+    [WALLET, USDC, amount, `0x${"11".repeat(32)}`],
+  );
+  return `0xe8017952${body.slice(2)}`;
+}
+
+describe("verifyBridgeDepositCalldata - the allowance-pulling overload is refused, never bound", () => {
+  const plan = { originToken: USDC, wallet: WALLET, principalRaw: PRINCIPAL };
+
+  it("refuses `0x5a1ee3ac` and names the selector, so the agent can re-quote", () => {
+    const verdict = verifyBridgeDepositCalldata(
+      { to: DEPOSITORY, data: allowancePullData(), value: 0n },
+      plan,
+    );
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.reason).toBe("deposit_allowance_pull_unbindable");
+      expect(verdict.detail).toContain("0x5a1ee3ac");
+      expect(verdict.detail).toMatch(/allowance/i);
+    }
+  });
+
+  it("refuses it even when the depositor and the token are this plan's own", () => {
+    // Every argument it DOES encode is correct; the refusal is about the
+    // argument it does not encode, which is the only one that moves money.
+    const verdict = verifyBridgeDepositCalldata(
+      { to: DEPOSITORY, data: allowancePullData(), value: 0n },
+      plan,
+    );
+    expect(verdict).toMatchObject({ ok: false, reason: "deposit_allowance_pull_unbindable" });
+  });
+
+  it("refuses it when Vex derived no principal at all", () => {
+    // A `null` principal is exactly the state in which the receipt floor is the
+    // only amount rule, so an unbindable pull must not slip through as bound.
+    const verdict = verifyBridgeDepositCalldata(
+      { to: DEPOSITORY, data: allowancePullData(), value: 0n },
+      { originToken: USDC, wallet: WALLET, principalRaw: null },
+    );
+    expect(verdict).toMatchObject({ ok: false, reason: "deposit_allowance_pull_unbindable" });
+  });
+
+  it("still binds the four-argument overload the live captures carry", () => {
+    expect(verifyBridgeDepositCalldata({ to: DEPOSITORY, data: boundDepositData(), value: 0n }, plan))
+      .toEqual({ ok: true, bound: true, signature: "depositErc20(address,address,uint256,bytes32)" });
+  });
+
+  it("still refuses the four-argument overload when the amount is not the principal", () => {
+    expect(verifyBridgeDepositCalldata({ to: DEPOSITORY, data: boundDepositData(1n), value: 0n }, plan))
+      .toMatchObject({ ok: false, reason: "deposit_principal_mismatch" });
+  });
+
+  it("still records, rather than refuses, a selector no authority confirms", () => {
+    expect(verifyBridgeDepositCalldata({ to: DEPOSITORY, data: `0xabcdef01${"00".repeat(32)}`, value: 0n }, plan))
+      .toEqual({ ok: true, bound: false, selector: "0xabcdef01" });
+  });
+});
+
+describe("logUnverifiedDepositSelector - provider-controlled keys are bounded", () => {
+  /** One more than the module's capacity, so the cap is crossed exactly once. */
+  const OVER_CAPACITY = 65;
+
+  function report(index: number): void {
+    logUnverifiedDepositSelector({
+      venue: "relay.bridge",
+      chainId: 8453,
+      selector: `0x${index.toString(16).padStart(8, "0")}`,
+      target: DEPOSITORY,
+    });
+  }
+
+  it("reports each shape once, then evicts the oldest key and says how many it dropped", () => {
+    info.mockClear();
+    for (let index = 0; index < OVER_CAPACITY; index++) report(index);
+    // Every distinct shape is still REPORTED: the bound is on what is
+    // remembered, never on what the operator is told.
+    expect(info).toHaveBeenCalledTimes(OVER_CAPACITY);
+    const repeated = info.mock.calls.length;
+    // The shape reported most recently is still deduplicated.
+    report(OVER_CAPACITY - 1);
+    expect(info.mock.calls.length).toBe(repeated);
+
+    // The OLDEST shape was evicted to make room, so it reports a second time -
+    // and the line carries the eviction count that explains why.
+    report(0);
+    expect(info.mock.calls.length).toBe(repeated + 1);
+    const last = info.mock.calls.at(-1);
+    const meta = last?.[1] as { dedupEvictedKeys?: number } | undefined;
+    expect(meta?.dedupEvictedKeys).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/tools/evm-chains/erc20-approve-step-guard.test.ts
+++ b/src/__tests__/tools/evm-chains/erc20-approve-step-guard.test.ts
@@ -1,0 +1,243 @@
+/**
+ * The approve-step guard: what a bridge may and may not sign on the user's own
+ * token.
+ *
+ * WHY THIS SUITE EXISTS. Both bridge venues signed a provider's approve step
+ * after checking only the chain, the sender and the native value; the spender,
+ * the token and the allowance were decoded afterwards, to record evidence. A
+ * provider returning `approve(stranger, 2^256-1)` on the origin token therefore
+ * signed cleanly and left the user's whole balance of that token drainable. The
+ * table below is the state cross-product of that decision: origin asset x
+ * approve step x deposit kind x allowance, every cell either allowed with an
+ * exact allowance or a NAMED refusal.
+ *
+ * The pin-note cases are not decoration. viem 2.54.3 decodes a canonical
+ * `approve` blob with trailing bytes appended and SILENTLY discards them, so a
+ * guard that trusted `decodeFunctionData` alone would sign calldata whose tail
+ * it never looked at.
+ */
+
+import { describe, expect, it } from "vitest";
+import { encodeFunctionData, getAddress } from "viem";
+
+import {
+  refuseApproveStep,
+  verifyApproveStepAuthorizesDeposit,
+  verifyApproveStepBindsPlanAmount,
+  type ApproveStepCall,
+  type Erc20ApproveStepRefusalReason,
+  type Erc20ApproveStepVerdict,
+} from "@tools/evm-chains/erc20-approve-step-guard.js";
+
+const USDC = getAddress("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+const DAI = getAddress("0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb");
+const DEPOSIT_TARGET = getAddress("0x4cD00E387622C35bDDB9b4c962C136462338BC31");
+const STRANGER = getAddress("0x000000000000000000000000000000000000dEaD");
+const WALLET = getAddress("0x33eF6673BD80cB11fcC41b82Bc2181E65cC4d2fA");
+
+/** The post-Vex-fee principal Vex asked the venue to bridge. */
+const PRINCIPAL = 5_000_000n;
+const UNLIMITED = (1n << 256n) - 1n;
+
+const APPROVE_ABI = [{
+  type: "function", name: "approve", stateMutability: "nonpayable",
+  inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+  outputs: [{ name: "", type: "bool" }],
+}] as const;
+
+function approveData(spender: string, allowance: bigint): string {
+  return encodeFunctionData({ abi: APPROVE_ABI, functionName: "approve", args: [getAddress(spender), allowance] });
+}
+
+/**
+ * Both rules, in the order a venue that sees the whole plan runs them: the
+ * plan-internal binding first, then the Vex-derived amounts. The first refusal
+ * wins, which is why a plan with no deposit call refuses before the origin
+ * asset is even considered.
+ */
+function verifyApproveStep(
+  call: ApproveStepCall,
+  plan: { depositTarget: string | null; originToken: string | null; wallet: string; principalRaw: bigint | null },
+): Erc20ApproveStepVerdict {
+  const bound = verifyApproveStepAuthorizesDeposit(call, { depositTarget: plan.depositTarget });
+  if (!bound.ok) return bound;
+  return verifyApproveStepBindsPlanAmount(call, {
+    originToken: plan.originToken,
+    wallet: plan.wallet,
+    principalRaw: plan.principalRaw,
+  });
+}
+
+// ── The state cross-product ─────────────────────────────────────────────────
+//
+// Origin asset x deposit kind x allowance, for a plan that DOES carry an
+// approve step. The "approve step absent" half of the product is proven at the
+// planners (a native Relay quote and a Khalani TRANSFER plan carry none), where
+// the absence is observable; here there would be no call to make.
+//
+// Deposit kind collapses to one fact this guard can see: the address an
+// approval may name. A Relay deposit step and a Khalani CONTRACT_CALL both
+// carry a deposit CALL, so they behave identically and are asserted as one
+// row each; a Khalani TRANSFER makes no call at all, so its deposit target is
+// `null` and NO approve step in such a plan is legitimate.
+
+type DepositKind = "relay_deposit_tx" | "khalani_contract_call" | "khalani_transfer";
+type AllowanceKind = "equal" | "larger" | "unlimited" | "smaller";
+
+const ALLOWANCES: Readonly<Record<AllowanceKind, bigint>> = {
+  equal: PRINCIPAL,
+  larger: PRINCIPAL + 1n,
+  unlimited: UNLIMITED,
+  smaller: PRINCIPAL - 1n,
+};
+
+const DEPOSIT_TARGETS: Readonly<Record<DepositKind, string | null>> = {
+  relay_deposit_tx: DEPOSIT_TARGET,
+  khalani_contract_call: DEPOSIT_TARGET,
+  khalani_transfer: null,
+};
+
+interface Cell {
+  readonly origin: "native" | "erc20";
+  readonly deposit: DepositKind;
+  readonly allowance: AllowanceKind;
+  /** `null` means allowed, and the allowance granted must be the exact principal. */
+  readonly refusal: Erc20ApproveStepRefusalReason | null;
+}
+
+const CROSS_PRODUCT: readonly Cell[] = (["relay_deposit_tx", "khalani_contract_call", "khalani_transfer"] as const)
+  .flatMap((deposit) => (["native", "erc20"] as const)
+    .flatMap((origin) => (["equal", "larger", "unlimited", "smaller"] as const)
+      .map((allowance): Cell => {
+        // A plan with no deposit call refuses first, whatever the origin asset
+        // or the amount: there is nothing in it an allowance could serve.
+        if (deposit === "khalani_transfer") return { origin, deposit, allowance, refusal: "plan_has_no_deposit_call" };
+        // A native origin moves its money as `tx.value`; there is no token to
+        // approve, so an approve step on one is a step Vex never asked for.
+        if (origin === "native") return { origin, deposit, allowance, refusal: "approve_on_native_origin" };
+        return { origin, deposit, allowance, refusal: allowance === "equal" ? null : "allowance_not_principal" };
+      })));
+
+describe("approve-step guard - the state cross-product", () => {
+  it("covers every origin x deposit-kind x allowance cell exactly once", () => {
+    expect(CROSS_PRODUCT).toHaveLength(24);
+    expect(new Set(CROSS_PRODUCT.map((c) => `${c.origin}/${c.deposit}/${c.allowance}`)).size).toBe(24);
+  });
+
+  for (const cell of CROSS_PRODUCT) {
+    const name = `${cell.origin} origin, ${cell.deposit}, ${cell.allowance} allowance`;
+    it(cell.refusal === null ? `${name}: allowed for exactly the principal` : `${name}: refused as ${cell.refusal}`, () => {
+      const allowance = ALLOWANCES[cell.allowance];
+      const verdict = verifyApproveStep(
+        { to: USDC, data: approveData(DEPOSIT_TARGET, allowance), value: 0n, from: WALLET },
+        {
+          depositTarget: DEPOSIT_TARGETS[cell.deposit],
+          originToken: cell.origin === "native" ? null : USDC,
+          wallet: WALLET,
+          principalRaw: PRINCIPAL,
+        },
+      );
+      if (cell.refusal === null) {
+        expect(verdict).toEqual({ ok: true, spender: DEPOSIT_TARGET, allowance: PRINCIPAL });
+      } else {
+        expect(verdict.ok).toBe(false);
+        if (!verdict.ok) expect(verdict.reason).toBe(cell.refusal);
+      }
+    });
+  }
+});
+
+describe("approve-step guard - rule 1, the spender must be this plan's deposit", () => {
+  it("refuses an allowance granted to an address the plan never calls", () => {
+    const verdict = verifyApproveStepAuthorizesDeposit(
+      { to: USDC, data: approveData(STRANGER, PRINCIPAL), value: 0n },
+      { depositTarget: DEPOSIT_TARGET },
+    );
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("spender_not_deposit_target");
+  });
+
+  it("accepts the live shape: spender IS the deposit target, compared without regard to checksum case", () => {
+    const verdict = verifyApproveStepAuthorizesDeposit(
+      { to: USDC, data: approveData(DEPOSIT_TARGET, PRINCIPAL), value: 0n },
+      { depositTarget: DEPOSIT_TARGET.toLowerCase() },
+    );
+    expect(verdict).toEqual({ ok: true, spender: DEPOSIT_TARGET, allowance: PRINCIPAL });
+  });
+
+  it("refuses an approval that also sends native currency", () => {
+    const verdict = verifyApproveStepAuthorizesDeposit(
+      { to: USDC, data: approveData(DEPOSIT_TARGET, PRINCIPAL), value: 1n },
+      { depositTarget: DEPOSIT_TARGET },
+    );
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("approve_carries_native_value");
+  });
+
+  it("reports a second grant in the plan's own vocabulary", () => {
+    const verdict = refuseApproveStep("extra_approve_step", "two grants");
+    expect(verdict).toEqual({ ok: false, reason: "extra_approve_step", detail: "two grants" });
+  });
+});
+
+describe("approve-step guard - rule 2, the token, the sender and the exact allowance", () => {
+  const bind = (call: ApproveStepCall, principalRaw: bigint | null = PRINCIPAL): Erc20ApproveStepVerdict =>
+    verifyApproveStepBindsPlanAmount(call, { originToken: USDC, wallet: WALLET, principalRaw });
+
+  it("refuses an approval on a token that is not the origin currency", () => {
+    const verdict = bind({ to: DAI, data: approveData(DEPOSIT_TARGET, PRINCIPAL), value: 0n });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("token_not_origin_currency");
+  });
+
+  it("refuses an approval sent from an address that is not the selected wallet", () => {
+    const verdict = bind({ to: USDC, data: approveData(DEPOSIT_TARGET, PRINCIPAL), value: 0n, from: STRANGER });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("sender_not_selected_wallet");
+  });
+
+  it("accepts an approval that names no sender at all, as Khalani plans sometimes do", () => {
+    expect(bind({ to: USDC, data: approveData(DEPOSIT_TARGET, PRINCIPAL), value: 0n }).ok).toBe(true);
+  });
+
+  it("refuses when Vex derived no principal, rather than binding to nothing", () => {
+    const verdict = bind({ to: USDC, data: approveData(DEPOSIT_TARGET, PRINCIPAL), value: 0n }, null);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("principal_not_derivable");
+  });
+
+  it("names the granted and the required amount, so an agent can report the difference", () => {
+    const verdict = bind({ to: USDC, data: approveData(DEPOSIT_TARGET, UNLIMITED), value: 0n });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.detail).toContain(`${UNLIMITED}`);
+    if (!verdict.ok) expect(verdict.detail).toContain(`${PRINCIPAL}`);
+  });
+});
+
+// ── Pin-note: measured viem 2.54.3 behaviour, 2026-09-04 ────────────────────
+
+describe("approve-step guard - calldata canonicality (viem 2.54.3 pin-note)", () => {
+  const canonical = approveData(DEPOSIT_TARGET, PRINCIPAL);
+  const rows: readonly (readonly [string, string | undefined])[] = [
+    ["trailing bytes viem would silently discard", `${canonical}deadbeef`],
+    ["a trailing zero word", `${canonical}${"00".repeat(32)}`],
+    ["a transfer selector", `0xa9059cbb${canonical.slice(10)}`],
+    ["the approve selector with no arguments", "0x095ea7b3"],
+    ["a truncated argument body", canonical.slice(0, 74)],
+    ["empty calldata", "0x"],
+    ["no calldata at all", undefined],
+  ];
+
+  for (const [label, data] of rows) {
+    it(`refuses ${label} as non-canonical`, () => {
+      const verdict = verifyApproveStepAuthorizesDeposit({ to: USDC, data, value: 0n }, { depositTarget: DEPOSIT_TARGET });
+      expect(verdict.ok).toBe(false);
+      if (!verdict.ok) expect(verdict.reason).toBe("not_canonical_approve");
+    });
+  }
+
+  it("accepts the exact 68-byte body the live quotes carry", () => {
+    expect(canonical).toHaveLength(138);
+    expect(verifyApproveStepAuthorizesDeposit({ to: USDC, data: canonical, value: 0n }, { depositTarget: DEPOSIT_TARGET }).ok).toBe(true);
+  });
+});

--- a/src/__tests__/tools/evm-chains/erc20-approve-step-guard.test.ts
+++ b/src/__tests__/tools/evm-chains/erc20-approve-step-guard.test.ts
@@ -22,8 +22,9 @@ import { encodeFunctionData, getAddress } from "viem";
 
 import {
   refuseApproveStep,
+  verifyApprovalSequence,
   verifyApproveStepAuthorizesDeposit,
-  verifyApproveStepBindsPlanAmount,
+  verifyApproveStepBindsPlan,
   type ApproveStepCall,
   type Erc20ApproveStepRefusalReason,
   type Erc20ApproveStepVerdict,
@@ -61,7 +62,7 @@ function verifyApproveStep(
 ): Erc20ApproveStepVerdict {
   const bound = verifyApproveStepAuthorizesDeposit(call, { depositTarget: plan.depositTarget });
   if (!bound.ok) return bound;
-  return verifyApproveStepBindsPlanAmount(call, {
+  return verifyApproveStepBindsPlan(call, {
     originToken: plan.originToken,
     wallet: plan.wallet,
     principalRaw: plan.principalRaw,
@@ -82,13 +83,16 @@ function verifyApproveStep(
 // `null` and NO approve step in such a plan is legitimate.
 
 type DepositKind = "relay_deposit_tx" | "khalani_contract_call" | "khalani_transfer";
-type AllowanceKind = "equal" | "larger" | "unlimited" | "smaller";
+type AllowanceKind = "equal" | "larger" | "unlimited" | "smaller" | "reset";
 
 const ALLOWANCES: Readonly<Record<AllowanceKind, bigint>> = {
   equal: PRINCIPAL,
   larger: PRINCIPAL + 1n,
   unlimited: UNLIMITED,
   smaller: PRINCIPAL - 1n,
+  // The `approve(spender, 0)` a non-standard token needs before a new grant.
+  // Exempt from the amount EQUALITY and from nothing else.
+  reset: 0n,
 };
 
 const DEPOSIT_TARGETS: Readonly<Record<DepositKind, string | null>> = {
@@ -107,7 +111,7 @@ interface Cell {
 
 const CROSS_PRODUCT: readonly Cell[] = (["relay_deposit_tx", "khalani_contract_call", "khalani_transfer"] as const)
   .flatMap((deposit) => (["native", "erc20"] as const)
-    .flatMap((origin) => (["equal", "larger", "unlimited", "smaller"] as const)
+    .flatMap((origin) => (["equal", "larger", "unlimited", "smaller", "reset"] as const)
       .map((allowance): Cell => {
         // A plan with no deposit call refuses first, whatever the origin asset
         // or the amount: there is nothing in it an allowance could serve.
@@ -115,13 +119,16 @@ const CROSS_PRODUCT: readonly Cell[] = (["relay_deposit_tx", "khalani_contract_c
         // A native origin moves its money as `tx.value`; there is no token to
         // approve, so an approve step on one is a step Vex never asked for.
         if (origin === "native") return { origin, deposit, allowance, refusal: "approve_on_native_origin" };
-        return { origin, deposit, allowance, refusal: allowance === "equal" ? null : "allowance_not_principal" };
+        // A zero reset passes rule 2's amount check by definition; every other
+        // amount must equal the principal exactly.
+        if (allowance === "equal" || allowance === "reset") return { origin, deposit, allowance, refusal: null };
+        return { origin, deposit, allowance, refusal: "allowance_not_principal" };
       })));
 
 describe("approve-step guard - the state cross-product", () => {
   it("covers every origin x deposit-kind x allowance cell exactly once", () => {
-    expect(CROSS_PRODUCT).toHaveLength(24);
-    expect(new Set(CROSS_PRODUCT.map((c) => `${c.origin}/${c.deposit}/${c.allowance}`)).size).toBe(24);
+    expect(CROSS_PRODUCT).toHaveLength(30);
+    expect(new Set(CROSS_PRODUCT.map((c) => `${c.origin}/${c.deposit}/${c.allowance}`)).size).toBe(30);
   });
 
   for (const cell of CROSS_PRODUCT) {
@@ -138,7 +145,7 @@ describe("approve-step guard - the state cross-product", () => {
         },
       );
       if (cell.refusal === null) {
-        expect(verdict).toEqual({ ok: true, spender: DEPOSIT_TARGET, allowance: PRINCIPAL });
+        expect(verdict).toEqual({ ok: true, spender: DEPOSIT_TARGET, allowance });
       } else {
         expect(verdict.ok).toBe(false);
         if (!verdict.ok) expect(verdict.reason).toBe(cell.refusal);
@@ -181,8 +188,12 @@ describe("approve-step guard - rule 1, the spender must be this plan's deposit",
 });
 
 describe("approve-step guard - rule 2, the token, the sender and the exact allowance", () => {
-  const bind = (call: ApproveStepCall, principalRaw: bigint | null = PRINCIPAL): Erc20ApproveStepVerdict =>
-    verifyApproveStepBindsPlanAmount(call, { originToken: USDC, wallet: WALLET, principalRaw });
+  const bind = (
+    call: ApproveStepCall,
+    principalRaw: bigint | null = PRINCIPAL,
+    originToken: string | null = USDC,
+  ): Erc20ApproveStepVerdict =>
+    verifyApproveStepBindsPlan(call, { originToken, wallet: WALLET, principalRaw });
 
   it("refuses an approval on a token that is not the origin currency", () => {
     const verdict = bind({ to: DAI, data: approveData(DEPOSIT_TARGET, PRINCIPAL), value: 0n });
@@ -211,6 +222,126 @@ describe("approve-step guard - rule 2, the token, the sender and the exact allow
     expect(verdict.ok).toBe(false);
     if (!verdict.ok) expect(verdict.detail).toContain(`${UNLIMITED}`);
     if (!verdict.ok) expect(verdict.detail).toContain(`${PRINCIPAL}`);
+  });
+});
+
+// ── The zero reset: exempt from the amount, from nothing else ───────────────
+//
+// A non-standard token requires `approve(spender, 0)` before a new grant, so
+// binding the reset's zero to the principal would refuse the one sequence such
+// a token needs. Everything ELSE a grant must satisfy, a reset must satisfy:
+// `approve(x, 0)` on a token the user is not bridging, or from an account that
+// is not theirs, is an unauthorized state change on their own asset paid for
+// with their own gas.
+
+describe("approve-step guard - a zero reset gets every check except the amount", () => {
+  const reset = (over: Partial<ApproveStepCall> = {}): ApproveStepCall => ({
+    to: USDC, data: approveData(DEPOSIT_TARGET, 0n), value: 0n, from: WALLET, ...over,
+  });
+
+  it("accepts the reset a non-standard token needs, on the origin token, from the wallet", () => {
+    expect(bindReset(reset())).toEqual({ ok: true, spender: DEPOSIT_TARGET, allowance: 0n });
+  });
+
+  it("refuses a reset on a token that is not the origin currency", () => {
+    const verdict = bindReset(reset({ to: DAI }));
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("token_not_origin_currency");
+  });
+
+  it("refuses a reset sent from an address that is not the selected wallet", () => {
+    const verdict = bindReset(reset({ from: STRANGER }));
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("sender_not_selected_wallet");
+  });
+
+  it("refuses a reset when the origin asset is the chain's native currency", () => {
+    const verdict = verifyApproveStepBindsPlan(reset(), { originToken: null, wallet: WALLET, principalRaw: PRINCIPAL });
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("approve_on_native_origin");
+  });
+
+  it("refuses a reset whose spender is not this plan's deposit target", () => {
+    const verdict = verifyApproveStepAuthorizesDeposit(
+      { to: USDC, data: approveData(STRANGER, 0n), value: 0n },
+      { depositTarget: DEPOSIT_TARGET },
+    );
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("spender_not_deposit_target");
+  });
+
+  it("accepts a reset even when Vex derived no principal: zero binds to nothing", () => {
+    expect(verifyApproveStepBindsPlan(reset(), { originToken: USDC, wallet: WALLET, principalRaw: null }).ok).toBe(true);
+  });
+
+  function bindReset(call: ApproveStepCall): Erc20ApproveStepVerdict {
+    return verifyApproveStepBindsPlan(call, { originToken: USDC, wallet: WALLET, principalRaw: PRINCIPAL });
+  }
+});
+
+// ── The order: reset -> exact grant -> deposit, and nothing else ────────────
+
+describe("verifyApprovalSequence - the only approval shape a bridge may sign", () => {
+  const GRANT = PRINCIPAL;
+
+  it("accepts a plan with no approval at all", () => {
+    expect(verifyApprovalSequence([], 0)).toEqual({ ok: true });
+  });
+
+  it("accepts one grant before the deposit", () => {
+    expect(verifyApprovalSequence([{ position: 0, allowance: GRANT }], 1)).toEqual({ ok: true });
+  });
+
+  it("accepts reset then grant, both before the deposit", () => {
+    expect(verifyApprovalSequence(
+      [{ position: 0, allowance: 0n }, { position: 1, allowance: GRANT }],
+      2,
+    )).toEqual({ ok: true });
+  });
+
+  it("refuses a grant sequenced AFTER the deposit", () => {
+    const verdict = verifyApprovalSequence([{ position: 1, allowance: GRANT }], 0);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("approve_after_deposit");
+  });
+
+  it("refuses a reset-only plan, which is a bare revocation", () => {
+    const verdict = verifyApprovalSequence([{ position: 0, allowance: 0n }], 1);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("allowance_reset_without_grant");
+  });
+
+  it("refuses a reset sequenced after its grant, which would leave the deposit unfunded", () => {
+    const verdict = verifyApprovalSequence(
+      [{ position: 0, allowance: GRANT }, { position: 1, allowance: 0n }],
+      2,
+    );
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("allowance_reset_after_grant");
+  });
+
+  it("refuses two grants", () => {
+    const verdict = verifyApprovalSequence(
+      [{ position: 0, allowance: GRANT }, { position: 1, allowance: GRANT }],
+      2,
+    );
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("extra_approve_step");
+  });
+
+  it("refuses two resets", () => {
+    const verdict = verifyApprovalSequence(
+      [{ position: 0, allowance: 0n }, { position: 1, allowance: 0n }, { position: 2, allowance: GRANT }],
+      3,
+    );
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("extra_approve_step");
+  });
+
+  it("refuses any approval in a plan that makes no deposit call", () => {
+    const verdict = verifyApprovalSequence([{ position: 0, allowance: GRANT }], null);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) expect(verdict.reason).toBe("plan_has_no_deposit_call");
   });
 });
 

--- a/src/__tests__/tools/khalani/approve-step-binding.test.ts
+++ b/src/__tests__/tools/khalani/approve-step-binding.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Khalani: a provider approval never becomes a planned leg unless it is bound
+ * to the deposit call the same plan makes.
+ *
+ * WHY THIS SUITE EXISTS. `planKhalaniDepositLegs` decoded a CONTRACT_CALL
+ * plan's approvals only to STAMP the deposit leg with the spenders its confirm
+ * site may look for. Nothing compared them: an `approve(stranger, 2^256-1)` on
+ * the user's origin token planned, signed and left a standing allowance behind.
+ *
+ * NOTHING IS SIGNED ON A REFUSAL, structurally: the planner is network-free and
+ * throws INSTEAD OF RETURNING legs, and every signer downstream
+ * (`signStageKhalaniLeg`) takes a planned leg as its argument. No legs, no
+ * signature, and no `agent_activity` row either, since the handler creates rows
+ * from the returned plan.
+ *
+ * WHAT THIS PLANNER CANNOT YET PROVE, and the reason it is not asserted here:
+ * `ContractCallDepositPlan` carries only the approvals, and the caller passes
+ * the chain and the fee leg, so the origin token and the bridged principal do
+ * not reach this function. The allowance bound (`verifyApproveStepBindsPlanAmount`)
+ * therefore runs on Relay only until `fromToken` and `bridgedAmountRaw` are
+ * threaded in from the handler, which is the named follow-up.
+ *
+ * Shapes are live: the 2026-09-04 `/v1/deposit/build` CONTRACT_CALL plan for
+ * Base USDC approved EXACTLY the quoted input to the deposit call's own target,
+ * and the TRANSFER plan for the same route carried no approvals at all.
+ */
+
+import { describe, expect, it } from "vitest";
+import { encodeFunctionData, getAddress } from "viem";
+
+import { planKhalaniDepositLegs } from "@tools/khalani/bridge-executor.js";
+import type { DepositPlan, KhalaniChain } from "@tools/khalani/types.js";
+
+const USDC = getAddress("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+const DEPOSIT_TARGET = getAddress("0x1A7c327d0f402AEf2eD3D20D1141bD71BA1C317B");
+const STRANGER = getAddress("0x000000000000000000000000000000000000dEaD");
+const WALLET = getAddress("0x33eF6673BD80cB11fcC41b82Bc2181E65cC4d2fA");
+const BASE: KhalaniChain = { id: 8453, name: "Base", type: "eip155" } as KhalaniChain;
+
+const PRINCIPAL = 5_000_000n;
+const UNLIMITED = (1n << 256n) - 1n;
+
+const APPROVE_ABI = [{
+  type: "function", name: "approve", stateMutability: "nonpayable",
+  inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+  outputs: [{ name: "", type: "bool" }],
+}] as const;
+
+function approveData(spender: string, allowance: bigint): string {
+  return encodeFunctionData({ abi: APPROVE_ABI, functionName: "approve", args: [getAddress(spender), allowance] });
+}
+
+function send(to: string, data: string, deposit: boolean, value?: string) {
+  return {
+    type: "eip1193_request" as const,
+    deposit,
+    request: { method: "eth_sendTransaction", params: [{ from: WALLET, to, data, ...(value ? { value } : {}) }] },
+  };
+}
+
+function contractCallPlan(...approvals: unknown[]): DepositPlan {
+  return { kind: "CONTRACT_CALL", approvals } as unknown as DepositPlan;
+}
+
+/** The deposit call of the live plan: the target every approval must name. */
+const depositCall = send(DEPOSIT_TARGET, "0xf3125a1f", true);
+
+describe("planKhalaniDepositLegs - a CONTRACT_CALL approval must authorize this plan's deposit", () => {
+  it("plans the live shape: approve(deposit target, quoted input) then the deposit call", () => {
+    const legs = planKhalaniDepositLegs(
+      contractCallPlan(send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false), depositCall),
+      BASE,
+    );
+    expect(legs.map((leg) => leg.role)).toEqual(["allowance", "bridge_deposit"]);
+  });
+
+  it("plans a reset alongside its grant, both naming the deposit target", () => {
+    // Non-standard tokens require `approve(spender, 0)` before a new grant, and
+    // the leg vocabulary names the reset. Counting GRANTS rather than approval
+    // legs is what keeps that legitimate pattern signable.
+    const legs = planKhalaniDepositLegs(
+      contractCallPlan(
+        send(USDC, approveData(DEPOSIT_TARGET, 0n), false),
+        send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false),
+        depositCall,
+      ),
+      BASE,
+    );
+    expect(legs.map((leg) => leg.role)).toEqual(["allowance_reset", "allowance", "bridge_deposit"]);
+  });
+
+  const refused: readonly (readonly [string, unknown[]])[] = [
+    ["an allowance granted to an address the plan never calls",
+      [send(USDC, approveData(STRANGER, PRINCIPAL), false), depositCall]],
+    ["an unlimited allowance granted to a stranger",
+      [send(USDC, approveData(STRANGER, UNLIMITED), false), depositCall]],
+    ["an approval carrying native value",
+      [send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false, "0x1"), depositCall]],
+    ["a non-deposit call that is not an approval at all",
+      [send(USDC, "0xa9059cbb", false), depositCall]],
+    ["trailing bytes after a canonical approve",
+      [send(USDC, `${approveData(DEPOSIT_TARGET, PRINCIPAL)}deadbeef`, false), depositCall]],
+    ["a second GRANT in one plan",
+      [
+        send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false),
+        send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false),
+        depositCall,
+      ]],
+  ];
+
+  for (const [label, approvals] of refused) {
+    it(`refuses ${label}, returning no legs to sign`, () => {
+      expect(() => planKhalaniDepositLegs(contractCallPlan(...approvals), BASE))
+        .toThrow(/refused before signing the khalani token approval/i);
+    });
+  }
+
+  it("states that nothing was signed and names the remedy", () => {
+    try {
+      planKhalaniDepositLegs(
+        contractCallPlan(send(USDC, approveData(STRANGER, UNLIMITED), false), depositCall),
+        BASE,
+      );
+      expect.unreachable("an approval to a stranger must not plan");
+    } catch (err) {
+      const error = err as { code?: string; message?: string; hint?: string };
+      expect(error.code).toBe("KHALANI_DEPOSIT_FAILED");
+      expect(error.message).toMatch(/nothing was signed or broadcast/i);
+      expect(error.hint).toMatch(/khalani__bridge_quote/);
+    }
+  });
+
+  it("leaves the Vex fee leg out of the rule: it is a transfer Vex itself built", () => {
+    const legs = planKhalaniDepositLegs(
+      contractCallPlan(send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false), depositCall),
+      BASE,
+      { tokenAddress: USDC, feeRaw: 12_500n },
+    );
+    expect(legs.map((leg) => leg.purpose)).toEqual(["bridge", "bridge", "vex_fee"]);
+  });
+});
+
+describe("planKhalaniDepositLegs - a TRANSFER deposit has no approval to bind", () => {
+  it("plans the single Vex-built transfer, as the live TRANSFER plan describes it", () => {
+    const legs = planKhalaniDepositLegs(
+      {
+        kind: "TRANSFER",
+        depositAddress: "0x4cC2210F9534DD393bfF110B826571871fda57E9",
+        token: USDC,
+        amount: PRINCIPAL.toString(),
+        chainId: 8453,
+      } as unknown as DepositPlan,
+      BASE,
+    );
+    expect(legs).toHaveLength(1);
+    expect(legs[0]!.isDeposit).toBe(true);
+    // No approval leg exists, so no allowance is granted to anyone by this plan.
+    expect(legs.filter((leg) => leg.role === "allowance")).toHaveLength(0);
+  });
+});

--- a/src/__tests__/tools/khalani/approve-step-binding.test.ts
+++ b/src/__tests__/tools/khalani/approve-step-binding.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { encodeFunctionData, getAddress } from "viem";
+import { encodeAbiParameters, encodeFunctionData, getAddress } from "viem";
 
 import { planKhalaniDepositLegs } from "@tools/khalani/bridge-executor.js";
 import type {
@@ -270,5 +270,107 @@ describe("planKhalaniDepositLegs - a TRANSFER deposit has no approval to bind", 
     expect(first?.isDeposit).toBe(true);
     // No approval leg exists, so no allowance is granted to anyone by this plan.
     expect(legs.filter((leg) => leg.role === "allowance")).toHaveLength(0);
+  });
+});
+
+// ── The order, by LEG ORDER ────────────────────────────────────────────────
+
+describe("planKhalaniDepositLegs - reset then grant then deposit, and nothing else", () => {
+  const rejected: readonly (readonly [string, EvmApproval[]])[] = [
+    ["a grant sequenced AFTER the deposit", [depositCall, send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false)]],
+    ["a reset sequenced AFTER the deposit", [depositCall, send(USDC, approveData(DEPOSIT_TARGET, 0n), false)]],
+    ["a reset-only plan, which grants nothing the deposit could spend", [
+      send(USDC, approveData(DEPOSIT_TARGET, 0n), false),
+      depositCall,
+    ]],
+    ["a reset placed after its own grant", [
+      send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false),
+      send(USDC, approveData(DEPOSIT_TARGET, 0n), false),
+      depositCall,
+    ]],
+    ["two resets before the grant", [
+      send(USDC, approveData(DEPOSIT_TARGET, 0n), false),
+      send(USDC, approveData(DEPOSIT_TARGET, 0n), false),
+      send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false),
+      depositCall,
+    ]],
+  ];
+
+  for (const [label, approvals] of rejected) {
+    it(`refuses ${label}, returning no legs to sign`, () => {
+      expect(() => planKhalaniDepositLegs(contractCallPlan(...approvals), BASE, null, ORIGIN))
+        .toThrow(/refused before signing the khalani token approval/i);
+    });
+  }
+});
+
+// ── A zero reset gets every check except the amount ─────────────────────────
+
+describe("planKhalaniDepositLegs - a reset is bound like a grant, minus the amount", () => {
+  const resetNegatives: readonly (readonly [string, EvmApproval, typeof ORIGIN])[] = [
+    ["a reset on a token that is not the origin currency",
+      send(FOREIGN_TOKEN, approveData(DEPOSIT_TARGET, 0n), false), ORIGIN],
+    ["a reset sent from an address that is not the selected wallet",
+      {
+        type: "eip1193_request" as const,
+        deposit: false,
+        request: {
+          method: "eth_sendTransaction",
+          params: [{ from: STRANGER, to: USDC, data: approveData(DEPOSIT_TARGET, 0n) }],
+        },
+      },
+      ORIGIN],
+    ["a reset when the origin asset is the chain's native currency",
+      send(USDC, approveData(DEPOSIT_TARGET, 0n), false), { ...ORIGIN, fromToken: "native" }],
+    ["a reset naming a spender the plan never calls",
+      send(USDC, approveData(STRANGER, 0n), false), ORIGIN],
+  ];
+
+  for (const [label, reset, origin] of resetNegatives) {
+    it(`refuses ${label}`, () => {
+      expect(() => planKhalaniDepositLegs(
+        contractCallPlan(reset, send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false), depositCall),
+        BASE,
+        null,
+        origin,
+      )).toThrow(/refused before signing the khalani token approval/i);
+    });
+  }
+});
+
+// ── The deposit call itself ────────────────────────────────────────────────
+
+describe("planKhalaniDepositLegs - the deposit selector is recorded, not trusted", () => {
+  it("plans the live CONTRACT_CALL deposit whose selector no authority confirms", () => {
+    // `0xf3125a1f` is unverified: the target is unverified on the Base explorer
+    // and on Sourcify, and Khalani publishes no deposit ABI. Refusing it would
+    // break honest traffic, so it is recorded and the receipt floor guards the
+    // money instead.
+    const legs = planKhalaniDepositLegs(
+      contractCallPlan(send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false), depositCall),
+      BASE,
+      null,
+      ORIGIN,
+    );
+    expect(legs.filter((leg) => leg.isDeposit)).toHaveLength(1);
+  });
+
+  it("refuses a CONFIRMED deposit selector that would move less than the principal", () => {
+    // `depositErc20(address,address,uint256,bytes32)` is confirmed against the
+    // verified RelayDepository source; a Khalani plan that used it would be
+    // bound exactly as the Relay one is.
+    const body = encodeAbiParameters(
+      [{ type: "address" }, { type: "address" }, { type: "uint256" }, { type: "bytes32" }],
+      [WALLET, USDC, 1n, `0x${"11".repeat(32)}`],
+    );
+    expect(() => planKhalaniDepositLegs(
+      contractCallPlan(
+        send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false),
+        send(DEPOSIT_TARGET, `0xe8017952${body.slice(2)}`, true),
+      ),
+      BASE,
+      null,
+      ORIGIN,
+    )).toThrow(/refused before signing the khalani deposit/i);
   });
 });

--- a/src/__tests__/tools/khalani/approve-step-binding.test.ts
+++ b/src/__tests__/tools/khalani/approve-step-binding.test.ts
@@ -13,12 +13,12 @@
  * signature, and no `agent_activity` row either, since the handler creates rows
  * from the returned plan.
  *
- * WHAT THIS PLANNER CANNOT YET PROVE, and the reason it is not asserted here:
- * `ContractCallDepositPlan` carries only the approvals, and the caller passes
- * the chain and the fee leg, so the origin token and the bridged principal do
- * not reach this function. The allowance bound (`verifyApproveStepBindsPlanAmount`)
- * therefore runs on Relay only until `fromToken` and `bridgedAmountRaw` are
- * threaded in from the handler, which is the named follow-up.
+ * BOTH RULES ARE ASSERTED HERE. The caller now hands the planner Vex's own view
+ * of the bridge (`KhalaniDepositOriginBinding`: the origin token, the selected
+ * wallet, and the post-fee principal the handler quoted), so the allowance bound
+ * `verifyApproveStepBindsPlanAmount` runs on Khalani exactly as it does on
+ * Relay: an allowance that is unlimited, larger, or smaller than the principal
+ * refuses, and so does an approval on any token that is not the origin currency.
  *
  * Shapes are live: the 2026-09-04 `/v1/deposit/build` CONTRACT_CALL plan for
  * Base USDC approved EXACTLY the quoted input to the deposit call's own target,
@@ -29,7 +29,12 @@ import { describe, expect, it } from "vitest";
 import { encodeFunctionData, getAddress } from "viem";
 
 import { planKhalaniDepositLegs } from "@tools/khalani/bridge-executor.js";
-import type { DepositPlan, KhalaniChain } from "@tools/khalani/types.js";
+import type {
+  ContractCallDepositPlan,
+  EvmApproval,
+  KhalaniChain,
+  TransferDepositPlan,
+} from "@tools/khalani/types.js";
 
 const USDC = getAddress("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
 const DEPOSIT_TARGET = getAddress("0x1A7c327d0f402AEf2eD3D20D1141bD71BA1C317B");
@@ -39,6 +44,15 @@ const BASE: KhalaniChain = { id: 8453, name: "Base", type: "eip155" } as Khalani
 
 const PRINCIPAL = 5_000_000n;
 const UNLIMITED = (1n << 256n) - 1n;
+const FOREIGN_TOKEN = getAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+
+/**
+ * What Vex itself decided: the origin currency of this bridge, the selected
+ * wallet, and the exact post-fee principal it asked Khalani to move. Every
+ * number here is Vex's own, which is what makes rule 2 a BOUND rather than a
+ * restatement of what the provider sent back.
+ */
+const ORIGIN = { fromToken: USDC, wallet: WALLET, bridgedAmountRaw: PRINCIPAL.toString() };
 
 const APPROVE_ABI = [{
   type: "function", name: "approve", stateMutability: "nonpayable",
@@ -50,16 +64,16 @@ function approveData(spender: string, allowance: bigint): string {
   return encodeFunctionData({ abi: APPROVE_ABI, functionName: "approve", args: [getAddress(spender), allowance] });
 }
 
-function send(to: string, data: string, deposit: boolean, value?: string) {
+function send(to: string, data: string, deposit: boolean, value?: string): EvmApproval {
   return {
-    type: "eip1193_request" as const,
+    type: "eip1193_request",
     deposit,
     request: { method: "eth_sendTransaction", params: [{ from: WALLET, to, data, ...(value ? { value } : {}) }] },
   };
 }
 
-function contractCallPlan(...approvals: unknown[]): DepositPlan {
-  return { kind: "CONTRACT_CALL", approvals } as unknown as DepositPlan;
+function contractCallPlan(...approvals: EvmApproval[]): ContractCallDepositPlan {
+  return { kind: "CONTRACT_CALL", approvals };
 }
 
 /** The deposit call of the live plan: the target every approval must name. */
@@ -70,6 +84,8 @@ describe("planKhalaniDepositLegs - a CONTRACT_CALL approval must authorize this 
     const legs = planKhalaniDepositLegs(
       contractCallPlan(send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false), depositCall),
       BASE,
+      null,
+      ORIGIN,
     );
     expect(legs.map((leg) => leg.role)).toEqual(["allowance", "bridge_deposit"]);
   });
@@ -85,6 +101,8 @@ describe("planKhalaniDepositLegs - a CONTRACT_CALL approval must authorize this 
         depositCall,
       ),
       BASE,
+      null,
+      ORIGIN,
     );
     expect(legs.map((leg) => leg.role)).toEqual(["allowance_reset", "allowance", "bridge_deposit"]);
   });
@@ -106,11 +124,35 @@ describe("planKhalaniDepositLegs - a CONTRACT_CALL approval must authorize this 
         send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false),
         depositCall,
       ]],
+    // Rule 2: the allowance is bound to the principal VEX derived, so the
+    // genuine deposit target buys the provider nothing. An unlimited grant to
+    // the real router still leaves standing authority behind after the bridge,
+    // which is the whole reason a wallet calls those out.
+    ["an UNLIMITED allowance granted to the genuine deposit target",
+      [send(USDC, approveData(DEPOSIT_TARGET, UNLIMITED), false), depositCall]],
+    ["an allowance LARGER than the principal, on the genuine deposit target",
+      [send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL + 1n), false), depositCall]],
+    ["an allowance SMALLER than the principal, which could not fund the deposit",
+      [send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL - 1n), false), depositCall]],
+    ["an approval on a token that is not the origin currency",
+      [send(FOREIGN_TOKEN, approveData(DEPOSIT_TARGET, PRINCIPAL), false), depositCall]],
+    ["an approval sent from an address that is not the selected wallet",
+      [
+        {
+          type: "eip1193_request" as const,
+          deposit: false,
+          request: {
+            method: "eth_sendTransaction",
+            params: [{ from: STRANGER, to: USDC, data: approveData(DEPOSIT_TARGET, PRINCIPAL) }],
+          },
+        },
+        depositCall,
+      ]],
   ];
 
   for (const [label, approvals] of refused) {
     it(`refuses ${label}, returning no legs to sign`, () => {
-      expect(() => planKhalaniDepositLegs(contractCallPlan(...approvals), BASE))
+      expect(() => planKhalaniDepositLegs(contractCallPlan(...approvals), BASE, null, ORIGIN))
         .toThrow(/refused before signing the khalani token approval/i);
     });
   }
@@ -120,6 +162,8 @@ describe("planKhalaniDepositLegs - a CONTRACT_CALL approval must authorize this 
       planKhalaniDepositLegs(
         contractCallPlan(send(USDC, approveData(STRANGER, UNLIMITED), false), depositCall),
         BASE,
+        null,
+        ORIGIN,
       );
       expect.unreachable("an approval to a stranger must not plan");
     } catch (err) {
@@ -135,25 +179,95 @@ describe("planKhalaniDepositLegs - a CONTRACT_CALL approval must authorize this 
       contractCallPlan(send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false), depositCall),
       BASE,
       { tokenAddress: USDC, feeRaw: 12_500n },
+      ORIGIN,
     );
     expect(legs.map((leg) => leg.purpose)).toEqual(["bridge", "bridge", "vex_fee"]);
   });
 });
 
+describe("planKhalaniDepositLegs - rule 2 binds the allowance to Vex's own principal", () => {
+  it("names the exact allowance and the exact principal in the refusal", () => {
+    try {
+      planKhalaniDepositLegs(
+        contractCallPlan(send(USDC, approveData(DEPOSIT_TARGET, UNLIMITED), false), depositCall),
+        BASE,
+        null,
+        ORIGIN,
+      );
+      expect.unreachable("an unlimited allowance must not plan");
+    } catch (err) {
+      const error = err as { code?: string; message?: string; hint?: string };
+      expect(error.code).toBe("KHALANI_DEPOSIT_FAILED");
+      expect(error.message).toContain(UNLIMITED.toString());
+      expect(error.message).toContain(PRINCIPAL.toString());
+      expect(error.message).toMatch(/nothing was signed or broadcast/i);
+      // The same remediation the Relay side gives: re-quote this route.
+      expect(error.hint).toMatch(/khalani__bridge_quote/);
+    }
+  });
+
+  it("refuses when Vex derived no readable principal at all", () => {
+    // Fail-closed: an allowance can only be bound to a number Vex actually has.
+    expect(() => planKhalaniDepositLegs(
+      contractCallPlan(send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false), depositCall),
+      BASE,
+      null,
+      { ...ORIGIN, bridgedAmountRaw: "" },
+    )).toThrow(/refused before signing the khalani token approval/i);
+  });
+
+  it("refuses every approval when the origin asset is the native currency", () => {
+    // A native origin has no token contract, so no approval in the plan can be
+    // legitimate however well-formed it looks.
+    expect(() => planKhalaniDepositLegs(
+      contractCallPlan(send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false), depositCall),
+      BASE,
+      null,
+      { ...ORIGIN, fromToken: "native" },
+    )).toThrow(/refused before signing the khalani token approval/i);
+  });
+
+  it("plans the reset-then-grant sequence: the zero reset is exempt, the grant is bound", () => {
+    const legs = planKhalaniDepositLegs(
+      contractCallPlan(
+        send(USDC, approveData(DEPOSIT_TARGET, 0n), false),
+        send(USDC, approveData(DEPOSIT_TARGET, PRINCIPAL), false),
+        depositCall,
+      ),
+      BASE,
+      null,
+      ORIGIN,
+    );
+    expect(legs.map((leg) => leg.role)).toEqual(["allowance_reset", "allowance", "bridge_deposit"]);
+  });
+
+  it("refuses a reset whose grant is unlimited, so the reset alone plans nothing", () => {
+    expect(() => planKhalaniDepositLegs(
+      contractCallPlan(
+        send(USDC, approveData(DEPOSIT_TARGET, 0n), false),
+        send(USDC, approveData(DEPOSIT_TARGET, UNLIMITED), false),
+        depositCall,
+      ),
+      BASE,
+      null,
+      ORIGIN,
+    )).toThrow(/refused before signing the khalani token approval/i);
+  });
+});
+
 describe("planKhalaniDepositLegs - a TRANSFER deposit has no approval to bind", () => {
   it("plans the single Vex-built transfer, as the live TRANSFER plan describes it", () => {
-    const legs = planKhalaniDepositLegs(
-      {
-        kind: "TRANSFER",
-        depositAddress: "0x4cC2210F9534DD393bfF110B826571871fda57E9",
-        token: USDC,
-        amount: PRINCIPAL.toString(),
-        chainId: 8453,
-      } as unknown as DepositPlan,
-      BASE,
-    );
+    const transfer: TransferDepositPlan = {
+      kind: "TRANSFER",
+      depositAddress: "0x4cC2210F9534DD393bfF110B826571871fda57E9",
+      token: USDC,
+      amount: PRINCIPAL.toString(),
+      chainId: 8453,
+    };
+    const legs = planKhalaniDepositLegs(transfer, BASE, null, ORIGIN);
     expect(legs).toHaveLength(1);
-    expect(legs[0]!.isDeposit).toBe(true);
+    const first = legs.at(0);
+    expect(first?.isDeposit).toBe(true);
     // No approval leg exists, so no allowance is granted to anyone by this plan.
     expect(legs.filter((leg) => leg.role === "allowance")).toHaveLength(0);
   });

--- a/src/__tests__/tools/relay/approve-step-binding.test.ts
+++ b/src/__tests__/tools/relay/approve-step-binding.test.ts
@@ -282,6 +282,42 @@ describe("classifyRelayBridgeSteps - reset then grant then deposit, and nothing 
   }
 });
 
+// ── Exactly one deposit ────────────────────────────────────────────────────
+//
+// The approve binding proves ONE grant equal to the principal. It says nothing
+// about how many times that grant is spent, and a quote may legitimately carry
+// no approval at all when an allowance already exists. A step list with two
+// deposits would move the principal twice on one consent, so the count is the
+// step policy's own invariant - it is the only gate that sees the whole list.
+
+describe("classifyRelayBridgeSteps - a plain bridge deposits exactly once", () => {
+  it("rejects a second deposit step against one exact-principal approval", () => {
+    const result = classifyRelayBridgeSteps(
+      quote(approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL)), depositStep(), depositStep()),
+      ORIGIN,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("unsupported_deposit_step_count");
+      expect(result.detail).toMatch(/nothing was signed/i);
+      expect(result.detail).toMatch(/relay__bridge_quote_get/);
+    }
+    // No step list is returned, so the handler has nothing to broadcast.
+    expect("steps" in result).toBe(false);
+  });
+
+  it("rejects two deposit steps on a standing allowance, where no approve step exists at all", () => {
+    const result = classifyRelayBridgeSteps(quote(depositStep(), depositStep()), ORIGIN);
+    expect(result).toMatchObject({ ok: false, reason: "unsupported_deposit_step_count" });
+    expect("steps" in result).toBe(false);
+  });
+
+  it("accepts the single-deposit shape unchanged", () => {
+    expect(classifyRelayBridgeSteps(quote(approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL)), depositStep()), ORIGIN).ok)
+      .toBe(true);
+  });
+});
+
 // ── The deposit call itself ────────────────────────────────────────────────
 //
 // The exact allowance proves what the depository MAY pull; only the deposit
@@ -314,6 +350,26 @@ describe("planRelayStepTx - the deposit moves exactly the principal", () => {
         .toThrow(/refused before signing the relay deposit/i);
     });
   }
+
+  it("refuses the allowance-pulling overload, which encodes no amount to bind", () => {
+    // `depositErc20(depositor, token, id)` pulls the whole EFFECTIVE allowance.
+    // This plan may carry no approve step at all (Relay omits it on a standing
+    // allowance), so nothing here proves that allowance is the principal.
+    const body = encodeAbiParameters(
+      [{ type: "address" }, { type: "address" }, { type: "bytes32" }],
+      [WALLET, USDC, `0x${"11".repeat(32)}`],
+    );
+    try {
+      planRelayStepTx(depositStep(`0x5a1ee3ac${body.slice(2)}`), ORIGIN, WALLET, depositContext());
+      expect.unreachable("an amount-free deposit overload must not plan");
+    } catch (err) {
+      const error = err as { code?: string; message?: string; hint?: string };
+      expect(error.code).toBe("RELAY_BRIDGE_FAILED");
+      expect(error.message).toMatch(/refused before signing the relay deposit/i);
+      expect(error.message).toContain("0x5a1ee3ac");
+      expect(error.hint).toMatch(/fresh relay__bridge_quote_get/);
+    }
+  });
 
   it("records rather than refuses a selector no authority confirms", () => {
     // Refusing an unconfirmed selector would break honest traffic the moment

--- a/src/__tests__/tools/relay/approve-step-binding.test.ts
+++ b/src/__tests__/tools/relay/approve-step-binding.test.ts
@@ -42,6 +42,7 @@ const { planRelayStepTx } = await import("@tools/relay/execute.js");
 const { classifyRelayBridgeSteps } = await import("@tools/relay/step-policy.js");
 
 import type { RelayStepNativeValueContext } from "@tools/relay/native-value.js";
+import { RelayQuoteResponseSchema, RelayStepSchema } from "@tools/relay/types.js";
 import type { RelayQuoteResponse, RelayStep } from "@tools/relay/types.js";
 
 const ORIGIN = 8453;
@@ -67,23 +68,23 @@ function approveData(spender: string, allowance: bigint): string {
 }
 
 function approveStep(data: string, over: { to?: string; value?: string } = {}): RelayStep {
-  return {
+  return RelayStepSchema.parse({
     id: "approve",
     kind: "transaction",
     items: [{ data: { to: over.to ?? USDC, value: over.value ?? "0", data, chainId: ORIGIN } }],
-  } as unknown as RelayStep;
+  });
 }
 
 function depositStep(): RelayStep {
-  return {
+  return RelayStepSchema.parse({
     id: "deposit",
     kind: "transaction",
     items: [{ data: { to: DEPOSIT_TARGET, value: "0", data: "0xe8017952", chainId: ORIGIN } }],
-  } as unknown as RelayStep;
+  });
 }
 
 function quote(...steps: RelayStep[]): RelayQuoteResponse {
-  return { steps } as unknown as RelayQuoteResponse;
+  return RelayQuoteResponseSchema.parse({ steps });
 }
 
 function allowanceContext(over: Partial<RelayStepNativeValueContext> = {}): RelayStepNativeValueContext {
@@ -176,11 +177,11 @@ describe("planRelayStepTx - the allowance is bound to the principal Vex derived"
   }
 
   it("refuses an approval whose declared sender is not the selected wallet", () => {
-    const step = {
+    const step = RelayStepSchema.parse({
       id: "approve",
       kind: "transaction",
       items: [{ data: { from: STRANGER, to: USDC, value: "0", data: approveData(DEPOSIT_TARGET, PRINCIPAL), chainId: ORIGIN } }],
-    } as unknown as RelayStep;
+    });
     // The planner's own sender check fires first; either way nothing is signed.
     expect(() => planRelayStepTx(step, ORIGIN, WALLET, allowanceContext())).toThrow(/sender|wallet/i);
   });

--- a/src/__tests__/tools/relay/approve-step-binding.test.ts
+++ b/src/__tests__/tools/relay/approve-step-binding.test.ts
@@ -41,6 +41,8 @@ vi.mock("@tools/relay/client.js", () => ({
 const { planRelayStepTx } = await import("@tools/relay/execute.js");
 const { classifyRelayBridgeSteps } = await import("@tools/relay/step-policy.js");
 
+import { encodeAbiParameters } from "viem";
+
 import type { RelayStepNativeValueContext } from "@tools/relay/native-value.js";
 import { RelayQuoteResponseSchema, RelayStepSchema } from "@tools/relay/types.js";
 import type { RelayQuoteResponse, RelayStep } from "@tools/relay/types.js";
@@ -75,11 +77,30 @@ function approveStep(data: string, over: { to?: string; value?: string } = {}): 
   });
 }
 
-function depositStep(): RelayStep {
+/**
+ * `depositErc20(depositor, token, amount, id)` as the live Relay quotes carry
+ * it: selector `0xe8017952`, four words, the requested input as the amount.
+ * The signature is the one published in the verified `RelayDepository` source
+ * for this very target address.
+ */
+function depositErc20Data(over: { depositor?: string; token?: string; amount?: bigint } = {}): string {
+  const body = encodeAbiParameters(
+    [{ type: "address" }, { type: "address" }, { type: "uint256" }, { type: "bytes32" }],
+    [
+      getAddress(over.depositor ?? WALLET),
+      getAddress(over.token ?? USDC),
+      over.amount ?? PRINCIPAL,
+      `0x${"11".repeat(32)}`,
+    ],
+  );
+  return `0xe8017952${body.slice(2)}`;
+}
+
+function depositStep(data: string = depositErc20Data()): RelayStep {
   return RelayStepSchema.parse({
     id: "deposit",
     kind: "transaction",
-    items: [{ data: { to: DEPOSIT_TARGET, value: "0", data: "0xe8017952", chainId: ORIGIN } }],
+    items: [{ data: { to: DEPOSIT_TARGET, value: "0", data, chainId: ORIGIN } }],
   });
 }
 
@@ -186,12 +207,13 @@ describe("planRelayStepTx - the allowance is bound to the principal Vex derived"
     expect(() => planRelayStepTx(step, ORIGIN, WALLET, allowanceContext())).toThrow(/sender|wallet/i);
   });
 
-  it("leaves the deposit step alone: the binding is a rule about approvals only", () => {
+  it("plans the live deposit step: the approve rules are about approvals only", () => {
+    const data = depositErc20Data();
     const tx = planRelayStepTx(depositStep(), ORIGIN, WALLET, allowanceContext({
       role: "bridge_deposit",
       originCurrency: USDC,
     }));
-    expect(tx).toEqual({ to: DEPOSIT_TARGET, data: "0xe8017952", value: 0n });
+    expect(tx).toEqual({ to: DEPOSIT_TARGET, data, value: 0n });
   });
 
   it("states the refusal and the remedy inside the message the agent reads", () => {
@@ -204,5 +226,101 @@ describe("planRelayStepTx - the allowance is bound to the principal Vex derived"
       expect(error.message).toMatch(/nothing was signed or broadcast/i);
       expect(error.hint).toMatch(/fresh relay__bridge_quote_get/);
     }
+  });
+});
+
+// ── The order, by STEP INDEX ────────────────────────────────────────────────
+//
+// Rule 1 and rule 2 both look at ONE approval. Neither looks at WHEN it is
+// signed, and Relay broadcasts its steps in quote order, so an approval that
+// sits after the deposit is a standing allowance created after the only
+// transaction that justified it. A reset with no grant behind it is the mirror
+// image: the user's bridge becomes a bare revocation on their own token.
+
+describe("classifyRelayBridgeSteps - reset then grant then deposit, and nothing else", () => {
+  it("accepts reset then grant then deposit, the sequence a non-standard token needs", () => {
+    const result = classifyRelayBridgeSteps(
+      quote(
+        approveStep(approveData(DEPOSIT_TARGET, 0n)),
+        approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL)),
+        depositStep(),
+      ),
+      ORIGIN,
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  const rejected: readonly (readonly [string, RelayStep[]])[] = [
+    ["a grant sequenced AFTER the deposit", [depositStep(), approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL))]],
+    ["a reset sequenced AFTER the deposit", [
+      depositStep(),
+      approveStep(approveData(DEPOSIT_TARGET, 0n)),
+    ]],
+    ["a reset-only quote, which grants nothing the deposit could spend", [
+      approveStep(approveData(DEPOSIT_TARGET, 0n)),
+      depositStep(),
+    ]],
+    ["a reset placed after its own grant", [
+      approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL)),
+      approveStep(approveData(DEPOSIT_TARGET, 0n)),
+      depositStep(),
+    ]],
+    ["two grants to the deposit target", [
+      approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL)),
+      approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL)),
+      depositStep(),
+    ]],
+  ];
+
+  for (const [label, steps] of rejected) {
+    it(`rejects ${label}, pre-intent, with no step list to sign`, () => {
+      const result = classifyRelayBridgeSteps(quote(...steps), ORIGIN);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("approve_not_bound_to_deposit");
+      expect("steps" in result).toBe(false);
+    });
+  }
+});
+
+// ── The deposit call itself ────────────────────────────────────────────────
+//
+// The exact allowance proves what the depository MAY pull; only the deposit
+// calldata proves what it is ASKED to pull. Relay's two deposit selectors come
+// from the verified `RelayDepository` source for the very address every live
+// capture calls, so both are bound before signing.
+
+describe("planRelayStepTx - the deposit moves exactly the principal", () => {
+  const depositContext = (over: Partial<RelayStepNativeValueContext> = {}): RelayStepNativeValueContext =>
+    allowanceContext({ role: "bridge_deposit", ...over });
+
+  it("plans the live ERC-20 deposit: the origin token, the wallet, the exact principal", () => {
+    const data = depositErc20Data();
+    expect(planRelayStepTx(depositStep(data), ORIGIN, WALLET, depositContext()))
+      .toEqual({ to: DEPOSIT_TARGET, data, value: 0n });
+  });
+
+  const refused: readonly (readonly [string, string])[] = [
+    ["a deposit of one unit against the whole quote", depositErc20Data({ amount: 1n })],
+    ["a deposit of one unit less than the principal", depositErc20Data({ amount: PRINCIPAL - 1n })],
+    ["a deposit of MORE than the principal", depositErc20Data({ amount: PRINCIPAL + 1n })],
+    ["a deposit of a token that is not the origin currency", depositErc20Data({ token: DAI })],
+    ["a deposit credited to somebody who is not the selected wallet", depositErc20Data({ depositor: STRANGER })],
+    ["a confirmed selector with an argument body that will not decode", "0xe801795200"],
+  ];
+
+  for (const [label, data] of refused) {
+    it(`refuses ${label} without producing a signable transaction`, () => {
+      expect(() => planRelayStepTx(depositStep(data), ORIGIN, WALLET, depositContext()))
+        .toThrow(/refused before signing the relay deposit/i);
+    });
+  }
+
+  it("records rather than refuses a selector no authority confirms", () => {
+    // Refusing an unconfirmed selector would break honest traffic the moment
+    // Relay upgrades its router, on nothing but our own ignorance. The receipt
+    // floor stays the money guard for it.
+    const data = `0xabcdef01${"00".repeat(32)}`;
+    expect(planRelayStepTx(depositStep(data), ORIGIN, WALLET, depositContext()))
+      .toEqual({ to: DEPOSIT_TARGET, data, value: 0n });
   });
 });

--- a/src/__tests__/tools/relay/approve-step-binding.test.ts
+++ b/src/__tests__/tools/relay/approve-step-binding.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Relay: a provider approval reaches no signer unless it is bound to the plan.
+ *
+ * WHY THIS SUITE EXISTS. Relay's approve step used to be signed after checks on
+ * the chain, the sender, the address shape and the native value only. The
+ * spender and the allowance were decoded in `broadcast.ts` AFTER planning, to
+ * record evidence, so a quote carrying `approve(stranger, 2^256-1)` on the
+ * origin token was signed and the user's whole balance of that token stayed
+ * drainable afterwards.
+ *
+ * The binding is in two gates because the facts are in two places, and both are
+ * asserted here:
+ *  - `classifyRelayBridgeSteps` (pre-intent, sees every step): one approval at
+ *    most, and its spender must be the deposit step's own target;
+ *  - `planRelayStepTx` (the last call before `signStageBroadcast`): the origin
+ *    token, the selected wallet, and the allowance EXACTLY equal to the
+ *    principal Vex derived.
+ *
+ * NOTHING IS SIGNED ON A REFUSAL, structurally: both are pure functions that
+ * sit upstream of the signer. `classifyRelayBridgeSteps` returns a rejection
+ * instead of a step list, so the handler aborts before an intent, a wallet or a
+ * nonce exists; `planRelayStepTx` throws instead of RETURNING the transaction,
+ * and `signStageBroadcast` can only be reached with a returned transaction (it
+ * is the caller's argument). A refusal therefore reserves no nonce and produces
+ * no signature by construction, not by convention.
+ *
+ * Allowance shapes are the live ones: every ERC-20 quote measured on
+ * 2026-09-04 (base/arbitrum/ethereum USDC, three amounts) approved EXACTLY the
+ * requested input to the deposit step's own target, and the native-origin quote
+ * carried no approval step at all.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { encodeFunctionData, getAddress } from "viem";
+
+vi.mock("@tools/relay/client.js", () => ({
+  getRelayClient: () => ({ getIntentStatus: vi.fn() }),
+  RELAY_INTENT_STATUS_PATH: "/intents/status/v3",
+}));
+
+const { planRelayStepTx } = await import("@tools/relay/execute.js");
+const { classifyRelayBridgeSteps } = await import("@tools/relay/step-policy.js");
+
+import type { RelayStepNativeValueContext } from "@tools/relay/native-value.js";
+import type { RelayQuoteResponse, RelayStep } from "@tools/relay/types.js";
+
+const ORIGIN = 8453;
+const USDC = getAddress("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+const DAI = getAddress("0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb");
+const DEPOSIT_TARGET = getAddress("0x4cD00E387622C35bDDB9b4c962C136462338BC31");
+const STRANGER = getAddress("0x000000000000000000000000000000000000dEaD");
+const WALLET = getAddress("0x33eF6673BD80cB11fcC41b82Bc2181E65cC4d2fA");
+const NATIVE = "0x0000000000000000000000000000000000000000";
+
+/** The post-Vex-fee amount Vex asked Relay to bridge. */
+const PRINCIPAL = 5_000_000n;
+const UNLIMITED = (1n << 256n) - 1n;
+
+const APPROVE_ABI = [{
+  type: "function", name: "approve", stateMutability: "nonpayable",
+  inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+  outputs: [{ name: "", type: "bool" }],
+}] as const;
+
+function approveData(spender: string, allowance: bigint): string {
+  return encodeFunctionData({ abi: APPROVE_ABI, functionName: "approve", args: [getAddress(spender), allowance] });
+}
+
+function approveStep(data: string, over: { to?: string; value?: string } = {}): RelayStep {
+  return {
+    id: "approve",
+    kind: "transaction",
+    items: [{ data: { to: over.to ?? USDC, value: over.value ?? "0", data, chainId: ORIGIN } }],
+  } as unknown as RelayStep;
+}
+
+function depositStep(): RelayStep {
+  return {
+    id: "deposit",
+    kind: "transaction",
+    items: [{ data: { to: DEPOSIT_TARGET, value: "0", data: "0xe8017952", chainId: ORIGIN } }],
+  } as unknown as RelayStep;
+}
+
+function quote(...steps: RelayStep[]): RelayQuoteResponse {
+  return { steps } as unknown as RelayQuoteResponse;
+}
+
+function allowanceContext(over: Partial<RelayStepNativeValueContext> = {}): RelayStepNativeValueContext {
+  return {
+    role: "allowance",
+    originCurrency: USDC,
+    tradeType: "EXACT_INPUT",
+    bridgedAmountRaw: PRINCIPAL.toString(),
+    ...over,
+  };
+}
+
+// ── Gate 1: the closed step policy, pre-intent ──────────────────────────────
+
+describe("classifyRelayBridgeSteps - the approval must authorize this quote's own deposit", () => {
+  it("accepts the live shape: approve(deposit target, amount) then the deposit", () => {
+    const result = classifyRelayBridgeSteps(
+      quote(approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL)), depositStep()),
+      ORIGIN,
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a quote with no approval at all (native origin, or allowance already sufficient)", () => {
+    expect(classifyRelayBridgeSteps(quote(depositStep()), ORIGIN).ok).toBe(true);
+  });
+
+  const rejected: readonly (readonly [string, RelayStep[]])[] = [
+    ["an approval naming a spender the plan never calls", [approveStep(approveData(STRANGER, PRINCIPAL)), depositStep()]],
+    ["an unlimited approval to a stranger", [approveStep(approveData(STRANGER, UNLIMITED)), depositStep()]],
+    ["an approval with no deposit step to authorize", [approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL))]],
+    ["an approval carrying native value", [approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL), { value: "1" }), depositStep()]],
+    ["an approval whose selector is not approve", [approveStep("0xa9059cbb"), depositStep()]],
+    ["an approval with trailing bytes viem would discard", [approveStep(`${approveData(DEPOSIT_TARGET, PRINCIPAL)}deadbeef`), depositStep()]],
+    ["a second approval step", [
+      approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL)),
+      approveStep(approveData(STRANGER, UNLIMITED)),
+      depositStep(),
+    ]],
+  ];
+
+  for (const [label, steps] of rejected) {
+    it(`rejects ${label}, pre-intent, with no step list to sign`, () => {
+      const result = classifyRelayBridgeSteps(quote(...steps), ORIGIN);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("approve_not_bound_to_deposit");
+        // The agent must be able to act: the refusal names a re-quote.
+        expect(result.detail).toMatch(/nothing was signed/i);
+        expect(result.detail).toMatch(/relay__bridge_quote_get/);
+      }
+      // A rejection carries no steps, so the handler has nothing to broadcast.
+      expect("steps" in result).toBe(false);
+    });
+  }
+});
+
+// ── Gate 2: the last call before the signer ─────────────────────────────────
+
+describe("planRelayStepTx - the allowance is bound to the principal Vex derived", () => {
+  it("plans the live shape unchanged: the origin token, zero value, exactly the principal", () => {
+    const tx = planRelayStepTx(
+      approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL)),
+      ORIGIN,
+      WALLET,
+      allowanceContext(),
+    );
+    expect(tx).toEqual({ to: USDC, data: approveData(DEPOSIT_TARGET, PRINCIPAL), value: 0n });
+  });
+
+  const refused: readonly (readonly [string, RelayStep, RelayStepNativeValueContext])[] = [
+    ["an unlimited allowance", approveStep(approveData(DEPOSIT_TARGET, UNLIMITED)), allowanceContext()],
+    ["an allowance larger than the principal", approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL + 1n)), allowanceContext()],
+    ["an allowance smaller than the principal", approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL - 1n)), allowanceContext()],
+    ["an approval on a foreign token", approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL), { to: DAI }), allowanceContext()],
+    ["an approval on a native origin, which has no token to approve",
+      approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL)), allowanceContext({ originCurrency: NATIVE })],
+    ["an unknown selector", approveStep("0xa9059cbb"), allowanceContext()],
+    ["trailing bytes after a canonical approve",
+      approveStep(`${approveData(DEPOSIT_TARGET, PRINCIPAL)}deadbeef`), allowanceContext()],
+    ["a trade type where the derived amount is not the input",
+      approveStep(approveData(DEPOSIT_TARGET, PRINCIPAL)), allowanceContext({ tradeType: "EXACT_OUTPUT" })],
+  ];
+
+  for (const [label, step, context] of refused) {
+    it(`refuses ${label} without producing a signable transaction`, () => {
+      expect(() => planRelayStepTx(step, ORIGIN, WALLET, context))
+        .toThrow(/refused before signing the relay token approval/i);
+    });
+  }
+
+  it("refuses an approval whose declared sender is not the selected wallet", () => {
+    const step = {
+      id: "approve",
+      kind: "transaction",
+      items: [{ data: { from: STRANGER, to: USDC, value: "0", data: approveData(DEPOSIT_TARGET, PRINCIPAL), chainId: ORIGIN } }],
+    } as unknown as RelayStep;
+    // The planner's own sender check fires first; either way nothing is signed.
+    expect(() => planRelayStepTx(step, ORIGIN, WALLET, allowanceContext())).toThrow(/sender|wallet/i);
+  });
+
+  it("leaves the deposit step alone: the binding is a rule about approvals only", () => {
+    const tx = planRelayStepTx(depositStep(), ORIGIN, WALLET, allowanceContext({
+      role: "bridge_deposit",
+      originCurrency: USDC,
+    }));
+    expect(tx).toEqual({ to: DEPOSIT_TARGET, data: "0xe8017952", value: 0n });
+  });
+
+  it("states the refusal and the remedy inside the message the agent reads", () => {
+    try {
+      planRelayStepTx(approveStep(approveData(DEPOSIT_TARGET, UNLIMITED)), ORIGIN, WALLET, allowanceContext());
+      expect.unreachable("an unlimited allowance must not plan");
+    } catch (err) {
+      const error = err as { code?: string; message?: string; hint?: string };
+      expect(error.code).toBe("RELAY_BRIDGE_FAILED");
+      expect(error.message).toMatch(/nothing was signed or broadcast/i);
+      expect(error.hint).toMatch(/fresh relay__bridge_quote_get/);
+    }
+  });
+});

--- a/src/__tests__/tools/relay/native-value-gate.test.ts
+++ b/src/__tests__/tools/relay/native-value-gate.test.ts
@@ -15,7 +15,7 @@
  * regression guard for exactly that.
  */
 import { describe, it, expect, vi } from "vitest";
-import { getAddress } from "viem";
+import { encodeFunctionData, getAddress } from "viem";
 
 // `execute.ts` imports the Relay client module; nothing here polls, but the
 // module must load without a configured client.
@@ -40,12 +40,28 @@ const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 /** The post-Vex-fee amount Vex asked Relay to bridge (0.001 ETH minus 25 bps). */
 const BRIDGED_WEI = "997500000000000";
 
-function step(value: string, data = "0x"): RelayStep {
+function step(value: string, data = "0x", to: string = TO): RelayStep {
   return {
     id: "deposit",
     kind: "transaction",
-    items: [{ data: { to: TO, value, data, chainId: ORIGIN } }],
+    items: [{ data: { to, value, data, chainId: ORIGIN } }],
   } as unknown as RelayStep;
+}
+
+/**
+ * A REAL `approve(deposit target, principal)` blob. The suite used to pass the
+ * bare selector `0x095ea7b3`, which the approve-step guard now refuses as
+ * non-canonical calldata (viem decodes a 4-byte body as nothing at all), so
+ * these cases would have been testing the wrong refusal.
+ */
+const APPROVE_ABI = [{
+  type: "function", name: "approve", stateMutability: "nonpayable",
+  inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+  outputs: [{ name: "", type: "bool" }],
+}] as const;
+
+function approveData(allowanceRaw: bigint, spender: string = TO): string {
+  return encodeFunctionData({ abi: APPROVE_ABI, functionName: "approve", args: [getAddress(spender), allowanceRaw] });
 }
 
 function nativeInDeposit(over: Partial<RelayStepNativeValueContext> = {}): RelayStepNativeValueContext {
@@ -99,9 +115,12 @@ describe("planRelayStepTx — native value must be authorized before signing", (
   it("an allowance step signs at zero value and is REFUSED at any non-zero value", () => {
     // An allowance leg has no principal to claim — it grants a spend, it does
     // not move the user's money — so ANY native value on it is unattributable.
-    const approve: RelayStepNativeValueContext = nativeInDeposit({ role: "allowance" });
-    expect(planRelayStepTx(step("0", "0x095ea7b3"), ORIGIN, FROM, approve).value).toBe(0n);
-    expect(() => planRelayStepTx(step("1", "0x095ea7b3"), ORIGIN, FROM, approve))
+    // An ERC-20 origin, because a native origin has no approval step at all
+    // (measured: every native-origin Relay quote carries only a deposit step).
+    const approve: RelayStepNativeValueContext = erc20Deposit({ role: "allowance" });
+    const data = approveData(BigInt(approve.bridgedAmountRaw));
+    expect(planRelayStepTx(step("0", data, USDC), ORIGIN, FROM, approve).value).toBe(0n);
+    expect(() => planRelayStepTx(step("1", data, USDC), ORIGIN, FROM, approve))
       .toThrow(/could not be attributed/i);
   });
 

--- a/src/__tests__/tools/relay/step-policy.test.ts
+++ b/src/__tests__/tools/relay/step-policy.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { encodeFunctionData, getAddress } from "viem";
 
 import { classifyRelayBridgeSteps, type RelayStepRejectionReason } from "@tools/relay/step-policy.js";
 import type { RelayQuoteResponse } from "@tools/relay/types.js";
@@ -17,8 +18,26 @@ const DEST = 4663;
 const OTHER = 1;
 const TO = "0x2222222222222222222222222222222222222222";
 
+const APPROVE_ABI = [{
+  type: "function", name: "approve", stateMutability: "nonpayable",
+  inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+  outputs: [{ name: "", type: "bool" }],
+}] as const;
+
+/** A canonical `approve(spender, allowance)` blob, as the live quotes carry it. */
+function approveData(spender: string = TO, allowanceRaw = 5_000_000n): string {
+  return encodeFunctionData({ abi: APPROVE_ABI, functionName: "approve", args: [getAddress(spender), allowanceRaw] });
+}
+
+/**
+ * An `approve` step carries REAL approve calldata naming the deposit target:
+ * since the cross-step binding landed, an approval whose blob is not a
+ * canonical `approve` for this plan's own deposit is rejected, so a `0x`
+ * placeholder would test the wrong rule.
+ */
 function step(id: string, kind: string, chainIds: number[]) {
-  return { id, kind, items: chainIds.map((chainId) => ({ data: { to: TO, value: "0", data: "0x", chainId } })) };
+  const data = id === "approve" ? approveData() : "0x";
+  return { id, kind, items: chainIds.map((chainId) => ({ data: { to: TO, value: "0", data, chainId } })) };
 }
 function quote(...steps: unknown[]): RelayQuoteResponse {
   return { steps } as unknown as RelayQuoteResponse;

--- a/src/__tests__/vex-agent/db/repos/agent-activity-abort-planned-events.test.ts
+++ b/src/__tests__/vex-agent/db/repos/agent-activity-abort-planned-events.test.ts
@@ -136,6 +136,32 @@ describe("abortPlannedEvents", () => {
     expect(mockSettleLinkedActivityRowsWith).toHaveBeenCalledTimes(1);
   });
 
+  it("binds the EXCLUSIVE upper bound so a single row can be aborted alone", async () => {
+    // The fee-withholding path aborts `[feeLegIndex, feeLegIndex + 1)`: the fee
+    // row and nothing else, because the logical `bridge_fill_expected` row sits
+    // at the next index and its deposit reached the provider.
+    mockQuery.mockResolvedValueOnce([activityRow({ id: 9, event_index: 3 })]);
+    const rows = await repo.abortPlannedEvents(42, 3, "deposit proved less than the quoted principal", 4);
+
+    const sql = lastSql();
+    expect(sql).toMatch(/event_index\s*>=\s*\$2/);
+    expect(sql).toMatch(/event_index\s*<\s*\$4/);
+    expect(lastParams()).toEqual([
+      42,
+      3,
+      "not attempted: deposit proved less than the quoted principal",
+      4,
+    ]);
+    // Only the fee row came back: the row at `event_index` 4 is outside the
+    // range the statement can touch, so it stays pending for the W4 sweep.
+    expect(rows.map((row) => row.id)).toEqual([9]);
+  });
+
+  it("passes a NULL bound when no upper bound is given, so the range stays open", async () => {
+    await repo.abortPlannedEvents(42, 1, "earlier leg reverted");
+    expect(lastParams()[3]).toBeNull();
+  });
+
   // THE LENGTH CAP WAS REMOVED, THE REDACTION WAS NOT (funded live audit,
   // 2026-08-18). The old 500-char slice cut a Morpho failure exactly where its
   // standing-allowance disclosure and remediation began, so the ledger and the

--- a/src/__tests__/vex-agent/sync/executed-amount-fallback-venues.test.ts
+++ b/src/__tests__/vex-agent/sync/executed-amount-fallback-venues.test.ts
@@ -170,7 +170,7 @@ describe("the crash-window bridge deposit", () => {
     mockListCandidates.mockResolvedValue([depositRow()]);
 
     const result = await repairMissingExecutedAmounts(deps({
-      logs: [transferLog(WALLET, DEPOSITORY, 999_000n)],
+      logs: [transferLog(WALLET, DEPOSITORY, 1_000_000n)],
       transactions: { [DEPOSIT_HASH]: depositTx },
     }));
 
@@ -179,20 +179,35 @@ describe("the crash-window bridge deposit", () => {
       id: 11,
       expectedTxHash: DEPOSIT_HASH,
       expectedChainId: 8453,
-      amounts: { executedAmountInRaw: "999000" },
+      amounts: { executedAmountInRaw: "1000000" },
     });
+  });
+
+  it("DECLINES a deposit below the receipt floor instead of back-filling it", async () => {
+    // The venue records a shortfall for review at return time; this lane must
+    // not quietly turn that disputed deposit into a settled amount later.
+    mockListCandidates.mockResolvedValue([depositRow()]);
+
+    const result = await repairMissingExecutedAmounts(deps({
+      logs: [transferLog(WALLET, DEPOSITORY, 999_999n)],
+      transactions: { [DEPOSIT_HASH]: depositTx },
+    }));
+
+    expect(result).toMatchObject({ declined: 1, filled: 0 });
+    expect(mockFill).not.toHaveBeenCalled();
+    expect(mockDeclined).toHaveBeenCalledWith(11, "amounts_undecodable");
   });
 
   it("works for khalani rows too - the rule is the venue-independent one", async () => {
     mockListCandidates.mockResolvedValue([depositRow({ protocol: "khalani" })]);
 
     await repairMissingExecutedAmounts(deps({
-      logs: [transferLog(WALLET, DEPOSITORY, 999_000n)],
+      logs: [transferLog(WALLET, DEPOSITORY, 1_000_000n)],
       transactions: { [DEPOSIT_HASH]: depositTx },
     }));
 
     expect(mockFill).toHaveBeenCalledWith(expect.objectContaining({
-      amounts: { executedAmountInRaw: "999000" },
+      amounts: { executedAmountInRaw: "1000000" },
     }));
   });
 
@@ -201,15 +216,15 @@ describe("the crash-window bridge deposit", () => {
     mockListLegs.mockResolvedValue([allowanceLeg(), depositRow()]);
 
     await repairMissingExecutedAmounts(deps({
-      logs: [transferLog(WALLET, SPENDER, 800_000n)],
+      logs: [transferLog(WALLET, SPENDER, 1_000_000n)],
       transactions: {
         [DEPOSIT_HASH]: depositTx,
-        [APPROVE_HASH]: { from: WALLET, to: TOKEN, input: approveCalldata(SPENDER, 900_000n), valueRaw: "0" },
+        [APPROVE_HASH]: { from: WALLET, to: TOKEN, input: approveCalldata(SPENDER, 1_000_000n), valueRaw: "0" },
       },
     }));
 
     expect(mockFill).toHaveBeenCalledWith(expect.objectContaining({
-      amounts: { executedAmountInRaw: "800000" },
+      amounts: { executedAmountInRaw: "1000000" },
     }));
   });
 
@@ -489,7 +504,7 @@ describe("the candidate window has to ROTATE", () => {
     mockListCandidates.mockResolvedValue([depositRow()]);
 
     await repairMissingExecutedAmounts(deps({
-      logs: [transferLog(WALLET, DEPOSITORY, 999_000n)],
+      logs: [transferLog(WALLET, DEPOSITORY, 1_000_000n)],
       transactions: { [DEPOSIT_HASH]: depositTx },
     }));
 
@@ -544,7 +559,7 @@ describe("the three interleavings of the two writers", () => {
     mockListCandidates.mockResolvedValue([depositRow()]);
 
     await repairMissingExecutedAmounts(deps({
-      logs: [transferLog(WALLET, DEPOSITORY, 999_000n)],
+      logs: [transferLog(WALLET, DEPOSITORY, 1_000_000n)],
       transactions: { [DEPOSIT_HASH]: depositTx },
     }));
 
@@ -559,7 +574,7 @@ describe("the three interleavings of the two writers", () => {
     mockFill.mockResolvedValue({ outcome: "conflict", row: depositRow() });
 
     const result = await repairMissingExecutedAmounts(deps({
-      logs: [transferLog(WALLET, DEPOSITORY, 999_000n)],
+      logs: [transferLog(WALLET, DEPOSITORY, 1_000_000n)],
       transactions: { [DEPOSIT_HASH]: depositTx },
     }));
 

--- a/src/__tests__/vex-agent/tools/bridge-deposit-evidence.test.ts
+++ b/src/__tests__/vex-agent/tools/bridge-deposit-evidence.test.ts
@@ -20,9 +20,13 @@ vi.mock("@vex-agent/db/repos/agent-activity.js", () => ({
   provenLegAmounts: vi.fn(),
 }));
 
-const { proveErc20DepositAmount, authorizedDepositRecipients } = await import(
-  "@vex-agent/tools/protocols/bridge-deposit-evidence.js"
-);
+const {
+  authorizedDepositRecipients,
+  bridgeDepositFloor,
+  FEE_ON_TRANSFER_DEDUCTIONS,
+  proveErc20DepositAmount,
+  withholdFeeOnDepositShortfall,
+} = await import("@vex-agent/tools/protocols/bridge-deposit-evidence.js");
 type DepositTransferLog =
   import("@vex-agent/tools/protocols/bridge-deposit-evidence.js").DepositTransferLog;
 
@@ -59,6 +63,7 @@ function transferLog(args: {
 function request(overrides: Partial<Parameters<typeof proveErc20DepositAmount>[0]> = {}) {
   return proveErc20DepositAmount({
     logs: [transferLog({})],
+    chainId: 8453,
     tokenAddress: TOKEN,
     senderAddress: WALLET,
     recipients: [{ address: DEPOSITORY, maxAmountRaw: null }],
@@ -149,15 +154,19 @@ describe("proveErc20DepositAmount", () => {
     expect(outcome).toEqual({ kind: "proven", amountRaw: "1000000" });
   });
 
-  it("accepts a fee-on-transfer shortfall only while ONE candidate remains", () => {
-    // The token skimmed its own fee to a third party, so the deposit log carries
-    // less than the plan. The deposit transfer is still the single candidate.
+  it("reports a fee-on-transfer shortfall as SHORT, because no deduction is measured for this token", () => {
+    // This case used to assert `proven: 990000` against a
+    // quoted 1,000,000, and that acceptance is exactly the hole: the amount was
+    // declared, the full fixed Vex fee then followed, and the user consented to
+    // a card that said the whole 1,000,000 would travel. "Some tokens skim a
+    // fee" is not evidence about THIS token; only a measured entry in
+    // `FEE_ON_TRANSFER_DEDUCTIONS` lowers the floor, and it is empty.
     const feeSkim = transferLog({ to: STRANGER, amount: 10_000n });
     const outcome = request({
       logs: [feeSkim, transferLog({ amount: 990_000n })],
       expectedAmountRaw: "1000000",
     });
-    expect(outcome).toEqual({ kind: "proven", amountRaw: "990000" });
+    expect(outcome).toEqual({ kind: "short", provenAmountRaw: "990000", quotedAmountRaw: "1000000" });
   });
 
   it("declines a fee-on-transfer shortfall that leaves two possible deposits", () => {
@@ -177,6 +186,23 @@ describe("proveErc20DepositAmount", () => {
       ],
     });
     expect(outcome).toEqual({ kind: "proven", amountRaw: "1000000" });
+  });
+
+  it("reports a one-unit deposit against the whole quote as SHORT, not as an amount", () => {
+    // The shape that used to pay a full fixed fee for a bridge that moved
+    // nothing worth the name.
+    expect(request({ logs: [transferLog({ amount: 1n })] }))
+      .toEqual({ kind: "short", provenAmountRaw: "1", quotedAmountRaw: "1000000" });
+  });
+
+  it("proves the exact quoted principal, which is the floor", () => {
+    expect(request({ logs: [transferLog({ amount: 1_000_000n })] }))
+      .toEqual({ kind: "proven", amountRaw: "1000000" });
+  });
+
+  it("reports one unit below the floor as SHORT", () => {
+    expect(request({ logs: [transferLog({ amount: 999_999n })] }))
+      .toEqual({ kind: "short", provenAmountRaw: "999999", quotedAmountRaw: "1000000" });
   });
 
   it("declines an empty receipt", () => {
@@ -240,12 +266,24 @@ describe("proveErc20DepositAmount - the allowance is an absolute ceiling", () =>
     { address: STRANGER, maxAmountRaw },
   ];
 
-  it("proves a transfer within the spender's effective allowance", () => {
+  it("proves a transfer to a spender when it also reaches the quoted floor", () => {
+    // The allowance is the CEILING for a spender recipient; the quoted
+    // principal is still the FLOOR, so the two only agree at the principal
+    // itself. That is the live shape: the approve guard binds the allowance to
+    // exactly the amount being bridged.
+    const outcome = request({
+      logs: [transferLog({ to: STRANGER, amount: 1_000_000n })],
+      recipients: spenderRecipients(1_000_000n),
+    });
+    expect(outcome).toEqual({ kind: "proven", amountRaw: "1000000" });
+  });
+
+  it("reports a transfer inside the allowance but under the quote as SHORT", () => {
     const outcome = request({
       logs: [transferLog({ to: STRANGER, amount: 400_000n })],
       recipients: spenderRecipients(400_000n),
     });
-    expect(outcome).toEqual({ kind: "proven", amountRaw: "400000" });
+    expect(outcome).toEqual({ kind: "short", provenAmountRaw: "400000", quotedAmountRaw: "1000000" });
   });
 
   it("declines a transfer larger than the spender could ever have pulled", () => {
@@ -262,5 +300,82 @@ describe("proveErc20DepositAmount - the allowance is an absolute ceiling", () =>
       recipients: spenderRecipients(10_000_000n),
     });
     expect(outcome).toEqual({ kind: "declined", reason: "no_candidate_transfer", candidateCount: 0 });
+  });
+});
+
+// ── The floor and its fee-on-transfer table ────────────────────────────────
+
+describe("bridgeDepositFloor - the deposit floor and the table that may lower it", () => {
+  it("ships with an EMPTY table, so the floor is the quote itself", () => {
+    expect(FEE_ON_TRANSFER_DEDUCTIONS.size).toBe(0);
+    expect(bridgeDepositFloor({ chainId: 8453, tokenAddress: TOKEN, quotedRaw: 1_000_000n }))
+      .toBe(1_000_000n);
+  });
+
+  it("lowers the floor by the MEASURED absolute deduction for that chain and token", () => {
+    const measured = new Map<string, bigint>([[`8453:${TOKEN.toLowerCase()}`, 2_500n]]);
+    expect(bridgeDepositFloor({ chainId: 8453, tokenAddress: TOKEN, quotedRaw: 1_000_000n, deductions: measured }))
+      .toBe(997_500n);
+  });
+
+  it("keeps the deduction ABSOLUTE: ten times the trade gets the same allowance, not ten times it", () => {
+    // Rule 90: a money tolerance is absolute, never a percentage that grows
+    // with trade size. The same 2,500 units on a ten-times-larger trade.
+    const measured = new Map<string, bigint>([[`8453:${TOKEN.toLowerCase()}`, 2_500n]]);
+    expect(bridgeDepositFloor({ chainId: 8453, tokenAddress: TOKEN, quotedRaw: 10_000_000n, deductions: measured }))
+      .toBe(9_997_500n);
+  });
+
+  it("does not apply another chain's measurement to this chain", () => {
+    const measured = new Map<string, bigint>([[`1:${TOKEN.toLowerCase()}`, 2_500n]]);
+    expect(bridgeDepositFloor({ chainId: 8453, tokenAddress: TOKEN, quotedRaw: 1_000_000n, deductions: measured }))
+      .toBe(1_000_000n);
+  });
+
+  it("does not apply another token's measurement to this token", () => {
+    const measured = new Map<string, bigint>([[`8453:${OTHER_TOKEN.toLowerCase()}`, 2_500n]]);
+    expect(bridgeDepositFloor({ chainId: 8453, tokenAddress: TOKEN, quotedRaw: 1_000_000n, deductions: measured }))
+      .toBe(1_000_000n);
+  });
+});
+
+// ── The fee decision for a short deposit ───────────────────────────────────
+
+describe("withholdFeeOnDepositShortfall - a short bridge is never charged", () => {
+  const shortfall = { provenAmountRaw: "999999", quotedAmountRaw: "1000000" };
+
+  it("aborts the planned fee row and takes no fee", async () => {
+    const aborted: Array<readonly [number, string]> = [];
+    const collection = await withholdFeeOnDepositShortfall({
+      shortfall,
+      executionId: 42,
+      feeLegIndex: 2,
+      logScope: "relay.bridge",
+      abortPlannedFeeRow: async (fromIndex, reason) => {
+        aborted.push([fromIndex, reason]);
+      },
+    });
+    expect(collection.collection).toBe("not_attempted");
+    expect(aborted).toHaveLength(1);
+    expect(aborted[0]?.[0]).toBe(2);
+  });
+
+  it("names BOTH figures in the note the agent and the human read", async () => {
+    const collection = await withholdFeeOnDepositShortfall({
+      shortfall, executionId: 42, feeLegIndex: 2, logScope: "khalani.bridge",
+      abortPlannedFeeRow: async () => undefined,
+    });
+    expect(collection.collectionNote).toContain("999999");
+    expect(collection.collectionNote).toContain("1000000");
+    expect(collection.collectionNote).toMatch(/no vex fee was taken/i);
+  });
+
+  it("aborts nothing when this bridge planned no fee row at all", async () => {
+    let called = false;
+    await withholdFeeOnDepositShortfall({
+      shortfall, executionId: 42, feeLegIndex: -1, logScope: "relay.bridge",
+      abortPlannedFeeRow: async () => { called = true; },
+    });
+    expect(called).toBe(false);
   });
 });

--- a/src/__tests__/vex-agent/tools/bridge-deposit-evidence.test.ts
+++ b/src/__tests__/vex-agent/tools/bridge-deposit-evidence.test.ts
@@ -345,19 +345,38 @@ describe("withholdFeeOnDepositShortfall - a short bridge is never charged", () =
   const shortfall = { provenAmountRaw: "999999", quotedAmountRaw: "1000000" };
 
   it("aborts the planned fee row and takes no fee", async () => {
-    const aborted: Array<readonly [number, string]> = [];
+    const aborted: Array<readonly [number, string, number]> = [];
     const collection = await withholdFeeOnDepositShortfall({
       shortfall,
       executionId: 42,
       feeLegIndex: 2,
       logScope: "relay.bridge",
-      abortPlannedFeeRow: async (fromIndex, reason) => {
-        aborted.push([fromIndex, reason]);
+      abortPlannedFeeRow: async (fromIndex, reason, toIndexExclusive) => {
+        aborted.push([fromIndex, reason, toIndexExclusive]);
       },
     });
     expect(collection.collection).toBe("not_attempted");
     expect(aborted).toHaveLength(1);
     expect(aborted[0]?.[0]).toBe(2);
+  });
+
+  it("bounds the abort to the fee row ALONE, leaving the logical fill row pending", async () => {
+    // The deposit WAS submitted to the provider: it merely moved less than the
+    // quote. Its `bridge_fill_expected` row is the next event index, and
+    // `abortPlannedEvents` finalizes every hashless pending row from
+    // `fromIndex` onward, so an unbounded abort would terminalize the
+    // reconciliation row and release the in-flight guard of a live bridge.
+    const aborted: Array<readonly [number, string, number]> = [];
+    await withholdFeeOnDepositShortfall({
+      shortfall,
+      executionId: 42,
+      feeLegIndex: 3,
+      logScope: "khalani.bridge",
+      abortPlannedFeeRow: async (fromIndex, reason, toIndexExclusive) => {
+        aborted.push([fromIndex, reason, toIndexExclusive]);
+      },
+    });
+    expect(aborted).toEqual([[3, "deposit proved less than the quoted principal", 4]]);
   });
 
   it("names BOTH figures in the note the agent and the human read", async () => {

--- a/src/__tests__/vex-agent/tools/bridge-shortfall-abort-bound.test.ts
+++ b/src/__tests__/vex-agent/tools/bridge-shortfall-abort-bound.test.ts
@@ -1,0 +1,66 @@
+/**
+ * A short deposit costs Vex its fee. It must not cost the user their
+ * reconciliation row.
+ *
+ * `abortPlannedEvents` finalizes EVERY hashless pending row from `fromIndex`
+ * onward, and the logical `bridge_fill_expected` row is planned at the index
+ * right after the Vex fee row on both venues. A deposit that came up short was
+ * still SUBMITTED to the provider, so its fill may still land: aborting that row
+ * would terminalize a live bridge's reconciliation record and release its
+ * in-flight guard, which is what lets a duplicate bridge through.
+ *
+ * This suite pins the pass-through both venues use for the withholding path:
+ * `abortRemaining(executionId, fromIndex, reason, toIndexExclusive)` reaches the
+ * repository with the exclusive bound intact, and the unbounded form still
+ * exists for the callers that legitimately abort a tail.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockAbort = vi.fn(async (..._args: unknown[]) => []);
+vi.mock("@vex-agent/db/repos/agent-activity.js", () => ({
+  abortPlannedEvents: (...args: unknown[]) => mockAbort(...args),
+  attachProviderOrderId: vi.fn(),
+}));
+vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({ pinTrackedToken: vi.fn() }));
+vi.mock("@utils/logger.js", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+const relay = await import("@vex-agent/tools/protocols/relay/handlers/bridge/recording.js");
+const khalani = await import("@vex-agent/tools/protocols/khalani/handlers/bridge-support.js");
+
+const VENUES: readonly (readonly [string, (
+  executionId: number,
+  fromIndex: number,
+  reason: string,
+  toIndexExclusive?: number,
+) => Promise<void>])[] = [
+  ["relay.bridge", relay.abortRemaining],
+  ["khalani.bridge", khalani.abortRemaining],
+];
+
+beforeEach(() => {
+  mockAbort.mockClear();
+});
+
+describe("abortRemaining - the exclusive bound reaches the repository", () => {
+  for (const [venue, abortRemaining] of VENUES) {
+    it(`${venue}: the fee row alone, with the fill row's index as the exclusive bound`, async () => {
+      await abortRemaining(42, 3, "deposit proved less than the quoted principal", 4);
+      expect(mockAbort).toHaveBeenCalledTimes(1);
+      expect(mockAbort).toHaveBeenCalledWith(42, 3, "deposit proved less than the quoted principal", 4);
+    });
+
+    it(`${venue}: an unbounded abort still passes no bound at all`, async () => {
+      await abortRemaining(42, 3, "earlier leg reverted");
+      expect(mockAbort).toHaveBeenCalledWith(42, 3, "earlier leg reverted");
+    });
+
+    it(`${venue}: a repository failure is swallowed, never flipping the caller's result`, async () => {
+      mockAbort.mockRejectedValueOnce(new Error("pool down"));
+      await expect(abortRemaining(42, 3, "deposit proved less than the quoted principal", 4))
+        .resolves.toBeUndefined();
+    });
+  }
+});

--- a/src/__tests__/vex-agent/tools/khalani-handlers/bridge-fee-execute.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-handlers/bridge-fee-execute.test.ts
@@ -355,6 +355,45 @@ describe("khalani.bridge — leg ordering: deposit first, fee last", () => {
     expect(mockSubmitDeposit).not.toHaveBeenCalled();
   });
 
+  it("a deposit ONE UNIT BELOW the quoted principal means NO treasury transfer at all", async () => {
+    // The receipt floor (`bridge-deposit-evidence.ts`). The deposit landed, so
+    // the bridge is not failed; it moved less than the card the user consented
+    // to said it would, so the fee it charges for is not owed. `floor - 1` is
+    // the exact shape that used to pay a full fixed fee.
+    const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+    const padded = (address: string): string => `0x${"0".repeat(24)}${address.slice(2).toLowerCase()}`;
+    mockSignStageKhalaniLeg.mockImplementation(async (leg: KhalaniStagedLeg, _c, _ch, _s, hooks) => {
+      callLog.push(`sign:${leg.purpose}:${leg.role}`);
+      await hooks.onHashStaged({ txHash: `0x${leg.purpose}`, fromAddress: SESSION_EVM.address, nonce: 1 });
+      await hooks.onAccepted();
+      return {
+        kind: "confirmed",
+        txHash: `0x${leg.purpose}`,
+        settledAtBlock: null,
+        receiptLogs: leg.isDeposit
+          ? [{
+            address: FROM_TOKEN,
+            topics: [TRANSFER_TOPIC, padded(SESSION_EVM.address), padded(ROUTER)],
+            data: `0x${(1_496_249n).toString(16).padStart(64, "0")}`,
+          }]
+          : null,
+      };
+    });
+
+    const result = await execute();
+
+    // Nothing with `vex_fee` purpose ever reached the signer, so no nonce was
+    // reserved and no treasury transfer was staged or broadcast for it.
+    expect(signedLegs().some((l) => l.purpose === "vex_fee")).toBe(false);
+    expect(callLog).not.toContain("sign:vex_fee:bridge_fee");
+    expect(mockMarkActivityBroadcast.mock.calls.map((c) => c[0])).not.toContain(102);
+    // The tool result names BOTH figures, so the human can compare them.
+    const fee = parse(result.output).vexFee as Record<string, unknown>;
+    expect(fee.collection).toBe("not_attempted");
+    expect(String(fee.collectionNote)).toContain("1496249");
+    expect(String(fee.collectionNote)).toContain("1496250");
+  });
+
   it("an AMBIGUOUS deposit means no treasury transfer, and the fee row is aborted below the logical row", async () => {
     mockSignStageKhalaniLeg.mockImplementation(async (leg: KhalaniStagedLeg, _c, _ch, _s, hooks) => {
       await hooks.onHashStaged({ txHash: "0xh", fromAddress: SESSION_EVM.address, nonce: 1 });

--- a/src/__tests__/vex-agent/tools/khalani-handlers/bridge-fee-execute.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-handlers/bridge-fee-execute.test.ts
@@ -22,6 +22,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { encodeFunctionData, getAddress } from "viem";
 import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
 
 const SESSION_EVM = {
@@ -33,6 +34,16 @@ const SESSION_EVM = {
 const FROM_TOKEN = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 const TO_TOKEN = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831";
 const ROUTER = "0x1111111111111111111111111111111111111111";
+
+const APPROVE_ABI = [{
+  type: "function", name: "approve", stateMutability: "nonpayable",
+  inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+  outputs: [{ name: "", type: "bool" }],
+}] as const;
+
+function approveCalldata(spender: string, allowance: bigint): string {
+  return encodeFunctionData({ abi: APPROVE_ABI, functionName: "approve", args: [getAddress(spender), allowance] });
+}
 const FUTURE = Math.floor(Date.now() / 1000) + 3600;
 
 vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
@@ -235,7 +246,11 @@ beforeEach(() => {
   }));
   mockBuildDeposit.mockResolvedValue({
     kind: "CONTRACT_CALL",
-    approvals: [evmSend(FROM_TOKEN, "0x095ea7b3", false), evmSend(ROUTER, "0xdeadbeef", true)],
+    // A REAL `approve(router, netAmount)`: the planner refuses an approval it
+    // cannot bind to the deposit call it precedes
+    // (`@tools/evm-chains/erc20-approve-step-guard.ts`), so the bare selector
+    // this fixture used to carry is no longer a plannable approval.
+    approvals: [evmSend(FROM_TOKEN, approveCalldata(ROUTER, 1_496_250n), false), evmSend(ROUTER, "0xdeadbeef", true)],
   });
   mockSearchTokens.mockImplementation(async (address: string) => ({
     data: [{ address, chainId: address === FROM_TOKEN ? 8453 : 42161, symbol: "USDC", decimals: 6, extensions: { price: { usd: "1" } } }],

--- a/src/__tests__/vex-agent/tools/khalani-handlers/bridge-fee-execute.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-handlers/bridge-fee-execute.test.ts
@@ -244,13 +244,21 @@ beforeEach(() => {
       quote: { amountIn: req.amount, amountOut: "1495000", expectedDurationSeconds: 5, quoteExpiresAt: FUTURE },
     }],
   }));
-  mockBuildDeposit.mockResolvedValue({
-    kind: "CONTRACT_CALL",
-    // A REAL `approve(router, netAmount)`: the planner refuses an approval it
-    // cannot bind to the deposit call it precedes
-    // (`@tools/evm-chains/erc20-approve-step-guard.ts`), so the bare selector
-    // this fixture used to carry is no longer a plannable approval.
-    approvals: [evmSend(FROM_TOKEN, approveCalldata(ROUTER, 1_496_250n), false), evmSend(ROUTER, "0xdeadbeef", true)],
+  // A REAL `approve(router, <the amount this run was quoted for>)`. The planner
+  // refuses an approval it cannot bind to the deposit call it precedes AND one
+  // whose allowance is not exactly the principal Vex asked the venue to bridge
+  // (`@tools/evm-chains/erc20-approve-step-guard.ts`), so the fixture must
+  // follow the quote the way the live provider does: the fee-charged runs quote
+  // 1_496_250 and the fee-skipped runs quote the full amount.
+  mockBuildDeposit.mockImplementation(async () => {
+    const quoted = (mockGetQuotes.mock.calls.at(-1)?.[0] as { amount: string } | undefined)?.amount;
+    return {
+      kind: "CONTRACT_CALL",
+      approvals: [
+        evmSend(FROM_TOKEN, approveCalldata(ROUTER, BigInt(quoted ?? "1496250")), false),
+        evmSend(ROUTER, "0xdeadbeef", true),
+      ],
+    };
   });
   mockSearchTokens.mockImplementation(async (address: string) => ({
     data: [{ address, chainId: address === FROM_TOKEN ? 8453 : 42161, symbol: "USDC", decimals: 6, extensions: { price: { usd: "1" } } }],
@@ -562,5 +570,87 @@ describe("khalani.bridge — caller-supplied fee params are still rejected by na
     expect(result.output).toMatch(/never takes fee parameters from tool input/);
     expect(mockGetQuotes).not.toHaveBeenCalled();
     expect(mockSignStageKhalaniLeg).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The approve binding at the HANDLER, over the real planner: the provider's
+ * approval reaches `planKhalaniDepositLegs` with Vex's own origin token, wallet
+ * and post-fee principal, so an approval that does not match them refuses
+ * before any leg is signed, any nonce is reserved (the signer owns the
+ * reservation) and any durable row exists.
+ *
+ * The default arrangement quotes 1_496_250 (1_500_000 less the 25 bps fee), so
+ * that is the ONLY allowance a plan for this bridge may grant.
+ */
+describe("khalani.bridge - a provider approval is bound to the deposit principal before anything signs", () => {
+  const NET = 1_496_250n;
+  const UNLIMITED = (1n << 256n) - 1n;
+  const FOREIGN_TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+  /** A CONTRACT_CALL plan whose single approval is the one under test. */
+  function planApproving(token: string, spender: string, allowance: bigint): void {
+    mockBuildDeposit.mockResolvedValue({
+      kind: "CONTRACT_CALL",
+      approvals: [evmSend(token, approveCalldata(spender, allowance), false), evmSend(ROUTER, "0xdeadbeef", true)],
+    });
+  }
+
+  function assertNothingSigned(): void {
+    expect(mockSignStageKhalaniLeg).not.toHaveBeenCalled();
+    expect(mockCreateBridgeActivityIntent).not.toHaveBeenCalled();
+    expect(mockSubmitDeposit).not.toHaveBeenCalled();
+  }
+
+  const refused: readonly (readonly [string, string, string, bigint])[] = [
+    ["an UNLIMITED allowance to the genuine deposit target", FROM_TOKEN, ROUTER, UNLIMITED],
+    ["an allowance LARGER than the principal", FROM_TOKEN, ROUTER, NET + 1n],
+    ["an allowance SMALLER than the principal", FROM_TOKEN, ROUTER, NET - 1n],
+    ["an approval on a token that is not the origin currency", FOREIGN_TOKEN, ROUTER, NET],
+  ];
+
+  for (const [label, token, spender, allowance] of refused) {
+    it(`REFUSES ${label}, signing nothing and recording nothing`, async () => {
+      planApproving(token, spender, allowance);
+
+      const result = await execute();
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("khalani.bridge failed:");
+      expect(result.output).toMatch(/refused before signing the khalani token approval/i);
+      assertNothingSigned();
+    });
+  }
+
+  it("plans and signs the exact principal to the genuine deposit target (positive control)", async () => {
+    // The shape of the archived live `/v1/deposit/build` CONTRACT_CALL capture:
+    // approve(deposit target, quoted input) followed by the deposit call.
+    planApproving(FROM_TOKEN, ROUTER, NET);
+
+    await execute();
+
+    expect(signedLegs().map((l) => l.purpose)).toEqual(["bridge", "bridge", "vex_fee"]);
+    expect(signedLegs().map((l) => l.role)).toEqual(["allowance", "bridge_deposit", "bridge_fee"]);
+  });
+
+  it("plans the reset-then-grant sequence a non-standard token needs", async () => {
+    mockBuildDeposit.mockResolvedValue({
+      kind: "CONTRACT_CALL",
+      approvals: [
+        evmSend(FROM_TOKEN, approveCalldata(ROUTER, 0n), false),
+        evmSend(FROM_TOKEN, approveCalldata(ROUTER, NET), false),
+        evmSend(ROUTER, "0xdeadbeef", true),
+      ],
+    });
+
+    await execute();
+
+    // The BRIDGE legs are the subject: the reset is exempt from the allowance
+    // bound (it grants nothing) and the grant that follows it is bound. The fee
+    // leg is left out of the assertion because this suite's intent mock returns
+    // exactly three leg rows, so a four-leg plan has no row for it.
+    expect(signedLegs().map((l) => l.role).slice(0, 3)).toEqual([
+      "allowance_reset", "allowance", "bridge_deposit",
+    ]);
   });
 });

--- a/src/__tests__/vex-agent/tools/khalani-handlers/deposit-amounts.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-handlers/deposit-amounts.test.ts
@@ -178,12 +178,21 @@ describe("khalani.bridge deposit amounts", () => {
     expect(mockDecline).toHaveBeenCalledWith(DEPOSIT_ROW_ID, "amounts_undecodable");
   });
 
-  it("takes a fee-on-transfer shortfall while one candidate remains", async () => {
-    await runLoop({
+  it("records a fee-on-transfer shortfall for review instead of declaring it", async () => {
+    // This case used to declare 990,000 of a quoted
+    // 1,000,000 and let the full fixed Vex fee follow. No deduction is measured
+    // for this token, so the deposit is SHORT: the row keeps no executed
+    // amount, it is marked for review, and the caller withholds the fee.
+    const run = await runLoop({
       stagedLegs: transferPlanLegs(TOKEN, "1000000"),
       logs: [transferLog(WALLET, STRANGER, 10_000n), transferLog(WALLET, DEPOSITORY, 990_000n)],
     });
-    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, { executedAmountInRaw: "990000" });
+    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, {});
+    expect(mockDecline).toHaveBeenCalledWith(DEPOSIT_ROW_ID, "amounts_incomplete");
+    expect(run.outcome).toBe("confirmed");
+    if (run.outcome === "confirmed") {
+      expect(run.depositShortfall).toEqual({ provenAmountRaw: "990000", quotedAmountRaw: "1000000" });
+    }
   });
 
   it("stamps a native TRANSFER from the value Vex signed", async () => {
@@ -194,12 +203,38 @@ describe("khalani.bridge deposit amounts", () => {
     expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, { executedAmountInRaw: "7000" });
   });
 
-  it("proves a CONTRACT_CALL deposit from the transfer into the call target", async () => {
-    await runLoop({
+  it("proves a CONTRACT_CALL deposit that moved the whole quoted principal", async () => {
+    const run = await runLoop({
       stagedLegs: contractCallPlanLegs(),
-      logs: [transferLog(WALLET, DEPOSITORY, 800_000n)],
+      logs: [transferLog(WALLET, DEPOSITORY, 1_000_000n)],
     });
-    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, { executedAmountInRaw: "800000" });
+    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, { executedAmountInRaw: "1000000" });
+    if (run.outcome === "confirmed") expect(run.depositShortfall).toBeNull();
+  });
+
+  it("records a CONTRACT_CALL deposit ONE UNIT below the floor as short, and signs no fee", async () => {
+    // `floor - 1`: the exact shape that used to pay a full fixed fee for a
+    // bridge that moved less than the user consented to.
+    const run = await runLoop({
+      stagedLegs: contractCallPlanLegs(),
+      logs: [transferLog(WALLET, DEPOSITORY, 999_999n)],
+    });
+    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, {});
+    expect(mockDecline).toHaveBeenCalledWith(DEPOSIT_ROW_ID, "amounts_incomplete");
+    expect(run.outcome).toBe("confirmed");
+    if (run.outcome === "confirmed") {
+      expect(run.depositShortfall).toEqual({ provenAmountRaw: "999999", quotedAmountRaw: "1000000" });
+    }
+  });
+
+  it("records a one-unit CONTRACT_CALL deposit against the whole quote as short", async () => {
+    const run = await runLoop({
+      stagedLegs: contractCallPlanLegs(),
+      logs: [transferLog(WALLET, DEPOSITORY, 1n)],
+    });
+    if (run.outcome === "confirmed") {
+      expect(run.depositShortfall).toEqual({ provenAmountRaw: "1", quotedAmountRaw: "1000000" });
+    }
   });
 
   it("declines a CONTRACT_CALL deposit whose transfer exceeds the quoted bound", async () => {
@@ -214,9 +249,9 @@ describe("khalani.bridge deposit amounts", () => {
   it("admits a spender this bridge approved FOR THE INPUT TOKEN", async () => {
     await runLoop({
       stagedLegs: withApprovedSpenders(contractCallPlanLegs(), [{ token: TOKEN, spender: STRANGER, amountRaw: UNLIMITED }]),
-      logs: [transferLog(WALLET, STRANGER, 700_000n)],
+      logs: [transferLog(WALLET, STRANGER, 1_000_000n)],
     });
-    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, { executedAmountInRaw: "700000" });
+    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, { executedAmountInRaw: "1000000" });
   });
 
   it("declines a transfer to a spender that was only approved for a DIFFERENT token", async () => {

--- a/src/__tests__/vex-agent/tools/khalani-handlers/deposit-amounts.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-handlers/deposit-amounts.test.ts
@@ -79,19 +79,28 @@ function contractCallPlanLegs(approvals: unknown[] = []) {
   );
 }
 
-/** `approve(spender, 2^256-1)` on `token` - the approval leg of a CONTRACT_CALL plan. */
-function approvalOf(token: string, spender: string, amount = (1n << 256n) - 1n) {
-  return {
-    type: "eip1193_request",
-    request: {
-      method: "eth_sendTransaction",
-      params: [{
-        to: token,
-        data: `0x095ea7b3${padded(spender).slice(2)}${amount.toString(16).padStart(64, "0")}`,
-      }],
-    },
-  };
+/**
+ * The approved spenders stamped on a planned CONTRACT_CALL deposit leg.
+ *
+ * These used to be built by handing the planner an `approve(spender, amount)`
+ * leg. The planner now REFUSES an approval whose spender is not the plan's own
+ * deposit target (`@tools/evm-chains/erc20-approve-step-guard.ts`), so a plan
+ * naming STRANGER can no longer exist and cannot be used as a fixture. The
+ * subject of these cases is the CONFIRM-SITE rule over the stamp, not the
+ * planner, so the stamp is stated directly instead of smuggled through a plan
+ * the planner is right to reject.
+ */
+function withApprovedSpenders(
+  legs: ReturnType<typeof contractCallPlanLegs>,
+  approvedSpenders: ReadonlyArray<{ token: string; spender: string; amountRaw: bigint }>,
+): ReturnType<typeof contractCallPlanLegs> {
+  return legs.map((leg) => {
+    if (leg.kind !== "evm" || !leg.isDeposit || leg.depositEvidence?.kind !== "provider_contract_call") return leg;
+    return { ...leg, depositEvidence: { ...leg.depositEvidence, approvedSpenders } };
+  }) as ReturnType<typeof contractCallPlanLegs>;
 }
+
+const UNLIMITED = (1n << 256n) - 1n;
 
 async function runLoop(args: {
   stagedLegs: ReturnType<typeof transferPlanLegs>;
@@ -193,7 +202,7 @@ describe("khalani.bridge deposit amounts", () => {
 
   it("admits a spender this bridge approved FOR THE INPUT TOKEN", async () => {
     await runLoop({
-      stagedLegs: contractCallPlanLegs([approvalOf(TOKEN, STRANGER)]),
+      stagedLegs: withApprovedSpenders(contractCallPlanLegs(), [{ token: TOKEN, spender: STRANGER, amountRaw: UNLIMITED }]),
       logs: [transferLog(WALLET, STRANGER, 700_000n)],
     });
     expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, { executedAmountInRaw: "700000" });
@@ -202,7 +211,7 @@ describe("khalani.bridge deposit amounts", () => {
   it("declines a transfer to a spender that was only approved for a DIFFERENT token", async () => {
     const otherToken = "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984";
     await runLoop({
-      stagedLegs: contractCallPlanLegs([approvalOf(otherToken, STRANGER)]),
+      stagedLegs: withApprovedSpenders(contractCallPlanLegs(), [{ token: otherToken, spender: STRANGER, amountRaw: UNLIMITED }]),
       logs: [transferLog(WALLET, STRANGER, 700_000n)],
     });
     expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, {});
@@ -211,7 +220,7 @@ describe("khalani.bridge deposit amounts", () => {
 
   it("declines a transfer above the spender's effective allowance", async () => {
     await runLoop({
-      stagedLegs: contractCallPlanLegs([approvalOf(TOKEN, STRANGER, 500_000n)]),
+      stagedLegs: withApprovedSpenders(contractCallPlanLegs(), [{ token: TOKEN, spender: STRANGER, amountRaw: 500_000n }]),
       logs: [transferLog(WALLET, STRANGER, 700_000n)],
     });
     expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, {});
@@ -220,9 +229,9 @@ describe("khalani.bridge deposit amounts", () => {
 
   it("declines a spender whose allowance the plan reset to zero after granting it", async () => {
     await runLoop({
-      stagedLegs: contractCallPlanLegs([
-        approvalOf(TOKEN, STRANGER, 900_000n),
-        approvalOf(TOKEN, STRANGER, 0n),
+      stagedLegs: withApprovedSpenders(contractCallPlanLegs(), [
+        { token: TOKEN, spender: STRANGER, amountRaw: 900_000n },
+        { token: TOKEN, spender: STRANGER, amountRaw: 0n },
       ]),
       logs: [transferLog(WALLET, STRANGER, 700_000n)],
     });

--- a/src/__tests__/vex-agent/tools/khalani-handlers/deposit-amounts.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-handlers/deposit-amounts.test.ts
@@ -19,6 +19,13 @@ const DEPOSITORY = "0x2222222222222222222222222222222222222222";
 const STRANGER = "0x3333333333333333333333333333333333333333";
 const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
+/**
+ * The origin binding the planner needs. Every plan here is approval-free (the
+ * approved-spender stamps are stated directly, see below), so the binding is
+ * never the subject of these cases.
+ */
+const ORIGIN = { fromToken: TOKEN, wallet: WALLET, bridgedAmountRaw: "1000000" };
+
 function padded(address: string): string {
   return `0x${"0".repeat(24)}${address.slice(2).toLowerCase()}`;
 }
@@ -62,6 +69,8 @@ function transferPlanLegs(token: string, amount: string) {
   return planKhalaniDepositLegs(
     { kind: "TRANSFER", depositAddress: DEPOSITORY, amount, token, chainId: 8453 },
     CHAIN,
+    null,
+    ORIGIN,
   );
 }
 
@@ -76,6 +85,8 @@ function contractCallPlanLegs(approvals: unknown[] = []) {
       }] as never,
     },
     CHAIN,
+    null,
+    ORIGIN,
   );
 }
 

--- a/src/__tests__/vex-agent/tools/khalani-handlers/executor-staged-leg-plan.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-handlers/executor-staged-leg-plan.test.ts
@@ -53,8 +53,23 @@ describe("bridge-executor — planKhalaniDepositLegs", () => {
     expect(() => planKhalaniDepositLegs({ kind: "PERMIT2", permit: {}, transferDetails: {} }, BASE_CHAIN)).toThrow(/PERMIT2/);
   });
 
-  it("requires exactly one deposit leg", async () => {
+  it("plans nothing from a CONTRACT_CALL with no deposit leg", async () => {
+    // The refusal now comes from the approval binding rather than the
+    // deposit-count rule: a non-deposit call in a plan that makes no deposit
+    // authorizes nothing, so it is refused before the count is reached
+    // (`@tools/evm-chains/erc20-approve-step-guard.ts`). Same fail-closed
+    // outcome, an earlier and more specific cause.
     const plan = { kind: "CONTRACT_CALL" as const, approvals: [{ type: "eip1193_request" as const, request: { method: "eth_sendTransaction", params: [{ to: EVM_ADDRESS, data: "0xdead" }] } }] };
-    expect(() => planKhalaniDepositLegs(plan, BASE_CHAIN)).toThrow(/deposit=true/);
+    expect(() => planKhalaniDepositLegs(plan, BASE_CHAIN)).toThrow(/token approval/i);
+  });
+
+  it("still refuses a plan that marks more than one deposit leg", async () => {
+    const depositCall = (data: string) => ({
+      type: "eip1193_request" as const,
+      request: { method: "eth_sendTransaction", params: [{ to: EVM_ADDRESS, data }] },
+      deposit: true,
+    });
+    const plan = { kind: "CONTRACT_CALL" as const, approvals: [depositCall("0xdead"), depositCall("0xbeef")] };
+    expect(() => planKhalaniDepositLegs(plan, BASE_CHAIN)).toThrow(/more than one action with deposit=true/);
   });
 });

--- a/src/__tests__/vex-agent/tools/khalani-handlers/executor-staged-leg-plan.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-handlers/executor-staged-leg-plan.test.ts
@@ -11,6 +11,18 @@ const BASE_CHAIN = {
 };
 const EVM_ADDRESS = getAddress("0x1234567890abcdef1234567890abcdef12345678");
 
+/**
+ * Vex's own view of the bridge. The role-classification plan below approves
+ * 100 units of `EVM_ADDRESS` to the deposit target, so the binding names that
+ * token and that principal; anything else would be refused by rule 2 of
+ * `@tools/evm-chains/erc20-approve-step-guard.ts`.
+ */
+const ORIGIN = {
+  fromToken: EVM_ADDRESS,
+  wallet: getAddress("0x33eF6673BD80cB11fcC41b82Bc2181E65cC4d2fA"),
+  bridgedAmountRaw: "100",
+};
+
 describe("bridge-executor — planKhalaniDepositLegs", () => {
   it("classifies roles: deposit → bridge_deposit, approve(0) → allowance_reset, other approve → allowance", async () => {
     const resetCalldata = encodeFunctionData({
@@ -31,7 +43,7 @@ describe("bridge-executor — planKhalaniDepositLegs", () => {
         { type: "eip1193_request" as const, request: { method: "eth_sendTransaction", params: [{ to: EVM_ADDRESS, data: "0xdeadbeef" }] }, deposit: true },
       ],
     };
-    const legs = planKhalaniDepositLegs(plan, BASE_CHAIN);
+    const legs = planKhalaniDepositLegs(plan, BASE_CHAIN, null, ORIGIN);
     expect(legs.map((leg) => leg.role)).toEqual(["allowance_reset", "allowance", "bridge_deposit"]);
     expect(legs.filter((leg) => leg.isDeposit)).toHaveLength(1);
   });
@@ -44,13 +56,13 @@ describe("bridge-executor — planKhalaniDepositLegs", () => {
         { type: "eip1193_request" as const, request: { method: "eth_sendTransaction", params: [{ to: EVM_ADDRESS, data: "0xdead" }] }, deposit: true },
       ],
     };
-    const legs = planKhalaniDepositLegs(plan, BASE_CHAIN);
+    const legs = planKhalaniDepositLegs(plan, BASE_CHAIN, null, ORIGIN);
     expect(legs).toHaveLength(1);
     expect(legs.at(0)?.role).toBe("bridge_deposit");
   });
 
   it("blocks PERMIT2", async () => {
-    expect(() => planKhalaniDepositLegs({ kind: "PERMIT2", permit: {}, transferDetails: {} }, BASE_CHAIN)).toThrow(/PERMIT2/);
+    expect(() => planKhalaniDepositLegs({ kind: "PERMIT2", permit: {}, transferDetails: {} }, BASE_CHAIN, null, ORIGIN)).toThrow(/PERMIT2/);
   });
 
   it("plans nothing from a CONTRACT_CALL with no deposit leg", async () => {
@@ -60,7 +72,7 @@ describe("bridge-executor — planKhalaniDepositLegs", () => {
     // (`@tools/evm-chains/erc20-approve-step-guard.ts`). Same fail-closed
     // outcome, an earlier and more specific cause.
     const plan = { kind: "CONTRACT_CALL" as const, approvals: [{ type: "eip1193_request" as const, request: { method: "eth_sendTransaction", params: [{ to: EVM_ADDRESS, data: "0xdead" }] } }] };
-    expect(() => planKhalaniDepositLegs(plan, BASE_CHAIN)).toThrow(/token approval/i);
+    expect(() => planKhalaniDepositLegs(plan, BASE_CHAIN, null, ORIGIN)).toThrow(/token approval/i);
   });
 
   it("still refuses a plan that marks more than one deposit leg", async () => {
@@ -70,6 +82,6 @@ describe("bridge-executor — planKhalaniDepositLegs", () => {
       deposit: true,
     });
     const plan = { kind: "CONTRACT_CALL" as const, approvals: [depositCall("0xdead"), depositCall("0xbeef")] };
-    expect(() => planKhalaniDepositLegs(plan, BASE_CHAIN)).toThrow(/more than one action with deposit=true/);
+    expect(() => planKhalaniDepositLegs(plan, BASE_CHAIN, null, ORIGIN)).toThrow(/more than one action with deposit=true/);
   });
 });

--- a/src/__tests__/vex-agent/tools/relay-handlers/bridge.test.ts
+++ b/src/__tests__/vex-agent/tools/relay-handlers/bridge.test.ts
@@ -23,6 +23,15 @@ const SEL_EVM = "0x1111111111111111111111111111111111111111";
 const ZERO = "0x0000000000000000000000000000000000000000";
 const ERC20 = "0xc6911796042b15d7Fa4F6CDe69e245DdCd3d9c31";
 
+// The origin-token fee eligibility probe reaches a live token API. Only that
+// one export is replaced; everything else in the barrel (the fee split, the
+// activity role, the treasury transfer builder) stays real, because the fee
+// ARITHMETIC is part of what these tests assert.
+vi.mock("@tools/bridge-fee/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tools/bridge-fee/index.js")>();
+  return { ...actual, evaluateEvmBridgeFeeEligibility: async () => ({ charge: true } as const) };
+});
+
 vi.mock("@vex-agent/tools/protocols/bridge-token-identity.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@vex-agent/tools/protocols/bridge-token-identity.js")>();
   return {
@@ -909,5 +918,85 @@ describe("relay leg resolution — model-supplied params reach output only throu
     );
     expect(result.success).toBe(false);
     expect(result.output).not.toContain("sk-or-v1-abcdef0123456789");
+  });
+});
+
+// ── The receipt floor makes the Vex fee leg ineligible ─────────────────────
+//
+// A deposit that moved LESS than the principal the user consented to did not
+// perform the operation the fee is charged for (rule 90: take a fee only after
+// the operation it charges for succeeds). `floor - 1` on an ERC-20 origin:
+// nothing with a `vex_fee` role reaches `signStageBroadcast`, so no nonce is
+// reserved and nothing is staged for it, and the planned fee row is aborted.
+
+describe("relay.bridge - a deposit below the receipt floor is never charged a fee", () => {
+  const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+  const DEPOSIT_TARGET = "0x2222222222222222222222222222222222222222";
+  const padded = (address: string): string => `0x${"0".repeat(24)}${address.slice(2).toLowerCase()}`;
+  /** The post-fee principal for a 1,000,000-unit ERC-20 bridge at 25 bps. */
+  const PRINCIPAL = 997_500n;
+  const ERC20_PARAMS = { ...PARAMS, fromToken: ERC20, amountRaw: "1000000" };
+
+  /** Every leg confirms; the deposit's receipt carries one Transfer of `moved`. */
+  function signWithDepositTransfer(moved: bigint) {
+    return async (
+      _p: unknown, _w: unknown, tx: { to: string },
+      hooks: { onHashStaged: (h: unknown) => Promise<void>; onAccepted: () => Promise<void> },
+    ) => {
+      await hooks.onHashStaged({ txHash: "0xdep", fromAddress: SEL_EVM, nonce: 1 });
+      await hooks.onAccepted();
+      return {
+        kind: "confirmed",
+        txHash: "0xdep",
+        receipt: {
+          blockNumber: 1n,
+          logs: [{
+            address: ERC20,
+            topics: [TRANSFER_TOPIC, padded(SEL_EVM), padded(DEPOSIT_TARGET)],
+            data: `0x${moved.toString(16).padStart(64, "0")}`,
+          }],
+        },
+      };
+    };
+  }
+
+  beforeEach(() => {
+    mockFindFreshMatchedPrequote.mockResolvedValue(matchedPrequoteWithVexFee(boundChargedVexFee({
+      feeAmountRaw: "2500", netAmountRaw: "997500", totalDebitedRaw: "1000000",
+    })));
+    mockAdapt.mockReturnValue(adaptedOk({
+      currencyIn: {
+        symbol: "USDC", decimals: 6, currencyAddress: ERC20, amountRaw: "997500",
+        amountFormatted: "0.9975", amountUsd: "1.00", minimumAmountRaw: null,
+      },
+    }));
+    mockPlanStepTx.mockReturnValue({ to: DEPOSIT_TARGET, data: "0xe8017952", value: 0n });
+  });
+
+  it("signs the fee leg when the deposit moved the whole principal (positive control)", async () => {
+    mockSign.mockImplementation(signWithDepositTransfer(PRINCIPAL));
+
+    const result = await runBridge(ERC20_PARAMS);
+
+    // Two signatures: the deposit, then the Vex fee transfer.
+    expect(mockSign).toHaveBeenCalledTimes(2);
+    expect(outputOf(result).vexFee).toBeDefined();
+  });
+
+  it("signs NOTHING for the fee when the deposit moved one unit less than the principal", async () => {
+    mockSign.mockImplementation(signWithDepositTransfer(PRINCIPAL - 1n));
+
+    const result = await runBridge(ERC20_PARAMS);
+
+    // The deposit signed; the fee leg never reached the signer, so no nonce was
+    // reserved for it and nothing was staged or broadcast under its row.
+    expect(mockSign).toHaveBeenCalledTimes(1);
+    // The planned fee row is aborted rather than left pending forever.
+    expect(mockAbort).toHaveBeenCalled();
+    // The tool result names BOTH figures, so the human can compare them.
+    const body = JSON.stringify(outputOf(result));
+    expect(body).toContain("997499");
+    expect(body).toContain("997500");
+    expect(body).toMatch(/No Vex fee was taken/i);
   });
 });

--- a/src/__tests__/vex-agent/tools/relay-handlers/deposit-amounts.test.ts
+++ b/src/__tests__/vex-agent/tools/relay-handlers/deposit-amounts.test.ts
@@ -134,14 +134,53 @@ describe("relay.bridge deposit amounts", () => {
     mockDecline.mockResolvedValue({ applied: true });
   });
 
-  it("declares the ERC-20 amount its receipt proves", async () => {
+  it("declares the ERC-20 amount its receipt proves, when it is the whole quoted principal", async () => {
+    // This case used to accept 999,000 of a quoted
+    // 1,000,000 and let the full fixed Vex fee follow. There is no measured
+    // fee-on-transfer deduction for this token, so 999,000 is now a shortfall
+    // (asserted below) and only the exact principal proves the deposit.
+    const run = await runDeposit({
+      originCurrency: TOKEN,
+      logs: [transferLog(WALLET, DEPOSITORY, 1_000_000n)],
+    });
+    expect(run.kind).toBe("confirmed");
+    if (run.kind === "confirmed") expect(run.depositShortfall).toBeNull();
+    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, { executedAmountInRaw: "1000000" });
+    expect(mockDecline).not.toHaveBeenCalled();
+  });
+
+  it("records a deposit ONE UNIT below the floor as short, with no amount and no fee", async () => {
+    const run = await runDeposit({
+      originCurrency: TOKEN,
+      logs: [transferLog(WALLET, DEPOSITORY, 999_999n)],
+    });
+    expect(run.kind).toBe("confirmed");
+    if (run.kind === "confirmed") {
+      expect(run.depositShortfall).toEqual({ provenAmountRaw: "999999", quotedAmountRaw: "1000000" });
+    }
+    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, {});
+    expect(mockDecline).toHaveBeenCalledWith(DEPOSIT_ROW_ID, "amounts_incomplete");
+  });
+
+  it("records the old 999,000-of-1,000,000 acceptance as a shortfall instead", async () => {
     const run = await runDeposit({
       originCurrency: TOKEN,
       logs: [transferLog(WALLET, DEPOSITORY, 999_000n)],
     });
-    expect(run.kind).toBe("confirmed");
-    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, { executedAmountInRaw: "999000" });
-    expect(mockDecline).not.toHaveBeenCalled();
+    if (run.kind === "confirmed") {
+      expect(run.depositShortfall).toEqual({ provenAmountRaw: "999000", quotedAmountRaw: "1000000" });
+    }
+    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, {});
+  });
+
+  it("records a one-unit deposit against the whole quote as short", async () => {
+    const run = await runDeposit({
+      originCurrency: TOKEN,
+      logs: [transferLog(WALLET, DEPOSITORY, 1n)],
+    });
+    if (run.kind === "confirmed") {
+      expect(run.depositShortfall).toEqual({ provenAmountRaw: "1", quotedAmountRaw: "1000000" });
+    }
   });
 
   it("declares the native value Vex signed, which IS the principal", async () => {
@@ -182,9 +221,9 @@ describe("relay.bridge deposit amounts", () => {
     await runDeposit({
       originCurrency: TOKEN,
       approval: { token: TOKEN, spender },
-      logs: [transferLog(WALLET, spender, 700_000n)],
+      logs: [transferLog(WALLET, spender, 1_000_000n)],
     });
-    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, { executedAmountInRaw: "700000" });
+    expect(mockConfirm).toHaveBeenCalledWith(DEPOSIT_ROW_ID, { executedAmountInRaw: "1000000" });
   });
 
   it("declines a transfer to a spender that was only approved for a DIFFERENT token", async () => {
@@ -227,18 +266,27 @@ describe("relay.bridge deposit amounts", () => {
     mockConfirm.mockResolvedValue({ applied: false, row: { status: "confirmed", txHash: "0xhash" } });
     await runDeposit({
       originCurrency: TOKEN,
-      logs: [transferLog(WALLET, DEPOSITORY, 999_000n)],
+      logs: [transferLog(WALLET, DEPOSITORY, 1_000_000n)],
     });
     expect(mockFill).toHaveBeenCalledWith({
       id: DEPOSIT_ROW_ID,
       expectedTxHash: "0xhash",
       expectedChainId: 8453,
-      amounts: { executedAmountInRaw: "999000" },
+      amounts: { executedAmountInRaw: "1000000" },
     });
   });
 
   it("does not late-fill a row that is not confirmed", async () => {
     mockConfirm.mockResolvedValue({ applied: false, row: { status: "pending", txHash: "0xhash" } });
+    await runDeposit({
+      originCurrency: TOKEN,
+      logs: [transferLog(WALLET, DEPOSITORY, 1_000_000n)],
+    });
+    expect(mockFill).not.toHaveBeenCalled();
+  });
+
+  it("does not late-fill a SHORT deposit: a disputed amount is never back-filled", async () => {
+    mockConfirm.mockResolvedValue({ applied: false, row: { status: "confirmed", txHash: "0xhash" } });
     await runDeposit({
       originCurrency: TOKEN,
       logs: [transferLog(WALLET, DEPOSITORY, 999_000n)],

--- a/src/tools/evm-chains/bridge-deposit-calldata.ts
+++ b/src/tools/evm-chains/bridge-deposit-calldata.ts
@@ -1,0 +1,273 @@
+/**
+ * Binding a PROVIDER-SUPPLIED bridge DEPOSIT call to the principal Vex decided
+ * to bridge, BEFORE anything is signed.
+ *
+ * WHY IT EXISTS. The approve guard (`./erc20-approve-step-guard.ts`) closed the
+ * allowance hole: a bridge may only grant exactly the principal, and only to
+ * the deposit this same plan calls. It does NOT prove that the deposit then
+ * MOVES that principal. A depository that is handed `approve(target, 5_000_000)`
+ * can still be called with `depositErc20(user, token, 1, id)`: one unit bridged,
+ * the full fixed Vex fee charged, and the card that said the whole amount would
+ * travel is wrong. This module reads the deposit calldata and refuses that.
+ *
+ * WHAT MAY BE BOUND, AND WHAT MAY NOT. A selector is only a bound when its
+ * SIGNATURE is confirmed from an authoritative source - the provider's own
+ * public documentation, or a VERIFIED contract on a chain explorer for the very
+ * address the live capture calls. A four-byte value alone proves nothing: the
+ * 4byte and openchain directories are user-submitted, collide by construction,
+ * and a wrong argument layout read as a money bound is worse than no bound.
+ * So an UNCONFIRMED selector is NOT refused - refusing it would break honest
+ * traffic the moment a venue upgrades its router, on nothing more than our own
+ * ignorance. It is recorded as {@link DEPOSIT_SELECTOR_UNVERIFIED} and logged
+ * once, and the RECEIPT FLOOR
+ * (`@vex-agent/tools/protocols/bridge-deposit-evidence.ts`) stays the money
+ * guard for it: the deposit's own logs must prove the principal moved before
+ * any fee leg becomes eligible.
+ *
+ * THE SIGNATURE TABLE AND ITS PROVENANCE (researched 2026-09-04):
+ *
+ *  - `0xe8017952` = `depositErc20(address depositor, address token, uint256
+ *    amount, bytes32 id)`. Relay. CONFIRMED: the verified `RelayDepository`
+ *    source and ABI published by the Base explorer for
+ *    `0x4cD00e387622c35bDDB9B4C962C136462338BC31`, the very address all five
+ *    live Relay ERC-20 captures call
+ *    (`base.blockscout.com/api/v2/smart-contracts/0x4cD00e387622c35bDDB9B4C962C136462338BC31`,
+ *    `file_path: src/RelayDepository.sol`, `is_verified: true`). The selector
+ *    is the keccak prefix of that signature, and the decoded arguments of every
+ *    capture match the quote exactly: `token` is the requested
+ *    `originCurrency`, `amount` is the requested `amount`.
+ *  - `0x49290c1c` = `depositNative(address depositor, bytes32 id)`. Relay, same
+ *    verified contract and same source file. The principal is the transaction
+ *    VALUE, which `native-value-authorization` already attributes wei by wei,
+ *    so this entry binds the DEPOSITOR and leaves the amount to that gate.
+ *  - `0x5a1ee3ac` = `depositErc20(address depositor, address token, bytes32
+ *    id)`, the three-argument overload in the same verified source. It encodes
+ *    no amount: the depository pulls the whole ALLOWANCE, which the approve
+ *    guard has already bound to exactly the principal. Listed so the overload is
+ *    a KNOWN shape rather than an unverified one.
+ *  - `0xf3125a1f` = Khalani `CONTRACT_CALL` deposit, target
+ *    `0x1A7c327d0f402AEf2eD3D20D1141bD71BA1C317B` on Base. NOT CONFIRMED. That
+ *    address is unverified on the Base explorer (no ABI, no source) and on
+ *    Sourcify, and the Khalani/Hyperstream public documentation publishes no
+ *    deposit ABI. The head words of the live capture are consistent with
+ *    `(address token, uint256 amount, ...)` - the first word is the origin USDC
+ *    address and the second is the quoted input - but "consistent with" is a
+ *    guess, not a signature, and a guess must not become a money bound. It is
+ *    therefore recorded unverified and left to the receipt floor.
+ */
+
+import { decodeAbiParameters, getAddress, type Hex } from "viem";
+
+import logger from "../../utils/logger.js";
+
+/** The recorded outcome for a deposit whose selector no authority confirms. */
+export const DEPOSIT_SELECTOR_UNVERIFIED = "deposit_selector_unverified";
+
+/** What a confirmed signature lets this module compare, per argument. */
+interface VerifiedDepositSignature {
+  /** The human signature, for the log line and the refusal text. */
+  readonly signature: string;
+  /** ABI parameter types of the argument body, in order. */
+  readonly types: readonly { readonly type: string }[];
+  /** Index of the ERC-20 token argument, when the signature encodes one. */
+  readonly tokenArg: number | null;
+  /** Index of the principal argument, when the signature encodes one. */
+  readonly amountArg: number | null;
+  /** Index of the depositor argument, when the signature encodes one. */
+  readonly depositorArg: number | null;
+  /** True when the principal travels as the transaction value instead. */
+  readonly principalIsTxValue: boolean;
+}
+
+const ADDRESS = { type: "address" } as const;
+const UINT256 = { type: "uint256" } as const;
+const BYTES32 = { type: "bytes32" } as const;
+
+const VERIFIED_DEPOSIT_SIGNATURES: Readonly<Record<string, VerifiedDepositSignature>> = {
+  "0xe8017952": {
+    signature: "depositErc20(address,address,uint256,bytes32)",
+    types: [ADDRESS, ADDRESS, UINT256, BYTES32],
+    depositorArg: 0,
+    tokenArg: 1,
+    amountArg: 2,
+    principalIsTxValue: false,
+  },
+  "0x5a1ee3ac": {
+    signature: "depositErc20(address,address,bytes32)",
+    types: [ADDRESS, ADDRESS, BYTES32],
+    depositorArg: 0,
+    tokenArg: 1,
+    amountArg: null,
+    principalIsTxValue: false,
+  },
+  "0x49290c1c": {
+    signature: "depositNative(address,bytes32)",
+    types: [ADDRESS, BYTES32],
+    depositorArg: 0,
+    tokenArg: null,
+    amountArg: null,
+    principalIsTxValue: true,
+  },
+};
+
+/** Closed refusal vocabulary of the deposit binding. */
+export type BridgeDepositCalldataRefusalReason =
+  /** A confirmed selector whose argument body would not decode. */
+  | "deposit_calldata_undecodable"
+  /** A confirmed selector that moves a token other than the origin currency. */
+  | "deposit_token_not_origin"
+  /** A confirmed selector that moves an amount other than the quoted principal. */
+  | "deposit_principal_mismatch"
+  /** A confirmed selector crediting an account that is not the selected wallet. */
+  | "deposit_depositor_not_wallet";
+
+export type BridgeDepositCalldataVerdict =
+  | { readonly ok: true; readonly bound: true; readonly signature: string }
+  | { readonly ok: true; readonly bound: false; readonly selector: string }
+  | {
+      readonly ok: false;
+      readonly reason: BridgeDepositCalldataRefusalReason;
+      readonly detail: string;
+    };
+
+/** The deposit transaction as the plan carries it. */
+export interface BridgeDepositCall {
+  readonly to: string;
+  readonly data: string | undefined;
+  readonly value: bigint;
+}
+
+/** What VEX derived about this bridge, never a provider echo. */
+export interface BridgeDepositBinding {
+  /**
+   * The origin token contract, or `null` when the origin asset is the chain's
+   * native currency.
+   */
+  readonly originToken: string | null;
+  /** The selected wallet the deposit must credit. */
+  readonly wallet: string;
+  /**
+   * The exact principal Vex asked the venue to bridge (`bridgedRaw`), or `null`
+   * when Vex derived none. A `null` principal binds no amount: the receipt
+   * floor is then the only amount rule, exactly as for an unverified selector.
+   */
+  readonly principalRaw: bigint | null;
+}
+
+function selectorOf(data: string | undefined): string | null {
+  if (typeof data !== "string") return null;
+  if (!/^0x[0-9a-fA-F]{8}/.test(data)) return null;
+  return data.slice(0, 10).toLowerCase();
+}
+
+function sameAddress(a: string, b: string): boolean {
+  try {
+    return getAddress(a) === getAddress(b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Every (venue, chain, selector) already reported, so the unverified-selector
+ * line is emitted ONCE per shape rather than once per bridge. The set is
+ * bounded by the number of deposit shapes a build can meet, which is the
+ * number of entries a venue's router publishes: a handful, not a per-call
+ * growth.
+ */
+const reportedUnverified = new Set<string>();
+
+/** Report an unconfirmed deposit selector once per venue, chain and selector. */
+export function logUnverifiedDepositSelector(args: {
+  readonly venue: string;
+  readonly chainId: number;
+  readonly selector: string;
+  readonly target: string;
+}): void {
+  const key = `${args.venue}:${args.chainId}:${args.selector}`;
+  if (reportedUnverified.has(key)) return;
+  reportedUnverified.add(key);
+  logger.info(`${args.venue}.${DEPOSIT_SELECTOR_UNVERIFIED}`, {
+    chainId: args.chainId,
+    selector: args.selector,
+    target: args.target,
+  });
+}
+
+/**
+ * Bind a deposit call to the plan, or record that its selector is unconfirmed.
+ *
+ * Returns `{ ok: true, bound: false }` for a selector no authority confirms:
+ * that is a RECORD, not an acceptance of the amount. The caller logs it and the
+ * receipt floor still has to prove the principal moved before a fee is charged.
+ */
+export function verifyBridgeDepositCalldata(
+  call: BridgeDepositCall,
+  plan: BridgeDepositBinding,
+): BridgeDepositCalldataVerdict {
+  const selector = selectorOf(call.data);
+  if (selector === null) {
+    return { ok: true, bound: false, selector: "0x" };
+  }
+  const known = VERIFIED_DEPOSIT_SIGNATURES[selector];
+  if (known === undefined) {
+    return { ok: true, bound: false, selector };
+  }
+
+  let args: readonly unknown[];
+  try {
+    // `call.data` was proved to carry at least a selector above, and the ABI
+    // decoder owns the rest: a body that does not match the confirmed layout
+    // throws, and a throw is a refusal rather than a guess.
+    args = decodeAbiParameters(known.types, `0x${(call.data as string).slice(10)}` as Hex);
+  } catch {
+    return {
+      ok: false,
+      reason: "deposit_calldata_undecodable",
+      detail: `the deposit calls ${known.signature} with an argument body Vex could not decode`,
+    };
+  }
+
+  if (known.depositorArg !== null) {
+    const depositor = args[known.depositorArg];
+    if (typeof depositor !== "string" || !sameAddress(depositor, plan.wallet)) {
+      return {
+        ok: false,
+        reason: "deposit_depositor_not_wallet",
+        detail: "the deposit would be credited to an account that is not the selected wallet",
+      };
+    }
+  }
+
+  if (known.tokenArg !== null) {
+    const token = args[known.tokenArg];
+    if (plan.originToken === null || typeof token !== "string" || !sameAddress(token, plan.originToken)) {
+      return {
+        ok: false,
+        reason: "deposit_token_not_origin",
+        detail: "the deposit would move a token that is not the origin currency of this bridge",
+      };
+    }
+  }
+
+  if (plan.principalRaw !== null) {
+    if (known.amountArg !== null) {
+      const amount = args[known.amountArg];
+      if (typeof amount !== "bigint" || amount !== plan.principalRaw) {
+        return {
+          ok: false,
+          reason: "deposit_principal_mismatch",
+          detail: `the deposit would move ${typeof amount === "bigint" ? amount : "an unreadable amount"} where the plan bridges exactly ${plan.principalRaw}`,
+        };
+      }
+    } else if (known.principalIsTxValue && call.value !== plan.principalRaw) {
+      return {
+        ok: false,
+        reason: "deposit_principal_mismatch",
+        detail: `the deposit sends ${call.value} native wei where the plan bridges exactly ${plan.principalRaw}`,
+      };
+    }
+  }
+
+  return { ok: true, bound: true, signature: known.signature };
+}

--- a/src/tools/evm-chains/bridge-deposit-calldata.ts
+++ b/src/tools/evm-chains/bridge-deposit-calldata.ts
@@ -42,9 +42,19 @@
  *    so this entry binds the DEPOSITOR and leaves the amount to that gate.
  *  - `0x5a1ee3ac` = `depositErc20(address depositor, address token, bytes32
  *    id)`, the three-argument overload in the same verified source. It encodes
- *    no amount: the depository pulls the whole ALLOWANCE, which the approve
- *    guard has already bound to exactly the principal. Listed so the overload is
- *    a KNOWN shape rather than an unverified one.
+ *    NO amount and carries no native value: the depository pulls the whole
+ *    EFFECTIVE ALLOWANCE at execution time. Nothing on this path proves that
+ *    allowance equals the principal - the approve guard binds a grant this plan
+ *    CONTAINS, and a plan may legitimately carry no approve step at all when an
+ *    allowance already exists (`@tools/relay/step-policy.ts`), which no gate
+ *    compares to `bridgedRaw`. An allowance larger than the principal would
+ *    therefore be pulled in full. So this overload is REFUSED
+ *    ({@link BridgeDepositCalldataRefusalReason} `deposit_allowance_pull_unbindable`)
+ *    until an exact effective-allowance equality is read on-chain immediately
+ *    before signing. This is the same fail-closed choice
+ *    `@tools/kyberswap/evm/swap-calldata-guard.ts` makes for the simple-mode
+ *    entry point whose transfers it cannot express: a shape whose amount cannot
+ *    be bound is refused, never reported bound.
  *  - `0xf3125a1f` = Khalani `CONTRACT_CALL` deposit, target
  *    `0x1A7c327d0f402AEf2eD3D20D1141bD71BA1C317B` on Base. NOT CONFIRMED. That
  *    address is unverified on the Base explorer (no ABI, no source) and on
@@ -92,14 +102,6 @@ const VERIFIED_DEPOSIT_SIGNATURES: Readonly<Record<string, VerifiedDepositSignat
     amountArg: 2,
     principalIsTxValue: false,
   },
-  "0x5a1ee3ac": {
-    signature: "depositErc20(address,address,bytes32)",
-    types: [ADDRESS, ADDRESS, BYTES32],
-    depositorArg: 0,
-    tokenArg: 1,
-    amountArg: null,
-    principalIsTxValue: false,
-  },
   "0x49290c1c": {
     signature: "depositNative(address,bytes32)",
     types: [ADDRESS, BYTES32],
@@ -108,6 +110,16 @@ const VERIFIED_DEPOSIT_SIGNATURES: Readonly<Record<string, VerifiedDepositSignat
     amountArg: null,
     principalIsTxValue: true,
   },
+};
+
+/**
+ * Selectors whose SIGNATURE is confirmed but whose principal this module cannot
+ * bind to the plan, so they are refused rather than reported bound. Refusing is
+ * what keeps `bound: true` an honest claim: the alternative would be a verdict
+ * saying the deposit moves the principal when nothing proved it.
+ */
+const UNBINDABLE_DEPOSIT_SIGNATURES: Readonly<Record<string, string>> = {
+  "0x5a1ee3ac": "depositErc20(address,address,bytes32)",
 };
 
 /** Closed refusal vocabulary of the deposit binding. */
@@ -119,7 +131,9 @@ export type BridgeDepositCalldataRefusalReason =
   /** A confirmed selector that moves an amount other than the quoted principal. */
   | "deposit_principal_mismatch"
   /** A confirmed selector crediting an account that is not the selected wallet. */
-  | "deposit_depositor_not_wallet";
+  | "deposit_depositor_not_wallet"
+  /** A confirmed selector that pulls the allowance instead of a bindable amount. */
+  | "deposit_allowance_pull_unbindable";
 
 export type BridgeDepositCalldataVerdict =
   | { readonly ok: true; readonly bound: true; readonly signature: string }
@@ -169,13 +183,23 @@ function sameAddress(a: string, b: string): boolean {
 }
 
 /**
- * Every (venue, chain, selector) already reported, so the unverified-selector
- * line is emitted ONCE per shape rather than once per bridge. The set is
- * bounded by the number of deposit shapes a build can meet, which is the
- * number of entries a venue's router publishes: a handful, not a per-call
- * growth.
+ * How many (venue, chain, selector) keys the dedup remembers. An honest venue
+ * publishes a handful of deposit shapes, so this is far above real traffic; the
+ * cap exists because the SELECTOR half of every key is provider-controlled, and
+ * an unbounded set of provider-controlled strings is a memory the provider
+ * writes for the life of the process.
  */
-const reportedUnverified = new Set<string>();
+const UNVERIFIED_DEDUP_CAPACITY = 64;
+
+/**
+ * The (venue, chain, selector) keys already reported, most-recently-reported
+ * LAST: an insertion-ordered `Map` is the LRU, and the oldest key is evicted
+ * when the capacity is reached. Eviction is ACCOUNTED, never silent - the next
+ * line carries `dedupEvictedKeys`, so a reader can tell that an earlier shape
+ * may be reported a second time rather than believing the dedup was exact.
+ */
+const reportedUnverified = new Map<string, true>();
+let unverifiedDedupEvictions = 0;
 
 /** Report an unconfirmed deposit selector once per venue, chain and selector. */
 export function logUnverifiedDepositSelector(args: {
@@ -185,12 +209,25 @@ export function logUnverifiedDepositSelector(args: {
   readonly target: string;
 }): void {
   const key = `${args.venue}:${args.chainId}:${args.selector}`;
-  if (reportedUnverified.has(key)) return;
-  reportedUnverified.add(key);
+  if (reportedUnverified.has(key)) {
+    // Refresh recency: a shape a build keeps meeting must not be the one the
+    // cap evicts.
+    reportedUnverified.delete(key);
+    reportedUnverified.set(key, true);
+    return;
+  }
+  while (reportedUnverified.size >= UNVERIFIED_DEDUP_CAPACITY) {
+    const oldest = reportedUnverified.keys().next();
+    if (oldest.done === true) break;
+    reportedUnverified.delete(oldest.value);
+    unverifiedDedupEvictions++;
+  }
+  reportedUnverified.set(key, true);
   logger.info(`${args.venue}.${DEPOSIT_SELECTOR_UNVERIFIED}`, {
     chainId: args.chainId,
     selector: args.selector,
     target: args.target,
+    dedupEvictedKeys: unverifiedDedupEvictions,
   });
 }
 
@@ -208,6 +245,14 @@ export function verifyBridgeDepositCalldata(
   const selector = selectorOf(call.data);
   if (selector === null) {
     return { ok: true, bound: false, selector: "0x" };
+  }
+  const unbindable = UNBINDABLE_DEPOSIT_SIGNATURES[selector];
+  if (unbindable !== undefined) {
+    return {
+      ok: false,
+      reason: "deposit_allowance_pull_unbindable",
+      detail: `the deposit calls ${unbindable} (selector ${selector}), the overload that pulls the whole standing allowance instead of an amount Vex can bind to this plan`,
+    };
   }
   const known = VERIFIED_DEPOSIT_SIGNATURES[selector];
   if (known === undefined) {

--- a/src/tools/evm-chains/erc20-approve-step-guard.ts
+++ b/src/tools/evm-chains/erc20-approve-step-guard.ts
@@ -1,0 +1,307 @@
+/**
+ * Binding a PROVIDER-SUPPLIED ERC-20 `approve` step to the plan it claims to
+ * serve, BEFORE anything is signed.
+ *
+ * WHY IT EXISTS. Both bridge venues used to sign a provider's approve step
+ * after checking only the chain id, the sender, that `to` parsed as an address
+ * and that the native value was attributable. The spender, the token contract
+ * and the allowance were decoded ONLY afterwards, to record evidence
+ * (`erc20-approval.ts` on the Relay broadcast path, and the Khalani planner's
+ * `contractCallApprovedSpenders`). A provider returning
+ * `approve(attackerSpender, 2^256-1)` on the origin token therefore signed
+ * cleanly, and the user's ENTIRE balance of that token was drainable later with
+ * no further Vex signature. This module is the same class of gate
+ * `kyberswap/evm/swap-calldata-guard.ts` is for a swap blob, applied to the one
+ * calldata shape a bridge asks Vex to sign on the user's own token.
+ *
+ * TWO RULES, TWO SEAMS. An approve step is safe only if BOTH hold, and the two
+ * are checked where the facts actually live:
+ *
+ *  1. {@link verifyApproveStepAuthorizesDeposit} - plan-internal. The blob is a
+ *     canonical `approve`, it carries no native value, and the spender is the
+ *     plan's OWN deposit target. Needs nothing but the plan, so a venue whose
+ *     planner sees the whole step list can run it there.
+ *  2. {@link verifyApproveStepBindsPlanAmount} - Vex-derived. The token is the
+ *     origin currency the user approved, the sender is the selected wallet, and
+ *     the allowance is EXACTLY the principal Vex itself decided to bridge.
+ *     Needs numbers no provider supplied, so it runs where those numbers reach
+ *     the signer.
+ *
+ * Neither subsumes the other: rule 1 alone would allow an unlimited allowance
+ * to an honest deposit contract, and rule 2 alone would allow the exact
+ * principal to be handed to a stranger.
+ *
+ * Verdicts are returned, never thrown: each venue owns how a refusal is
+ * recorded and worded (`swap-calldata-guard.ts` makes the same choice).
+ *
+ * PIN-NOTE: viem 2.54.3 (`node_modules/viem/package.json`), probed 2026-09-04
+ * against `decodeFunctionData` with the `approve(address,uint256)` ABI below:
+ *  - canonical 68-byte blob: decodes, args `[checksummed spender, bigint]`;
+ *  - canonical blob PLUS trailing bytes ("deadbeef", and a full zero word):
+ *    DECODES SILENTLY and returns the same args, the extra bytes discarded;
+ *  - wrong selector (`0xa9059cbb`) and `0x`: throw
+ *    `AbiFunctionSignatureNotFoundError`;
+ *  - selector only: throws `SliceOffsetOutOfBoundsError`;
+ *  - truncated argument body: throws `PositionOutOfBoundsError`.
+ * The trailing-byte result is why this module measures the length itself:
+ * `decodeFunctionData` is NOT a canonicality check, and a token proxy that
+ * dispatches on extra calldata would do something the decode never showed. The
+ * error classes differ per malformation, so nothing here may match on one:
+ * every throw is one refusal.
+ *
+ * LIVE PROVENANCE (rule 10), captured 2026-09-04, read-only quotes archived
+ * under `session7/live/bridge-calldata/`: five Relay `/quote/v2` ERC-20 routes
+ * (base/arbitrum/ethereum/optimism USDC, three amounts), one native-origin
+ * Relay route, and one Khalani `/v1/deposit/build` CONTRACT_CALL plan with its
+ * TRANSFER sibling. EVERY approve step measured was
+ * exactly 68 bytes with no trailing data, carried `value` zero, targeted the
+ * origin token, named the deposit step's own target as spender, and set the
+ * allowance to EXACTLY the quoted input amount. A native-origin Relay quote
+ * carried NO approve step, and a Khalani TRANSFER plan carried no approvals at
+ * all. The rules below refuse nothing that honest traffic does.
+ */
+
+import { decodeFunctionData, getAddress, type Address, type Hex } from "viem";
+
+/** `approve(address,uint256)`. The only selector a bridge approve step may carry. */
+export const ERC20_APPROVE_SELECTOR = "0x095ea7b3";
+
+/**
+ * Canonical `approve` calldata length in hex characters: "0x" + 4 selector
+ * bytes + two 32-byte words. Anything longer carries trailing bytes viem would
+ * silently discard (see the pin-note); anything shorter cannot decode.
+ */
+const CANONICAL_APPROVE_HEX_LENGTH = 2 + 8 + 128;
+
+const APPROVE_ABI = [
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
+
+/**
+ * Closed refusal vocabulary. Each member is one distinct thing a provider did,
+ * so a venue can word its own remediation without re-deriving the cause.
+ */
+export type Erc20ApproveStepRefusalReason =
+  /** Not a canonical `approve`: unknown selector, undecodable body, or trailing bytes. */
+  | "not_canonical_approve"
+  /** An approve never sends native currency. */
+  | "approve_carries_native_value"
+  /** The spender is not the deposit this plan is about to make. */
+  | "spender_not_deposit_target"
+  /** The plan has no deposit call at all, so no approve step in it is legitimate. */
+  | "plan_has_no_deposit_call"
+  /** The origin asset is the chain's native currency, which is never approved. */
+  | "approve_on_native_origin"
+  /** The approval targets a token contract that is not the origin currency. */
+  | "token_not_origin_currency"
+  /** The approval would be sent from an address that is not the selected wallet. */
+  | "sender_not_selected_wallet"
+  /** The allowance is not exactly the principal Vex derived. */
+  | "allowance_not_principal"
+  /** Vex derived no principal for this plan, so no allowance can be bound. */
+  | "principal_not_derivable"
+  /** More than one approve step in one plan. */
+  | "extra_approve_step";
+
+export type Erc20ApproveStepVerdict =
+  | { readonly ok: true; readonly spender: Address; readonly allowance: bigint }
+  | {
+      readonly ok: false;
+      readonly reason: Erc20ApproveStepRefusalReason;
+      readonly detail: string;
+    };
+
+/** One transaction a provider asked Vex to sign, as the plan carries it. */
+export interface ApproveStepCall {
+  /** The transaction target. For an approve this is the token contract itself. */
+  readonly to: string;
+  readonly data: string | undefined;
+  /** Native value in wei. A missing value is zero at the venue boundary, never here. */
+  readonly value: bigint;
+  /** The sender the provider named, when it named one. */
+  readonly from?: string | undefined;
+}
+
+/** The plan-internal facts rule 1 binds against. */
+export interface ApproveDepositBinding {
+  /**
+   * The target of the deposit call this plan will make: the ONLY address an
+   * approve step in this plan may authorize. `null` when the plan makes no
+   * deposit CALL at all (a plain transfer to a deposit address), which makes
+   * every approve step in it illegitimate.
+   */
+  readonly depositTarget: string | null;
+}
+
+/** The Vex-derived facts rule 2 binds against. */
+export interface ApproveAmountBinding {
+  /**
+   * The origin token contract the user approved, or `null` when the origin
+   * asset is the chain's native currency. Each venue maps its own native
+   * sentinel before calling.
+   */
+  readonly originToken: string | null;
+  /** The selected wallet. */
+  readonly wallet: string;
+  /**
+   * The exact allowance this plan needs: the deposit principal VEX derived
+   * (the post-fee amount it asked the venue to bridge), never a provider echo.
+   * `null` when Vex derived no input amount for this plan, which fails closed.
+   */
+  readonly principalRaw: bigint | null;
+}
+
+/**
+ * Build a refusal in this module's vocabulary. Exported so a planner's own
+ * structural rules (there is at most one approve step in a plan) speak the same
+ * closed language as the calldata rules.
+ */
+export function refuseApproveStep(
+  reason: Erc20ApproveStepRefusalReason,
+  detail: string,
+): Erc20ApproveStepVerdict {
+  return { ok: false, reason, detail };
+}
+
+function sameAddress(a: string, b: string): boolean {
+  try {
+    return getAddress(a) === getAddress(b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decode calldata that is a CANONICAL `approve(spender, amount)` and nothing
+ * else, or return `null`.
+ *
+ * Stricter than `decodeErc20Approve` in `./erc20-approval.ts` on purpose. That
+ * one reads an approval back out of calldata for EVIDENCE, where a tolerant
+ * read is right; this one decides whether Vex signs, where the pin-note's
+ * trailing-byte behaviour makes tolerance a hole.
+ */
+function decodeCanonicalApprove(
+  data: string | undefined,
+): { readonly spender: Address; readonly allowance: bigint } | null {
+  if (typeof data !== "string") return null;
+  if (data.length !== CANONICAL_APPROVE_HEX_LENGTH) return null;
+  if (!data.toLowerCase().startsWith(ERC20_APPROVE_SELECTOR)) return null;
+  try {
+    const decoded = decodeFunctionData({ abi: APPROVE_ABI, data: data as Hex });
+    if (decoded.functionName !== "approve") return null;
+    return { spender: getAddress(decoded.args[0]), allowance: decoded.args[1] };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * RULE 1 (plan-internal): the step is a canonical, value-free `approve` whose
+ * spender is the deposit this same plan is about to make.
+ *
+ * This is the rule that closes the drain: an allowance granted to an address
+ * the plan never calls is authority the user's own bridge does not need, and it
+ * outlives the bridge.
+ */
+export function verifyApproveStepAuthorizesDeposit(
+  call: ApproveStepCall,
+  plan: ApproveDepositBinding,
+): Erc20ApproveStepVerdict {
+  const approve = decodeCanonicalApprove(call.data);
+  if (approve === null) {
+    return refuseApproveStep(
+      "not_canonical_approve",
+      "the approval step's calldata is not a canonical approve(address,uint256) call",
+    );
+  }
+  if (call.value !== 0n) {
+    return refuseApproveStep(
+      "approve_carries_native_value",
+      `the approval step attaches ${call.value} native wei, and an approval never sends value`,
+    );
+  }
+  if (plan.depositTarget === null) {
+    return refuseApproveStep(
+      "plan_has_no_deposit_call",
+      "the plan makes no deposit call, so no token approval in it is legitimate",
+    );
+  }
+  if (!sameAddress(approve.spender, plan.depositTarget)) {
+    return refuseApproveStep(
+      "spender_not_deposit_target",
+      "the approval names a spender that is not the deposit this plan makes",
+    );
+  }
+  return { ok: true, spender: approve.spender, allowance: approve.allowance };
+}
+
+/**
+ * RULE 2 (Vex-derived): the approval is on the origin token, from the selected
+ * wallet, for EXACTLY the principal Vex decided to bridge.
+ *
+ * Exact equality, both directions. A larger allowance (unlimited most of all)
+ * leaves standing authority behind after the bridge; a smaller one cannot fund
+ * the deposit the user approved, so signing it spends gas on a transaction that
+ * is known in advance to be insufficient. Every live capture is exact, so this
+ * refuses no honest route. If a venue is ever MEASURED to need more than the
+ * principal, the bound moves to that measured figure derived from the quote,
+ * never to unlimited.
+ */
+export function verifyApproveStepBindsPlanAmount(
+  call: ApproveStepCall,
+  plan: ApproveAmountBinding,
+): Erc20ApproveStepVerdict {
+  const approve = decodeCanonicalApprove(call.data);
+  if (approve === null) {
+    return refuseApproveStep(
+      "not_canonical_approve",
+      "the approval step's calldata is not a canonical approve(address,uint256) call",
+    );
+  }
+  if (call.value !== 0n) {
+    return refuseApproveStep(
+      "approve_carries_native_value",
+      `the approval step attaches ${call.value} native wei, and an approval never sends value`,
+    );
+  }
+  if (plan.originToken === null) {
+    return refuseApproveStep(
+      "approve_on_native_origin",
+      "the origin asset is the chain's native currency, which has no token approval",
+    );
+  }
+  if (!sameAddress(call.to, plan.originToken)) {
+    return refuseApproveStep(
+      "token_not_origin_currency",
+      "the approval targets a token contract that is not the origin currency of this bridge",
+    );
+  }
+  if (call.from !== undefined && call.from !== null && !sameAddress(call.from, plan.wallet)) {
+    return refuseApproveStep(
+      "sender_not_selected_wallet",
+      "the approval would be sent from an address that is not the selected wallet",
+    );
+  }
+  if (plan.principalRaw === null) {
+    return refuseApproveStep(
+      "principal_not_derivable",
+      "Vex derived no input amount for this bridge, so the allowance cannot be bound",
+    );
+  }
+  if (approve.allowance !== plan.principalRaw) {
+    return refuseApproveStep(
+      "allowance_not_principal",
+      `the approval grants ${approve.allowance} where the deposit needs exactly ${plan.principalRaw}`,
+    );
+  }
+  return { ok: true, spender: approve.spender, allowance: approve.allowance };
+}

--- a/src/tools/evm-chains/erc20-approve-step-guard.ts
+++ b/src/tools/evm-chains/erc20-approve-step-guard.ts
@@ -110,7 +110,13 @@ export type Erc20ApproveStepRefusalReason =
   /** Vex derived no principal for this plan, so no allowance can be bound. */
   | "principal_not_derivable"
   /** More than one approve step in one plan. */
-  | "extra_approve_step";
+  | "extra_approve_step"
+  /** An approval is sequenced at or after the deposit it claims to fund. */
+  | "approve_after_deposit"
+  /** A zero reset with no grant behind it: the plan asks for a bare revocation. */
+  | "allowance_reset_without_grant"
+  /** A zero reset sequenced after the grant it would cancel. */
+  | "allowance_reset_after_grant";
 
 export type Erc20ApproveStepVerdict =
   | { readonly ok: true; readonly spender: Address; readonly allowance: bigint }
@@ -246,7 +252,8 @@ export function verifyApproveStepAuthorizesDeposit(
 
 /**
  * RULE 2 (Vex-derived): the approval is on the origin token, from the selected
- * wallet, for EXACTLY the principal Vex decided to bridge.
+ * wallet, and - WHEN IT GRANTS ANYTHING - for EXACTLY the principal Vex decided
+ * to bridge.
  *
  * Exact equality, both directions. A larger allowance (unlimited most of all)
  * leaves standing authority behind after the bridge; a smaller one cannot fund
@@ -255,8 +262,20 @@ export function verifyApproveStepAuthorizesDeposit(
  * refuses no honest route. If a venue is ever MEASURED to need more than the
  * principal, the bound moves to that measured figure derived from the quote,
  * never to unlimited.
+ *
+ * A ZERO ALLOWANCE (`approve(spender, 0)`) is the one exemption, and it is an
+ * exemption from the EQUALITY ONLY. A non-standard token requires the reset
+ * before a new grant, so binding its zero to the principal would refuse the one
+ * sequence such a token needs. Everything else still applies to it: the reset
+ * must be a canonical value-free `approve` on the ORIGIN token, from the
+ * SELECTED wallet, naming this plan's own deposit target (rule 1). Signing a
+ * reset on a foreign token, from a foreign sender, or on a native origin is
+ * signing an unauthorized state change on the user's own asset and burning gas
+ * for it, which is why none of those checks is waived. The sequence rule
+ * ({@link verifyApprovalSequence}) is what stops a bare reset with no grant
+ * behind it from planning at all.
  */
-export function verifyApproveStepBindsPlanAmount(
+export function verifyApproveStepBindsPlan(
   call: ApproveStepCall,
   plan: ApproveAmountBinding,
 ): Erc20ApproveStepVerdict {
@@ -291,17 +310,119 @@ export function verifyApproveStepBindsPlanAmount(
       "the approval would be sent from an address that is not the selected wallet",
     );
   }
-  if (plan.principalRaw === null) {
+  if (approve.allowance !== 0n && plan.principalRaw === null) {
     return refuseApproveStep(
       "principal_not_derivable",
       "Vex derived no input amount for this bridge, so the allowance cannot be bound",
     );
   }
-  if (approve.allowance !== plan.principalRaw) {
+  if (approve.allowance !== 0n && approve.allowance !== plan.principalRaw) {
     return refuseApproveStep(
       "allowance_not_principal",
       `the approval grants ${approve.allowance} where the deposit needs exactly ${plan.principalRaw}`,
     );
   }
   return { ok: true, spender: approve.spender, allowance: approve.allowance };
+}
+
+/**
+ * One approval as the ORDERING rule sees it: where it sits in the plan, and
+ * whether it grants anything.
+ */
+export interface ApprovalSequenceEntry {
+  /**
+   * The approval's position in the plan, in the order the venue will sign:
+   * a Relay step index, a Khalani leg index. Positions only have to be
+   * comparable within one plan.
+   */
+  readonly position: number;
+  /** The allowance the approval encodes. Zero is a reset, anything else a grant. */
+  readonly allowance: bigint;
+}
+
+/** The sequence rule's own verdict. It binds no single call, so it names none. */
+export type ApprovalSequenceVerdict =
+  | { readonly ok: true }
+  | {
+      readonly ok: false;
+      readonly reason: Erc20ApproveStepRefusalReason;
+      readonly detail: string;
+    };
+
+/**
+ * THE ORDER, across the whole plan: `reset -> exact grant -> deposit` is the
+ * only approval shape a bridge may sign, and every shorter prefix of it.
+ *
+ * WHY ORDER IS A MONEY RULE AND NOT BOOKKEEPING. Rule 1 binds each approval to
+ * this plan's own deposit target and rule 2 binds the grant to the principal,
+ * but neither looks at WHEN the approval is signed. A plan whose allowance
+ * already covers the deposit can therefore let the deposit succeed and then
+ * hand Vex a fresh `approve(target, principal)` to sign AFTERWARDS: a standing
+ * allowance the bridge did not need, created after the only transaction that
+ * justified it, and outliving it. A reset with no grant behind it is the mirror
+ * image - the user's bridge becomes a bare allowance revocation on their own
+ * token, which is a state change nobody asked for and gas nobody authorized.
+ *
+ * The accepted shapes, exhaustively: no approval at all (Relay omits the step
+ * when the allowance already covers the deposit, and every native-origin quote
+ * measured live carries none); one grant before the deposit; one reset followed
+ * by one grant, both before the deposit. Everything else refuses.
+ *
+ * `depositPosition` is `null` when the plan makes no deposit CALL, which makes
+ * every approval in it illegitimate for the same reason rule 1 gives.
+ */
+export function verifyApprovalSequence(
+  approvals: readonly ApprovalSequenceEntry[],
+  depositPosition: number | null,
+): ApprovalSequenceVerdict {
+  if (approvals.length === 0) return { ok: true };
+  if (depositPosition === null) {
+    return {
+      ok: false,
+      reason: "plan_has_no_deposit_call",
+      detail: "the plan makes no deposit call, so no token approval in it is legitimate",
+    };
+  }
+  const late = approvals.find((entry) => entry.position >= depositPosition);
+  if (late !== undefined) {
+    return {
+      ok: false,
+      reason: "approve_after_deposit",
+      detail: "a token approval is sequenced at or after the deposit it claims to fund, so it would leave a standing allowance the bridge never needed",
+    };
+  }
+  const grants = approvals.filter((entry) => entry.allowance !== 0n);
+  const resets = approvals.filter((entry) => entry.allowance === 0n);
+  if (grants.length > 1) {
+    return {
+      ok: false,
+      reason: "extra_approve_step",
+      detail: `the plan grants a token allowance ${grants.length} times, and one deposit needs at most one grant`,
+    };
+  }
+  if (resets.length > 1) {
+    return {
+      ok: false,
+      reason: "extra_approve_step",
+      detail: `the plan resets the allowance ${resets.length} times, and one deposit needs at most one reset`,
+    };
+  }
+  const grant = grants.at(0);
+  const reset = resets.at(0);
+  if (reset === undefined) return { ok: true };
+  if (grant === undefined) {
+    return {
+      ok: false,
+      reason: "allowance_reset_without_grant",
+      detail: "the plan revokes an allowance and never grants one, so it is a bare approval change rather than the approval a deposit needs",
+    };
+  }
+  if (reset.position > grant.position) {
+    return {
+      ok: false,
+      reason: "allowance_reset_after_grant",
+      detail: "the plan resets the allowance after granting it, which would leave the deposit unfunded",
+    };
+  }
+  return { ok: true };
 }

--- a/src/tools/khalani/bridge-executor.ts
+++ b/src/tools/khalani/bridge-executor.ts
@@ -41,6 +41,9 @@ export {
 
 export { parseBigintish } from "./bridge-executor/approval-normalization.js";
 
-export { planKhalaniDepositLegs } from "./bridge-executor/deposit-plan.js";
+export {
+  planKhalaniDepositLegs,
+  type KhalaniDepositOriginBinding,
+} from "./bridge-executor/deposit-plan.js";
 
 export { signStageKhalaniLeg } from "./bridge-executor/leg-signing.js";

--- a/src/tools/khalani/bridge-executor/deposit-plan.ts
+++ b/src/tools/khalani/bridge-executor/deposit-plan.ts
@@ -17,18 +17,23 @@
  * below), so `approve(stranger, unlimited)` on the user's origin token planned
  * and signed cleanly, and the standing allowance outlived the bridge.
  *
- * WHAT IS BOUND HERE AND WHAT IS NOT. This planner receives the provider plan,
- * the chain and the Vex fee leg. It can therefore prove every plan-INTERNAL
- * fact (rule 1: canonical `approve`, no native value, spender == this plan's
- * own deposit target, at most one GRANT). It CANNOT yet prove the Vex-DERIVED
- * facts (rule 2: the token is the origin currency and the allowance is exactly
- * the bridged principal) because `ContractCallDepositPlan` carries neither the
- * origin token nor the amount, and the caller passes neither: the handler holds
- * both as `fromToken` and `bridgedAmountRaw` (it already hands them to
- * `authorizeKhalaniPlanNativeValue`). Wiring them into this planner and calling
- * `verifyApproveStepBindsPlanAmount` is the named follow-up; deriving the
- * principal here from `vexFee.feeRaw` was rejected because inverting a floored
- * bps split yields a RANGE, and a money bound must be exact.
+ * BOTH RULES ARE BOUND HERE. Rule 1 (canonical `approve`, no native value,
+ * spender == this plan's own deposit target, at most one GRANT) needs only the
+ * provider plan. Rule 2 (the approval targets the ORIGIN token, is sent from
+ * the selected wallet, and grants EXACTLY the principal Vex decided to bridge)
+ * needs numbers no provider supplied, so the caller hands them in as
+ * {@link KhalaniDepositOriginBinding} - the same `fromToken`, `fromAddress` and
+ * `bridgedAmountRaw` the handler already gives `authorizeKhalaniPlanNativeValue`.
+ * The binding is a REQUIRED parameter, not an optional one: a caller that could
+ * omit it would silently plan an unbound allowance, which is the exact hole this
+ * module closes. Deriving the principal here from `vexFee.feeRaw` was rejected
+ * because inverting a floored bps split yields a RANGE, and a money bound must
+ * be exact.
+ *
+ * The binding is CHAIN-SCOPED by construction: every EVM leg this planner
+ * builds is normalized onto `sourceChain` (`normalizeEvmApproval` rejects a
+ * switch to any other chain), so comparing an approval's `to` against the
+ * origin token address compares two addresses on the same chain.
  *
  * VEX FEE LEG (`src/tools/bridge-fee`): when a fee is charged, the plan gains
  * ONE extra leg APPENDED AFTER the deposit — Vex's own transfer of 25 bps of
@@ -62,6 +67,8 @@ import { decodeErc20Approve, type ApprovedSpender } from "@tools/evm-chains/erc2
 import {
   refuseApproveStep,
   verifyApproveStepAuthorizesDeposit,
+  verifyApproveStepBindsPlanAmount,
+  type ApproveAmountBinding,
   type Erc20ApproveStepVerdict,
 } from "@tools/evm-chains/erc20-approve-step-guard.js";
 import {
@@ -76,6 +83,48 @@ import {
   type KhalaniVexFeeLeg,
   type NormalizedEvmTx,
 } from "./staged-leg.js";
+
+/**
+ * What VEX itself decided about this bridge, as opposed to anything the
+ * provider echoed back. Rule 2 of the approve binding is checked against these
+ * three fields and nothing else.
+ */
+export interface KhalaniDepositOriginBinding {
+  /**
+   * The source-chain token being bridged, in the provider-native spelling the
+   * user's `fromToken` parameter carried. A native alias means the origin asset
+   * has no token contract, so no approval in the plan can be legitimate.
+   */
+  readonly fromToken: string;
+  /** The selected wallet every leg will be signed from. */
+  readonly wallet: string;
+  /**
+   * The amount actually being deposited (post Vex fee split), in smallest
+   * units, exactly as the handler derived it for the quote.
+   */
+  readonly bridgedAmountRaw: string;
+}
+
+/**
+ * Turn the caller's binding into the guard's rule-2 input. An unreadable or
+ * non-positive principal becomes `null`, which the guard refuses as
+ * `principal_not_derivable` rather than binding an allowance to a number Vex
+ * could not read.
+ */
+function approveAmountBinding(origin: KhalaniDepositOriginBinding): ApproveAmountBinding {
+  let principalRaw: bigint | null = null;
+  try {
+    const parsed = BigInt(origin.bridgedAmountRaw);
+    principalRaw = parsed > 0n ? parsed : null;
+  } catch {
+    principalRaw = null;
+  }
+  return {
+    originToken: isNativeTransferToken(origin.fromToken) ? null : origin.fromToken,
+    wallet: origin.wallet,
+    principalRaw,
+  };
+}
 
 /**
  * Classify an EVM leg's `tx.value` with only what the planner can prove
@@ -120,7 +169,11 @@ function contractCallApprovedSpenders(
   return approved;
 }
 
-function planContractCallLegs(plan: ContractCallDepositPlan, chain: KhalaniChain): KhalaniStagedLeg[] {
+function planContractCallLegs(
+  plan: ContractCallDepositPlan,
+  chain: KhalaniChain,
+  origin: KhalaniDepositOriginBinding,
+): KhalaniStagedLeg[] {
   const family: ChainFamily = chain.type;
   const legs: KhalaniStagedLeg[] = [];
   for (const approval of plan.approvals) {
@@ -158,46 +211,64 @@ function planContractCallLegs(plan: ContractCallDepositPlan, chain: KhalaniChain
       nativeValue: planLegNativeValue(chain.id, tx),
     });
   }
-  assertApprovalsAuthorizeDeposit(legs);
+  assertApprovalsAuthorizeDeposit(legs, origin);
   return attachContractCallDepositEvidence(legs);
 }
 
 /**
- * Rule 1 of the approve binding, across the whole CONTRACT_CALL plan: every
- * approval leg is a canonical, value-free `approve` naming this plan's OWN
- * deposit target, and at most one of them GRANTS an allowance.
+ * BOTH rules of the approve binding, across the whole CONTRACT_CALL plan.
+ *
+ * Rule 1 (plan-internal): every approval leg is a canonical, value-free
+ * `approve` naming this plan's OWN deposit target, and at most one of them
+ * GRANTS an allowance.
+ *
+ * Rule 2 (Vex-derived): every GRANT is on the origin token, from the selected
+ * wallet, for EXACTLY the principal Vex asked the venue to bridge. An unlimited
+ * allowance, a larger one and a smaller one all refuse, and so does a grant on
+ * a token that is not the origin currency.
  *
  * Grants are counted rather than approval legs, because a plan may legitimately
  * carry an `approve(spender, 0)` reset alongside its grant: non-standard tokens
  * require the reset, the leg role vocabulary already names it
  * (`allowance_reset`), and the confirm site replays resets on purpose. A reset
- * is bound to the deposit target exactly like a grant, so allowing it grants no
- * authority to anyone new.
+ * is bound to the deposit target exactly like a grant (rule 1), and is exempt
+ * from rule 2 BY DEFINITION: it grants no allowance at all, so binding its zero
+ * to the principal would refuse the one sequence a non-standard token needs.
  *
  * Throws: this runs inside the planner, whose whole contract is to throw a
  * typed `VexError` before any leg reaches a signer, a nonce or a durable row.
  */
-function assertApprovalsAuthorizeDeposit(legs: readonly KhalaniStagedLeg[]): void {
+function assertApprovalsAuthorizeDeposit(
+  legs: readonly KhalaniStagedLeg[],
+  origin: KhalaniDepositOriginBinding,
+): void {
   const deposit = legs.find((leg) => leg.kind === "evm" && leg.isDeposit);
   const depositTarget = deposit !== undefined && deposit.kind === "evm" ? deposit.tx.to : null;
+  const amountBinding = approveAmountBinding(origin);
   let grants = 0;
   for (const leg of legs) {
     if (leg.kind !== "evm" || leg.isDeposit || leg.purpose !== "bridge") continue;
-    let verdict: Erc20ApproveStepVerdict = verifyApproveStepAuthorizesDeposit(
-      { to: leg.tx.to, data: leg.tx.data, value: leg.tx.value ?? 0n, from: leg.tx.expectedFrom },
-      { depositTarget },
-    );
-    if (verdict.ok && verdict.allowance !== 0n && ++grants > 1) {
-      verdict = refuseApproveStep(
-        "extra_approve_step",
-        "the plan grants a token allowance more than once, and one deposit needs at most one grant",
-      );
+    const call = {
+      to: leg.tx.to,
+      data: leg.tx.data,
+      value: leg.tx.value ?? 0n,
+      from: leg.tx.expectedFrom,
+    };
+    let verdict: Erc20ApproveStepVerdict = verifyApproveStepAuthorizesDeposit(call, { depositTarget });
+    if (verdict.ok && verdict.allowance !== 0n) {
+      grants += 1;
+      verdict = grants > 1
+        ? refuseApproveStep(
+          "extra_approve_step",
+          "the plan grants a token allowance more than once, and one deposit needs at most one grant",
+        )
+        : verifyApproveStepBindsPlanAmount(call, amountBinding);
     }
     if (!verdict.ok) {
       throw new VexError(
         ErrorCodes.KHALANI_DEPOSIT_FAILED,
         `Refused before signing the Khalani token approval: ${verdict.detail}. Nothing was signed or broadcast.`,
-        "The provider's approval did not match the deposit plan. Take a fresh khalani__bridge_quote for this route and retry.",
+        "The provider's approval did not match the deposit plan. Take a fresh khalani__bridge_quote_get for this route and retry.",
       );
     }
   }
@@ -337,14 +408,18 @@ function planVexFeeLeg(fee: KhalaniVexFeeLeg, sourceChain: KhalaniChain): Khalan
  * `deposit` leg (the hash the caller later submits to Khalani).
  *
  * `vexFee`, when present, is APPENDED as the final leg — see the module doc for
- * why it must run after the deposit and never before it. Pass `null` (or omit)
- * when the fee floors to zero: a zero-value transfer would burn gas and move
- * nothing.
+ * why it must run after the deposit and never before it. Pass `null` when the
+ * fee floors to zero: a zero-value transfer would burn gas and move nothing.
+ *
+ * `origin` carries Vex's own view of the bridge (origin token, wallet, post-fee
+ * principal) and is REQUIRED: it is what rule 2 of the approve binding is
+ * checked against, so it has no default that could silently skip the check.
  */
 export function planKhalaniDepositLegs(
   plan: DepositPlan,
   sourceChain: KhalaniChain,
-  vexFee: KhalaniVexFeeLeg | null = null,
+  vexFee: KhalaniVexFeeLeg | null,
+  origin: KhalaniDepositOriginBinding,
 ): KhalaniStagedLeg[] {
   if (plan.kind === "PERMIT2") {
     throw new VexError(
@@ -355,7 +430,7 @@ export function planKhalaniDepositLegs(
   }
   const legs = plan.kind === "TRANSFER"
     ? planTransferLeg(plan, sourceChain)
-    : planContractCallLegs(plan, sourceChain);
+    : planContractCallLegs(plan, sourceChain, origin);
 
   const depositCount = legs.filter((leg) => leg.isDeposit).length;
   if (depositCount === 0) {

--- a/src/tools/khalani/bridge-executor/deposit-plan.ts
+++ b/src/tools/khalani/bridge-executor/deposit-plan.ts
@@ -9,6 +9,27 @@
  * treasury ATA's existence, both network reads, so `./leg-signing.ts`
  * materializes it against the same per-chain RPC it already signs on.
  *
+ * APPROVE BINDING (`@tools/evm-chains/erc20-approve-step-guard.ts`): a
+ * CONTRACT_CALL plan's approval legs are bound to the deposit call BEFORE the
+ * plan is returned, so nothing downstream can sign an approval this plan does
+ * not need. Until this landed the spender and the allowance were decoded only
+ * to STAMP the deposit leg with evidence (`contractCallApprovedSpenders`
+ * below), so `approve(stranger, unlimited)` on the user's origin token planned
+ * and signed cleanly, and the standing allowance outlived the bridge.
+ *
+ * WHAT IS BOUND HERE AND WHAT IS NOT. This planner receives the provider plan,
+ * the chain and the Vex fee leg. It can therefore prove every plan-INTERNAL
+ * fact (rule 1: canonical `approve`, no native value, spender == this plan's
+ * own deposit target, at most one GRANT). It CANNOT yet prove the Vex-DERIVED
+ * facts (rule 2: the token is the origin currency and the allowance is exactly
+ * the bridged principal) because `ContractCallDepositPlan` carries neither the
+ * origin token nor the amount, and the caller passes neither: the handler holds
+ * both as `fromToken` and `bridgedAmountRaw` (it already hands them to
+ * `authorizeKhalaniPlanNativeValue`). Wiring them into this planner and calling
+ * `verifyApproveStepBindsPlanAmount` is the named follow-up; deriving the
+ * principal here from `vexFee.feeRaw` was rejected because inverting a floored
+ * bps split yields a RANGE, and a money bound must be exact.
+ *
  * VEX FEE LEG (`src/tools/bridge-fee`): when a fee is charged, the plan gains
  * ONE extra leg APPENDED AFTER the deposit — Vex's own transfer of 25 bps of
  * the input token to the treasury. It is last on purpose: the deposit is
@@ -38,6 +59,11 @@ import type {
   TransferDepositPlan,
 } from "../types.js";
 import { decodeErc20Approve, type ApprovedSpender } from "@tools/evm-chains/erc20-approval.js";
+import {
+  refuseApproveStep,
+  verifyApproveStepAuthorizesDeposit,
+  type Erc20ApproveStepVerdict,
+} from "@tools/evm-chains/erc20-approve-step-guard.js";
 import {
   assertEvmApproval,
   classifyEvmApprovalRole,
@@ -132,7 +158,49 @@ function planContractCallLegs(plan: ContractCallDepositPlan, chain: KhalaniChain
       nativeValue: planLegNativeValue(chain.id, tx),
     });
   }
+  assertApprovalsAuthorizeDeposit(legs);
   return attachContractCallDepositEvidence(legs);
+}
+
+/**
+ * Rule 1 of the approve binding, across the whole CONTRACT_CALL plan: every
+ * approval leg is a canonical, value-free `approve` naming this plan's OWN
+ * deposit target, and at most one of them GRANTS an allowance.
+ *
+ * Grants are counted rather than approval legs, because a plan may legitimately
+ * carry an `approve(spender, 0)` reset alongside its grant: non-standard tokens
+ * require the reset, the leg role vocabulary already names it
+ * (`allowance_reset`), and the confirm site replays resets on purpose. A reset
+ * is bound to the deposit target exactly like a grant, so allowing it grants no
+ * authority to anyone new.
+ *
+ * Throws: this runs inside the planner, whose whole contract is to throw a
+ * typed `VexError` before any leg reaches a signer, a nonce or a durable row.
+ */
+function assertApprovalsAuthorizeDeposit(legs: readonly KhalaniStagedLeg[]): void {
+  const deposit = legs.find((leg) => leg.kind === "evm" && leg.isDeposit);
+  const depositTarget = deposit !== undefined && deposit.kind === "evm" ? deposit.tx.to : null;
+  let grants = 0;
+  for (const leg of legs) {
+    if (leg.kind !== "evm" || leg.isDeposit || leg.purpose !== "bridge") continue;
+    let verdict: Erc20ApproveStepVerdict = verifyApproveStepAuthorizesDeposit(
+      { to: leg.tx.to, data: leg.tx.data, value: leg.tx.value ?? 0n, from: leg.tx.expectedFrom },
+      { depositTarget },
+    );
+    if (verdict.ok && verdict.allowance !== 0n && ++grants > 1) {
+      verdict = refuseApproveStep(
+        "extra_approve_step",
+        "the plan grants a token allowance more than once, and one deposit needs at most one grant",
+      );
+    }
+    if (!verdict.ok) {
+      throw new VexError(
+        ErrorCodes.KHALANI_DEPOSIT_FAILED,
+        `Refused before signing the Khalani token approval: ${verdict.detail}. Nothing was signed or broadcast.`,
+        "The provider's approval did not match the deposit plan. Take a fresh khalani__bridge_quote for this route and retry.",
+      );
+    }
+  }
 }
 
 /**

--- a/src/tools/khalani/bridge-executor/deposit-plan.ts
+++ b/src/tools/khalani/bridge-executor/deposit-plan.ts
@@ -65,12 +65,17 @@ import type {
 } from "../types.js";
 import { decodeErc20Approve, type ApprovedSpender } from "@tools/evm-chains/erc20-approval.js";
 import {
-  refuseApproveStep,
+  verifyApprovalSequence,
   verifyApproveStepAuthorizesDeposit,
-  verifyApproveStepBindsPlanAmount,
+  verifyApproveStepBindsPlan,
+  type ApprovalSequenceEntry,
   type ApproveAmountBinding,
   type Erc20ApproveStepVerdict,
 } from "@tools/evm-chains/erc20-approve-step-guard.js";
+import {
+  logUnverifiedDepositSelector,
+  verifyBridgeDepositCalldata,
+} from "@tools/evm-chains/bridge-deposit-calldata.js";
 import {
   assertEvmApproval,
   classifyEvmApprovalRole,
@@ -211,42 +216,62 @@ function planContractCallLegs(
       nativeValue: planLegNativeValue(chain.id, tx),
     });
   }
-  assertApprovalsAuthorizeDeposit(legs, origin);
+  assertPlanAuthorizesDeposit(legs, chain, origin);
   return attachContractCallDepositEvidence(legs);
 }
 
 /**
- * BOTH rules of the approve binding, across the whole CONTRACT_CALL plan.
+ * BOTH rules of the approve binding, THE ORDER, and the deposit call itself,
+ * across the whole CONTRACT_CALL plan.
  *
  * Rule 1 (plan-internal): every approval leg is a canonical, value-free
- * `approve` naming this plan's OWN deposit target, and at most one of them
- * GRANTS an allowance.
+ * `approve` naming this plan's OWN deposit target.
  *
- * Rule 2 (Vex-derived): every GRANT is on the origin token, from the selected
- * wallet, for EXACTLY the principal Vex asked the venue to bridge. An unlimited
- * allowance, a larger one and a smaller one all refuse, and so does a grant on
- * a token that is not the origin currency.
+ * Rule 2 (Vex-derived): every approval - GRANT OR RESET - is on the origin
+ * token and from the selected wallet, and every GRANT is for EXACTLY the
+ * principal Vex asked the venue to bridge. An unlimited allowance, a larger one
+ * and a smaller one all refuse, and so does an approval on a token that is not
+ * the origin currency, from a sender that is not the wallet, or on a native
+ * origin that has no token to approve. A ZERO RESET is exempt from the amount
+ * equality and from NOTHING ELSE: `approve(x, 0)` on somebody else's token, or
+ * from somebody else's account, is still an unauthorized state change on the
+ * user's own asset and still burns their gas, so the reset gets every check a
+ * grant gets except the one that is meaningless for it.
  *
- * Grants are counted rather than approval legs, because a plan may legitimately
- * carry an `approve(spender, 0)` reset alongside its grant: non-standard tokens
- * require the reset, the leg role vocabulary already names it
- * (`allowance_reset`), and the confirm site replays resets on purpose. A reset
- * is bound to the deposit target exactly like a grant (rule 1), and is exempt
- * from rule 2 BY DEFINITION: it grants no allowance at all, so binding its zero
- * to the principal would refuse the one sequence a non-standard token needs.
+ * THE ORDER (`verifyApprovalSequence`): the approvals must form
+ * `reset -> exact grant -> deposit` or a prefix of it, by LEG ORDER. A grant
+ * sequenced after the deposit is a standing allowance created after the only
+ * transaction that justified it; a reset with no grant behind it is a bare
+ * revocation the bridge never needed.
+ *
+ * THE DEPOSIT CALL (`verifyBridgeDepositCalldata`): what the deposit is asked
+ * to move, for a selector an authoritative source confirms. Khalani's
+ * `CONTRACT_CALL` selector is NOT confirmed today (see that module's table), so
+ * the plan records it and logs it once rather than refusing honest traffic, and
+ * the receipt floor stays the money guard.
  *
  * Throws: this runs inside the planner, whose whole contract is to throw a
  * typed `VexError` before any leg reaches a signer, a nonce or a durable row.
  */
-function assertApprovalsAuthorizeDeposit(
+function assertPlanAuthorizesDeposit(
   legs: readonly KhalaniStagedLeg[],
+  chain: KhalaniChain,
   origin: KhalaniDepositOriginBinding,
 ): void {
-  const deposit = legs.find((leg) => leg.kind === "evm" && leg.isDeposit);
+  const depositIndex = legs.findIndex((leg) => leg.kind === "evm" && leg.isDeposit);
+  const deposit = depositIndex === -1 ? undefined : legs[depositIndex];
   const depositTarget = deposit !== undefined && deposit.kind === "evm" ? deposit.tx.to : null;
   const amountBinding = approveAmountBinding(origin);
-  let grants = 0;
-  for (const leg of legs) {
+  function refuse(detail: string): never {
+    throw new VexError(
+      ErrorCodes.KHALANI_DEPOSIT_FAILED,
+      `Refused before signing the Khalani token approval: ${detail}. Nothing was signed or broadcast.`,
+      "The provider's approval did not match the deposit plan. Take a fresh khalani__bridge_quote_get for this route and retry.",
+    );
+  }
+
+  const approvals: ApprovalSequenceEntry[] = [];
+  for (const [index, leg] of legs.entries()) {
     if (leg.kind !== "evm" || leg.isDeposit || leg.purpose !== "bridge") continue;
     const call = {
       to: leg.tx.to,
@@ -254,22 +279,39 @@ function assertApprovalsAuthorizeDeposit(
       value: leg.tx.value ?? 0n,
       from: leg.tx.expectedFrom,
     };
-    let verdict: Erc20ApproveStepVerdict = verifyApproveStepAuthorizesDeposit(call, { depositTarget });
-    if (verdict.ok && verdict.allowance !== 0n) {
-      grants += 1;
-      verdict = grants > 1
-        ? refuseApproveStep(
-          "extra_approve_step",
-          "the plan grants a token allowance more than once, and one deposit needs at most one grant",
-        )
-        : verifyApproveStepBindsPlanAmount(call, amountBinding);
-    }
+    const bound: Erc20ApproveStepVerdict = verifyApproveStepAuthorizesDeposit(call, { depositTarget });
+    if (!bound.ok) refuse(bound.detail);
+    const planned = verifyApproveStepBindsPlan(call, amountBinding);
+    if (!planned.ok) refuse(planned.detail);
+    approvals.push({ position: index, allowance: bound.allowance });
+  }
+
+  const sequence = verifyApprovalSequence(approvals, depositIndex === -1 ? null : depositIndex);
+  if (!sequence.ok) refuse(sequence.detail);
+
+  if (deposit !== undefined && deposit.kind === "evm") {
+    const verdict = verifyBridgeDepositCalldata(
+      { to: deposit.tx.to, data: deposit.tx.data, value: deposit.tx.value ?? 0n },
+      {
+        originToken: amountBinding.originToken,
+        wallet: origin.wallet,
+        principalRaw: amountBinding.principalRaw,
+      },
+    );
     if (!verdict.ok) {
       throw new VexError(
         ErrorCodes.KHALANI_DEPOSIT_FAILED,
-        `Refused before signing the Khalani token approval: ${verdict.detail}. Nothing was signed or broadcast.`,
-        "The provider's approval did not match the deposit plan. Take a fresh khalani__bridge_quote_get for this route and retry.",
+        `Refused before signing the Khalani deposit: ${verdict.detail}. Nothing was signed or broadcast.`,
+        "The provider's deposit call did not match the plan Vex approved. Take a fresh khalani__bridge_quote_get for this route and retry.",
       );
+    }
+    if (!verdict.bound) {
+      logUnverifiedDepositSelector({
+        venue: "khalani.bridge",
+        chainId: chain.id,
+        selector: verdict.selector,
+        target: deposit.tx.to,
+      });
     }
   }
 }

--- a/src/tools/relay/execute.ts
+++ b/src/tools/relay/execute.ts
@@ -44,7 +44,11 @@ import {
   createDynamicWalletClient,
 } from "@tools/khalani/evm-client.js";
 import { checkNativeValueAuthorizedForCall } from "@tools/evm-chains/native-value-authorization/index.js";
-import { verifyApproveStepBindsPlanAmount } from "@tools/evm-chains/erc20-approve-step-guard.js";
+import { verifyApproveStepBindsPlan } from "@tools/evm-chains/erc20-approve-step-guard.js";
+import {
+  logUnverifiedDepositSelector,
+  verifyBridgeDepositCalldata,
+} from "@tools/evm-chains/bridge-deposit-calldata.js";
 import { VexError, ErrorCodes } from "../../errors.js";
 import logger from "../../utils/logger.js";
 import { RELAY_NATIVE_CURRENCY } from "./chains.js";
@@ -144,6 +148,21 @@ export interface PlannedRelayStepTx {
  * `nativeValue` is REQUIRED: what Vex derived about this step's outflow cannot
  * be inferred from the step, and a caller who omits it must not compile.
  */
+/**
+ * The principal VEX derived for this bridge, or `null` when it derived none
+ * this gate may bind to. Only EXACT_INPUT makes `bridgedAmountRaw` the INPUT
+ * amount; on any other trade type Relay chooses the input, and an amount Vex
+ * cannot read at all is not a bound either.
+ */
+function relayDerivedPrincipal(nativeValue: RelayStepNativeValueContext): bigint | null {
+  if (nativeValue.tradeType !== "EXACT_INPUT") return null;
+  try {
+    return BigInt(nativeValue.bridgedAmountRaw);
+  } catch {
+    return null;
+  }
+}
+
 export function planRelayStepTx(
   step: RelayStep,
   originChainId: number,
@@ -216,19 +235,24 @@ export function planRelayStepTx(
   // reserves no nonce and signs nothing. `originCurrency` and `bridgedAmountRaw`
   // are Vex's own derivations, never the quote's echo, which is what makes this
   // a bound rather than a restatement of the provider's intent.
+  const originToken = nativeValue.originCurrency.toLowerCase() === RELAY_NATIVE_CURRENCY
+    ? null
+    : nativeValue.originCurrency;
+  // Only EXACT_INPUT makes `bridgedAmountRaw` the INPUT amount, which is the
+  // only thing an allowance or a deposit principal may be bound to. On any
+  // other trade type Relay chooses the input and Vex has derived nothing about
+  // it.
+  const derivedPrincipal = relayDerivedPrincipal(nativeValue);
+
   if (nativeValue.role === "allowance") {
-    const verdict = verifyApproveStepBindsPlanAmount(
+    const verdict = verifyApproveStepBindsPlan(
       { to, data: data.data, value, from: data.from },
       {
-        originToken: nativeValue.originCurrency.toLowerCase() === RELAY_NATIVE_CURRENCY
-          ? null
-          : nativeValue.originCurrency,
+        originToken,
         wallet: expectedFrom,
-        // Only EXACT_INPUT makes `bridgedAmountRaw` the INPUT amount, which is
-        // the only thing an allowance may be bound to. On any other trade type
-        // Relay chooses the input and Vex has derived nothing about it, so the
-        // guard fails closed rather than binding to an output.
-        principalRaw: nativeValue.tradeType === "EXACT_INPUT" ? BigInt(nativeValue.bridgedAmountRaw) : null,
+        // A `null` principal fails the guard closed rather than binding an
+        // allowance to an output amount.
+        principalRaw: derivedPrincipal,
       },
     );
     if (!verdict.ok) {
@@ -237,6 +261,36 @@ export function planRelayStepTx(
         `Refused before signing the Relay token approval: ${verdict.detail}. Nothing was signed or broadcast for this step.`,
         "The provider's approval did not match the plan Vex approved. Get a fresh relay__bridge_quote_get for this route and retry; if the same approval comes back, bridge this route with khalani__bridge_execute instead.",
       );
+    }
+  }
+
+  // THE DEPOSIT BINDING (`@tools/evm-chains/bridge-deposit-calldata.ts`). The
+  // exact allowance proves what the depository MAY pull; only the deposit
+  // calldata proves what it is being ASKED to pull. Both Relay deposit
+  // selectors are confirmed against the verified `RelayDepository` source, so a
+  // deposit that names another token, credits another account, or moves an
+  // amount that is not the principal refuses HERE, before any nonce or
+  // signature. A selector no authority confirms is recorded and logged once,
+  // never refused: the receipt floor is the money guard for it.
+  if (nativeValue.role === "bridge_deposit") {
+    const verdict = verifyBridgeDepositCalldata(
+      { to, data: data.data, value },
+      { originToken, wallet: expectedFrom, principalRaw: derivedPrincipal },
+    );
+    if (!verdict.ok) {
+      throw new VexError(
+        ErrorCodes.RELAY_BRIDGE_FAILED,
+        `Refused before signing the Relay deposit: ${verdict.detail}. Nothing was signed or broadcast for this step.`,
+        "The provider's deposit call did not match the plan Vex approved. Get a fresh relay__bridge_quote_get for this route and retry; if the same call comes back, bridge this route with khalani__bridge_execute instead.",
+      );
+    }
+    if (!verdict.bound) {
+      logUnverifiedDepositSelector({
+        venue: "relay.bridge",
+        chainId: originChainId,
+        selector: verdict.selector,
+        target: to,
+      });
     }
   }
 

--- a/src/tools/relay/execute.ts
+++ b/src/tools/relay/execute.ts
@@ -44,8 +44,10 @@ import {
   createDynamicWalletClient,
 } from "@tools/khalani/evm-client.js";
 import { checkNativeValueAuthorizedForCall } from "@tools/evm-chains/native-value-authorization/index.js";
+import { verifyApproveStepBindsPlanAmount } from "@tools/evm-chains/erc20-approve-step-guard.js";
 import { VexError, ErrorCodes } from "../../errors.js";
 import logger from "../../utils/logger.js";
+import { RELAY_NATIVE_CURRENCY } from "./chains.js";
 import { getRelayClient, RELAY_INTENT_STATUS_PATH } from "./client.js";
 import { resolveRelayOnlyStepClients } from "./chain-client.js";
 import {
@@ -130,6 +132,14 @@ export interface PlannedRelayStepTx {
  *     signature, so the gate is a property of the planner rather than a
  *     convention every caller has to remember (Khalani puts the same check
  *     inside its own signer, `signStageEvmLeg`).
+ *   - an ALLOWANCE step is bound to what Vex itself derived
+ *     (`@tools/evm-chains/erc20-approve-step-guard.ts`, rule 2): the approval
+ *     must be on the origin token, from the selected wallet, for EXACTLY the
+ *     principal Vex asked Relay to bridge. Until this existed the spender, the
+ *     token and the allowance were decoded only AFTER signing, to record
+ *     evidence, so `approve(stranger, unlimited)` on the user's origin token
+ *     signed cleanly. The cross-step half (one approval per quote, spender ==
+ *     the deposit step's target) runs earlier, in `./step-policy.ts`.
  *
  * `nativeValue` is REQUIRED: what Vex derived about this step's outflow cannot
  * be inferred from the step, and a caller who omits it must not compile.
@@ -199,6 +209,35 @@ export function planRelayStepTx(
       ErrorCodes.NATIVE_VALUE_UNAUTHORIZED,
       relayNativeValueRefusal(nativeValue.role, authorized.reason),
     );
+  }
+
+  // THE APPROVE BINDING (rule 2). Runs after the native-value gate, on the same
+  // canonicalized tuple, and still before `signStageBroadcast`: a refusal here
+  // reserves no nonce and signs nothing. `originCurrency` and `bridgedAmountRaw`
+  // are Vex's own derivations, never the quote's echo, which is what makes this
+  // a bound rather than a restatement of the provider's intent.
+  if (nativeValue.role === "allowance") {
+    const verdict = verifyApproveStepBindsPlanAmount(
+      { to, data: data.data, value, from: data.from },
+      {
+        originToken: nativeValue.originCurrency.toLowerCase() === RELAY_NATIVE_CURRENCY
+          ? null
+          : nativeValue.originCurrency,
+        wallet: expectedFrom,
+        // Only EXACT_INPUT makes `bridgedAmountRaw` the INPUT amount, which is
+        // the only thing an allowance may be bound to. On any other trade type
+        // Relay chooses the input and Vex has derived nothing about it, so the
+        // guard fails closed rather than binding to an output.
+        principalRaw: nativeValue.tradeType === "EXACT_INPUT" ? BigInt(nativeValue.bridgedAmountRaw) : null,
+      },
+    );
+    if (!verdict.ok) {
+      throw new VexError(
+        ErrorCodes.RELAY_BRIDGE_FAILED,
+        `Refused before signing the Relay token approval: ${verdict.detail}. Nothing was signed or broadcast for this step.`,
+        "The provider's approval did not match the plan Vex approved. Get a fresh relay__bridge_quote_get for this route and retry; if the same approval comes back, bridge this route with khalani__bridge_execute instead.",
+      );
+    }
   }
 
   return { to, data: data.data as Hex, value };

--- a/src/tools/relay/execute.ts
+++ b/src/tools/relay/execute.ts
@@ -266,12 +266,14 @@ export function planRelayStepTx(
 
   // THE DEPOSIT BINDING (`@tools/evm-chains/bridge-deposit-calldata.ts`). The
   // exact allowance proves what the depository MAY pull; only the deposit
-  // calldata proves what it is being ASKED to pull. Both Relay deposit
-  // selectors are confirmed against the verified `RelayDepository` source, so a
-  // deposit that names another token, credits another account, or moves an
-  // amount that is not the principal refuses HERE, before any nonce or
-  // signature. A selector no authority confirms is recorded and logged once,
-  // never refused: the receipt floor is the money guard for it.
+  // calldata proves what it is being ASKED to pull. Relay's amount-carrying
+  // deposit selectors are confirmed against the verified `RelayDepository`
+  // source, so a deposit that names another token, credits another account, or
+  // moves an amount that is not the principal refuses HERE, before any nonce or
+  // signature - and so does the amount-free overload, whose principal is the
+  // standing allowance and therefore cannot be bound at all. A selector no
+  // authority confirms is recorded and logged once, never refused: the receipt
+  // floor is the money guard for it.
   if (nativeValue.role === "bridge_deposit") {
     const verdict = verifyBridgeDepositCalldata(
       { to, data: data.data, value },

--- a/src/tools/relay/step-policy.ts
+++ b/src/tools/relay/step-policy.ts
@@ -25,9 +25,24 @@
  *    step. Any non-origin chainId → reject BEFORE any intent/sign.
  *  - Role map (closed): `approve` → `allowance`, `deposit` → `bridge_deposit`
  *    (the `agent_activity` roles W-SPINE's repo exposes). Truthful roles only.
+ *  - AT MOST ONE approve step, and its spender MUST be the deposit step's own
+ *    target (`@tools/evm-chains/erc20-approve-step-guard.ts`, rule 1). This is
+ *    the CROSS-STEP half of the approve binding, and it lives here because this
+ *    is the only place that sees the whole step list: a quote whose approval
+ *    hands the user's origin token to an address the plan never calls is
+ *    rejected pre-intent, before an intent exists, before a wallet is resolved
+ *    and before anything is signed. The per-step half (token, sender, and the
+ *    allowance bound to the principal Vex derived) runs in `planRelayStepTx`,
+ *    where the derived numbers are.
  */
 
-import type { RelayQuoteResponse, RelayStep } from "./types.js";
+import {
+  refuseApproveStep,
+  verifyApproveStepAuthorizesDeposit,
+  type Erc20ApproveStepVerdict,
+} from "@tools/evm-chains/erc20-approve-step-guard.js";
+
+import type { RelayQuoteResponse, RelayStep, RelayStepItemData } from "./types.js";
 
 /** `agent_activity` event role for a signable Relay bridge step. */
 export type RelayStepRole = "allowance" | "bridge_deposit";
@@ -36,7 +51,8 @@ export type RelayStepRejectionReason =
   | "unsupported_step_id"
   | "unsupported_step_kind"
   | "step_chain_not_origin"
-  | "missing_step_transaction";
+  | "missing_step_transaction"
+  | "approve_not_bound_to_deposit";
 
 /** One accepted, origin-scoped signable step + its role (original quote order). */
 export interface RelaySignableStep {
@@ -120,5 +136,87 @@ export function classifyRelayBridgeSteps(
     signable.push({ stepId: step.id, role, chainId: originChainId, step });
   }
 
+  const approveBinding = bindApproveStepsToDeposit(signable);
+  if (approveBinding !== null) return approveBinding;
+
   return { ok: true, steps: signable };
+}
+
+/** The single origin transaction a classified step carries, or `null`. */
+function stepTransaction(entry: RelaySignableStep): RelayStepItemData | null {
+  for (const item of entry.step.items) {
+    if (item.data) return item.data;
+  }
+  return null;
+}
+
+/**
+ * Rule 1 of the approve binding across the WHOLE step list: at most one approve
+ * step, and it may only authorize the deposit step this same quote carries.
+ *
+ * Returns the rejection, or `null` when the steps bind. A quote with no approve
+ * step binds trivially: Relay omits the step when the allowance already covers
+ * the deposit, and every native-origin quote measured live carries none.
+ */
+function bindApproveStepsToDeposit(
+  signable: readonly RelaySignableStep[],
+): RelayStepPolicyResult | null {
+  const approvals = signable.filter((entry) => entry.role === "allowance");
+  // `.at()` rather than an index: it reports the absence in the type, so the
+  // empty and the two-approval cases are both handled instead of asserted away.
+  const approval = approvals.at(0);
+  const secondApproval = approvals.at(1);
+  if (approval === undefined) return null;
+
+  const rejection = (entry: RelaySignableStep, verdict: Erc20ApproveStepVerdict): RelayStepPolicyResult | null => {
+    if (verdict.ok) return null;
+    return {
+      ok: false,
+      reason: "approve_not_bound_to_deposit",
+      stepId: entry.stepId,
+      detail: `Relay step "${entry.stepId}" is a token approval Vex will not sign: ${verdict.detail}. Nothing was signed. Get a fresh relay__bridge_quote_get for this route and retry.`,
+    };
+  };
+
+  if (secondApproval !== undefined) {
+    return rejection(
+      secondApproval,
+      refuseApproveStep("extra_approve_step", `the quote carries ${approvals.length} approval steps, and one bridge needs at most one`),
+    );
+  }
+
+  const deposit = signable.find((entry) => entry.role === "bridge_deposit");
+  const depositTx = deposit ? stepTransaction(deposit) : null;
+  const approvalTx = stepTransaction(approval);
+  if (approvalTx === null) {
+    // The loop above already proved every signable step carries exactly one
+    // origin transaction, so this is unreachable today. It refuses rather than
+    // passing, because an approval whose transaction this gate could not read
+    // is an approval it did not check.
+    return rejection(
+      approval,
+      refuseApproveStep("not_canonical_approve", "the approval step carries no transaction to read"),
+    );
+  }
+
+  let value: bigint;
+  try {
+    value = BigInt(approvalTx.value);
+  } catch {
+    // `planRelayStepTx` owns the canonicalization refusal; a value that is not
+    // an integer is refused here too, because this gate must not admit a step
+    // whose native charge it could not read.
+    return rejection(
+      approval,
+      refuseApproveStep("approve_carries_native_value", "its native value is not an integer, so Vex cannot read what it would send"),
+    );
+  }
+
+  return rejection(
+    approval,
+    verifyApproveStepAuthorizesDeposit(
+      { to: approvalTx.to, data: approvalTx.data, value },
+      { depositTarget: depositTx?.to ?? null },
+    ),
+  );
 }

--- a/src/tools/relay/step-policy.ts
+++ b/src/tools/relay/step-policy.ts
@@ -25,6 +25,14 @@
  *    step. Any non-origin chainId → reject BEFORE any intent/sign.
  *  - Role map (closed): `approve` → `allowance`, `deposit` → `bridge_deposit`
  *    (the `agent_activity` roles W-SPINE's repo exposes). Truthful roles only.
+ *  - EXACTLY ONE DEPOSIT STEP. A plain bridge moves the principal once. A quote
+ *    carrying two deposit steps is rejected HERE, before any signable step is
+ *    returned: the approve binding proves an allowance equal to the principal,
+ *    and a second deposit against that same grant (or against an allowance that
+ *    already existed) would move the principal twice on one consent. The
+ *    downstream handler also requires the deposit to be the LAST signable step,
+ *    but that is a second reader of the same fact; the invariant belongs to the
+ *    only owner that sees the whole step list.
  *  - THE APPROVAL SHAPE IS `reset -> exact grant -> deposit`, or a prefix of
  *    it: at most one grant, at most one reset before it, and every approval
  *    strictly BEFORE the deposit step. Each approval's spender MUST be the
@@ -55,7 +63,8 @@ export type RelayStepRejectionReason =
   | "unsupported_step_kind"
   | "step_chain_not_origin"
   | "missing_step_transaction"
-  | "approve_not_bound_to_deposit";
+  | "approve_not_bound_to_deposit"
+  | "unsupported_deposit_step_count";
 
 /** One accepted, origin-scoped signable step + its role (original quote order). */
 export interface RelaySignableStep {
@@ -142,7 +151,26 @@ export function classifyRelayBridgeSteps(
   const approveBinding = bindApproveStepsToDeposit(signable);
   if (approveBinding !== null) return approveBinding;
 
+  const depositCount = countDeposits(signable);
+  if (depositCount !== 1) {
+    return {
+      ok: false,
+      reason: "unsupported_deposit_step_count",
+      stepId: "deposit",
+      detail: `Relay returned ${depositCount} deposit steps for this bridge; Vex signs a plain bridge, which is exactly one. Nothing was signed. Get a fresh relay__bridge_quote_get for this route and retry.`,
+    };
+  }
+
   return { ok: true, steps: signable };
+}
+
+/** How many classified steps carry the deposit role. */
+function countDeposits(signable: readonly RelaySignableStep[]): number {
+  let deposits = 0;
+  for (const entry of signable) {
+    if (entry.role === "bridge_deposit") deposits++;
+  }
+  return deposits;
 }
 
 /** The single origin transaction a classified step carries, or `null`. */

--- a/src/tools/relay/step-policy.ts
+++ b/src/tools/relay/step-policy.ts
@@ -25,8 +25,10 @@
  *    step. Any non-origin chainId → reject BEFORE any intent/sign.
  *  - Role map (closed): `approve` → `allowance`, `deposit` → `bridge_deposit`
  *    (the `agent_activity` roles W-SPINE's repo exposes). Truthful roles only.
- *  - AT MOST ONE approve step, and its spender MUST be the deposit step's own
- *    target (`@tools/evm-chains/erc20-approve-step-guard.ts`, rule 1). This is
+ *  - THE APPROVAL SHAPE IS `reset -> exact grant -> deposit`, or a prefix of
+ *    it: at most one grant, at most one reset before it, and every approval
+ *    strictly BEFORE the deposit step. Each approval's spender MUST be the
+ *    deposit step's own target (`@tools/evm-chains/erc20-approve-step-guard.ts`, rule 1). This is
  *    the CROSS-STEP half of the approve binding, and it lives here because this
  *    is the only place that sees the whole step list: a quote whose approval
  *    hands the user's origin token to an address the plan never calls is
@@ -37,8 +39,9 @@
  */
 
 import {
-  refuseApproveStep,
+  verifyApprovalSequence,
   verifyApproveStepAuthorizesDeposit,
+  type ApprovalSequenceEntry,
   type Erc20ApproveStepVerdict,
 } from "@tools/evm-chains/erc20-approve-step-guard.js";
 
@@ -151,8 +154,16 @@ function stepTransaction(entry: RelaySignableStep): RelayStepItemData | null {
 }
 
 /**
- * Rule 1 of the approve binding across the WHOLE step list: at most one approve
- * step, and it may only authorize the deposit step this same quote carries.
+ * Rule 1 of the approve binding across the WHOLE step list, plus THE ORDER.
+ *
+ * Every approval step must be a canonical, value-free `approve` naming this
+ * quote's own deposit target (rule 1,
+ * `verifyApproveStepAuthorizesDeposit`), and the approvals as a set must form
+ * the only shape a bridge may sign: `reset -> exact grant -> deposit`, or any
+ * shorter prefix of it (`verifyApprovalSequence`). Relay's own order is the
+ * STEP INDEX, which is the order the handler broadcasts in, so an approval that
+ * sits at or after the deposit step is an allowance created after the only
+ * transaction that justified it.
  *
  * Returns the rejection, or `null` when the steps bind. A quote with no approve
  * step binds trivially: Relay omits the step when the allowance already covers
@@ -161,62 +172,51 @@ function stepTransaction(entry: RelaySignableStep): RelayStepItemData | null {
 function bindApproveStepsToDeposit(
   signable: readonly RelaySignableStep[],
 ): RelayStepPolicyResult | null {
-  const approvals = signable.filter((entry) => entry.role === "allowance");
-  // `.at()` rather than an index: it reports the absence in the type, so the
-  // empty and the two-approval cases are both handled instead of asserted away.
-  const approval = approvals.at(0);
-  const secondApproval = approvals.at(1);
-  if (approval === undefined) return null;
+  const rejection = (entry: RelaySignableStep, detail: string): RelayStepPolicyResult => ({
+    ok: false,
+    reason: "approve_not_bound_to_deposit",
+    stepId: entry.stepId,
+    detail: `Relay step "${entry.stepId}" is a token approval Vex will not sign: ${detail}. Nothing was signed. Get a fresh relay__bridge_quote_get for this route and retry.`,
+  });
 
-  const rejection = (entry: RelaySignableStep, verdict: Erc20ApproveStepVerdict): RelayStepPolicyResult | null => {
-    if (verdict.ok) return null;
-    return {
-      ok: false,
-      reason: "approve_not_bound_to_deposit",
-      stepId: entry.stepId,
-      detail: `Relay step "${entry.stepId}" is a token approval Vex will not sign: ${verdict.detail}. Nothing was signed. Get a fresh relay__bridge_quote_get for this route and retry.`,
-    };
-  };
+  const depositIndex = signable.findIndex((entry) => entry.role === "bridge_deposit");
+  const depositEntry = signable.at(depositIndex === -1 ? signable.length : depositIndex);
+  const depositTx = depositEntry === undefined ? null : stepTransaction(depositEntry);
+  const approvalEntries: ApprovalSequenceEntry[] = [];
 
-  if (secondApproval !== undefined) {
-    return rejection(
-      secondApproval,
-      refuseApproveStep("extra_approve_step", `the quote carries ${approvals.length} approval steps, and one bridge needs at most one`),
-    );
-  }
-
-  const deposit = signable.find((entry) => entry.role === "bridge_deposit");
-  const depositTx = deposit ? stepTransaction(deposit) : null;
-  const approvalTx = stepTransaction(approval);
-  if (approvalTx === null) {
-    // The loop above already proved every signable step carries exactly one
-    // origin transaction, so this is unreachable today. It refuses rather than
-    // passing, because an approval whose transaction this gate could not read
-    // is an approval it did not check.
-    return rejection(
-      approval,
-      refuseApproveStep("not_canonical_approve", "the approval step carries no transaction to read"),
-    );
-  }
-
-  let value: bigint;
-  try {
-    value = BigInt(approvalTx.value);
-  } catch {
-    // `planRelayStepTx` owns the canonicalization refusal; a value that is not
-    // an integer is refused here too, because this gate must not admit a step
-    // whose native charge it could not read.
-    return rejection(
-      approval,
-      refuseApproveStep("approve_carries_native_value", "its native value is not an integer, so Vex cannot read what it would send"),
-    );
-  }
-
-  return rejection(
-    approval,
-    verifyApproveStepAuthorizesDeposit(
+  for (const [index, entry] of signable.entries()) {
+    if (entry.role !== "allowance") continue;
+    const approvalTx = stepTransaction(entry);
+    if (approvalTx === null) {
+      // The classifier above already proved every signable step carries exactly
+      // one origin transaction, so this is unreachable today. It refuses rather
+      // than passing, because an approval whose transaction this gate could not
+      // read is an approval it did not check.
+      return rejection(entry, "the approval step carries no transaction to read");
+    }
+    let value: bigint;
+    try {
+      value = BigInt(approvalTx.value);
+    } catch {
+      // `planRelayStepTx` owns the canonicalization refusal; a value that is not
+      // an integer is refused here too, because this gate must not admit a step
+      // whose native charge it could not read.
+      return rejection(entry, "its native value is not an integer, so Vex cannot read what it would send");
+    }
+    const verdict: Erc20ApproveStepVerdict = verifyApproveStepAuthorizesDeposit(
       { to: approvalTx.to, data: approvalTx.data, value },
       { depositTarget: depositTx?.to ?? null },
-    ),
-  );
+    );
+    if (!verdict.ok) return rejection(entry, verdict.detail);
+    approvalEntries.push({ position: index, allowance: verdict.allowance });
+  }
+
+  const sequence = verifyApprovalSequence(approvalEntries, depositIndex === -1 ? null : depositIndex);
+  if (!sequence.ok) {
+    // The LAST approval is the one the sequence rule objects to on every shape
+    // it names, so it is the step the message points at.
+    const offending = signable.filter((entry) => entry.role === "allowance").at(-1);
+    if (offending !== undefined) return rejection(offending, sequence.detail);
+  }
+  return null;
 }

--- a/src/vex-agent/sync/executed-amount-fallback/deposit-evidence-resolver.ts
+++ b/src/vex-agent/sync/executed-amount-fallback/deposit-evidence-resolver.ts
@@ -114,6 +114,7 @@ export async function resolveBridgeDepositAmount(input: {
 
   const outcome = proveErc20DepositAmount({
     logs: input.logs,
+    chainId: row.chainId,
     tokenAddress: tokenInAddress,
     senderAddress: row.walletAddress,
     recipients: authorizedDepositRecipients({
@@ -124,12 +125,23 @@ export async function resolveBridgeDepositAmount(input: {
     quotedAmountInRaw: amountInRaw,
   });
 
-  return outcome.kind === "proven"
-    ? { kind: "decoded", executedAmountInRaw: outcome.amountRaw }
-    : {
+  if (outcome.kind === "proven") {
+    return { kind: "decoded", executedAmountInRaw: outcome.amountRaw };
+  }
+  // A SHORTFALL is not an amount this lane may write. The receipt proved a
+  // transfer BELOW the principal the row was quoted for, which the venue
+  // records for review at return time; back-filling it here would silently turn
+  // a disputed deposit into a settled one.
+  if (outcome.kind === "short") {
+    return {
       kind: "declined",
-      detail: `the receipt did not prove the deposit transfer (${outcome.reason}, candidates=${outcome.candidateCount})`,
+      detail: `the receipt proved ${outcome.provenAmountRaw} against a quoted ${outcome.quotedAmountRaw}, which is below the deposit floor`,
     };
+  }
+  return {
+    kind: "declined",
+    detail: `the receipt did not prove the deposit transfer (${outcome.reason}, candidates=${outcome.candidateCount})`,
+  };
 }
 
 /**

--- a/src/vex-agent/tools/protocols/bridge-deposit-evidence.ts
+++ b/src/vex-agent/tools/protocols/bridge-deposit-evidence.ts
@@ -23,6 +23,19 @@
  *     allowance when the recipient is a spender. Both bounds are ABSOLUTE, in
  *     raw units, so neither can scale with trade size and hide a real overspend.
  *
+ * AND THEN THE FLOOR. A ceiling alone is one-sided: it stops an overspend and
+ * says nothing about an UNDERSPEND. A deposit of one atomic unit against a
+ * million-unit quote used to be "proven" and then paid the whole fixed Vex fee,
+ * while the card the user consented to said the whole amount would travel. So
+ * the proven amount must EQUAL the quoted principal, minus only a deduction
+ * this repository has MEASURED for that exact (chain, token) pair
+ * ({@link FEE_ON_TRANSFER_DEDUCTIONS}, empty by default, absolute atomic units
+ * and never a percentage - a percentage tolerance scales with trade size, which
+ * is exactly what a money bound must not do). Anything below that floor is a
+ * `deposit_short` outcome carrying both figures: the venue records it for
+ * review, states both numbers in the tool result, and NO fee leg runs, because
+ * a fee is charged for an operation that succeeded as quoted.
+ *
  * Zero candidates or more than one: no amount, and a NAMED decline the caller
  * records and logs. Vex-built knowledge (a Khalani `TRANSFER` plan Vex composed
  * itself) NARROWS which candidate is ours through `expectedAmountRaw`; it never
@@ -60,6 +73,8 @@ export interface DepositTransferLog {
 
 export interface Erc20DepositEvidence {
   readonly logs: readonly DepositTransferLog[];
+  /** The chain the deposit settled on - half the key of the fee-on-transfer table. */
+  readonly chainId: number;
   /** The input token of the activity event whose amount is being established. */
   readonly tokenAddress: string;
   /** The wallet that signed the deposit. */
@@ -136,6 +151,42 @@ export function authorizedDepositRecipients(args: {
   return recipients;
 }
 
+/**
+ * The ONLY tokens whose deposits may prove LESS than the quoted principal, and
+ * exactly how much less, per chain.
+ *
+ * EMPTY BY DEFAULT, and that is the design rather than a placeholder. A
+ * fee-on-transfer token skims a deduction the sender cannot see in the quote,
+ * so its honest deposit really is short - but "some tokens do that" is not
+ * evidence about the token in front of us. An entry is added only when the
+ * deduction has been MEASURED on that chain for that token, and it is recorded
+ * in ABSOLUTE atomic units (rule 90: a money tolerance is absolute, never a
+ * percentage that grows with trade size).
+ *
+ * Key: lowercase `${chainId}:${tokenAddress}`.
+ */
+export const FEE_ON_TRANSFER_DEDUCTIONS: ReadonlyMap<string, bigint> = new Map<string, bigint>();
+
+/**
+ * The least a deposit of `quotedRaw` may prove and still count as the deposit
+ * the user consented to.
+ *
+ * `deductions` exists so the rule can be exercised against a MEASURED table
+ * without a checked-in entry standing in for a measurement; production always
+ * uses {@link FEE_ON_TRANSFER_DEDUCTIONS}, which is empty, so the floor is the
+ * quote itself.
+ */
+export function bridgeDepositFloor(args: {
+  readonly chainId: number;
+  readonly tokenAddress: string;
+  readonly quotedRaw: bigint;
+  readonly deductions?: ReadonlyMap<string, bigint>;
+}): bigint {
+  const table = args.deductions ?? FEE_ON_TRANSFER_DEDUCTIONS;
+  const deduction = table.get(`${args.chainId}:${args.tokenAddress.trim().toLowerCase()}`) ?? 0n;
+  return args.quotedRaw - deduction;
+}
+
 /** Why no amount could be declared. Named, so a decline is debuggable without the payload. */
 export type DepositEvidenceDeclineReason =
   /** No log satisfied every condition. */
@@ -147,6 +198,16 @@ export type DepositEvidenceDeclineReason =
 
 export type DepositEvidenceOutcome =
   | { readonly kind: "proven"; readonly amountRaw: string }
+  | {
+      /**
+       * The receipt proved a transfer, and it moved LESS than the plan bridged.
+       * A distinct outcome rather than a decline: the amount is known, which is
+       * precisely why the shortfall can be named and the fee withheld.
+       */
+      readonly kind: "short";
+      readonly provenAmountRaw: string;
+      readonly quotedAmountRaw: string;
+    }
   | {
       readonly kind: "declined";
       readonly reason: DepositEvidenceDeclineReason;
@@ -218,7 +279,7 @@ export function proveErc20DepositAmount(evidence: Erc20DepositEvidence): Deposit
     : parseRawAmount(evidence.expectedAmountRaw);
   if (expected !== null) {
     const exact = candidates.filter((amount) => amount === expected);
-    if (exact.length === 1) return { kind: "proven", amountRaw: expected.toString() };
+    if (exact.length === 1) return floored(expected, bound, evidence);
   }
 
   if (candidates.length === 0) {
@@ -231,7 +292,30 @@ export function proveErc20DepositAmount(evidence: Erc20DepositEvidence): Deposit
       candidateCount: candidates.length,
     };
   }
-  return { kind: "proven", amountRaw: candidates[0]!.toString() };
+  return floored(candidates[0]!, bound, evidence);
+}
+
+/**
+ * THE RECEIPT FLOOR. The single proven candidate is the amount only when it
+ * reaches the quoted principal, less a deduction MEASURED for this exact
+ * (chain, token) pair. Everything below is a named shortfall carrying both
+ * figures, which is what makes the fee leg ineligible and gives the human the
+ * two numbers to compare.
+ */
+function floored(
+  amount: bigint,
+  quoted: bigint,
+  evidence: Erc20DepositEvidence,
+): DepositEvidenceOutcome {
+  const floor = bridgeDepositFloor({
+    chainId: evidence.chainId,
+    tokenAddress: evidence.tokenAddress,
+    quotedRaw: quoted,
+  });
+  if (amount < floor) {
+    return { kind: "short", provenAmountRaw: amount.toString(), quotedAmountRaw: quoted.toString() };
+  }
+  return { kind: "proven", amountRaw: amount.toString() };
 }
 
 /**
@@ -243,16 +327,102 @@ export function proveErc20DepositAmount(evidence: Erc20DepositEvidence): Deposit
 export type DepositSettlement =
   | { readonly kind: "proven"; readonly evidence: LegAmountEvidence }
   | {
+      /**
+       * The receipt proved a transfer BELOW the quoted principal. The row is
+       * confirmed without amounts and marked for review, and the venue's fee
+       * leg is ineligible - see {@link DepositShortfall}.
+       */
+      readonly kind: "short";
+      readonly provenAmountRaw: string;
+      readonly quotedAmountRaw: string;
+    }
+  | {
       readonly kind: "declined";
       readonly reason: DepositEvidenceDeclineReason;
       readonly candidateCount: number;
     };
 
+/**
+ * What a venue hands its fee decision when the deposit came up short: the two
+ * figures the human has to compare, and nothing else.
+ *
+ * THE RULE IT CARRIES (rule 90, "take a fee only after the operation it charges
+ * for succeeds"): a bridge that moved less than the principal the user
+ * consented to did not do what the fee is charged for, so no fee signer runs,
+ * no nonce is reserved, and the planned fee row is aborted. The bridge itself
+ * is NOT failed by this: the deposit landed, and the destination fill is still
+ * the provider's to make.
+ */
+export interface DepositShortfall {
+  readonly provenAmountRaw: string;
+  readonly quotedAmountRaw: string;
+}
+
+/** The shortfall a settlement carries, or `null` when the deposit met the floor. */
+export function depositShortfallOf(settlement: DepositSettlement): DepositShortfall | null {
+  return settlement.kind === "short"
+    ? { provenAmountRaw: settlement.provenAmountRaw, quotedAmountRaw: settlement.quotedAmountRaw }
+    : null;
+}
+
+/**
+ * The sentence both venues put in front of the agent and the human when a
+ * deposit came up short. One owner, so the two surfaces cannot drift.
+ */
+export function depositShortfallNote(shortfall: DepositShortfall): string {
+  return `The bridge deposit moved ${shortfall.provenAmountRaw} raw units where the quote bridged ${shortfall.quotedAmountRaw}. No Vex fee was taken and the deposit is recorded for review; do not re-bridge, and check the transaction on the explorer before bridging this route again.`;
+}
+
+/** What a venue's fee surface takes: the collection state and its note. */
+export interface WithheldFeeCollection {
+  readonly collection: "not_attempted";
+  readonly collectionNote: string;
+}
+
+/**
+ * THE FEE DECISION FOR A SHORT DEPOSIT, owned once for both venues.
+ *
+ * It takes no signer, no wallet and no nonce owner BY CONSTRUCTION: the only
+ * effect it can have is aborting the planned fee row, so a bridge that came up
+ * short cannot reach a signature through this path however the caller wires it.
+ * The caller's own branch is `shortfall === null ? runFeeLeg(...) : this`, so
+ * the fee leg is never even constructed.
+ *
+ * The planned fee row is ABORTED rather than left planned: a row nobody will
+ * ever sign must not sit pending forever, and the abort is what releases it.
+ */
+export async function withholdFeeOnDepositShortfall(args: {
+  readonly shortfall: DepositShortfall;
+  readonly executionId: number;
+  /** Index of the planned fee row, or -1 when this bridge charges no fee. */
+  readonly feeLegIndex: number;
+  readonly logScope: string;
+  readonly abortPlannedFeeRow: (fromIndex: number, reason: string) => Promise<void>;
+}): Promise<WithheldFeeCollection> {
+  logger.warn(`${args.logScope}.fee_withheld_deposit_short`, {
+    executionId: args.executionId,
+    proven: args.shortfall.provenAmountRaw,
+    quoted: args.shortfall.quotedAmountRaw,
+  });
+  if (args.feeLegIndex !== -1) {
+    await args.abortPlannedFeeRow(args.feeLegIndex, "deposit proved less than the quoted principal");
+  }
+  return { collection: "not_attempted", collectionNote: depositShortfallNote(args.shortfall) };
+}
+
 /** Adapt a receipt verdict into the settlement the confirm-site writer takes. */
 export function receiptDepositSettlement(outcome: DepositEvidenceOutcome): DepositSettlement {
-  return outcome.kind === "proven"
-    ? { kind: "proven", evidence: { kind: "decoded_and_bounded", amountRaw: outcome.amountRaw } }
-    : { kind: "declined", reason: outcome.reason, candidateCount: outcome.candidateCount };
+  if (outcome.kind === "proven") {
+    return { kind: "proven", evidence: { kind: "decoded_and_bounded", amountRaw: outcome.amountRaw } };
+  }
+  if (outcome.kind === "short") {
+    return {
+      kind: "short",
+      provenAmountRaw: outcome.provenAmountRaw,
+      quotedAmountRaw: outcome.quotedAmountRaw,
+    };
+  }
+  return { kind: "declined", reason: outcome.reason, candidateCount: outcome.candidateCount };
 }
 
 export interface DepositSettlementRecord {
@@ -294,14 +464,33 @@ export async function confirmDepositWithProvenAmounts(
   // Everything below is MONEY bookkeeping on a row whose STATUS question the
   // confirm above already answered. A failure here must never be reported as an
   // unrecorded confirmation, so each writer carries its own failure.
-  if (record.settlement.kind === "declined") {
-    logger.info(`${record.logScope}.deposit_amount_declined`, {
-      id: record.eventId,
-      reason: record.settlement.reason,
-      candidates: record.settlement.candidateCount,
-    });
+  if (record.settlement.kind !== "proven") {
+    // A SHORTFALL is a known amount that contradicts the plan, and a DECLINE is
+    // an amount nothing could read. Both leave the row without an executed
+    // amount, and both mark it for the review that owns the difference; the
+    // reason vocabulary they stamp is the durable one this repository already
+    // has (`amounts_incomplete` / `amounts_undecodable`), so recording a
+    // shortfall needs no migration and invents no wire value. The two figures
+    // of a shortfall travel in the log line and in the tool result, which is
+    // where a human compares them.
+    if (record.settlement.kind === "short") {
+      logger.warn(`${record.logScope}.deposit_short`, {
+        id: record.eventId,
+        proven: record.settlement.provenAmountRaw,
+        quoted: record.settlement.quotedAmountRaw,
+      });
+    } else {
+      logger.info(`${record.logScope}.deposit_amount_declined`, {
+        id: record.eventId,
+        reason: record.settlement.reason,
+        candidates: record.settlement.candidateCount,
+      });
+    }
     try {
-      await noteSettlementDeclined(record.eventId, "amounts_undecodable");
+      await noteSettlementDeclined(
+        record.eventId,
+        record.settlement.kind === "short" ? "amounts_incomplete" : "amounts_undecodable",
+      );
     } catch (error) {
       logger.warn(`${record.logScope}.deposit_decline_note_failed`, {
         id: record.eventId,

--- a/src/vex-agent/tools/protocols/bridge-deposit-evidence.ts
+++ b/src/vex-agent/tools/protocols/bridge-deposit-evidence.ts
@@ -390,6 +390,14 @@ export interface WithheldFeeCollection {
  *
  * The planned fee row is ABORTED rather than left planned: a row nobody will
  * ever sign must not sit pending forever, and the abort is what releases it.
+ *
+ * THE ABORT IS EXACTLY ONE ROW WIDE. `abortPlannedEvents` finalizes every
+ * hashless pending row from `fromIndex` ONWARD, and the logical
+ * `bridge_fill_expected` row sits after the fee row: aborting it would
+ * terminalize the reconciliation row of a deposit that WAS submitted to the
+ * provider and release its in-flight guard while the bridge may still fill. So
+ * the range handed to the venue is `[feeLegIndex, feeLegIndex + 1)` and the
+ * fill row stays pending for the W4 sweep.
  */
 export async function withholdFeeOnDepositShortfall(args: {
   readonly shortfall: DepositShortfall;
@@ -397,7 +405,16 @@ export async function withholdFeeOnDepositShortfall(args: {
   /** Index of the planned fee row, or -1 when this bridge charges no fee. */
   readonly feeLegIndex: number;
   readonly logScope: string;
-  readonly abortPlannedFeeRow: (fromIndex: number, reason: string) => Promise<void>;
+  /**
+   * Finalize the planned rows in `[fromIndex, toIndexExclusive)`. Both venues
+   * pass this straight to their `abortRemaining`, whose third argument is the
+   * repository's own exclusive bound.
+   */
+  readonly abortPlannedFeeRow: (
+    fromIndex: number,
+    reason: string,
+    toIndexExclusive: number,
+  ) => Promise<void>;
 }): Promise<WithheldFeeCollection> {
   logger.warn(`${args.logScope}.fee_withheld_deposit_short`, {
     executionId: args.executionId,
@@ -405,7 +422,11 @@ export async function withholdFeeOnDepositShortfall(args: {
     quoted: args.shortfall.quotedAmountRaw,
   });
   if (args.feeLegIndex !== -1) {
-    await args.abortPlannedFeeRow(args.feeLegIndex, "deposit proved less than the quoted principal");
+    await args.abortPlannedFeeRow(
+      args.feeLegIndex,
+      "deposit proved less than the quoted principal",
+      args.feeLegIndex + 1,
+    );
   }
   return { collection: "not_attempted", collectionNote: depositShortfallNote(args.shortfall) };
 }

--- a/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute.ts
+++ b/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute.ts
@@ -461,7 +461,11 @@ export async function executeKhalaniBridge(
       executionId,
       feeLegIndex,
       logScope: "khalani.bridge",
-      abortPlannedFeeRow: (fromIndex, reason) => abortRemaining(executionId, fromIndex, reason),
+      // Exactly the fee row: the logical `bridge_fill_expected` row sits after
+      // it and must stay pending, because the deposit itself reached the
+      // provider and its reconciliation is still owed.
+      abortPlannedFeeRow: (fromIndex, reason, toIndexExclusive) =>
+        abortRemaining(executionId, fromIndex, reason, toIndexExclusive),
     })
     : await runKhalaniVexFeeLeg({
       executionId, feeLegIndex, stagedLegs, intentLegs: intent.legs,

--- a/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute.ts
+++ b/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute.ts
@@ -64,6 +64,7 @@ import {
 } from "./bridge-execute/fee-disclosure.js";
 import { runKhalaniBridgeLegs } from "./bridge-execute/legs.js";
 import { runKhalaniVexFeeLeg } from "./bridge-execute/fee-leg.js";
+import { withholdFeeOnDepositShortfall } from "@vex-agent/tools/protocols/bridge-deposit-evidence.js";
 import { submitKhalaniDeposit } from "./bridge-execute/submit.js";
 import type { KhalaniBridgePendingBase } from "./bridge-execute/types.js";
 import {
@@ -450,10 +451,22 @@ export async function executeKhalaniBridge(
   // risk. An ambiguous broadcast is left unresolved for the receipt sweep
   // exactly like any other staged transaction - a blind retry could charge the
   // user twice.
-  const feeOutcome = await runKhalaniVexFeeLeg({
-    executionId, feeLegIndex, stagedLegs, intentLegs: intent.legs,
-    sourceChain, chains, signer, fromChainId, fromChainName, recordedLegs,
-  });
+  // A DEPOSIT SHORTFALL MAKES THE FEE LEG INELIGIBLE. The fee is charged for
+  // bridging the principal the user consented to; a deposit whose own receipt
+  // proves less than that did not perform it, so no fee signer runs, no nonce
+  // is reserved, and the planned fee row is aborted rather than left pending.
+  const feeOutcome = legLoop.depositShortfall !== null
+    ? await withholdFeeOnDepositShortfall({
+      shortfall: legLoop.depositShortfall,
+      executionId,
+      feeLegIndex,
+      logScope: "khalani.bridge",
+      abortPlannedFeeRow: (fromIndex, reason) => abortRemaining(executionId, fromIndex, reason),
+    })
+    : await runKhalaniVexFeeLeg({
+      executionId, feeLegIndex, stagedLegs, intentLegs: intent.legs,
+      sourceChain, chains, signer, fromChainId, fromChainName, recordedLegs,
+    });
 
   // 16. In-turn order poll - truthful, never fabricated (R6/B4/Q2).
   const poll = await pollKhalaniOrderToTerminal(pollOrderId, context.abortSignal);

--- a/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute/deposit-plan.ts
+++ b/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute/deposit-plan.ts
@@ -90,6 +90,14 @@ export async function buildKhalaniDepositPlan(
       plan,
       input.sourceChain,
       input.chargeFee ? { tokenAddress: input.fromToken, feeRaw: input.feeRaw } : null,
+      // Vex's own view of the bridge, the same three facts
+      // `authorizeKhalaniPlanNativeValue` gets below. The planner binds the
+      // provider's approval to them (`erc20-approve-step-guard.ts` rule 2)
+      // BEFORE returning any leg, so an approval on a foreign token, from
+      // another sender, or for anything other than this exact principal
+      // (unlimited most of all) throws here and never reaches a signer, a
+      // nonce or a durable row.
+      { fromToken: input.fromToken, wallet: input.fromAddress, bridgedAmountRaw: input.bridgedAmountRaw },
     );
   } catch (err) {
     planError = err;

--- a/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute/legs.ts
+++ b/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute/legs.ts
@@ -27,9 +27,11 @@ import {
 import {
   authorizedDepositRecipients,
   confirmDepositWithProvenAmounts,
+  depositShortfallOf,
   proveErc20DepositAmount,
   receiptDepositSettlement,
   type DepositSettlement,
+  type DepositShortfall,
 } from "@vex-agent/tools/protocols/bridge-deposit-evidence.js";
 import logger from "@utils/logger.js";
 import { VexError, ErrorCodes } from "../../../../../../errors.js";
@@ -69,7 +71,17 @@ export interface KhalaniLegLoopInput {
 
 export type KhalaniLegLoopOutcome =
   /** Every bridge leg confirmed on-chain; `depositTxHash` is `undefined` only in the unreachable no-deposit case. */
-  | { readonly outcome: "confirmed"; readonly depositTxHash: string | undefined; readonly currentIndex: number }
+  | {
+      readonly outcome: "confirmed";
+      readonly depositTxHash: string | undefined;
+      readonly currentIndex: number;
+      /**
+       * The deposit's receipt proved LESS than the quote bridged, or `null`
+       * when it met the floor. A shortfall makes the Vex fee leg ineligible
+       * (`bridge-deposit-evidence.ts`): the caller must not run it.
+       */
+      readonly depositShortfall: DepositShortfall | null;
+    }
   /** The loop stopped and the handler must return this result verbatim. */
   | { readonly outcome: "halted"; readonly result: ToolResult; readonly currentIndex: number };
 
@@ -111,6 +123,7 @@ function khalaniDepositSettlement(
     });
   return receiptDepositSettlement(proveErc20DepositAmount({
     logs: outcome.receiptLogs,
+    chainId: input.fromChainId,
     tokenAddress: evidence.kind === "vex_built_erc20_transfer" ? evidence.token : input.fromToken,
     senderAddress: input.signer.address,
     recipients,
@@ -128,6 +141,9 @@ export async function runKhalaniBridgeLegs(input: KhalaniLegLoopInput): Promise<
   } = input;
 
   let depositTxHash: string | undefined;
+  // What the deposit's own receipt proved against what the plan bridged. Read
+  // by the caller's fee decision: a shortfall makes the Vex fee leg ineligible.
+  let depositShortfall: DepositShortfall | null = null;
   let currentIndex = 0;
   // Read-after-write anchor for the NEXT leg: the allowance this loop just
   // confirmed is exactly the state the deposit leg's pre-sign estimate depends
@@ -206,13 +222,17 @@ export async function runKhalaniBridgeLegs(input: KhalaniLegLoopInput): Promise<
         // deposit leg declares only what its own receipt proves, or declines by
         // name (`bridge-deposit-evidence.ts`). Confirming a leg proves inclusion
         // and never, on its own, the principal it carried.
-        const confirmResult = stagedLeg.isDeposit
+        const settlement = stagedLeg.isDeposit
+          ? khalaniDepositSettlement(stagedLeg, outcome, input)
+          : null;
+        if (settlement !== null) depositShortfall = depositShortfallOf(settlement);
+        const confirmResult = settlement !== null
           ? await confirmDepositWithProvenAmounts({
             eventId: legRow.id,
             role: legRow.eventRole,
             txHash: outcome.txHash,
             chainId: fromChainId,
-            settlement: khalaniDepositSettlement(stagedLeg, outcome, input),
+            settlement,
             logScope: "khalani.bridge",
           })
           : await confirmActivityEvent(
@@ -241,7 +261,7 @@ export async function runKhalaniBridgeLegs(input: KhalaniLegLoopInput): Promise<
     };
   }
 
-  return { outcome: "confirmed", depositTxHash, currentIndex };
+  return { outcome: "confirmed", depositTxHash, currentIndex, depositShortfall };
 }
 
 /**

--- a/src/vex-agent/tools/protocols/relay/handlers/bridge.ts
+++ b/src/vex-agent/tools/protocols/relay/handlers/bridge.ts
@@ -519,7 +519,11 @@ async function relayBridge(
       executionId,
       feeLegIndex,
       logScope: "relay.bridge",
-      abortPlannedFeeRow: (fromIndex, reason) => abortRemaining(executionId, fromIndex, reason),
+      // Exactly the fee row: the logical `bridge_fill_expected` row sits after
+      // it and must stay pending, because the deposit itself reached the
+      // provider and its reconciliation is still owed.
+      abortPlannedFeeRow: (fromIndex, reason, toIndexExclusive) =>
+        abortRemaining(executionId, fromIndex, reason, toIndexExclusive),
     })
     : feeLegIndex === -1
     ? NO_FEE_COLLECTION

--- a/src/vex-agent/tools/protocols/relay/handlers/bridge.ts
+++ b/src/vex-agent/tools/protocols/relay/handlers/bridge.ts
@@ -85,7 +85,8 @@ import {
   runRelayVexFeeLeg,
 } from "./bridge/fee-leg.js";
 import { runOriginBroadcasts, type OriginBroadcast } from "./bridge/broadcast.js";
-import { maybeAutoPin, relayLegInput } from "./bridge/recording.js";
+import { withholdFeeOnDepositShortfall } from "@vex-agent/tools/protocols/bridge-deposit-evidence.js";
+import { abortRemaining, maybeAutoPin, relayLegInput } from "./bridge/recording.js";
 import { failPreSign, inFlightResult, pendingResult } from "./bridge/results.js";
 import {
   noteHandlerPendingReason,
@@ -506,7 +507,21 @@ async function relayBridge(
   // own fill tracking (separate lifecycles sharing one plan). Its outcome
   // NEVER changes the bridge's: a fee that does not land is missed Vex
   // revenue on a bridge that DID happen.
-  const feeCollection = feeLegIndex === -1
+  // A DEPOSIT SHORTFALL MAKES THE FEE LEG INELIGIBLE. The fee is charged for
+  // bridging the principal the user consented to; a deposit whose own receipt
+  // proves less than that did not perform it, so no fee signer runs, no nonce
+  // is reserved, and the planned fee row is aborted rather than left pending.
+  // The bridge itself is untouched: the deposit landed and the fill is still
+  // the provider's to make.
+  const feeCollection = run.depositShortfall !== null
+    ? await withholdFeeOnDepositShortfall({
+      shortfall: run.depositShortfall,
+      executionId,
+      feeLegIndex,
+      logScope: "relay.bridge",
+      abortPlannedFeeRow: (fromIndex, reason) => abortRemaining(executionId, fromIndex, reason),
+    })
+    : feeLegIndex === -1
     ? NO_FEE_COLLECTION
     : await runRelayVexFeeLeg({
         executionId,

--- a/src/vex-agent/tools/protocols/relay/handlers/bridge/broadcast.ts
+++ b/src/vex-agent/tools/protocols/relay/handlers/bridge/broadcast.ts
@@ -38,9 +38,11 @@ import {
 import {
   authorizedDepositRecipients,
   confirmDepositWithProvenAmounts,
+  depositShortfallOf,
   proveErc20DepositAmount,
   receiptDepositSettlement,
   type DepositSettlement,
+  type DepositShortfall,
   type DepositTransferLog,
 } from "@vex-agent/tools/protocols/bridge-deposit-evidence.js";
 import { summarizeProtocolError } from "@vex-agent/tools/protocols/runtime/errors.js";
@@ -81,7 +83,16 @@ export interface OriginBroadcast {
  * already built.
  */
 export type OriginBroadcastRun =
-  | { readonly kind: "confirmed"; readonly broadcasts: OriginBroadcast[] }
+  | {
+      readonly kind: "confirmed";
+      readonly broadcasts: OriginBroadcast[];
+      /**
+       * The deposit's receipt proved LESS than the quote bridged, or `null`
+       * when it met the floor. A shortfall makes the Vex fee leg ineligible
+       * (`bridge-deposit-evidence.ts`): the caller must not run it.
+       */
+      readonly depositShortfall: DepositShortfall | null;
+    }
   | { readonly kind: "ended"; readonly result: ToolResult };
 
 export interface OriginBroadcastInput {
@@ -138,6 +149,7 @@ function relayDepositSettlement(args: {
   }
   return receiptDepositSettlement(proveErc20DepositAmount({
     logs: args.logs,
+    chainId: legs.originChainId,
     tokenAddress: legs.originCurrency,
     senderAddress: args.senderAddress,
     recipients: authorizedDepositRecipients({
@@ -163,6 +175,9 @@ export async function runOriginBroadcasts(input: OriginBroadcastInput): Promise<
   // target, the ones naming the ORIGIN currency are the only recipients a
   // deposit transfer may pay for its amount to count as proven.
   const approvedSpenders: ApprovedSpender[] = [];
+  // What the deposit's own receipt proved against what the plan bridged. Set
+  // once, on the deposit leg, and read by the caller's fee decision.
+  let depositShortfall: DepositShortfall | null = null;
   try {
     for (let i = 0; i < signable.length; i++) {
       currentIndex = i;
@@ -277,17 +292,21 @@ export async function runOriginBroadcasts(input: OriginBroadcastInput): Promise<
         // signed, or the single ERC-20 `Transfer` bound to the wallet, the
         // authorized recipient and the quoted amount
         // (`bridge-deposit-evidence.ts`). Anything else declines by name.
-        const confirmResult = stepEntry.role === "bridge_deposit"
+        const settlement = stepEntry.role === "bridge_deposit"
+          ? relayDepositSettlement({
+            legs, txParams, approvedSpenders,
+            logs: outcome.receipt.logs,
+            senderAddress: input.expectedFrom,
+          })
+          : null;
+        if (settlement !== null) depositShortfall = depositShortfallOf(settlement);
+        const confirmResult = settlement !== null
           ? await confirmDepositWithProvenAmounts({
             eventId: legRow.id,
             role: stepEntry.role,
             txHash: outcome.txHash,
             chainId: legs.originChainId,
-            settlement: relayDepositSettlement({
-              legs, txParams, approvedSpenders,
-              logs: outcome.receipt.logs,
-              senderAddress: input.expectedFrom,
-            }),
+            settlement,
             logScope: "relay.bridge",
           })
           : await confirmActivityEvent(
@@ -342,5 +361,5 @@ export async function runOriginBroadcasts(input: OriginBroadcastInput): Promise<
     };
   }
 
-  return { kind: "confirmed", broadcasts };
+  return { kind: "confirmed", broadcasts, depositShortfall };
 }

--- a/src/vex-agent/tools/tool-surface-spec/studio-mcp/wallet-reference-audit-2026-08-24.md
+++ b/src/vex-agent/tools/tool-surface-spec/studio-mcp/wallet-reference-audit-2026-08-24.md
@@ -100,17 +100,21 @@ of the reference behavior, with evidence)
   approve step: `@tools/evm-chains/erc20-approve-step-guard.ts` binds it
   before any signer, on both venues, to a canonical `approve` with no
   native value whose spender is the plan's own deposit target, and on
-  Relay additionally to the origin token and to an allowance EXACTLY
-  equal to the principal Vex derived. Rabby's approval card is the
-  reference for which three fields matter (token, spender, amount);
-  unlike Rabby, Vex has no human at the step, so the bound replaces the
-  human rather than informing one. STILL OPEN, and not claimed anywhere:
-  the deposit step's own calldata is not decoded on either venue (a
-  selector table needs the live captures archived on 2026-09-04), the
-  Khalani planner cannot yet bind the allowance to the principal because
-  neither the origin token nor the bridged amount reaches it, and the
-  ERC-20 receipt rule in `bridge-deposit-evidence.ts` still has a
-  ceiling but no floor.
+  BOTH venues additionally to the origin token, to the selected wallet
+  and to an allowance EXACTLY equal to the principal Vex derived. The
+  Khalani half closed second: `buildKhalaniDepositPlan` now hands
+  `planKhalaniDepositLegs` the origin token, the wallet and the post-fee
+  `bridgedAmountRaw` it already gives the native-value prover, so an
+  unlimited, larger, smaller or foreign-token approval refuses before any
+  leg, signer, nonce or durable row exists. An `approve(spender, 0)`
+  reset stays legitimate: it grants nothing, so only the grant beside it
+  is bound to the principal. Rabby's approval card is the reference for
+  which three fields matter (token, spender, amount); unlike Rabby, Vex
+  has no human at the step, so the bound replaces the human rather than
+  informing one. STILL OPEN, and not claimed anywhere: the deposit step's
+  own calldata is not decoded on either venue (a selector table needs the
+  live captures archived on 2026-09-04), and the ERC-20 receipt rule in
+  `bridge-deposit-evidence.ts` still has a ceiling but no floor.
 
 ## Reference caveat
 

--- a/src/vex-agent/tools/tool-surface-spec/studio-mcp/wallet-reference-audit-2026-08-24.md
+++ b/src/vex-agent/tools/tool-surface-spec/studio-mcp/wallet-reference-audit-2026-08-24.md
@@ -92,6 +92,26 @@ of the reference behavior, with evidence)
   only - our commit-time re-decode + re-simulate means nothing unsafe
   signs; intent TTL bounds the staleness window.
 
+  CORRECTION (2026-09-04). That sentence was true of the swap venues and
+  FALSE of the bridges when it was written: Relay and Khalani signed a
+  provider approve step after checking only the chain, the sender, the
+  address shape and the native value, and decoded the spender and the
+  allowance afterwards, to record evidence. What is true NOW is the
+  approve step: `@tools/evm-chains/erc20-approve-step-guard.ts` binds it
+  before any signer, on both venues, to a canonical `approve` with no
+  native value whose spender is the plan's own deposit target, and on
+  Relay additionally to the origin token and to an allowance EXACTLY
+  equal to the principal Vex derived. Rabby's approval card is the
+  reference for which three fields matter (token, spender, amount);
+  unlike Rabby, Vex has no human at the step, so the bound replaces the
+  human rather than informing one. STILL OPEN, and not claimed anywhere:
+  the deposit step's own calldata is not decoded on either venue (a
+  selector table needs the live captures archived on 2026-09-04), the
+  Khalani planner cannot yet bind the allowance to the principal because
+  neither the origin token nor the bridged amount reaches it, and the
+  ERC-20 receipt rule in `bridge-deposit-evidence.ts` still has a
+  ceiling but no floor.
+
 ## Reference caveat
 
 Rabby's full rule list lives in `@rabby-wallet/rabby-security-engine`

--- a/src/vex-agent/tools/tool-surface-spec/studio-mcp/wallet-reference-audit-2026-08-24.md
+++ b/src/vex-agent/tools/tool-surface-spec/studio-mcp/wallet-reference-audit-2026-08-24.md
@@ -111,10 +111,41 @@ of the reference behavior, with evidence)
   is bound to the principal. Rabby's approval card is the reference for
   which three fields matter (token, spender, amount); unlike Rabby, Vex
   has no human at the step, so the bound replaces the human rather than
-  informing one. STILL OPEN, and not claimed anywhere: the deposit step's
-  own calldata is not decoded on either venue (a selector table needs the
-  live captures archived on 2026-09-04), and the ERC-20 receipt rule in
-  `bridge-deposit-evidence.ts` still has a ceiling but no floor.
+  informing one.
+
+  SECOND CORRECTION (2026-09-04). The two items the paragraph
+  above left open are now closed, and the exact shape of each matters:
+
+  - THE ORDER. `reset -> exact grant -> deposit`, or a prefix of it, is
+    the only approval shape either venue signs
+    (`verifyApprovalSequence`). Relay orders by step index and Khalani by
+    leg order, so a grant sequenced AFTER the deposit (a standing
+    allowance created after the only transaction that justified it) and a
+    reset with no grant behind it (a bare revocation the bridge never
+    needed) both refuse pre-sign. A reset now gets every rule-2 check
+    except the amount equality: on the origin token, from the selected
+    wallet, naming this plan's deposit target.
+  - THE DEPOSIT CALLDATA. `@tools/evm-chains/bridge-deposit-calldata.ts`
+    binds the deposit call to the plan for every selector whose SIGNATURE
+    an authoritative source confirms. Relay's `0xe8017952`
+    (`depositErc20(address,address,uint256,bytes32)`), its three-argument
+    overload and `0x49290c1c` (`depositNative(address,bytes32)`) come
+    from the VERIFIED `RelayDepository` source the Base explorer
+    publishes for `0x4cD00e387622c35bDDB9B4C962C136462338BC31`, the very
+    address every live capture calls. Khalani's `0xf3125a1f` is NOT
+    confirmed: its target is unverified on that explorer and on Sourcify
+    and Khalani publishes no deposit ABI, so it is recorded as
+    `deposit_selector_unverified` and logged once rather than refused -
+    refusing honest traffic on our own ignorance is a worse failure than
+    leaving the money guard to the receipt.
+  - THE RECEIPT FLOOR. `bridge-deposit-evidence.ts` now has a floor as
+    well as a ceiling: the proven ERC-20 amount must EQUAL the quoted
+    principal unless the token has a MEASURED deduction in
+    `FEE_ON_TRANSFER_DEDUCTIONS` (empty, absolute atomic units, never a
+    percentage). A shortfall is a `deposit_short` outcome that records
+    the row for review without an amount and makes the Vex fee leg
+    INELIGIBLE on both venues, so a deposit of one unit against a
+    million-unit quote can no longer pay a full fixed fee.
 
 ## Reference caveat
 


### PR DESCRIPTION
## The hole

Both bridge venues signed a provider-supplied `approve` step after checking only `chainId`, `from`, that `to` is an address, and the native value. The spender, the token contract and the allowance were decoded only to record evidence after the fact. Measured on main with a throwaway test: the Relay planner accepts `approve(<stranger>, 2^256-1)` on the origin token and on a foreign contract alike. A compromised or buggy provider response could obtain a standing unlimited allowance on the user's whole balance of that token. The swap venues already refuse undecodable or mismatched calldata; the bridges did not.

## What changes

- **`erc20-approve-step-guard.ts`** (one owner, pure, closed verdict; viem 2.54.3 pin-note in the doc block: `decodeFunctionData` silently accepts trailing bytes, so the guard measures the canonical length itself). Rules: selector `approve`, canonical data, zero value, spender exactly this plan's deposit target, at most one grant per plan (a zero-allowance reset before a grant is a legitimate leg); on Relay additionally token = origin currency on the origin chain, owner = wallet, allowance = deposit principal exactly.
- **Relay** (`step-policy.ts`, `execute.ts`): runs after the native-value gate; a refusal produces no signable transaction. **Khalani** (`deposit-plan.ts`): runs before the evidence stamp.
- **Tests**: the 24-cell cross-product (origin x deposit kind x allowance) with every cell named; negative planner tests on both venues (wrong spender, foreign token, unlimited allowance, non-zero value, unknown selector, second approve) with no signer call; positive controls; existing tests that synthesised a bare 4-byte selector as an approval corrected.
- **Live captures** (rule 10, read-only, keyless, synthetic wallet): five Relay ERC-20 routes, one Relay native, one Khalani `CONTRACT_CALL`, one Khalani `TRANSFER`, archived with calldata. Every spender is the deposit step's own target and every allowance equals the requested input.
- The wallet reference audit's line claiming the bridges re-decode before signing is corrected.

## Known gap in this PR, to be closed on this branch

Khalani's allowance amount and origin token are not yet bound: the Khalani leg planner does not receive them, and the handler that owns those facts (`protocols/khalani/handlers/bridge-execute/deposit-plan.ts`) is being edited by another lane. Until then an unlimited allowance to Khalani's GENUINE deposit contract still signs; an allowance to a stranger does not.

## Escalation found by the captures (not this PR)

Relay `POST /quote/v2` answers 401 `UNAUTHORIZED_QUOTE` for a body carrying `referrer: "vex"` without an API key and 200 for the same body without the referrer. `src/tools/relay/client.ts` injects the referrer on every quote and treats `RELAY_API_KEY` as optional; the schema comment says bridging works without it. A deployment without the key may not be able to take a Relay quote at all. Needs its own lane after a live check through the real handler.

## Verification

- root vitest `src/__tests__/tools/{relay,khalani,evm-chains}`: 50 files, 591 passed, 1 skipped; root tsc clean; em-dash and unsafe-escapes gates green; the viem probe reproduced; all archived captures re-decoded.
- Deposit selectors seen live (`0xe8017952` Relay ERC-20, `0x49290c1c` Relay native, `0xf3125a1f` Khalani `CONTRACT_CALL`) are the evidence for the deposit selector table (follow-up), together with a floor under the receipt rule.

Reference reading: MetaMask `transaction-type.ts` (rejected as a signing gate: it labels, it does not refuse), Rabby `SignTx.tsx` (the three fields of an approval decision), our own `swap-calldata-guard.ts` (verdict shape, refuse-on-unknown, ABI provenance).
