### PR TITLE
fix(tools): compare before claim, fail-closed bridge fee gate, typed divergence reasons

### DIFF
--- a/src/__tests__/integration/repos/swap-prequotes-claim.int.test.ts
+++ b/src/__tests__/integration/repos/swap-prequotes-claim.int.test.ts
@@ -45,6 +45,43 @@ async function seedSession(): Promise<string> {
 const MATCH = "match-095";
 let counter = 0;
 
+/**
+ * The disclosure block every row in this file carries, and the value the claim's
+ * disclosure fence is asserted against. It is shaped like a real one (the fee
+ * statement is the part a person reads) because the fence compares the WHOLE
+ * `safety_detail` jsonb, and an empty object would make every equality trivially
+ * true.
+ */
+const DISCLOSURE: Record<string, unknown> = {
+  vexFee: {
+    v: 1, charged: true, bps: 25,
+    feeAmountRaw: "25000", netAmountRaw: "9975000", totalDebitedRaw: "10000000",
+    tokenAddress: "0xaaa", receiver: "0xfee", collection: "separate_transfer",
+  },
+};
+
+/** The claim as production makes it: identity plus the disclosure that was read. */
+function claim(
+  sessionId: string,
+  prequoteId: string,
+  claimedBy: string,
+  overrides: { matchHash?: string; expectedDisclosure?: Record<string, unknown> } = {},
+) {
+  return repo.claimVerifiedRowForExecute({
+    sessionId,
+    prequoteId,
+    matchHash: overrides.matchHash ?? MATCH,
+    kind: "swap",
+    expectedDisclosure: overrides.expectedDisclosure ?? DISCLOSURE,
+    claimedBy,
+  });
+}
+
+/** The diagnosis as production asks it. */
+function diagnose(sessionId: string, prequoteId: string, expected: Record<string, unknown> = DISCLOSURE) {
+  return repo.diagnoseUnclaimable(sessionId, prequoteId, expected);
+}
+
 async function insertQuote(
   sessionId: string,
   opts: {
@@ -52,6 +89,7 @@ async function insertQuote(
     expiresInMs?: number;
     matchHash?: string;
     routeRef?: Record<string, unknown> | null;
+    safetyDetail?: Record<string, unknown>;
   } = {},
 ): Promise<string> {
   const prequoteId = `prequote-095-${++counter}`;
@@ -69,7 +107,7 @@ async function insertQuote(
     amount: "10",
     slippageBps: 100,
     safetyVerdict: "pass",
-    safetyDetail: {},
+    safetyDetail: opts.safetyDetail ?? DISCLOSURE,
     routeRef: opts.routeRef ?? { v: 1, provider: "kyberswap", raw: "{}" },
     ...(opts.eligibilityKind === undefined ? {} : { eligibilityKind: opts.eligibilityKind }),
     expiresAt: new Date(Date.now() + (opts.expiresInMs ?? 15 * 60_000)).toISOString(),
@@ -127,8 +165,8 @@ describe("the claim is single-use and atomic", () => {
     const prequoteId = await insertQuote(sessionId);
 
     const [a, b] = await Promise.all([
-      repo.claimForExecute(sessionId, prequoteId, "execute-a"),
-      repo.claimForExecute(sessionId, prequoteId, "execute-b"),
+      claim(sessionId, prequoteId, "execute-a"),
+      claim(sessionId, prequoteId, "execute-b"),
     ]);
 
     const winners = [a, b].filter((r) => r !== null);
@@ -139,16 +177,16 @@ describe("the claim is single-use and atomic", () => {
     expect(["execute-a", "execute-b"]).toContain(winner.claimedBy);
 
     // The loser gets a TYPED reason, not silence.
-    expect(await repo.diagnoseUnclaimable(sessionId, prequoteId)).toBe("already_claimed");
+    expect(await diagnose(sessionId, prequoteId)).toBe("already_claimed");
   });
 
   it("a sequential second claim is refused already_claimed", async () => {
     const sessionId = await seedSession();
     const prequoteId = await insertQuote(sessionId);
 
-    expect(await repo.claimForExecute(sessionId, prequoteId, "first")).not.toBeNull();
-    expect(await repo.claimForExecute(sessionId, prequoteId, "second")).toBeNull();
-    expect(await repo.diagnoseUnclaimable(sessionId, prequoteId)).toBe("already_claimed");
+    expect(await claim(sessionId, prequoteId, "first")).not.toBeNull();
+    expect(await claim(sessionId, prequoteId, "second")).toBeNull();
+    expect(await diagnose(sessionId, prequoteId)).toBe("already_claimed");
     // The first claim's owner is not overwritten by the loser.
     const row = await queryOne<{ claimed_by: string }>(
       `SELECT claimed_by FROM swap_prequotes WHERE prequote_id = $1`, [prequoteId],
@@ -160,16 +198,16 @@ describe("the claim is single-use and atomic", () => {
     const sessionId = await seedSession();
     const prequoteId = await insertQuote(sessionId, { expiresInMs: -1000 });
 
-    expect(await repo.claimForExecute(sessionId, prequoteId, "e")).toBeNull();
-    expect(await repo.diagnoseUnclaimable(sessionId, prequoteId)).toBe("expired");
+    expect(await claim(sessionId, prequoteId, "e")).toBeNull();
+    expect(await diagnose(sessionId, prequoteId)).toBe("expired");
   });
 
   it("refuses an ineligible quote - it never authorized anything", async () => {
     const sessionId = await seedSession();
     const prequoteId = await insertQuote(sessionId, { eligibilityKind: "unpriceable_output" });
 
-    expect(await repo.claimForExecute(sessionId, prequoteId, "e")).toBeNull();
-    expect(await repo.diagnoseUnclaimable(sessionId, prequoteId)).toBe("not_executable");
+    expect(await claim(sessionId, prequoteId, "e")).toBeNull();
+    expect(await diagnose(sessionId, prequoteId)).toBe("not_executable");
   });
 
   it("is session-scoped: another session cannot claim this row even knowing its id", async () => {
@@ -177,10 +215,126 @@ describe("the claim is single-use and atomic", () => {
     const stranger = await seedSession();
     const prequoteId = await insertQuote(owner);
 
-    expect(await repo.claimForExecute(stranger, prequoteId, "e")).toBeNull();
-    expect(await repo.diagnoseUnclaimable(stranger, prequoteId)).toBe("missing");
+    expect(await claim(stranger, prequoteId, "e")).toBeNull();
+    expect(await diagnose(stranger, prequoteId)).toBe("missing");
     // ...and the owner can still claim it.
-    expect(await repo.claimForExecute(owner, prequoteId, "e")).not.toBeNull();
+    expect(await claim(owner, prequoteId, "e")).not.toBeNull();
+  });
+});
+
+/**
+ * THE ORDERING: read, compare, THEN claim.
+ *
+ * The executor now reads the authoritative row non-destructively, re-derives its
+ * fee statement and router input against it, and consumes the row only once
+ * every comparison has passed. What these cases prove against real Postgres is
+ * the property the mocked handler tests cannot: a refusal between the two steps
+ * leaves `claimed_at` and `claimed_by` NULL, and the very same row is still
+ * claimable afterwards - which is what makes "get a fresh quote and retry" a
+ * remedy rather than a dead end.
+ */
+describe("reading the authoritative row consumes nothing", () => {
+  it("a divergence between the read and the claim leaves the row unclaimed and reusable", async () => {
+    const sessionId = await seedSession();
+    const prequoteId = await insertQuote(sessionId);
+
+    // Step 1: the executor reads the row it would execute against.
+    const read = await repo.findClaimableForExecute(sessionId, prequoteId, MATCH, "swap");
+    expect(read?.prequoteId).toBe(prequoteId);
+
+    // Step 2: it re-derives its fee statement, finds it moved, and REFUSES -
+    // which in production means it simply never calls the claim.
+    const afterRefusal = await queryOne<{ claimed_at: string | null; claimed_by: string | null }>(
+      `SELECT claimed_at, claimed_by FROM swap_prequotes WHERE prequote_id = $1`, [prequoteId],
+    );
+    expect(afterRefusal?.claimed_at).toBeNull();
+    expect(afterRefusal?.claimed_by).toBeNull();
+
+    // Step 3: the retry the refusal asked for. The SAME row is still the
+    // authority and still claimable - the defect was that this returned
+    // `already_claimed`.
+    const retryRead = await repo.findClaimableForExecute(sessionId, prequoteId, MATCH, "swap");
+    expect(retryRead?.prequoteId).toBe(prequoteId);
+    const claimed = await claim(sessionId, prequoteId, "retry");
+    expect(claimed?.prequoteId).toBe(prequoteId);
+    expect(claimed?.claimedBy).toBe("retry");
+  });
+
+  it("the read applies the same predicate the claim does", async () => {
+    const sessionId = await seedSession();
+    const expired = await insertQuote(sessionId, { expiresInMs: -1000, matchHash: "identity-expired" });
+    const ineligible = await insertQuote(sessionId, {
+      eligibilityKind: "unpriceable_output", matchHash: "identity-ineligible",
+    });
+    const q1 = await insertQuote(sessionId);
+    await insertQuote(sessionId);
+
+    expect(await repo.findClaimableForExecute(sessionId, expired, "identity-expired", "swap")).toBeNull();
+    expect(await repo.findClaimableForExecute(sessionId, ineligible, "identity-ineligible", "swap")).toBeNull();
+    // Superseded by the newer row for the same identity.
+    expect(await repo.findClaimableForExecute(sessionId, q1, MATCH, "swap")).toBeNull();
+  });
+
+  it("the read is session- and identity-scoped, exactly like the claim", async () => {
+    const owner = await seedSession();
+    const stranger = await seedSession();
+    const prequoteId = await insertQuote(owner);
+
+    expect(await repo.findClaimableForExecute(stranger, prequoteId, MATCH, "swap")).toBeNull();
+    expect(await repo.findClaimableForExecute(owner, prequoteId, "another-trade", "swap")).toBeNull();
+    expect(await repo.findClaimableForExecute(owner, prequoteId, MATCH, "swap")).not.toBeNull();
+  });
+});
+
+/**
+ * THE DISCLOSURE FENCE. The claim asserts that the block the executor compared
+ * against is still the block on the row, so a row rewritten between the read and
+ * the claim cannot be consumed silently.
+ */
+describe("a claim whose disclosure no longer matches the row is refused typed", () => {
+  it("refuses, consumes nothing, and diagnoses `disclosure_changed`", async () => {
+    const sessionId = await seedSession();
+    const prequoteId = await insertQuote(sessionId);
+
+    const stale = { ...DISCLOSURE, vexFee: { ...(DISCLOSURE.vexFee as Record<string, unknown>), feeAmountRaw: "1" } };
+    expect(await claim(sessionId, prequoteId, "execute", { expectedDisclosure: stale })).toBeNull();
+
+    const untouched = await queryOne<{ claimed_at: string | null }>(
+      `SELECT claimed_at FROM swap_prequotes WHERE prequote_id = $1`, [prequoteId],
+    );
+    expect(untouched?.claimed_at).toBeNull();
+    expect(await diagnose(sessionId, prequoteId, stale)).toBe("disclosure_changed");
+
+    // The honest block still claims it: the fence refuses a CHANGED disclosure,
+    // never a correct one.
+    expect(await claim(sessionId, prequoteId, "execute")).not.toBeNull();
+  });
+
+  it("compares the block semantically, not by key order", async () => {
+    const sessionId = await seedSession();
+    const prequoteId = await insertQuote(sessionId);
+    const vexFee = DISCLOSURE.vexFee as Record<string, unknown>;
+    const reordered = {
+      vexFee: {
+        collection: vexFee.collection, receiver: vexFee.receiver, tokenAddress: vexFee.tokenAddress,
+        totalDebitedRaw: vexFee.totalDebitedRaw, netAmountRaw: vexFee.netAmountRaw,
+        feeAmountRaw: vexFee.feeAmountRaw, bps: vexFee.bps, charged: vexFee.charged, v: vexFee.v,
+      },
+    };
+
+    expect(await claim(sessionId, prequoteId, "execute", { expectedDisclosure: reordered })).not.toBeNull();
+  });
+
+  it("a superseded row still reports supersession, not the disclosure", async () => {
+    // Ordering of the diagnosis matters: the actionable truth for an agent whose
+    // quote was replaced is that a newer quote exists.
+    const sessionId = await seedSession();
+    const q1 = await insertQuote(sessionId);
+    await insertQuote(sessionId);
+
+    const stale = { ...DISCLOSURE, vexFee: { changed: true } };
+    expect(await claim(sessionId, q1, "execute", { expectedDisclosure: stale })).toBeNull();
+    expect(await diagnose(sessionId, q1, stale)).toBe("superseded");
   });
 });
 
@@ -191,8 +345,8 @@ describe("a later quote supersedes an earlier one for the same identity", () => 
       const q1 = await insertQuote(sessionId);
       await insertQuote(sessionId, { eligibilityKind: laterKind });
 
-      expect(await repo.claimForExecute(sessionId, q1, "execute-q1")).toBeNull();
-      expect(await repo.diagnoseUnclaimable(sessionId, q1)).toBe("superseded");
+      expect(await claim(sessionId, q1, "execute-q1")).toBeNull();
+      expect(await diagnose(sessionId, q1)).toBe("superseded");
     });
   }
 
@@ -206,9 +360,9 @@ describe("a later quote supersedes an earlier one for the same identity", () => 
     await insertQuote(sessionId, { eligibilityKind: "provider_usd_invalid" });
 
     expect(
-      await repo.claimBoundForExecute(sessionId, q1, MATCH, "swap", "approval-resume"),
+      await claim(sessionId, q1, "approval-resume"),
     ).toBeNull();
-    expect(await repo.diagnoseUnclaimable(sessionId, q1)).toBe("superseded");
+    expect(await diagnose(sessionId, q1)).toBe("superseded");
   });
 
   it("the approved row is the one that is claimed, even when a NEWER row exists", async () => {
@@ -221,7 +375,7 @@ describe("a later quote supersedes an earlier one for the same identity", () => 
     const q2 = await insertQuote(sessionId);
 
     expect((await repo.findLatestExecutableByMatch(sessionId, MATCH, "swap"))?.prequoteId).toBe(q2);
-    expect(await repo.claimBoundForExecute(sessionId, q1, MATCH, "swap", "resume")).toBeNull();
+    expect(await claim(sessionId, q1, "resume")).toBeNull();
     // ...and Q2 was NOT consumed by that refusal.
     const untouched = await queryOne<{ claimed_at: string | null }>(
       `SELECT claimed_at FROM swap_prequotes WHERE prequote_id = $1`, [q2],
@@ -233,7 +387,7 @@ describe("a later quote supersedes an earlier one for the same identity", () => 
     const sessionId = await seedSession();
     const q1 = await insertQuote(sessionId);
 
-    const claimed = await repo.claimBoundForExecute(sessionId, q1, MATCH, "swap", "resume");
+    const claimed = await claim(sessionId, q1, "resume");
     expect(claimed?.prequoteId).toBe(q1);
     expect(claimed?.claimedBy).toBe("resume");
   });
@@ -242,7 +396,7 @@ describe("a later quote supersedes an earlier one for the same identity", () => 
     const sessionId = await seedSession();
     const other = await insertQuote(sessionId, { matchHash: "identity-other" });
 
-    expect(await repo.claimBoundForExecute(sessionId, other, MATCH, "swap", "resume")).toBeNull();
+    expect(await claim(sessionId, other, "resume")).toBeNull();
     // The row is intact - a mismatched binding must not burn someone else's quote.
     const untouched = await queryOne<{ claimed_at: string | null }>(
       `SELECT claimed_at FROM swap_prequotes WHERE prequote_id = $1`, [other],
@@ -255,12 +409,12 @@ describe("a later quote supersedes an earlier one for the same identity", () => 
     const q1 = await insertQuote(sessionId);
 
     const [a, b] = await Promise.all([
-      repo.claimBoundForExecute(sessionId, q1, MATCH, "swap", "resume-a"),
-      repo.claimBoundForExecute(sessionId, q1, MATCH, "swap", "resume-b"),
+      claim(sessionId, q1, "resume-a"),
+      claim(sessionId, q1, "resume-b"),
     ]);
 
     expect([a, b].filter((r) => r !== null)).toHaveLength(1);
-    expect(await repo.diagnoseUnclaimable(sessionId, q1)).toBe("already_claimed");
+    expect(await diagnose(sessionId, q1)).toBe("already_claimed");
   });
 
   it("the candidate an execute picks is the NEWEST executable row", async () => {
@@ -270,7 +424,7 @@ describe("a later quote supersedes an earlier one for the same identity", () => 
 
     const candidate = await repo.findLatestExecutableByMatch(sessionId, MATCH, "swap");
     expect(candidate?.prequoteId).toBe(q2);
-    expect(await repo.claimForExecute(sessionId, q2, "execute")).not.toBeNull();
+    expect(await claim(sessionId, q2, "execute")).not.toBeNull();
   });
 
   it("a different identity is untouched - supersession is per (session, match, kind)", async () => {
@@ -278,7 +432,7 @@ describe("a later quote supersedes an earlier one for the same identity", () => 
     const q1 = await insertQuote(sessionId, { matchHash: "identity-a" });
     await insertQuote(sessionId, { matchHash: "identity-b", eligibilityKind: "unpriceable_output" });
 
-    expect(await repo.claimForExecute(sessionId, q1, "execute")).not.toBeNull();
+    expect(await claim(sessionId, q1, "execute", { matchHash: "identity-a" })).not.toBeNull();
   });
 
   it("an ineligible row never becomes the execute's candidate", async () => {

--- a/src/__tests__/kyberswap/fixtures/route-build/approved-quote.ts
+++ b/src/__tests__/kyberswap/fixtures/route-build/approved-quote.ts
@@ -86,7 +86,21 @@ export function legsForAllowancePlan(plan: {
   ];
 }
 
-/** The successful arm of `claimSwapExecutionSnapshot`, for a route summary and tolerance. */
+/**
+ * The ticket `readSwapExecutionSnapshot` hands to the later claim. Its contents
+ * are the repository's business; what the handler suites assert with it is
+ * WHETHER the claim is reached at all, and with which row.
+ */
+export const FIXTURE_CLAIM_TICKET = {
+  sessionId: "session-1",
+  prequoteId: "prequote-fixture",
+  matchHash: "h".repeat(64),
+  kind: "swap" as const,
+  expectedDisclosure: {},
+  freshQuoteTool: "kyberswap__swap_quote",
+};
+
+/** The successful arm of `readSwapExecutionSnapshot`, for a route summary and tolerance. */
 export function approvedClaim(
   routeSummary: unknown,
   slippageBps: number,
@@ -100,6 +114,7 @@ export function approvedClaim(
   return {
     ok: true as const,
     prequoteId: "prequote-fixture",
+    claim: FIXTURE_CLAIM_TICKET,
     routeSummary,
     vexFee: fixtureVexFeeBlock(options.amountInRaw ?? BigInt(readAmountIn(routeSummary))),
     snapshot: sealRouteSnapshot({

--- a/src/__tests__/vex-agent/agent-scan/kyberswap-swap-execute-adversarial.test.ts
+++ b/src/__tests__/vex-agent/agent-scan/kyberswap-swap-execute-adversarial.test.ts
@@ -207,7 +207,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // broadcast-path behaviour under test is reached.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/agent-scan/uniswap-swap-execute-adversarial.test.ts
+++ b/src/__tests__/vex-agent/agent-scan/uniswap-swap-execute-adversarial.test.ts
@@ -31,7 +31,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { uniswapSpendabilityFake } from "../tools/_uniswap-spendability-fake.js";
-import { claimStandingInForTheParams } from "../tools/_uniswap-approved-snapshot.js";
+import { readStandingInForTheParams } from "../tools/_uniswap-approved-snapshot.js";
 import { VexError, ErrorCodes } from "../../../errors.js";
 import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
 
@@ -153,10 +153,11 @@ vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
 // The execute is bound to an APPROVED quote (2026-08-27 incident): it claims one
 // before it prices anything. This suite's subject is elsewhere, so the claim
 // stands in with the quote this very call would have produced.
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...args: unknown[]) => claimUniswapExecutionSnapshot(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...args: unknown[]) => readUniswapExecutionSnapshot(...args),
 }));
 
 vi.mock("@utils/logger.js", () => ({ default: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() } }));
@@ -181,8 +182,8 @@ function executeCall(extra: Record<string, unknown> = {}) {
 describe("uniswap.swap.execute — adversarial (FIX2-W0)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    claimUniswapExecutionSnapshot.mockImplementation(
-      claimStandingInForTheParams({ chainId: 4663, weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73" }),
+    readUniswapExecutionSnapshot.mockImplementation(
+      readStandingInForTheParams({ chainId: 4663, weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73" }),
     );
     ensureErc20Balance.mockResolvedValue(undefined);
     validateUniswapSpender.mockReturnValue(undefined);

--- a/src/__tests__/vex-agent/tools/_uniswap-approved-snapshot.ts
+++ b/src/__tests__/vex-agent/tools/_uniswap-approved-snapshot.ts
@@ -140,8 +140,8 @@ export async function approvedUniswapVexFee(input: ApprovedSnapshotInput): Promi
   return block;
 }
 
-/** The claim result the store would hand an execute for that snapshot. */
-export async function claimedUniswapSnapshot(input: ApprovedSnapshotInput): Promise<{
+/** The non-destructive READ result the store would hand an execute for that snapshot. */
+export async function readUniswapSnapshotFixture(input: ApprovedSnapshotInput): Promise<{
   readonly ok: true;
   readonly prequoteId: string;
   readonly snapshot: UniswapExecutionSnapshot;
@@ -158,20 +158,23 @@ export async function claimedUniswapSnapshot(input: ApprovedSnapshotInput): Prom
 }
 
 /**
- * A `claimUniswapExecutionSnapshot` stand-in that answers with the quote THIS
+ * A `readUniswapExecutionSnapshot` stand-in that answers with the quote THIS
  * call would have produced: it resolves the params' own legs through the same
  * resolver the handler uses, so a suite that swaps a native leg in and out of
  * its params needs no second fixture.
  *
- * Suites whose subject IS the binding drive the claim explicitly instead.
+ * It stands in for the READ, which consumes nothing: the separate
+ * `commitPrequoteClaim` is what a suite mocks when the consumption is its
+ * subject. Suites whose subject IS the binding drive the read explicitly
+ * instead.
  */
-export function claimStandingInForTheParams(deployment: {
+export function readStandingInForTheParams(deployment: {
   readonly chainId: number;
   readonly weth: string;
   readonly approvedAmountOutRaw?: bigint;
   readonly approvedMinOutRaw?: bigint;
   /**
-   * The allowance the quote saw, read AT CLAIM TIME so a suite that changes its
+   * The allowance the quote saw, read AT READ TIME so a suite that changes its
    * allowance mock between tests gets a snapshot bound to the matching leg set.
    */
   readonly currentAllowance?: () => bigint;
@@ -180,7 +183,7 @@ export function claimStandingInForTheParams(deployment: {
     const dep = { chainId: deployment.chainId, weth: deployment.weth } as UniswapDeployment;
     const tokenIn = await resolveUniswapToken(dep, String(params.tokenIn));
     const tokenOut = await resolveUniswapToken(dep, String(params.tokenOut));
-    return claimedUniswapSnapshot({
+    return readUniswapSnapshotFixture({
       chainId: deployment.chainId,
       tokenIn,
       tokenOut,

--- a/src/__tests__/vex-agent/tools/khalani-handlers/bridge-fee-execute.test.ts
+++ b/src/__tests__/vex-agent/tools/khalani-handlers/bridge-fee-execute.test.ts
@@ -159,6 +159,7 @@ import {
   boundSkippedVexFee,
   matchedPrequoteWithVexFee,
 } from "../../../tools/bridge-fee/bound-vex-fee.js";
+import { BRIDGE_FEE_RECEIVER_EVM } from "@tools/bridge-fee/index.js";
 import type { KhalaniStagedLeg } from "@tools/khalani/bridge-executor.js";
 
 function evmSend(to: string, data: string, deposit: boolean) {
@@ -535,6 +536,103 @@ describe("khalani.bridge - the fee must still match the statement the approval w
   it("a dryRun never reads the bound row: it is a preview, it signs nothing", async () => {
     await execute({ dryRun: true });
     expect(mockFindFreshMatchedPrequote).not.toHaveBeenCalled();
+  });
+
+  /**
+   * An absent execute-gate registration is an internal
+   * AUTHORIZATION failure, never permission to sign.
+   *
+   * `not_gated` is exactly what the gate answers when this tool has no registry
+   * entry - the state a registry refactor produces. The handler used to read it
+   * as "there is no approved statement to contradict" and carry on to the
+   * signer, turning the loss of the fee's whole authority into a licence to take
+   * it. Driven through the public handler with the registration absent.
+   */
+  it("REFUSES when this fee-bearing tool has no registered quote gate at all", async () => {
+    mockFindFreshMatchedPrequote.mockResolvedValue({ ok: false, reason: "not_gated" });
+
+    const result = await execute();
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("fee-bearing tool with no registered quote gate");
+    expect(result.output).toContain("no funds moved");
+    expect(result.output).not.toContain("approve the fresh quote");
+    assertNothingHappened();
+  });
+
+  /**
+   * The typed reason must reach the RESULT, not only the log line: an agent
+   * reading "khalani.bridge failed" cannot tell a moved fee statement (re-quote)
+   * from an unregistered gate (report a build defect).
+   */
+  describe("the typed refusal reason reaches the tool result", () => {
+    function refusalOf(result: { readonly data?: Record<string, unknown> }): Record<string, unknown> {
+      const block = result.data?._vexFeeRefusal;
+      if (block === undefined || block === null || typeof block !== "object") {
+        throw new Error("expected the result to carry a typed _vexFeeRefusal block");
+      }
+      return block as Record<string, unknown>;
+    }
+
+    it("carries `vex_fee_statement_changed` and the field that moved", async () => {
+      mockFindFreshMatchedPrequote.mockResolvedValue(matchedPrequoteWithVexFee(boundChargedVexFee({
+        feeAmountRaw: "3000", netAmountRaw: "1497000", totalDebitedRaw: "1500000",
+      })));
+
+      const refusal = refusalOf(await execute());
+
+      expect(refusal.reason).toBe("vex_fee_statement_changed");
+      expect(refusal.movedFields).toEqual(["feeAmountRaw"]);
+      expect(String(refusal.remediation)).toContain("khalani__bridge_quote_get");
+    });
+
+    it("carries `vex_fee_statement_missing` when the bound row states no fee", async () => {
+      mockFindFreshMatchedPrequote.mockResolvedValue(matchedPrequoteWithVexFee(undefined));
+
+      expect(refusalOf(await execute()).reason).toBe("vex_fee_statement_missing");
+    });
+
+    it("carries `vex_fee_gate_unregistered` and a remedy that is not a re-quote", async () => {
+      mockFindFreshMatchedPrequote.mockResolvedValue({ ok: false, reason: "not_gated" });
+
+      const refusal = refusalOf(await execute());
+
+      expect(refusal.reason).toBe("vex_fee_gate_unregistered");
+      expect(String(refusal.remediation)).toContain("build defect");
+    });
+  });
+
+  /**
+   * PIN, DO NOT RE-DERIVE (fixed decision 2026-09-04, recorded beside
+   * `vexFeePreviewSchema`).
+   *
+   * The fee leg is signed last, after the deposit is confirmed AND registered
+   * with the provider. The approved statement is its authority there: it signs
+   * the staged leg planned before anything was signed, so an eligibility read
+   * that flips in that window changes nothing about what is signed and cannot
+   * raise the fee above the statement.
+   */
+  it("signs the staged fee leg the approved statement fixed, planned before any signature", async () => {
+    const result = await execute();
+    expect(parse(result.output).status).toBe("pending");
+
+    const legs = signedLegs();
+    const feeLeg = legs.find((l) => l.purpose === "vex_fee");
+    if (feeLeg === undefined) throw new Error("this arrangement must sign a fee leg");
+    // The fee leg is LAST, and its transaction is the one the plan built.
+    expect(legs.indexOf(feeLeg)).toBe(legs.length - 1);
+    const disclosed = parse(result.output).vexFee as Record<string, unknown>;
+    expect(disclosed.feeAmountRaw).toBe("3750");
+    const tx = (feeLeg as { readonly tx?: { readonly to: string; readonly data?: string } }).tx;
+    if (tx === undefined) throw new Error("an EVM fee leg must carry its transaction");
+    const feeHex = BigInt(String(disclosed.feeAmountRaw)).toString(16).padStart(64, "0");
+    expect(String(tx.data).toLowerCase().endsWith(feeHex)).toBe(true);
+    // The receiver is the build constant, carried in the calldata itself.
+    expect(String(tx.data).toLowerCase()).toContain(BRIDGE_FEE_RECEIVER_EVM.slice(2).toLowerCase());
+    // Eligibility was read exactly once, in the pre-sign window, and never again
+    // between the confirmed deposit and the fee transfer.
+    expect(mockFindFreshMatchedPrequote).toHaveBeenCalledTimes(1);
+    expect(mockHoneypotFot).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/approved-floor-settlement.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/approved-floor-settlement.test.ts
@@ -121,7 +121,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // behaviour under test.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 const mockLoggerWarn = vi.fn();

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/build-router-verification.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/build-router-verification.test.ts
@@ -108,7 +108,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // behaviour under test.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/execute-safety-gate.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/execute-safety-gate.test.ts
@@ -126,7 +126,8 @@ const mockLoggerWarn = vi.fn();
 // behaviour under test.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/mined-revert-role-wording.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/mined-revert-role-wording.test.ts
@@ -122,7 +122,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // behaviour under test.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/negative-price-impact-note.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/negative-price-impact-note.test.ts
@@ -66,7 +66,8 @@ vi.mock("@tools/kyberswap/aggregator/client.js", () => ({
 // behaviour under test.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/post-buy-delivery.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/post-buy-delivery.test.ts
@@ -111,7 +111,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // behaviour under test.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/pre-sign-revert-refusal.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/pre-sign-revert-refusal.test.ts
@@ -116,7 +116,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // behaviour under test.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/pre-sign-total-debit.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/pre-sign-total-debit.test.ts
@@ -112,7 +112,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/price-floor-gate.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/price-floor-gate.test.ts
@@ -118,7 +118,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // drive the real handler unchanged.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/quote-bound-execute.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/quote-bound-execute.test.ts
@@ -114,7 +114,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // the floor and the refusal wording through the real handler.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/staged-execute-safety.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/staged-execute-safety.test.ts
@@ -125,7 +125,8 @@ const mockLoggerWarn = vi.fn();
 // behaviour under test.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/swap-fee.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/swap-fee.test.ts
@@ -133,7 +133,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // behaviour under test.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/venue-unavailable-fallback.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/venue-unavailable-fallback.test.ts
@@ -97,7 +97,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // behaviour under test.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/vex-fee-record.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/vex-fee-record.test.ts
@@ -111,8 +111,10 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // back a real snapshot of this file's own route so the handler reaches the
 // behaviour under test.
 const mockClaim = vi.fn();
+const mockCommitPrequoteClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: (...args: unknown[]) => mockCommitPrequoteClaim(...args),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {
@@ -255,6 +257,7 @@ describe("kyberswap.swap.execute — the Vex fee recorded as a token amount", ()
       amountInRaw: capture.routeSummary.amountIn,
       amountOutRaw: capture.build.amountOut,
     });
+    mockCommitPrequoteClaim.mockResolvedValue({ ok: true });
   });
 
   it("records the exact fee the router keeps, with its token and decimals", async () => {
@@ -360,6 +363,7 @@ describe("kyberswap.swap.execute - the approved Vex fee statement is re-checked 
       amountInRaw: capture.routeSummary.amountIn,
       amountOutRaw: capture.build.amountOut,
     });
+    mockCommitPrequoteClaim.mockResolvedValue({ ok: true });
   });
 
   /** The claim the store hands back, carrying `vexFee` for `amountInRaw`. */
@@ -431,5 +435,159 @@ describe("kyberswap.swap.execute - the approved Vex fee statement is re-checked 
     expect(mockCreateAgentActivityIntent).not.toHaveBeenCalled();
     expect(mockSignStageBroadcast).not.toHaveBeenCalled();
     expect(result.output).toContain("the approved quote states no Vex fee at all");
+  });
+});
+
+/**
+ * Read, compare, THEN claim.
+ *
+ * KyberSwap used to claim the approved row in the handler, before Phase A had
+ * fetched the build, run the calldata guard or compared the fee statement. Every
+ * refusal in this phase therefore spent the quote, and the retry those refusals
+ * instruct the agent to make got `already_claimed`. The claim is now the last
+ * thing Phase A does that writes anything - after the guard, the fee comparison
+ * and the debit-plan comparison, immediately before the durable intent.
+ */
+describe("kyberswap.swap.execute - a refused execute leaves the approved quote unconsumed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveSelectedAddress.mockReturnValue(SESSION_EVM.address);
+    mockResolveSigningWallet.mockReturnValue(SESSION_EVM);
+    mockReadErc20Metadata.mockImplementation(async (_slug: string, address: string) => ({
+      address, symbol: "USDC", name: "USD Coin", decimals: 6, isNative: false as const,
+    }));
+    planAllowance({ needsReset: false, needsApprove: false });
+    mockGetRoute.mockResolvedValue({
+      data: {
+        routeSummary: {
+          amountIn: capture.routeSummary.amountIn,
+          amountOut: ROUTE_OUT,
+          gasUsd: "0.01", routeID: "r1", checksum: "c1",
+          route: ROUTE_PATHS,
+        },
+        routerAddress: capture.routerAddress,
+      },
+    });
+    mockBuildRoute.mockResolvedValue(buildResponse());
+    mockCreateAgentActivityIntent.mockResolvedValue({ executionId: 42, events: [{ id: 100 }, { id: 101 }] });
+    mockSignStageBroadcast.mockResolvedValue({ kind: "confirmed", txHash: "0xswap", receipt: { logs: [] } });
+    mockDecodeKyberSwapSettlement.mockReturnValue({
+      amountInRaw: capture.routeSummary.amountIn,
+      amountOutRaw: capture.build.amountOut,
+    });
+    mockCommitPrequoteClaim.mockResolvedValue({ ok: true });
+    claimFor(AMOUNT_IN_RAW);
+  });
+
+  /** The row the store hands back, stating the fee for `amountInRaw`. */
+  function claimFor(amountInRaw: bigint): void {
+    mockClaim.mockImplementation(
+      async (_toolId: unknown, _sessionId: unknown, params: Record<string, unknown>) =>
+        approvedClaim(
+          {
+            amountIn: capture.routeSummary.amountIn,
+            amountOut: ROUTE_OUT,
+            gasUsd: "0.01", routeID: "r1", checksum: "c1",
+            route: ROUTE_PATHS,
+          },
+          typeof params.slippageBps === "number" ? params.slippageBps : VEX_DEFAULT_SLIPPAGE_BPS,
+          { legs: approvedLegs, amountInRaw },
+        ),
+    );
+  }
+
+  it("does not claim the row when the fee statement disagrees with the build", async () => {
+    claimFor(AMOUNT_IN_RAW * 2n);
+
+    const result = await execute();
+
+    expect(result.success).toBe(false);
+    expect(mockCommitPrequoteClaim).not.toHaveBeenCalled();
+    expect(mockCreateAgentActivityIntent).not.toHaveBeenCalled();
+    expect(mockSignStageBroadcast).not.toHaveBeenCalled();
+  });
+
+  it("does not claim the row when the build itself is refused", async () => {
+    // A build whose router is not the one Vex verified: the calldata guard (real
+    // in this suite) refuses it. The quote must survive that refusal too.
+    mockBuildRoute.mockResolvedValue(buildResponse({ data: "0xdeadbeef" }));
+
+    const result = await execute();
+
+    expect(result.success).toBe(false);
+    expect(mockCommitPrequoteClaim).not.toHaveBeenCalled();
+  });
+
+  it("claims the row that was read, once, immediately before the intent", async () => {
+    const result = await execute();
+
+    expect(result.success, `handler output: ${result.output}`).toBe(true);
+    expect(mockCommitPrequoteClaim).toHaveBeenCalledTimes(1);
+    const [ticket, claimedBy] = mockCommitPrequoteClaim.mock.calls[0] as [{ prequoteId: string }, string];
+    expect(ticket.prequoteId).toBe("prequote-fixture");
+    expect(claimedBy).toContain("kyberswap.swap.execute");
+    // The order is the contract: the claim writes, then the intent.
+    const [claimOrder] = mockCommitPrequoteClaim.mock.invocationCallOrder;
+    const [intentOrder] = mockCreateAgentActivityIntent.mock.invocationCallOrder;
+    if (claimOrder === undefined || intentOrder === undefined) {
+      throw new Error("both the claim and the intent write must have been called");
+    }
+    expect(claimOrder).toBeLessThan(intentOrder);
+  });
+
+  it("refuses without signing when a concurrent execute won the same row", async () => {
+    mockCommitPrequoteClaim.mockResolvedValue({
+      ok: false,
+      refusal: { kind: "already_claimed", message: "Refused before signing: this quote has already been claimed." },
+    });
+
+    const result = await execute();
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("already been claimed");
+    expect(mockCreateAgentActivityIntent).not.toHaveBeenCalled();
+    expect(mockSignStageBroadcast).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The typed reason must reach the RESULT, not only the log line. KyberSwap
+   * throws its refusal out of Phase A, so the reason travels on the thrown
+   * `VexFeeStatementRefusal` and is merged into the result's data by the
+   * pre-broadcast recorder.
+   */
+  it("carries the typed fee reason on the tool result", async () => {
+    claimFor(AMOUNT_IN_RAW * 2n);
+
+    const result = await execute();
+
+    const refusal = (result.data as Record<string, unknown>)._vexFeeRefusal as Record<string, unknown>;
+    expect(refusal.reason).toBe("vex_fee_statement_changed");
+    expect(refusal.movedFields).toContain("feeAmountRaw");
+    expect(String(refusal.remediation)).toContain("kyberswap__swap_quote");
+    expect(JSON.stringify(refusal)).not.toMatch(/0x[0-9a-fA-F]{40}/);
+  });
+
+  /**
+   * PIN, DO NOT RE-DERIVE (fixed decision 2026-09-04, recorded beside
+   * `vexFeePreviewSchema`).
+   *
+   * KyberSwap has no separate fee leg at all: the fee is inside the router
+   * calldata the pre-sign guard accepted, so the amount that is signed cannot
+   * differ from the compared statement by construction, and nothing after the
+   * comparison can raise it. What is signed is the build response's own bytes.
+   */
+  it("signs the build's bytes, with the fee inside them and nothing re-derived", async () => {
+    const result = await execute();
+    expect(result.success, `handler output: ${result.output}`).toBe(true);
+
+    expect(mockSignStageBroadcast).toHaveBeenCalledTimes(1);
+    const signedCall = mockSignStageBroadcast.mock.calls[0];
+    if (signedCall === undefined) throw new Error("the swap leg must have been signed");
+    const request = signedCall[2] as { readonly to: string; readonly data: string };
+    expect(request.data).toBe(capture.build.data);
+    expect(request.to.toLowerCase()).toBe(getAddress(capture.routerAddress).toLowerCase());
+    // The fee the row recorded is the router's own arithmetic over the amount
+    // the guard pinned, and the disclosure says it is taken inside the route.
+    expect(swapLeg().vexFee?.amountRaw).toBe(EXPECTED_FEE_RAW.toString());
   });
 });

--- a/src/__tests__/vex-agent/tools/kyberswap-handlers/wallet-resolution.test.ts
+++ b/src/__tests__/vex-agent/tools/kyberswap-handlers/wallet-resolution.test.ts
@@ -99,7 +99,8 @@ vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({
 // behaviour under test.
 const mockClaim = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: (...args: unknown[]) => mockClaim(...args),
 }));
 
 vi.mock("@utils/logger.js", () => {

--- a/src/__tests__/vex-agent/tools/protocols/quote-authority/approved-quote-claim.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/quote-authority/approved-quote-claim.test.ts
@@ -28,15 +28,15 @@ import {
 } from "@vex-agent/tools/protocols/quote-authority/snapshot.js";
 import { buildBoundDebitPlan } from "@vex-agent/tools/protocols/quote-authority/debit-plan.js";
 
-const mockClaimBound = vi.fn();
-const mockClaimForExecute = vi.fn();
+const mockFindClaimable = vi.fn();
+const mockClaimVerified = vi.fn();
 const mockFindLatestExecutable = vi.fn();
 const mockFindLatestFresh = vi.fn();
 const mockDiagnose = vi.fn();
 
 vi.mock("@vex-agent/db/repos/swap-prequotes.js", () => ({
-  claimBoundForExecute: (...a: unknown[]) => mockClaimBound(...a),
-  claimForExecute: (...a: unknown[]) => mockClaimForExecute(...a),
+  findClaimableForExecute: (...a: unknown[]) => mockFindClaimable(...a),
+  claimVerifiedRowForExecute: (...a: unknown[]) => mockClaimVerified(...a),
   findLatestExecutableByMatch: (...a: unknown[]) => mockFindLatestExecutable(...a),
   findLatestFreshByMatch: (...a: unknown[]) => mockFindLatestFresh(...a),
   diagnoseUnclaimable: (...a: unknown[]) => mockDiagnose(...a),
@@ -51,7 +51,10 @@ vi.mock("@utils/logger.js", () => {
   return { default: stub, logger: stub };
 });
 
-import { claimSwapExecutionSnapshot } from "@vex-agent/tools/protocols/prequote/claim.js";
+import {
+  commitPrequoteClaim,
+  readSwapExecutionSnapshot,
+} from "@vex-agent/tools/protocols/prequote/claim.js";
 
 const TOKEN_IN = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 const TOKEN_OUT = "0x17f31d221a86c091a32d398653f5306fc4d93c0d";
@@ -165,43 +168,43 @@ function claim(
   bound: ReturnType<typeof authority> | null,
   opts: { readonly approvalResume?: boolean } = {},
 ) {
-  return claimSwapExecutionSnapshot(
-    "kyberswap.swap.execute", "session-1", PARAMS, ctx(bound, opts), "execute-1",
+  return readSwapExecutionSnapshot(
+    "kyberswap.swap.execute", "session-1", PARAMS, ctx(bound, opts),
   );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockClaimBound.mockResolvedValue(row());
-  mockClaimForExecute.mockResolvedValue(row());
+  mockFindClaimable.mockResolvedValue(row({ claimedAt: null, claimedBy: null }));
+  mockClaimVerified.mockResolvedValue(row());
   mockFindLatestExecutable.mockResolvedValue(row({ prequoteId: "prequote-q2", claimedAt: null }));
   mockFindLatestFresh.mockResolvedValue(null);
   mockDiagnose.mockResolvedValue("superseded");
 });
 
-describe("a bound approval claims exactly the row it named", () => {
-  it("claims Q1 by id and never asks which row is newest", async () => {
+describe("a bound approval reads exactly the row it named", () => {
+  it("reads Q1 by id, consumes NOTHING, and never asks which row is newest", async () => {
     const result = await claim(authority());
 
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.prequoteId).toBe(Q1);
     // The identity of the trade is still asserted at the row, so a bound id from
     // another trade matches nothing.
-    expect(mockClaimBound).toHaveBeenCalledTimes(1);
-    const [sessionId, prequoteId, matchHash, kind] = mockClaimBound.mock.calls[0] as string[];
+    expect(mockFindClaimable).toHaveBeenCalledTimes(1);
+    const [sessionId, prequoteId, matchHash, kind] = mockFindClaimable.mock.calls[0] as string[];
     expect(sessionId).toBe("session-1");
     expect(prequoteId).toBe(Q1);
     expect(typeof matchHash).toBe("string");
     expect(kind).toBe("swap");
-    // THE DEFECT, as an absence: the newest-row selector is not consulted at all
-    // on a bound claim, and the unbound claim is never reached.
+    // As an absence: reading the authority spends nothing, so
+    // a divergence the caller finds next leaves the quote reusable.
+    expect(mockClaimVerified).not.toHaveBeenCalled();
     expect(mockFindLatestExecutable).not.toHaveBeenCalled();
-    expect(mockClaimForExecute).not.toHaveBeenCalled();
   });
 
   it("refuses `superseded` when a newer quote arrived after the approval", async () => {
     // The repo's currency predicate is what fails; the diagnosis names why.
-    mockClaimBound.mockResolvedValue(null);
+    mockFindClaimable.mockResolvedValue(null);
     mockDiagnose.mockResolvedValue("superseded");
 
     const result = await claim(authority());
@@ -221,7 +224,7 @@ describe("a bound approval claims exactly the row it named", () => {
     ["missing", "missing_snapshot"],
   ] as const) {
     it(`maps an unclaimable bound row (${reason}) to the typed refusal ${kind}`, async () => {
-      mockClaimBound.mockResolvedValue(null);
+      mockFindClaimable.mockResolvedValue(null);
       mockDiagnose.mockResolvedValue(reason);
 
       const result = await claim(authority());
@@ -261,14 +264,70 @@ describe("the bound row's CONTENT must be the content that was approved", () => 
   });
 });
 
-describe("an UNBOUND claim is unchanged when no approval is in play", () => {
+describe("an UNBOUND read is unchanged when no approval is in play", () => {
   it("selects the newest executable row, as every full-permission execute does", async () => {
     const result = await claim(null, { approvalResume: false });
 
     expect(result.ok).toBe(true);
     expect(mockFindLatestExecutable).toHaveBeenCalledTimes(1);
-    expect(mockClaimForExecute).toHaveBeenCalledTimes(1);
-    expect(mockClaimBound).not.toHaveBeenCalled();
+    expect(mockFindClaimable).not.toHaveBeenCalled();
+    // Still nothing consumed by the read itself.
+    expect(mockClaimVerified).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * THE ORDERING THE MONEY PATH REQUIRES (review finding, 2026-09-04).
+ *
+ * The quote is consumed by a SECOND, explicit call, so every divergence the
+ * executor finds between the read and the commit leaves `claimed_at` null and
+ * the quote reusable. MetaMask's `#approveTransaction` behaves the same way: a
+ * failed attempt releases its reservation and the transaction stays usable.
+ */
+describe("the commit is the only thing that consumes a quote", () => {
+  it("claims the exact row that was read, asserting its disclosure block", async () => {
+    const read = await claim(authority());
+    if (!read.ok) throw new Error("fixture read must succeed");
+
+    const committed = await commitPrequoteClaim(read.claim, "execute-1");
+
+    expect(committed.ok).toBe(true);
+    expect(mockClaimVerified).toHaveBeenCalledTimes(1);
+    const [arg] = mockClaimVerified.mock.calls[0] as [Record<string, unknown>];
+    expect(arg.prequoteId).toBe(Q1);
+    expect(arg.sessionId).toBe("session-1");
+    expect(arg.kind).toBe("swap");
+    expect(typeof arg.matchHash).toBe("string");
+    expect(arg.expectedDisclosure).toEqual({});
+    expect(arg.claimedBy).toBe("execute-1");
+  });
+
+  it("refuses typed when the row's disclosure moved between the read and the claim", async () => {
+    const read = await claim(authority());
+    if (!read.ok) throw new Error("fixture read must succeed");
+    mockClaimVerified.mockResolvedValue(null);
+    mockDiagnose.mockResolvedValue("disclosure_changed");
+
+    const committed = await commitPrequoteClaim(read.claim, "execute-1");
+
+    expect(committed.ok).toBe(false);
+    if (!committed.ok) {
+      expect(committed.refusal.kind).toBe("disclosure_changed");
+      expect(committed.refusal.message).toContain("Nothing was signed");
+      expect(committed.refusal.message).toContain("kyberswap__swap_quote");
+    }
+  });
+
+  it("refuses `already_claimed` when a concurrent execute won the same row", async () => {
+    const read = await claim(authority());
+    if (!read.ok) throw new Error("fixture read must succeed");
+    mockClaimVerified.mockResolvedValue(null);
+    mockDiagnose.mockResolvedValue("already_claimed");
+
+    const committed = await commitPrequoteClaim(read.claim, "execute-1");
+
+    expect(committed.ok).toBe(false);
+    if (!committed.ok) expect(committed.refusal.kind).toBe("already_claimed");
   });
 });
 
@@ -293,9 +352,9 @@ describe("an approval that names no quote is refused", () => {
       expect(result.refusal.message).toContain("Nothing was signed");
       expect(result.refusal.message).toContain("kyberswap__swap_quote");
     }
-    // No row was read for a candidate and no row was consumed, by either claim.
+    // No row was read for a candidate and no row was consumed.
     expect(mockFindLatestExecutable).not.toHaveBeenCalled();
-    expect(mockClaimForExecute).not.toHaveBeenCalled();
-    expect(mockClaimBound).not.toHaveBeenCalled();
+    expect(mockFindClaimable).not.toHaveBeenCalled();
+    expect(mockClaimVerified).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/vex-agent/tools/relay-handlers/bridge.test.ts
+++ b/src/__tests__/vex-agent/tools/relay-handlers/bridge.test.ts
@@ -171,6 +171,7 @@ const {
   boundSkippedVexFee,
   matchedPrequoteWithVexFee,
 } = await import("../../../tools/bridge-fee/bound-vex-fee.js");
+const { BRIDGE_FEE_RECEIVER_EVM } = await import("@tools/bridge-fee/index.js");
 const { DependentLegGasEstimateError, DEPENDENT_LEG_ESTIMATE_MARKER } =
   await import("@tools/evm-chains/dependent-leg-gas-estimate.js");
 
@@ -363,6 +364,118 @@ describe("relay.bridge - the fee must still match the statement the approval was
     await runBridge({ ...PARAMS, dryRun: true });
     expect(mockFindFreshMatchedPrequote).not.toHaveBeenCalled();
     expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  /**
+   * losing the execute-gate registration is an internal
+   * AUTHORIZATION failure, not permission to sign.
+   *
+   * `not_gated` is what the gate answers when this tool has no entry in the
+   * execute-gate registry - the exact state a registry refactor produces. The
+   * handler used to read that as "no approved statement exists to contradict"
+   * and carry on to the signer, so the loss of the fee's entire authority became
+   * a licence to take it. This drives the public handler with the registration
+   * absent and proves the refusal happens before any signer, nonce reservation,
+   * staging or broadcast.
+   */
+  it("REFUSES when this fee-bearing tool has no registered quote gate at all", async () => {
+    mockFindFreshMatchedPrequote.mockResolvedValue({ ok: false, reason: "not_gated" });
+
+    const result = await runBridge();
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("fee-bearing tool with no registered quote gate");
+    expect(result.output).toContain("no funds moved");
+    // Not phrased as a re-quote: re-quoting cannot restore a missing mapping.
+    expect(result.output).not.toContain("approve the fresh quote");
+    assertNothingHappened();
+    expect(mockPreFail).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The typed reason must survive to the RESULT, not only to a log line. An
+   * agent that reads "relay.bridge failed" cannot tell a moved fee statement
+   * (re-quote) from a missing registration (report a build defect).
+   */
+  describe("the typed refusal reason reaches the tool result", () => {
+    function refusalOf(result: { readonly data?: Record<string, unknown> }): Record<string, unknown> {
+      const block = result.data?._vexFeeRefusal;
+      if (block === undefined || block === null || typeof block !== "object") {
+        throw new Error("expected the result to carry a typed _vexFeeRefusal block");
+      }
+      return block as Record<string, unknown>;
+    }
+
+    it("carries `vex_fee_statement_changed` and the field that moved", async () => {
+      mockFindFreshMatchedPrequote.mockResolvedValue(matchedPrequoteWithVexFee(boundChargedVexFee({
+        feeAmountRaw: "2000000000000", netAmountRaw: "998000000000000", totalDebitedRaw: "1000000000000000",
+      })));
+
+      const refusal = refusalOf(await runBridge());
+
+      expect(refusal.reason).toBe("vex_fee_statement_changed");
+      expect(refusal.movedFields).toEqual(["feeAmountRaw"]);
+      expect(String(refusal.remediation)).toContain("relay__bridge_quote_get");
+    });
+
+    it("carries `vex_fee_statement_missing` when the bound row states no fee", async () => {
+      mockFindFreshMatchedPrequote.mockResolvedValue(matchedPrequoteWithVexFee(undefined));
+
+      expect(refusalOf(await runBridge()).reason).toBe("vex_fee_statement_missing");
+    });
+
+    it("carries `vex_fee_gate_unregistered` and a remedy that is not a re-quote", async () => {
+      mockFindFreshMatchedPrequote.mockResolvedValue({ ok: false, reason: "not_gated" });
+
+      const refusal = refusalOf(await runBridge());
+
+      expect(refusal.reason).toBe("vex_fee_gate_unregistered");
+      expect(String(refusal.remediation)).toContain("build defect");
+    });
+
+    it("never leaks the treasury address into the typed block", async () => {
+      mockFindFreshMatchedPrequote.mockResolvedValue(matchedPrequoteWithVexFee(boundChargedVexFee({
+        feeAmountRaw: "2000000000000", netAmountRaw: "998000000000000", totalDebitedRaw: "1000000000000000",
+      })));
+
+      expect(JSON.stringify(refusalOf(await runBridge()))).not.toMatch(/0x[0-9a-fA-F]{40}/);
+    });
+  });
+
+  /**
+   * PIN, DO NOT RE-DERIVE (fixed decision 2026-09-04, recorded beside
+   * `vexFeePreviewSchema`).
+   *
+   * The fee leg signs after the origin deposit has already confirmed. A reviewer
+   * proposed re-running authoritative eligibility inside that window; the owner
+   * decision is that the APPROVED STATEMENT is the authority there, so the leg
+   * signs exactly the amount and the receiver that were compared before anything
+   * was signed - whatever a later eligibility read would say.
+   *
+   * Proved on the SIGNER, not on the wording: the fee transfer's calldata is the
+   * ERC-20 `transfer(receiver, amount)` this bridge planned.
+   */
+  it("signs exactly the approved fee amount and receiver, even after the deposit confirms", async () => {
+    const result = await runBridge();
+    expect(outputOf(result).status).toBe("pending");
+
+    // Two signed legs: the deposit, then the fee transfer.
+    expect(mockSign).toHaveBeenCalledTimes(2);
+    const feeCall = mockSign.mock.calls[1] as unknown[];
+    const request = feeCall[2] as { readonly to: string; readonly data: string; readonly value: bigint };
+
+    // 25 bps of 1e15 wei, the figure the disclosure on this same result states.
+    const disclosed = outputOf(result).vexFee as Record<string, unknown>;
+    expect(disclosed.feeAmountRaw).toBe("2500000000000");
+    // This route's origin currency is native, so the transfer IS the value: the
+    // amount signed and the receiver are both read straight off the request.
+    expect(String(request.value)).toBe(String(disclosed.feeAmountRaw));
+    expect(request.to.toLowerCase()).toBe(BRIDGE_FEE_RECEIVER_EVM.toLowerCase());
+    expect(request.data).toBe("0x");
+    // Nothing re-read eligibility between the deposit and the fee: the gate was
+    // consulted exactly once, in the pre-sign window.
+    expect(mockFindFreshMatchedPrequote).toHaveBeenCalledTimes(1);
+    expect(firstCallOrder(mockFindFreshMatchedPrequote)).toBeLessThan(firstCallOrder(mockSign));
   });
 });
 

--- a/src/__tests__/vex-agent/tools/uniswap-balance-preflight-handler.test.ts
+++ b/src/__tests__/vex-agent/tools/uniswap-balance-preflight-handler.test.ts
@@ -5,7 +5,7 @@
  * pre-broadcast failure (plan §11.1) rather than silently dropped.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { claimStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
+import { readStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
 import { VexError, ErrorCodes } from "../../../errors.js";
 import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
 
@@ -118,10 +118,11 @@ vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
 // before it prices anything. This suite's subject is elsewhere, so the claim
 // stands in with the quote this very call would have produced - see
 // `_uniswap-approved-snapshot.ts`.
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...args: unknown[]) => claimUniswapExecutionSnapshot(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...args: unknown[]) => readUniswapExecutionSnapshot(...args),
 }));
 
 vi.mock("@utils/logger.js", () => ({ default: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() } }));
@@ -139,8 +140,8 @@ const context = {
 describe("Uniswap execute — balance preflight", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    claimUniswapExecutionSnapshot.mockImplementation(
-      claimStandingInForTheParams({ chainId: 4663, weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73" }),
+    readUniswapExecutionSnapshot.mockImplementation(
+      readStandingInForTheParams({ chainId: 4663, weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73" }),
     );
     ensureErc20Balance.mockRejectedValue(new VexError(ErrorCodes.INSUFFICIENT_BALANCE, "short balance"));
     createAgentActivityPreBroadcastFailure.mockResolvedValue({ executionId: 42, event: {} });

--- a/src/__tests__/vex-agent/tools/uniswap-debit-plan-binding.test.ts
+++ b/src/__tests__/vex-agent/tools/uniswap-debit-plan-binding.test.ts
@@ -55,7 +55,7 @@ const CHAIN_GAS_PRICE_WEI = 9_999n;
 
 const quoteBestRoute = vi.fn();
 const runStagedBroadcast = vi.fn();
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
 const createAgentActivityIntent = vi.fn();
 const createAgentActivityPreBroadcastFailure = vi.fn();
 const readUniswapAllowance = vi.fn();
@@ -136,8 +136,9 @@ vi.mock("@vex-agent/tools/protocols/uniswap/handlers/swap/execute-broadcast.js",
   runStagedBroadcast: (...args: unknown[]) => runStagedBroadcast(...args),
 }));
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...args: unknown[]) => claimUniswapExecutionSnapshot(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...args: unknown[]) => readUniswapExecutionSnapshot(...args),
 }));
 vi.mock("@utils/logger.js", () => {
   const stub = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
@@ -229,7 +230,7 @@ beforeEach(async () => {
   runStagedBroadcast.mockResolvedValue({
     kind: "confirmed", txHash: "0xswap", receipt: { logs: [] }, settledAtBlock: 1n,
   });
-  claimUniswapExecutionSnapshot.mockResolvedValue({
+  readUniswapExecutionSnapshot.mockResolvedValue({
     ok: true, prequoteId: "prequote-plan", snapshot: await snapshotBoundTo(["swap", "swap_fee"]),
     vexFee: await approvedVexFee(),
   });
@@ -260,7 +261,7 @@ describe("the transaction set is bound quote-to-execute", () => {
     // The mirror case: the quote was answered when an approve was needed, and
     // by execute time the allowance is in place. Fewer transactions is still a
     // different plan, and the card's disclosed debit no longer describes it.
-    claimUniswapExecutionSnapshot.mockResolvedValue({
+    readUniswapExecutionSnapshot.mockResolvedValue({
       ok: true,
       prequoteId: "prequote-plan",
       snapshot: await snapshotBoundTo(["allowance", "swap", "swap_fee"]),

--- a/src/__tests__/vex-agent/tools/uniswap-execute-final-request-gate.test.ts
+++ b/src/__tests__/vex-agent/tools/uniswap-execute-final-request-gate.test.ts
@@ -31,7 +31,7 @@ const ROUTER = getAddress("0x89e5db8b5aa49aa85ac63f691524311aeb649eba");
 const CHAIN_ID = 4663;
 
 const quoteBestRoute = vi.fn();
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
 const createAgentActivityIntent = vi.fn();
 const createAgentActivityPreBroadcastFailure = vi.fn();
 const signUniswapTransaction = vi.fn();
@@ -112,8 +112,9 @@ vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
   walletScopeErrorToResult: vi.fn((err: unknown) => ({ success: false, output: String(err) })),
 }));
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...args: unknown[]) => claimUniswapExecutionSnapshot(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...args: unknown[]) => readUniswapExecutionSnapshot(...args),
 }));
 vi.mock("@utils/logger.js", () => {
   const stub = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
@@ -204,7 +205,7 @@ beforeEach(async () => {
     ],
   });
   createAgentActivityPreBroadcastFailure.mockResolvedValue({ executionId: 999, event: {} });
-  claimUniswapExecutionSnapshot.mockResolvedValue({
+  readUniswapExecutionSnapshot.mockResolvedValue({
     ok: true, prequoteId: "prequote-1", snapshot: await approved(),
     vexFee: await approvedVexFee(),
   });

--- a/src/__tests__/vex-agent/tools/uniswap-execute-staged-broadcast.test.ts
+++ b/src/__tests__/vex-agent/tools/uniswap-execute-staged-broadcast.test.ts
@@ -38,7 +38,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { uniswapSpendabilityFake } from "./_uniswap-spendability-fake.js";
-import { claimStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
+import { readStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
 import { InvalidParamsRpcError } from "viem";
 import { VexError, ErrorCodes } from "../../../errors.js";
 import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
@@ -164,10 +164,11 @@ vi.mock("@tools/kyberswap/token-api/client.js", () => ({
 // before it prices anything. This suite's subject is elsewhere, so the claim
 // stands in with the quote this very call would have produced - see
 // `_uniswap-approved-snapshot.ts`.
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...args: unknown[]) => claimUniswapExecutionSnapshot(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...args: unknown[]) => readUniswapExecutionSnapshot(...args),
 }));
 
 vi.mock("@utils/logger.js", () => ({
@@ -202,8 +203,8 @@ function setAllowance(value: bigint): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  claimUniswapExecutionSnapshot.mockImplementation(
-    claimStandingInForTheParams({
+  readUniswapExecutionSnapshot.mockImplementation(
+    readStandingInForTheParams({
       chainId: 4663,
       weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
       currentAllowance: () => currentAllowance,
@@ -253,7 +254,7 @@ describe("contract metadata is re-read before signing", () => {
 
     expect(result.success).toBe(false);
     expect(createAgentActivityPreBroadcastFailure).toHaveBeenCalledTimes(1);
-    expect(claimUniswapExecutionSnapshot).not.toHaveBeenCalled();
+    expect(readUniswapExecutionSnapshot).not.toHaveBeenCalled();
     expect(createAgentActivityIntent).not.toHaveBeenCalled();
     expect(signUniswapTransaction).not.toHaveBeenCalled();
   });

--- a/src/__tests__/vex-agent/tools/uniswap-fee-ordering.test.ts
+++ b/src/__tests__/vex-agent/tools/uniswap-fee-ordering.test.ts
@@ -17,7 +17,7 @@ import assert from "node:assert/strict";
 import { uniswapSpendabilityFake } from "./_uniswap-spendability-fake.js";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { claimStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
+import { readStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
 import { decodeFunctionData, getAddress, parseAbi, type Address, type Hex, type TransactionReceipt } from "viem";
 
 import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
@@ -177,10 +177,11 @@ vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
 // before it prices anything. This suite's subject is elsewhere, so the claim
 // stands in with the quote this very call would have produced - see
 // `_uniswap-approved-snapshot.ts`.
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...args: unknown[]) => claimUniswapExecutionSnapshot(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...args: unknown[]) => readUniswapExecutionSnapshot(...args),
 }));
 
 vi.mock("@utils/logger.js", () => ({
@@ -250,8 +251,8 @@ function setAllowance(value: bigint): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  claimUniswapExecutionSnapshot.mockImplementation(
-    claimStandingInForTheParams({
+  readUniswapExecutionSnapshot.mockImplementation(
+    readStandingInForTheParams({
       chainId: 4663,
       weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
       currentAllowance: () => currentAllowance,
@@ -527,8 +528,8 @@ describe("quote / execute parity", () => {
     });
 
     vi.clearAllMocks();
-    claimUniswapExecutionSnapshot.mockImplementation(
-      claimStandingInForTheParams({
+    readUniswapExecutionSnapshot.mockImplementation(
+      readStandingInForTheParams({
       chainId: 4663,
       weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
       currentAllowance: () => currentAllowance,

--- a/src/__tests__/vex-agent/tools/uniswap-post-buy-delivery.test.ts
+++ b/src/__tests__/vex-agent/tools/uniswap-post-buy-delivery.test.ts
@@ -13,7 +13,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { uniswapSpendabilityFake } from "./_uniswap-spendability-fake.js";
-import { claimStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
+import { readStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
 import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
 
 const TOKEN_IN = "0x8Ff92566f2e81BDd68EDfAa8cde73942A723796b";
@@ -121,10 +121,11 @@ vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
 // before it prices anything. This suite's subject is elsewhere, so the claim
 // stands in with the quote this very call would have produced - see
 // `_uniswap-approved-snapshot.ts`.
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...args: unknown[]) => claimUniswapExecutionSnapshot(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...args: unknown[]) => readUniswapExecutionSnapshot(...args),
 }));
 
 vi.mock("@utils/logger.js", () => ({ default: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() } }));
@@ -153,8 +154,8 @@ const ZERO_VERDICT = "balanceOf returned zero immediately after the confirmed bu
 
 beforeEach(() => {
   vi.clearAllMocks();
-  claimUniswapExecutionSnapshot.mockImplementation(
-    claimStandingInForTheParams({ chainId: 4663, weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73" }),
+  readUniswapExecutionSnapshot.mockImplementation(
+    readStandingInForTheParams({ chainId: 4663, weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73" }),
   );
   readUniswapAllowance.mockResolvedValue(10n ** 30n);
   signUniswapTransaction.mockResolvedValue({ serializedTransaction: "0xsigned", txHash: "0xhash", fromAddress: WALLET, nonce: 1 });

--- a/src/__tests__/vex-agent/tools/uniswap-pre-sign-revert-refusal.test.ts
+++ b/src/__tests__/vex-agent/tools/uniswap-pre-sign-revert-refusal.test.ts
@@ -23,7 +23,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { uniswapSpendabilityFake } from "./_uniswap-spendability-fake.js";
-import { claimStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
+import { readStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
 import { ExecutionRevertedError } from "viem";
 import { VexError, ErrorCodes } from "../../../errors.js";
 import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
@@ -143,10 +143,11 @@ vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
 // before it prices anything. This suite's subject is elsewhere, so the claim
 // stands in with the quote this very call would have produced - see
 // `_uniswap-approved-snapshot.ts`.
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...args: unknown[]) => claimUniswapExecutionSnapshot(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...args: unknown[]) => readUniswapExecutionSnapshot(...args),
 }));
 
 vi.mock("@utils/logger.js", () => ({
@@ -189,8 +190,8 @@ function setAllowance(value: bigint): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  claimUniswapExecutionSnapshot.mockImplementation(
-    claimStandingInForTheParams({
+  readUniswapExecutionSnapshot.mockImplementation(
+    readStandingInForTheParams({
       chainId: 4663,
       weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
       currentAllowance: () => currentAllowance,

--- a/src/__tests__/vex-agent/tools/uniswap-pre-sign-total-debit.test.ts
+++ b/src/__tests__/vex-agent/tools/uniswap-pre-sign-total-debit.test.ts
@@ -32,7 +32,7 @@ import {
   uniswapSpendabilityFake,
   type UniswapSpendabilityFakeOptions,
 } from "./_uniswap-spendability-fake.js";
-import { claimStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
+import { readStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
 
 const TOKEN_IN = getAddress("0x8Ff92566f2e81BDd68EDfAa8cde73942A723796b");
 const TOKEN_OUT = getAddress("0xc6911796042b15d7Fa4F6CDe69e245DdCd3d9c31");
@@ -60,7 +60,7 @@ const failActivityEvent = vi.fn();
 const abortPlannedEvents = vi.fn();
 const createAgentActivityPreBroadcastFailure = vi.fn();
 const waitForSuccessfulReceipt = vi.fn();
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
 const quoteBestRoute = vi.fn();
 
 /** Every block tag the execution's balance reads asked for, in order. */
@@ -179,8 +179,9 @@ vi.mock("@vex-agent/db/repos/agent-activity.js", () => ({
 }));
 vi.mock("@vex-agent/db/repos/tracked-tokens.js", () => ({ pinTrackedToken: vi.fn() }));
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...args: unknown[]) => claimUniswapExecutionSnapshot(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...args: unknown[]) => readUniswapExecutionSnapshot(...args),
 }));
 vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
   resolveSelectedAddress: vi.fn(() => WALLET),
@@ -228,8 +229,8 @@ beforeEach(() => {
     route: { version: "v2", path: [TOKEN_IN, TOKEN_OUT], amountOut: QUOTED_OUT },
     priceImpact: 0.001,
   });
-  claimUniswapExecutionSnapshot.mockImplementation(
-    claimStandingInForTheParams({ chainId: CHAIN_ID, weth: WETH }),
+  readUniswapExecutionSnapshot.mockImplementation(
+    readStandingInForTheParams({ chainId: CHAIN_ID, weth: WETH }),
   );
   createAgentActivityIntent.mockResolvedValue({
     executionId: 1,

--- a/src/__tests__/vex-agent/tools/uniswap-quote-bound-execute.test.ts
+++ b/src/__tests__/vex-agent/tools/uniswap-quote-bound-execute.test.ts
@@ -48,7 +48,7 @@ const CHAIN_ID = 4663;
 
 const quoteBestRoute = vi.fn();
 const runStagedBroadcast = vi.fn();
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
 const createAgentActivityPreBroadcastFailure = vi.fn();
 const createAgentActivityIntent = vi.fn();
 
@@ -131,8 +131,9 @@ vi.mock("@vex-agent/tools/protocols/uniswap/handlers/swap/execute-broadcast.js",
 // `integration/repos/swap-prequotes-claim.int.test.ts`. Here it stands for "the
 // store handed the execute THIS approved quote".
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...args: unknown[]) => claimUniswapExecutionSnapshot(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...args: unknown[]) => readUniswapExecutionSnapshot(...args),
 }));
 vi.mock("@utils/logger.js", () => {
   const stub = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
@@ -222,7 +223,7 @@ beforeEach(async () => {
   runStagedBroadcast.mockResolvedValue({
     kind: "confirmed", txHash: "0xswap", receipt: { logs: [] }, settledAtBlock: 1n,
   });
-  claimUniswapExecutionSnapshot.mockResolvedValue({
+  readUniswapExecutionSnapshot.mockResolvedValue({
     ok: true, prequoteId: "prequote-incident", snapshot: await approved(),
     // The row's own Vex fee statement. The execute re-derives it and refuses
     // before signing when the two disagree, so a claim without one signs
@@ -295,7 +296,7 @@ describe("the 2026-08-27 incident shape", () => {
 
 describe("the claim", () => {
   it("is taken BEFORE any route is priced, so a spent quote never re-quotes", async () => {
-    claimUniswapExecutionSnapshot.mockResolvedValue({
+    readUniswapExecutionSnapshot.mockResolvedValue({
       ok: false, refusal: snapshotRefusal("already_claimed", "uniswap__swap_quote"),
     });
 
@@ -310,7 +311,7 @@ describe("the claim", () => {
   it.each(["superseded", "expired", "digest_mismatch", "not_executable"] as const)(
     "surfaces the typed %s refusal with a fresh quote as the way out",
     async (kind) => {
-      claimUniswapExecutionSnapshot.mockResolvedValue({
+      readUniswapExecutionSnapshot.mockResolvedValue({
         ok: false, refusal: snapshotRefusal(kind, "uniswap__swap_quote"),
       });
 
@@ -327,7 +328,7 @@ describe("router input and fee drift", () => {
   it("refuses when the amount reaching the router is not the approved one", async () => {
     // The approved quote was answered for a DIFFERENT total, so the router
     // input derived from it cannot match this execute's.
-    claimUniswapExecutionSnapshot.mockResolvedValue({
+    readUniswapExecutionSnapshot.mockResolvedValue({
       ok: true, prequoteId: "p", snapshot: await approved({ amountInRaw: AMOUNT_IN_RAW * 2n }),
     });
 
@@ -341,7 +342,7 @@ describe("router input and fee drift", () => {
 
   it("refuses when the approved quote carried no fee and one now applies", async () => {
     const snapshot = await approved();
-    claimUniswapExecutionSnapshot.mockResolvedValue({
+    readUniswapExecutionSnapshot.mockResolvedValue({
       ok: true,
       prequoteId: "p",
       // Sealed by the codec, so the row is internally consistent: this is a
@@ -366,7 +367,7 @@ describe("router input and fee drift", () => {
   it("refuses when the fee alone resolved differently than it was disclosed", async () => {
     const snapshot = await approved();
     const { sealUniswapSnapshot } = await import("@vex-agent/tools/protocols/quote-authority/uniswap.js");
-    claimUniswapExecutionSnapshot.mockResolvedValue({
+    readUniswapExecutionSnapshot.mockResolvedValue({
       ok: true,
       prequoteId: "p",
       snapshot: sealUniswapSnapshot({
@@ -402,7 +403,7 @@ describe("venue honesty", () => {
 
     expect(result.success).toBe(false);
     expect(result.output).toContain("WalletWrapPrepare");
-    expect(claimUniswapExecutionSnapshot).not.toHaveBeenCalled();
+    expect(readUniswapExecutionSnapshot).not.toHaveBeenCalled();
   });
 
   it("states what was actually probed when no route exists, never 'may have no liquidity'", async () => {

--- a/src/__tests__/vex-agent/tools/uniswap-tracked-token-pin.test.ts
+++ b/src/__tests__/vex-agent/tools/uniswap-tracked-token-pin.test.ts
@@ -22,7 +22,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { uniswapSpendabilityFake } from "./_uniswap-spendability-fake.js";
-import { claimStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
+import { readStandingInForTheParams } from "./_uniswap-approved-snapshot.js";
 import type { ProtocolExecutionContext } from "@vex-agent/tools/protocols/types.js";
 
 const TOKEN_IN = "0x8Ff92566f2e81BDd68EDfAa8cde73942A723796b";
@@ -133,10 +133,11 @@ vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
 // before it prices anything. This suite's subject is elsewhere, so the claim
 // stands in with the quote this very call would have produced - see
 // `_uniswap-approved-snapshot.ts`.
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...args: unknown[]) => claimUniswapExecutionSnapshot(...args),
+  commitPrequoteClaim: vi.fn(async () => ({ ok: true })),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...args: unknown[]) => readUniswapExecutionSnapshot(...args),
 }));
 
 vi.mock("@utils/logger.js", () => ({ default: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() } }));
@@ -153,8 +154,8 @@ const context = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  claimUniswapExecutionSnapshot.mockImplementation(
-    claimStandingInForTheParams({ chainId: 4663, weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73" }),
+  readUniswapExecutionSnapshot.mockImplementation(
+    readStandingInForTheParams({ chainId: 4663, weth: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73" }),
   );
   ensureErc20Balance.mockResolvedValue(undefined);
   readUniswapAllowance.mockResolvedValue(10n ** 30n); // sufficient — no allowance events planned

--- a/src/__tests__/vex-agent/tools/uniswap-vex-fee-presign-binding.test.ts
+++ b/src/__tests__/vex-agent/tools/uniswap-vex-fee-presign-binding.test.ts
@@ -63,7 +63,8 @@ const createAgentActivityPreBroadcastFailure = vi.fn();
 const waitForSuccessfulReceipt = vi.fn();
 const getHoneypotFotInfo = vi.fn();
 const signStageBroadcast = vi.fn();
-const claimUniswapExecutionSnapshot = vi.fn();
+const readUniswapExecutionSnapshot = vi.fn();
+const commitPrequoteClaim = vi.fn();
 
 vi.mock("@tools/uniswap/chains.js", () => ({
   resolveUniswapDeployment: vi.fn(() => ({
@@ -140,8 +141,9 @@ vi.mock("@vex-agent/tools/internal/wallet/resolve.js", () => ({
   walletScopeErrorToResult: vi.fn((err: unknown) => ({ success: false, output: String(err) })),
 }));
 vi.mock("@vex-agent/tools/protocols/prequote/claim.js", () => ({
-  claimSwapExecutionSnapshot: vi.fn(),
-  claimUniswapExecutionSnapshot: (...a: unknown[]) => claimUniswapExecutionSnapshot(...a),
+  commitPrequoteClaim: (...a: unknown[]) => commitPrequoteClaim(...a),
+  readSwapExecutionSnapshot: vi.fn(),
+  readUniswapExecutionSnapshot: (...a: unknown[]) => readUniswapExecutionSnapshot(...a),
 }));
 vi.mock("@utils/logger.js", () => {
   const stub = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
@@ -183,6 +185,19 @@ function oracleSaysFeeOnTransfer(): void {
 }
 
 /**
+ * The ticket the read hands to the claim. Its contents are the repository's
+ * business; what this file asserts is WHETHER the claim is reached at all.
+ */
+const CLAIM_TICKET = {
+  sessionId: "session-1",
+  prequoteId: "prequote-fee",
+  matchHash: "h".repeat(64),
+  kind: "swap" as const,
+  expectedDisclosure: {},
+  freshQuoteTool: "uniswap__swap_quote",
+};
+
+/**
  * Build a snapshot and a fee block under the eligibility the callback installs,
  * then restore the oracle the execute itself will read.
  *
@@ -200,7 +215,7 @@ async function claimedRow(input: {
   input.blockUnder();
   const vexFee = await approvedUniswapVexFee(SNAPSHOT_INPUT);
   input.executeUnder();
-  return { ok: true as const, prequoteId: "prequote-fee", snapshot, vexFee };
+  return { ok: true as const, prequoteId: "prequote-fee", snapshot, vexFee, claim: CLAIM_TICKET };
 }
 
 function run() {
@@ -220,6 +235,7 @@ function expectNothingSigned(): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  commitPrequoteClaim.mockResolvedValue({ ok: true });
   oracleSaysClean();
   // A router allowance already in place, so the plan is swap plus fee leg and no
   // allowance leg is needed. The allowance case is covered by its own suite; the
@@ -256,7 +272,7 @@ describe("the fee statement the card made is re-checked before signing", () => {
     // token fee-on-transfer, so this execute would swap the FULL amount and take
     // nothing. The snapshot agrees with the execute, so the trade-level binding
     // passes; the card-level one does not.
-    claimUniswapExecutionSnapshot.mockResolvedValue(
+    readUniswapExecutionSnapshot.mockResolvedValue(
       await claimedRow({
         snapshotUnder: oracleSaysFeeOnTransfer,
         blockUnder: oracleSaysClean,
@@ -284,8 +300,8 @@ describe("the fee statement the card made is re-checked before signing", () => {
       receiver: "0x9999999999999999999999999999999999999999",
     });
     if (redirected === undefined) throw new Error("the redirected block must still project");
-    claimUniswapExecutionSnapshot.mockResolvedValue({
-      ok: true, prequoteId: "prequote-fee", snapshot, vexFee: redirected,
+    readUniswapExecutionSnapshot.mockResolvedValue({
+      ok: true, prequoteId: "prequote-fee", snapshot, vexFee: redirected, claim: CLAIM_TICKET,
     });
 
     const result = await run();
@@ -301,11 +317,12 @@ describe("the fee statement the card made is re-checked before signing", () => {
   it("fails closed when the claimed row carries no fee statement at all", async () => {
     // The gate refuses a fee-bearing execute in this state, so reaching the
     // executor means the gate was bypassed. It signs nothing either way.
-    claimUniswapExecutionSnapshot.mockResolvedValue({
+    readUniswapExecutionSnapshot.mockResolvedValue({
       ok: true,
       prequoteId: "prequote-fee",
       snapshot: await approvedUniswapSnapshot(SNAPSHOT_INPUT),
       vexFee: undefined,
+      claim: CLAIM_TICKET,
     });
 
     const result = await run();
@@ -316,7 +333,7 @@ describe("the fee statement the card made is re-checked before signing", () => {
   });
 
   it("executes when the statement still holds - the check is not a blanket refusal", async () => {
-    claimUniswapExecutionSnapshot.mockResolvedValue(
+    readUniswapExecutionSnapshot.mockResolvedValue(
       await claimedRow({
         snapshotUnder: oracleSaysClean,
         blockUnder: oracleSaysClean,
@@ -334,7 +351,7 @@ describe("the fee statement the card made is re-checked before signing", () => {
   it("executes a genuinely fee-free trade when the card said the fee was declined", async () => {
     // The mirror of the first case, and the reason `charged` is compared in both
     // directions: a quote that honestly disclosed no fee must still execute.
-    claimUniswapExecutionSnapshot.mockResolvedValue(
+    readUniswapExecutionSnapshot.mockResolvedValue(
       await claimedRow({
         snapshotUnder: oracleSaysFeeOnTransfer,
         blockUnder: oracleSaysFeeOnTransfer,
@@ -346,5 +363,190 @@ describe("the fee statement the card made is re-checked before signing", () => {
 
     expect(result.success, `handler output: ${result.output}`).toBe(true);
     expect(signStageBroadcast).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * a divergence must not burn the approved quote.
+ *
+ * Before the fix the handler claimed the row before it had re-derived anything,
+ * so a refusal here spent the quote on the way out and the retry the refusal
+ * instructed the agent to make got `already_claimed`. The claim is now a
+ * separate, later call, and these cases prove it is never reached on a
+ * divergence - which is what makes "request a fresh quote" a real remedy.
+ */
+describe("a refused execute leaves the approved quote unconsumed", () => {
+  it("does not claim the row when the card's fee statement no longer holds", async () => {
+    readUniswapExecutionSnapshot.mockResolvedValue(
+      await claimedRow({
+        snapshotUnder: oracleSaysFeeOnTransfer,
+        blockUnder: oracleSaysClean,
+        executeUnder: oracleSaysFeeOnTransfer,
+      }),
+    );
+
+    const result = await run();
+
+    expect(result.success).toBe(false);
+    expectNothingSigned();
+    expect(commitPrequoteClaim).not.toHaveBeenCalled();
+  });
+
+  it("does not claim the row when the approved quote carries no fee statement", async () => {
+    readUniswapExecutionSnapshot.mockResolvedValue({
+      ok: true,
+      prequoteId: "prequote-fee",
+      snapshot: await approvedUniswapSnapshot(SNAPSHOT_INPUT),
+      vexFee: undefined,
+      claim: CLAIM_TICKET,
+    });
+
+    await run();
+
+    expect(commitPrequoteClaim).not.toHaveBeenCalled();
+  });
+
+  it("claims the row that was read, once, when every comparison passes", async () => {
+    readUniswapExecutionSnapshot.mockResolvedValue(
+      await claimedRow({
+        snapshotUnder: oracleSaysClean,
+        blockUnder: oracleSaysClean,
+        executeUnder: oracleSaysClean,
+      }),
+    );
+
+    const result = await run();
+
+    expect(result.success, `handler output: ${result.output}`).toBe(true);
+    expect(commitPrequoteClaim).toHaveBeenCalledTimes(1);
+    const [ticket, claimedBy] = commitPrequoteClaim.mock.calls[0] as [typeof CLAIM_TICKET, string];
+    expect(ticket).toBe(CLAIM_TICKET);
+    expect(claimedBy).toContain("uniswap.swap.execute");
+  });
+
+  it("refuses without signing when a concurrent execute won the same row", async () => {
+    // The one state where "already claimed" is the truth: the comparison passed
+    // and another execute took the row first. The signing wallet is resolved
+    // only after this point, so nothing is signed either.
+    readUniswapExecutionSnapshot.mockResolvedValue(
+      await claimedRow({
+        snapshotUnder: oracleSaysClean,
+        blockUnder: oracleSaysClean,
+        executeUnder: oracleSaysClean,
+      }),
+    );
+    commitPrequoteClaim.mockResolvedValue({
+      ok: false,
+      refusal: { kind: "already_claimed", message: "Refused before signing: this quote has already been claimed." },
+    });
+
+    const result = await run();
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("already been claimed");
+    expectNothingSigned();
+  });
+});
+
+/**
+ * The typed reason must reach the RESULT, not only the log line: an agent that
+ * reads "uniswap.swap.execute failed" cannot tell a moved fee statement from any
+ * other swap failure, and the two have different remedies.
+ */
+describe("the typed refusal reason reaches the tool result", () => {
+  function refusalOf(result: { readonly data?: Record<string, unknown> }): Record<string, unknown> {
+    const block = result.data?._vexFeeRefusal;
+    if (block === undefined || block === null || typeof block !== "object") {
+      throw new Error("expected the result to carry a typed _vexFeeRefusal block");
+    }
+    return block as Record<string, unknown>;
+  }
+
+  it("carries `vex_fee_statement_changed` and the fields that moved", async () => {
+    readUniswapExecutionSnapshot.mockResolvedValue(
+      await claimedRow({
+        snapshotUnder: oracleSaysFeeOnTransfer,
+        blockUnder: oracleSaysClean,
+        executeUnder: oracleSaysFeeOnTransfer,
+      }),
+    );
+
+    const refusal = refusalOf(await run());
+
+    expect(refusal.reason).toBe("vex_fee_statement_changed");
+    expect(refusal.movedFields).toContain("charged");
+    expect(String(refusal.remediation)).toContain("uniswap__swap_quote");
+  });
+
+  it("carries `vex_fee_statement_missing` when the approved quote states no fee", async () => {
+    readUniswapExecutionSnapshot.mockResolvedValue({
+      ok: true,
+      prequoteId: "prequote-fee",
+      snapshot: await approvedUniswapSnapshot(SNAPSHOT_INPUT),
+      vexFee: undefined,
+      claim: CLAIM_TICKET,
+    });
+
+    expect(refusalOf(await run()).reason).toBe("vex_fee_statement_missing");
+  });
+
+  it("never leaks an address into the typed block", async () => {
+    const snapshot = await approvedUniswapSnapshot(SNAPSHOT_INPUT);
+    const honest = await approvedUniswapVexFee(SNAPSHOT_INPUT);
+    const redirected = toVexFeePreview("uniswap.swap.quote", {
+      ...honest,
+      swappedAmountRaw: honest.netAmountRaw,
+      receiver: "0x9999999999999999999999999999999999999999",
+    });
+    if (redirected === undefined) throw new Error("the redirected block must still project");
+    readUniswapExecutionSnapshot.mockResolvedValue({
+      ok: true, prequoteId: "prequote-fee", snapshot, vexFee: redirected, claim: CLAIM_TICKET,
+    });
+
+    expect(JSON.stringify(refusalOf(await run()))).not.toMatch(/0x[0-9a-fA-F]{40}/);
+  });
+});
+
+/**
+ * PIN, DO NOT RE-DERIVE (fixed decision 2026-09-04, recorded beside
+ * `vexFeePreviewSchema`).
+ *
+ * The Vex fee transfer is the LAST leg: it is signed after the swap has already
+ * confirmed. The approved statement is its authority there, so a token the
+ * oracle flags in that window changes nothing about what is signed, and nothing
+ * on the path can raise the fee above the statement.
+ */
+describe("the fee leg signs exactly the approved statement", () => {
+  it("signs the approved amount and receiver even when eligibility flips after the swap confirms", async () => {
+    readUniswapExecutionSnapshot.mockResolvedValue(
+      await claimedRow({
+        snapshotUnder: oracleSaysClean,
+        blockUnder: oracleSaysClean,
+        executeUnder: oracleSaysClean,
+      }),
+    );
+    // The statement the card made, captured before the oracle turns.
+    oracleSaysClean();
+    const approved = await approvedUniswapVexFee(SNAPSHOT_INPUT);
+    if (!approved.charged) throw new Error("this arrangement must state a charged fee");
+    // The oracle turns hostile the moment the swap leg confirms - the exact
+    // window a late re-derivation would read.
+    signUniswapTransaction.mockImplementation(async () => {
+      oracleSaysFeeOnTransfer();
+      return { serializedTransaction: "0xsigned", txHash: "0xswap", fromAddress: WALLET, nonce: 1 };
+    });
+
+    const result = await run();
+    expect(result.success, `handler output: ${result.output}`).toBe(true);
+
+    // The fee leg is signed through the staged broadcaster, exactly once.
+    expect(signStageBroadcast).toHaveBeenCalledTimes(1);
+    const feeCall = signStageBroadcast.mock.calls[0];
+    if (feeCall === undefined) throw new Error("the fee leg must have been signed");
+    const request = feeCall[2] as { readonly to: string; readonly data: string };
+    const feeHex = BigInt(approved.feeAmountRaw).toString(16).padStart(64, "0");
+    expect(request.data.toLowerCase().endsWith(feeHex)).toBe(true);
+    expect(request.data.toLowerCase()).toContain(UNISWAP_FEE_RECEIVER_EVM.slice(2).toLowerCase());
+    expect(request.to.toLowerCase()).toBe(TOKEN_IN.toLowerCase());
   });
 });

--- a/src/tools/bridge-fee/fee-revalidation.ts
+++ b/src/tools/bridge-fee/fee-revalidation.ts
@@ -65,8 +65,8 @@ export const VEX_FEE_GATE_UNREGISTERED_REASON = "vex_fee_gate_unregistered";
 export const VEX_FEE_QUOTE_UNAUTHORIZED_REASON = "vex_fee_quote_unauthorized";
 
 /**
- * A bridge refusal as the PUBLIC tool result must carry it (Codex round-2
- * suggestion, rule 04 layer 3).
+ * A bridge refusal as the PUBLIC tool result must carry it (review finding,
+ * 2026-09-04).
  *
  * The venues used to return a bare sentence, so the typed reason existed only in
  * a log line and the agent-facing result collapsed every fee-statement refusal

--- a/src/tools/bridge-fee/fee-revalidation.ts
+++ b/src/tools/bridge-fee/fee-revalidation.ts
@@ -66,7 +66,7 @@ export const VEX_FEE_QUOTE_UNAUTHORIZED_REASON = "vex_fee_quote_unauthorized";
 
 /**
  * A bridge refusal as the PUBLIC tool result must carry it (review finding,
- * 2026-09-04).
+ * 2026-09-04; rule 04, layer 3).
  *
  * The venues used to return a bare sentence, so the typed reason existed only in
  * a log line and the agent-facing result collapsed every fee-statement refusal

--- a/src/tools/bridge-fee/fee-revalidation.ts
+++ b/src/tools/bridge-fee/fee-revalidation.ts
@@ -55,6 +55,53 @@ export const VEX_FEE_STATEMENT_CHANGED_REASON = "vex_fee_statement_changed";
 export const VEX_FEE_STATEMENT_MISSING_REASON = "vex_fee_statement_missing";
 
 /**
+ * The bounded reason for a fee-bearing handler whose prequote registration is
+ * absent. NOT a market state and not a user error: these tools are gated by
+ * construction, so a missing mapping is an internal authorization failure.
+ */
+export const VEX_FEE_GATE_UNREGISTERED_REASON = "vex_fee_gate_unregistered";
+
+/** The bounded reason for a bound row that authorizes no execute at all. */
+export const VEX_FEE_QUOTE_UNAUTHORIZED_REASON = "vex_fee_quote_unauthorized";
+
+/**
+ * A bridge refusal as the PUBLIC tool result must carry it (Codex round-2
+ * suggestion, rule 04 layer 3).
+ *
+ * The venues used to return a bare sentence, so the typed reason existed only in
+ * a log line and the agent-facing result collapsed every fee-statement refusal
+ * into the venue's generic bridge failure. An agent cannot pick a remedy from
+ * that: "the approved fee moved, re-quote" and "the bridge failed" are different
+ * situations.
+ *
+ * Bounded by construction: a reason token, the FIELD names that moved (never
+ * their values, never an address) and one first-party remediation sentence.
+ */
+export interface BridgeFeeRefusal {
+  readonly reason: string;
+  readonly movedFields: readonly BridgeFeeStatementField[];
+  /** The agent-facing sentence, already built by the message helpers below. */
+  readonly message: string;
+  readonly remediation: string;
+}
+
+/**
+ * The `data` block a refusing bridge result carries. The key and shape are the
+ * same `_vexFeeRefusal` the swap venues emit (`tools/vex-fee/fee-revalidation.
+ * ts`), so one agent-side reader covers all four venues, and the `_` prefix is
+ * the established convention for a Vex-authored field on these results.
+ */
+export function bridgeFeeRefusalData(refusal: BridgeFeeRefusal): Record<string, unknown> {
+  return {
+    _vexFeeRefusal: {
+      reason: refusal.reason,
+      movedFields: [...refusal.movedFields],
+      remediation: refusal.remediation,
+    },
+  };
+}
+
+/**
  * The fields compared, in the order they are compared. `charged` first because
  * a disposition change makes every amount below it incomparable, and naming the
  * amount instead of the disposition would describe the symptom.
@@ -216,9 +263,8 @@ export function missingBridgeFeeStatementMessage(quoteToolName: string): string 
  *
  * Shared by both bridge venues for the same reason the comparison is: the two
  * handlers refuse the same states, so they must refuse them in the same
- * vocabulary. `not_gated` is absent on purpose - it is structural, it means no
- * quote channel exists for this tool at all, and the caller skips the
- * revalidation rather than refusing an ungated call it cannot bind.
+ * vocabulary. `not_gated` is absent on purpose - it is not a quote state at all,
+ * and its refusal is `unregisteredBridgeFeeGateMessage` below.
  */
 export function unauthorizedBridgeQuoteMessage(
   refusal: {
@@ -254,4 +300,25 @@ export function unauthorizedBridgeQuoteMessage(
         + ` one that was approved. Nothing was signed or broadcast. Call ${quoteToolName} again and approve`
         + " the fresh quote.";
   }
+}
+
+/**
+ * A fee-bearing bridge handler whose execute-gate registration is missing.
+ *
+ * `not_gated` used to be answered with `null` - "proceed" - on both bridge
+ * venues, which made the loss of the registry mapping a grant of permission to
+ * sign (review finding, 2026-09-04). These two tools are gated BY CONSTRUCTION:
+ * their whole fee authority is the prequote row, so an absent registration means
+ * this build cannot bind the fee to anything a person approved. Rule 07: missing
+ * or unknown authority fails closed.
+ *
+ * It is deliberately NOT phrased as a quote problem. Re-quoting cannot fix a
+ * build that lost its mapping, and telling an agent to retry a call that can
+ * never succeed is the dead end this vocabulary avoids everywhere else.
+ */
+export function unregisteredBridgeFeeGateMessage(bridgeToolId: string): string {
+  return `${bridgeToolId} is a fee-bearing tool with no registered quote gate in this build, so the Vex fee`
+    + " it would take cannot be bound to any approved quote. Nothing was signed, nothing was broadcast and"
+    + " no funds moved. This is a Vex build defect, not a state you can clear: report it. A bridge is still"
+    + " possible through the other bridge venue.";
 }

--- a/src/tools/bridge-fee/index.ts
+++ b/src/tools/bridge-fee/index.ts
@@ -61,12 +61,17 @@ export {
 } from "./fee-eligibility.js";
 
 export {
+  bridgeFeeRefusalData,
   bridgeFeeStatementChangedMessage,
   checkBridgeFeeStatementUnchanged,
   missingBridgeFeeStatementMessage,
   unauthorizedBridgeQuoteMessage,
+  unregisteredBridgeFeeGateMessage,
+  VEX_FEE_GATE_UNREGISTERED_REASON,
+  VEX_FEE_QUOTE_UNAUTHORIZED_REASON,
   VEX_FEE_STATEMENT_CHANGED_REASON,
   VEX_FEE_STATEMENT_MISSING_REASON,
+  type BridgeFeeRefusal,
   type BridgeFeeStatementCheck,
   type BridgeFeeStatementDivergence,
   type BridgeFeeStatementField,

--- a/src/tools/vex-fee/fee-revalidation.ts
+++ b/src/tools/vex-fee/fee-revalidation.ts
@@ -44,6 +44,7 @@
  * would take that decision away from them.
  */
 
+import { VexError } from "../../errors.js";
 import type { VexFeePreview } from "@vex-agent/tools/protocols/prequote/fee-disclosure.js";
 
 /** Digits only - the shape the persisted block's amount fields are validated to. */
@@ -197,4 +198,69 @@ function sameAddress(a: string, b: string): boolean {
   if (a === b) return true;
   if (!EVM_ADDRESS.test(a) || !EVM_ADDRESS.test(b)) return false;
   return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
+ * The typed refusal, as it must reach the PUBLIC tool result.
+ *
+ * Rule 04 layer 3: a trusted agent-facing error is "sanitized, concrete enough
+ * to remediate, bounded, and correlated". Until this existed, every venue folded
+ * a fee-statement refusal into its own generic swap failure code
+ * (`SWAP_FAILED`, `KYBER_MALFORMED_PARAMS`) and the only machine-readable trace
+ * of WHY was a log line an agent cannot read - so an agent could not tell "the
+ * approved fee moved, re-quote" apart from "the swap failed", which have
+ * different remedies.
+ *
+ * It is deliberately data on the result rather than a new `ErrorCodes` member:
+ * the code vocabulary is a shared contract owned elsewhere, and what an agent
+ * needs here is the bounded reason plus the fields that moved. Amounts and
+ * addresses are absent by construction - `movedFields` names figures, never
+ * their values.
+ */
+export interface VexFeeRefusalDisclosure {
+  readonly reason: VexFeeRevalidationReason;
+  readonly movedFields: readonly VexFeeBoundField[];
+  /** The one recovery, in the venue's own vocabulary. */
+  readonly remediation: string;
+}
+
+/**
+ * The `data` block a refusing tool result carries, under a Vex-authored
+ * `_`-prefixed key - the same convention `_executionId` already uses on these
+ * results, so no consumer of the documented fields is affected.
+ */
+export function vexFeeRefusalData(
+  disclosure: VexFeeRefusalDisclosure,
+): Record<string, unknown> {
+  return { _vexFeeRefusal: { ...disclosure, movedFields: [...disclosure.movedFields] } };
+}
+
+/**
+ * The refusal as a THROWN value, for the venues whose pre-sign phase reports by
+ * throwing (KyberSwap's Phase A).
+ *
+ * It exists so a phase that can only throw still reaches the public result with
+ * its typed reason intact: the recorder at the catch site asks
+ * `vexFeeRefusalOf` and merges the disclosure into the tool result's `data`.
+ * Without it the reason survives only in a log line, which is the collapse rule
+ * 04 forbids.
+ *
+ * `code` stays the venue's own existing `ErrorCodes` member: the durable failure
+ * mapping and every consumer of that vocabulary are unchanged by this class.
+ */
+export class VexFeeStatementRefusal extends VexError {
+  constructor(
+    code: string,
+    message: string,
+    hint: string,
+    readonly disclosure: VexFeeRefusalDisclosure,
+  ) {
+    super(code, message, hint);
+    this.name = "VexFeeStatementRefusal";
+  }
+}
+
+/** The disclosure a thrown fee refusal carries, or `undefined` for anything else. */
+export function vexFeeRefusalOf(err: unknown): VexFeeRefusalDisclosure | undefined {
+  return err instanceof VexFeeStatementRefusal ? err.disclosure : undefined;
 }

--- a/src/vex-agent/db/repos/swap-prequotes.ts
+++ b/src/vex-agent/db/repos/swap-prequotes.ts
@@ -379,8 +379,8 @@ const CLAIMABLE_PREDICATE = `
 /**
  * The exact row a claim would consume, read WITHOUT consuming it.
  *
- * This exists because of the ordering the money path requires (Codex round-2
- * blocker 1): an executor must be able to re-derive its fee statement and its
+ * This exists because of the ordering the money path requires (review finding,
+ * 2026-09-04): an executor must be able to re-derive its fee statement and its
  * router input against the row that authorizes the fill, and REFUSE, before the
  * row is spent. Claiming first turned every divergence into a burnt quote - the
  * refusal was correct and the retry got `already_claimed`.

--- a/src/vex-agent/db/repos/swap-prequotes.ts
+++ b/src/vex-agent/db/repos/swap-prequotes.ts
@@ -351,11 +351,12 @@ export async function findLatestExecutableByMatch(
   return row ? mapRow(row) : null;
 }
 
-// ── claimForExecute (atomic, single-use) ────────────────────────────────
+// ── read, then claim (atomic, single-use) ────────────────────
 
 /**
- * The claimable predicate, shared by the claim and by the diagnosis below so
- * the two can never disagree about what "claimable" means.
+ * The claimable predicate, shared by the non-destructive read, the claim and
+ * the diagnosis below so the three can never disagree about what "claimable"
+ * means.
  *
  * `NOT EXISTS (newer row for this identity)` is the supersession clause: a
  * later quote for the same (session, match_hash, kind) makes every earlier one
@@ -376,7 +377,46 @@ const CLAIMABLE_PREDICATE = `
     )`;
 
 /**
- * Consume a prequote for exactly one execute.
+ * The exact row a claim would consume, read WITHOUT consuming it.
+ *
+ * This exists because of the ordering the money path requires (Codex round-2
+ * blocker 1): an executor must be able to re-derive its fee statement and its
+ * router input against the row that authorizes the fill, and REFUSE, before the
+ * row is spent. Claiming first turned every divergence into a burnt quote - the
+ * refusal was correct and the retry got `already_claimed`.
+ *
+ * It applies the SAME predicate the claim applies, so a row this read returns is
+ * a row the claim would have taken at that instant. It is deliberately NOT
+ * authority: the claim re-evaluates the predicate atomically, and between the
+ * two statements a concurrent execute or a newer quote can still take the row
+ * away. That is a typed refusal, not a fill.
+ *
+ * Identity is asserted, never assumed: `matchHash` and `kind` are what tie a
+ * stored id to the trade the params describe, so a bound id belonging to another
+ * trade reads as `null` here exactly as it claims nothing below.
+ */
+export async function findClaimableForExecute(
+  sessionId: string,
+  prequoteId: string,
+  matchHash: string,
+  kind: PrequoteKind,
+): Promise<SwapPrequote | null> {
+  const row = await queryOne<Record<string, unknown>>(
+    `SELECT ${SELECT_COLUMNS} FROM swap_prequotes AS p
+      WHERE p.prequote_id = $1
+        AND p.session_id = $2
+        AND p.match_hash = $3
+        AND p.kind = $4
+        AND ${CLAIMABLE_PREDICATE}`,
+    [prequoteId, sessionId, matchHash, kind],
+  );
+  return row ? mapRow(row) : null;
+}
+
+/**
+ * Consume ONE named prequote row for exactly one execute, after its caller has
+ * already compared everything the row disclosed against what this execution
+ * would actually do.
  *
  * ONE statement, so the read of the claimable predicate and the write of the
  * claim cannot be separated by another caller: Postgres serializes concurrent
@@ -384,58 +424,57 @@ const CLAIMABLE_PREDICATE = `
  * committed claim and matches zero rows. Exactly one caller ever receives a
  * row.
  *
+ * FOUR things are asserted, and each closes a different substitution:
+ *
+ *   `prequote_id` + `session_id` - the row the caller read and compared, owned
+ *      by the session that quoted it.
+ *   `match_hash` + `kind`        - the TRADE that row authorizes. A bound id
+ *      belonging to another trade matches zero rows and consumes nothing.
+ *   `CLAIMABLE_PREDICATE`        - still unclaimed, unexpired, executable and
+ *      current (a quote recorded while the human decided supersedes it).
+ *   `safety_detail`              - THE DISCLOSURE FENCE. The caller compared the
+ *      fee statement, the spendability plan and the safety detail this row
+ *      carried; this makes the claim itself conditional on that block still
+ *      being byte-equal, so a row rewritten between the read and the claim
+ *      matches zero rows and is diagnosed `disclosure_changed` rather than
+ *      claimed silently. Postgres `jsonb` equality is canonical (key order and
+ *      whitespace are normalised at write time), so passing the block read back
+ *      IS the digest comparison, with no second column to keep in step.
+ *
  * Returns `null` when the row was not claimable for ANY reason. The caller asks
  * `diagnoseUnclaimable` for the reason - deliberately a second, non-atomic read,
  * because it feeds a refusal message only and must never decide anything.
+ *
+ * `claimedBy` is the caller's correlation for the audit trail; it is stored on
+ * the row and never used to decide anything.
  */
-export async function claimForExecute(
-  sessionId: string,
-  prequoteId: string,
-  claimedBy: string,
-): Promise<SwapPrequote | null> {
+export async function claimVerifiedRowForExecute(input: {
+  readonly sessionId: string;
+  readonly prequoteId: string;
+  readonly matchHash: string;
+  readonly kind: PrequoteKind;
+  /** The `safetyDetail` block the caller read and compared against. */
+  readonly expectedDisclosure: Record<string, unknown>;
+  readonly claimedBy: string;
+}): Promise<SwapPrequote | null> {
   const row = await queryOne<Record<string, unknown>>(
     `UPDATE swap_prequotes AS p
-        SET claimed_at = NOW(), claimed_by = $3
+        SET claimed_at = NOW(), claimed_by = $6
       WHERE p.prequote_id = $1
         AND p.session_id = $2
+        AND p.match_hash = $3
+        AND p.kind = $4
+        AND p.safety_detail = $5::jsonb
         AND ${CLAIMABLE_PREDICATE}
       RETURNING ${SELECT_COLUMNS}`,
-    [prequoteId, sessionId, claimedBy],
-  );
-  return row ? mapRow(row) : null;
-}
-
-/**
- * Consume THE ROW AN APPROVAL WAS BOUND TO, for exactly one execute.
- *
- * The difference from `claimForExecute` is the identity predicate, and it is the
- * whole point: an approval names one `prequote_id`, and this claim succeeds only
- * if that row is still the CURRENT executable row for the trade identity the
- * caller recomputed. A Q2 recorded while the human was deciding makes the bound
- * row non-current through the shared `CLAIMABLE_PREDICATE`, so the resumed
- * execute refuses instead of silently filling against a quote nobody approved.
- *
- * `matchHash` and `kind` are asserted rather than assumed: they are what ties the
- * stored id to the trade the params describe, so a bound id belonging to another
- * trade matches zero rows and consumes nothing.
- */
-export async function claimBoundForExecute(
-  sessionId: string,
-  prequoteId: string,
-  matchHash: string,
-  kind: PrequoteKind,
-  claimedBy: string,
-): Promise<SwapPrequote | null> {
-  const row = await queryOne<Record<string, unknown>>(
-    `UPDATE swap_prequotes AS p
-        SET claimed_at = NOW(), claimed_by = $3
-      WHERE p.prequote_id = $1
-        AND p.session_id = $2
-        AND p.match_hash = $4
-        AND p.kind = $5
-        AND ${CLAIMABLE_PREDICATE}
-      RETURNING ${SELECT_COLUMNS}`,
-    [prequoteId, sessionId, claimedBy, matchHash, kind],
+    [
+      input.prequoteId,
+      input.sessionId,
+      input.matchHash,
+      input.kind,
+      jsonb(input.expectedDisclosure),
+      input.claimedBy,
+    ],
   );
   return row ? mapRow(row) : null;
 }
@@ -446,17 +485,23 @@ export type UnclaimableReason =
   | "already_claimed"
   | "expired"
   | "not_executable"
-  | "superseded";
+  | "superseded"
+  | "disclosure_changed";
 
 /**
  * Explain a failed claim for the agent-facing refusal. Read-only and
  * advisory: the claim itself already decided, and a state that changed between
  * the two statements can only make this message less specific, never let an
  * unclaimed row through.
+ *
+ * `expectedDisclosure` is the block the caller compared against, so a claim that
+ * missed on the disclosure fence alone is reported as what it is rather than as
+ * the conservative `superseded`.
  */
 export async function diagnoseUnclaimable(
   sessionId: string,
   prequoteId: string,
+  expectedDisclosure: Record<string, unknown>,
 ): Promise<UnclaimableReason> {
   const row = await queryOne<Record<string, unknown>>(
     `SELECT
@@ -469,18 +514,20 @@ export async function diagnoseUnclaimable(
              AND newer.match_hash = p.match_hash
              AND newer.kind = p.kind
              AND (newer.created_at, newer.prequote_id) > (p.created_at, p.prequote_id)
-        )                                       AS superseded
+        )                                       AS superseded,
+        (p.safety_detail IS DISTINCT FROM $3::jsonb) AS disclosure_changed
        FROM swap_prequotes AS p
       WHERE p.prequote_id = $1 AND p.session_id = $2`,
-    [prequoteId, sessionId],
+    [prequoteId, sessionId, jsonb(expectedDisclosure)],
   );
   if (row === null) return "missing";
   if (row.claimed === true) return "already_claimed";
   if (row.expired === true) return "expired";
   if (row.ineligible === true) return "not_executable";
   if (row.superseded === true) return "superseded";
+  if (row.disclosure_changed === true) return "disclosure_changed";
   // The claim's own predicate and this read disagree only when the row became
   // claimable again between the two statements, which nothing does. Report the
-  // conservative reason rather than inventing a sixth state.
+  // conservative reason rather than inventing a seventh state.
   return "superseded";
 }

--- a/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute.ts
+++ b/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute.ts
@@ -55,6 +55,7 @@ import {
   type RecordedLeg,
 } from "./bridge-support.js";
 import { interpretPoll } from "./bridge-poll.js";
+import { bridgeFeeRefusalData } from "@tools/bridge-fee/index.js";
 import { quoteKhalaniBridgeRoute } from "./bridge-execute/quote.js";
 import { buildKhalaniDepositPlan } from "./bridge-execute/deposit-plan.js";
 import {
@@ -279,7 +280,15 @@ export async function executeKhalaniBridge(
     params, context, sessionId, derivedNow: vexFee,
   });
   if (feeStatementRefusal !== null) {
-    return { success: false, output: `${toolId} failed: ${feeStatementRefusal}` };
+    // The TYPED reason travels on the result, not only in the log line: a moved
+    // fee statement, a missing one and an unregistered gate have three different
+    // remedies, and collapsing them into "bridge failed" leaves an agent
+    // guessing which one it is looking at.
+    return {
+      success: false,
+      output: `${toolId} failed: ${feeStatementRefusal.message}`,
+      data: bridgeFeeRefusalData(feeStatementRefusal),
+    };
   }
 
   // 8. Fail closed on the plan and on its native-cost classification. An

--- a/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute/fee-disclosure.ts
+++ b/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute/fee-disclosure.ts
@@ -112,7 +112,7 @@ const KHALANI_QUOTE_TOOL_NAME = "khalani__bridge_quote_get";
  * carries its bounded reason so the public result can state WHY instead of
  * collapsing into a generic bridge failure.
  *
- * `not_gated` IS A REFUSAL HERE (round-2 blocker 4). Answering `null` turned the
+ * `not_gated` IS A REFUSAL HERE (review finding, 2026-09-04). Answering `null` turned the
  * loss of this tool's registry mapping into permission to sign a fee, and this
  * handler is gated by construction: the prequote row is its entire fee
  * authority. Rule 07, fail closed.

--- a/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute/fee-disclosure.ts
+++ b/src/vex-agent/tools/protocols/khalani/handlers/bridge-execute/fee-disclosure.ts
@@ -15,9 +15,13 @@ import {
   checkBridgeFeeStatementUnchanged,
   missingBridgeFeeStatementMessage,
   unauthorizedBridgeQuoteMessage,
+  unregisteredBridgeFeeGateMessage,
+  VEX_FEE_GATE_UNREGISTERED_REASON,
+  VEX_FEE_QUOTE_UNAUTHORIZED_REASON,
   VEX_FEE_STATEMENT_CHANGED_REASON,
   VEX_FEE_STATEMENT_MISSING_REASON,
   type BridgeFeeDisclosure,
+  type BridgeFeeRefusal,
   type BridgeFeeSplit,
 } from "@tools/bridge-fee/index.js";
 import { findFreshMatchedPrequote } from "@vex-agent/tools/protocols/prequote/gate.js";
@@ -104,9 +108,14 @@ const KHALANI_QUOTE_TOOL_NAME = "khalani__bridge_quote_get";
  * approved, this call states what would actually happen, and a disagreement
  * REFUSES rather than picking one.
  *
- * Returns the agent-facing refusal, or `null` when the call may proceed - which
- * is also the answer when the tool carries no prequote channel at all, since
- * there is then no approved statement in existence to contradict.
+ * Returns the typed refusal, or `null` when the call may proceed. Every refusal
+ * carries its bounded reason so the public result can state WHY instead of
+ * collapsing into a generic bridge failure.
+ *
+ * `not_gated` IS A REFUSAL HERE (round-2 blocker 4). Answering `null` turned the
+ * loss of this tool's registry mapping into permission to sign a fee, and this
+ * handler is gated by construction: the prequote row is its entire fee
+ * authority. Rule 07, fail closed.
  *
  * Runs before the deposit plan is committed, before the in-flight guard, before
  * the intent and before the signing wallet is resolved, so a refusal signs
@@ -118,7 +127,7 @@ export async function khalaniVexFeeStatementRefusal(input: {
   readonly sessionId: string;
   /** The disposition this call would actually execute on, freshly derived. */
   readonly derivedNow: BridgeFeeDisclosure;
-}): Promise<string | null> {
+}): Promise<BridgeFeeRefusal | null> {
   const matched = await findFreshMatchedPrequote(
     KHALANI_BRIDGE_TOOL_ID,
     input.sessionId,
@@ -126,15 +135,35 @@ export async function khalaniVexFeeStatementRefusal(input: {
     input.context,
   );
   if (!matched.ok) {
-    // Destructured so the literal narrows: `not_gated` is the one refusal that
-    // is not a refusal at all, it says this tool carries no prequote channel.
+    // Destructured so the literal narrows.
     const { reason, eligibilityKind } = matched;
-    if (reason === "not_gated") return null;
-    return unauthorizedBridgeQuoteMessage({ reason, eligibilityKind }, KHALANI_QUOTE_TOOL_NAME);
+    if (reason === "not_gated") {
+      logger.error("khalani.bridge.vex_fee_gate_unregistered", {
+        reason: VEX_FEE_GATE_UNREGISTERED_REASON,
+        toolId: KHALANI_BRIDGE_TOOL_ID,
+      });
+      return {
+        reason: VEX_FEE_GATE_UNREGISTERED_REASON,
+        movedFields: [],
+        message: unregisteredBridgeFeeGateMessage(KHALANI_BRIDGE_TOOL_ID),
+        remediation: "Report this build defect; a re-quote cannot clear it.",
+      };
+    }
+    return {
+      reason: VEX_FEE_QUOTE_UNAUTHORIZED_REASON,
+      movedFields: [],
+      message: unauthorizedBridgeQuoteMessage({ reason, eligibilityKind }, KHALANI_QUOTE_TOOL_NAME),
+      remediation: `Call ${KHALANI_QUOTE_TOOL_NAME} again and approve the fresh quote.`,
+    };
   }
   if (matched.vexFee === undefined) {
     logger.warn("khalani.bridge.vex_fee_statement_missing", { reason: VEX_FEE_STATEMENT_MISSING_REASON });
-    return missingBridgeFeeStatementMessage(KHALANI_QUOTE_TOOL_NAME);
+    return {
+      reason: VEX_FEE_STATEMENT_MISSING_REASON,
+      movedFields: [],
+      message: missingBridgeFeeStatementMessage(KHALANI_QUOTE_TOOL_NAME),
+      remediation: `Call ${KHALANI_QUOTE_TOOL_NAME} again and approve the fresh quote.`,
+    };
   }
   const check = checkBridgeFeeStatementUnchanged({
     statedOnCard: matched.vexFee,
@@ -147,7 +176,12 @@ export async function khalaniVexFeeStatementRefusal(input: {
     reason: VEX_FEE_STATEMENT_CHANGED_REASON,
     field: check.field,
   });
-  return bridgeFeeStatementChangedMessage(check, KHALANI_QUOTE_TOOL_NAME);
+  return {
+    reason: VEX_FEE_STATEMENT_CHANGED_REASON,
+    movedFields: [check.field],
+    message: bridgeFeeStatementChangedMessage(check, KHALANI_QUOTE_TOOL_NAME),
+    remediation: `Call ${KHALANI_QUOTE_TOOL_NAME} again and approve the fresh quote.`,
+  };
 }
 
 /**

--- a/src/vex-agent/tools/protocols/kyberswap/handlers/swap/activity-recording.ts
+++ b/src/vex-agent/tools/protocols/kyberswap/handlers/swap/activity-recording.ts
@@ -20,6 +20,7 @@ import type { ToolResult } from "../../../../types.js";
 import { kyberFailureMessage } from "./error-output.js";
 import { PROTOCOL } from "./protocol-id.js";
 import { venueFallbackNoteOnFailure } from "./fallback-messaging.js";
+import { vexFeeRefusalData, vexFeeRefusalOf } from "@tools/vex-fee/fee-revalidation.js";
 
 /** A route/validation failure before anything could be signed - hashless `definitively_failed` row. */
 export async function failPreBroadcast(
@@ -56,10 +57,17 @@ export async function failPreBroadcast(
     },
   });
   const fallbackNote = venueFallbackNoteOnFailure(err, sessionId, tokenInputsValidated);
+  // The typed fee-statement reason, when the thrown value carried one. Merged
+  // under the same Vex-authored `_` prefix `_executionId` already uses, so the
+  // documented result shape is unchanged for every other failure.
+  const feeRefusal = vexFeeRefusalOf(err);
   return {
     success: false,
     output: `${toolId} failed: ${failureReason}.${fallbackNote}`,
-    data: { _executionId: executionId },
+    data: {
+      _executionId: executionId,
+      ...(feeRefusal ? vexFeeRefusalData(feeRefusal) : {}),
+    },
   };
 }
 

--- a/src/vex-agent/tools/protocols/kyberswap/handlers/swap/execute-handler.ts
+++ b/src/vex-agent/tools/protocols/kyberswap/handlers/swap/execute-handler.ts
@@ -35,7 +35,7 @@ import { describeUnavailableSafetyCheck, type SafetyCheckUnavailable } from "./s
 import { venueFallbackNoteOnFailure } from "./fallback-messaging.js";
 import { resolveKyberSlippageBps } from "./slippage.js";
 import type { KyberGetRouteResponse } from "./route-request.js";
-import { claimSwapExecutionSnapshot } from "../../../prequote/claim.js";
+import { readSwapExecutionSnapshot, commitPrequoteClaim } from "../../../prequote/claim.js";
 
 export const executeHandler: ProtocolHandler = async (p, context): Promise<ToolResult> => {
   const toolId = "kyberswap.swap.execute";
@@ -165,7 +165,13 @@ export const executeHandler: ProtocolHandler = async (p, context): Promise<ToolR
   // The claim is single-use and atomic, so a second execute of the same quote
   // is a typed refusal rather than a second fill, and a later quote for the
   // same trade supersedes this one even when it is unexpired and unclaimed.
-  const claimed = await claimSwapExecutionSnapshot(toolId, sessionId, p, context, `${toolId}:${sessionId}`);
+  //
+  // It is READ here and CLAIMED in Phase A, after the build, the calldata guard,
+  // the fee-statement comparison and the debit-plan comparison have all passed
+  // (round-2 blocker 1). Claiming here spent the approved quote on the way out
+  // of a correct refusal, and the retry the refusal asked for got
+  // `already_claimed`.
+  const claimed = await readSwapExecutionSnapshot(toolId, sessionId, p, context);
   if (!claimed.ok) {
     return failPreBroadcast(
       toolId, p, sessionId, walletAddress, chainId, slug,
@@ -193,9 +199,14 @@ export const executeHandler: ProtocolHandler = async (p, context): Promise<ToolR
       tokenIn, tokenOut, amountIn, amountInRaw, slippage, routerAddress,
       approvedSummary, approvedSnapshot: claimed.snapshot,
       safetyCheckUnavailable,
-      // The claimed row's own Vex fee statement, carried into Phase A so the
-      // fee this build will sign can be held to the one the card stated.
+      // The row's own Vex fee statement, carried into Phase A so the fee this
+      // build will sign can be held to the one the card stated.
       approvedVexFee: claimed.vexFee,
+      // Consumed by Phase A at its last non-destructive point: after every
+      // comparison, immediately before the durable intent. Phase A throws its
+      // refusal, which the catch below records exactly as any other pre-intent
+      // failure - with nothing signed and, on a divergence, nothing claimed.
+      commitApprovedQuote: () => commitPrequoteClaim(claimed.claim, `${toolId}:${sessionId}`),
     });
   } catch (err) {
     return failPreBroadcast(toolId, p, sessionId, walletAddress, chainId, slug, legInput(tokenIn), legInput(tokenOut), err, true);

--- a/src/vex-agent/tools/protocols/kyberswap/handlers/swap/execute-handler.ts
+++ b/src/vex-agent/tools/protocols/kyberswap/handlers/swap/execute-handler.ts
@@ -168,7 +168,7 @@ export const executeHandler: ProtocolHandler = async (p, context): Promise<ToolR
   //
   // It is READ here and CLAIMED in Phase A, after the build, the calldata guard,
   // the fee-statement comparison and the debit-plan comparison have all passed
-  // (round-2 blocker 1). Claiming here spent the approved quote on the way out
+  // (review finding, 2026-09-04). Claiming here spent the approved quote on the way out
   // of a correct refusal, and the retry the refusal asked for got
   // `already_claimed`.
   const claimed = await readSwapExecutionSnapshot(toolId, sessionId, p, context);

--- a/src/vex-agent/tools/protocols/kyberswap/handlers/swap/execute-plan.ts
+++ b/src/vex-agent/tools/protocols/kyberswap/handlers/swap/execute-plan.ts
@@ -29,7 +29,7 @@ import { KYBER_FRESH_QUOTE_TOOL } from "../../../quote-authority/refusal.js";
 import { computeKyberVexFeeRaw } from "@tools/kyberswap/swap-vex-fee.js";
 import { buildKyberFeeDisclosure } from "@tools/kyberswap/fee-disclosure.js";
 import { KYBERSWAP_FEE_RECEIVER } from "@tools/kyberswap/constants.js";
-import { revalidateVexFeeStatement } from "@tools/vex-fee/fee-revalidation.js";
+import { revalidateVexFeeStatement, VexFeeStatementRefusal } from "@tools/vex-fee/fee-revalidation.js";
 import { toVexFeePreview, type VexFeePreview } from "../../../prequote/fee-disclosure.js";
 import logger from "@utils/logger.js";
 import { ensureErc20Balance } from "@tools/evm-chains/erc20-balance-guard.js";
@@ -120,6 +120,20 @@ export interface PrepareSwapExecutionInput {
    * own re-derivation before anything is signed; `undefined` fails closed.
    */
   readonly approvedVexFee: VexFeePreview | undefined;
+  /**
+   * Consume the approved prequote row, called at the LAST point in this phase
+   * that writes nothing: after the calldata guard, the fee-statement comparison
+   * and the debit-plan comparison, immediately before the durable intent.
+   *
+   * It is an injected callback rather than a repo call because the row identity
+   * belongs to the handler that read it (`prequote/claim.ts` issues the ticket)
+   * and this phase owns only WHEN the consumption is safe. A refusal is thrown
+   * like every other failure here, so the caller's single catch records it
+   * pre-intent with nothing signed.
+   */
+  readonly commitApprovedQuote: () => Promise<
+    { readonly ok: true } | { readonly ok: false; readonly refusal: { readonly message: string } }
+  >;
 }
 
 /**
@@ -317,10 +331,18 @@ export async function prepareSwapExecution(input: PrepareSwapExecutionInput): Pr
       reason: feeVerdict.reason,
       movedFields: feeVerdict.movedFields,
     });
-    throw new VexError(
+    // Thrown as the TYPED refusal so the reason reaches the tool result's data
+    // and not only this log line: an agent that cannot tell a moved fee
+    // statement from any other build failure cannot pick the right remedy.
+    throw new VexFeeStatementRefusal(
       ErrorCodes.KYBER_MALFORMED_PARAMS,
       `Refused before signing: ${feeVerdict.summary} disagrees with the approved quote, which cannot happen on this venue.`,
       "Nothing was signed. This is a Vex defect, not a market move: get a fresh kyberswap__swap_quote and report it if it repeats.",
+      {
+        reason: feeVerdict.reason,
+        movedFields: feeVerdict.movedFields,
+        remediation: `Get a fresh ${KYBER_FRESH_QUOTE_TOOL} and approve that one.`,
+      },
     );
   }
 
@@ -446,6 +468,23 @@ export async function prepareSwapExecution(input: PrepareSwapExecutionInput): Pr
     source: sourceAssetOf(tokenIn),
     sourceRequiredRaw: amountIn.toString(10),
   });
+
+  // ── ONLY NOW is the approved quote consumed ──
+  //
+  // Everything this execution could compare has been compared: the build's
+  // calldata against the approved route, the fee statement against the card's,
+  // and the transaction set against the approved debit plan. A refusal above
+  // this line leaves `claimed_at` and `claimed_by` null and the quote reusable,
+  // which is what makes the "get a fresh quote" remedy in those refusals a
+  // remedy rather than a dead end. Nothing has been signed either way: every
+  // signature happens in Phase B.
+  const consumed = await input.commitApprovedQuote();
+  if (!consumed.ok) {
+    throw new VexError(
+      ErrorCodes.KYBER_PRICE_FLOOR_VIOLATED,
+      consumed.refusal.message,
+    );
+  }
 
   const created = await createAgentActivityIntent({
     toolId,

--- a/src/vex-agent/tools/protocols/prequote/claim.ts
+++ b/src/vex-agent/tools/protocols/prequote/claim.ts
@@ -16,10 +16,36 @@
  * recorded for the same identity. The claim therefore binds to the approved
  * `prequote_id` (`ProtocolExecutionContext.approvedQuoteAuthority`, host-side
  * evidence read from the approval envelope) and re-checks the digest, the floor
- * and the expiry the card stated. See `claimPrequoteRow`.
+ * and the expiry the card stated. See `readPrequoteRow`.
+ *
+ * ## READ, COMPARE, THEN CLAIM (review finding, 2026-09-04)
+ *
+ * The claim used to run FIRST, before the executor had re-derived anything, so a
+ * fee statement or a router input that had moved refused correctly and burnt the
+ * approved quote on the way out: the retry the refusal told the agent to make got
+ * `already_claimed`. The fixed product decision is that the executor never
+ * consumes the bound block on divergence, so this module is now TWO steps:
+ *
+ *   `read*ExecutionSnapshot` - non-destructive. Picks the authoritative row
+ *      exactly as the claim used to, restores and digest-checks its snapshot,
+ *      and hands back the row's fee statement plus a `claim` ticket. Writes
+ *      nothing.
+ *   `commitPrequoteClaim`     - atomic. Consumes THAT row, asserting its id,
+ *      session, trade identity, claimability and disclosure block in one
+ *      statement. A divergence refused before this call leaves `claimed_at` and
+ *      `claimed_by` null and the quote reusable.
+ *
+ * What this deliberately gives up: two concurrent executes of one quote now both
+ * price a route before one of them wins the claim. Nothing is signed, reserved or
+ * recorded before the commit on either, so the loser is a typed `already_claimed`
+ * refusal exactly as before - it just wasted a quote request rather than a quote.
+ * MetaMask makes the same trade (`TransactionController.#approveTransaction`
+ * holds its per-transaction reservation and its nonce lock across signing only,
+ * and a failed attempt releases both and leaves the transaction reusable).
  */
 
 import * as prequoteRepo from "@vex-agent/db/repos/swap-prequotes.js";
+import type { PrequoteKind, SwapPrequote } from "@vex-agent/db/repos/swap-prequotes.js";
 
 import type { ProtocolExecutionContext } from "../types.js";
 import {
@@ -37,7 +63,23 @@ import { EXECUTE_GATE_TOOLS } from "./registry.js";
 import { vexFeeFromSafetyDetail, type VexFeePreview } from "./fee-disclosure.js";
 import { computeGateMatch } from "./gate/identity.js";
 
-export type ClaimedSwapSnapshot =
+/**
+ * The ticket a reader hands to `commitPrequoteClaim`: everything the atomic
+ * claim asserts about the row that was read, and nothing the caller could
+ * substitute. It carries the row's own disclosure block, so the commit is
+ * conditional on that block still being what the comparison was made against.
+ */
+export interface PrequoteClaimTicket {
+  readonly sessionId: string;
+  readonly prequoteId: string;
+  readonly matchHash: string;
+  readonly kind: PrequoteKind;
+  readonly expectedDisclosure: Record<string, unknown>;
+  /** The venue's own quote tool, so a refused commit points at the right one. */
+  readonly freshQuoteTool: string | undefined;
+}
+
+export type ReadSwapSnapshot =
   | {
       readonly ok: true;
       readonly prequoteId: string;
@@ -56,28 +98,28 @@ export type ClaimedSwapSnapshot =
        * refuses that row first.
        */
       readonly vexFee: VexFeePreview | undefined;
+      /** Hand this to `commitPrequoteClaim` once every comparison has passed. */
+      readonly claim: PrequoteClaimTicket;
     }
   | { readonly ok: false; readonly refusal: SnapshotRefusal };
 
 /**
- * Claim the approved quote for exactly one execute, then verify its snapshot.
+ * Read the approved quote for this execute and verify its snapshot, WITHOUT
+ * consuming it.
  *
- * Order matters and is deliberate: the CLAIM runs first, so two concurrent
- * executes for one quote resolve to exactly one winner before either touches a
- * key. The digest check runs on the claimed row, so a snapshot that fails it
- * has already consumed its own quote and cannot be retried into a race.
- *
- * `claimedBy` is the caller's correlation for the audit trail; it is stored on
- * the row and never used to decide anything.
+ * The caller re-derives its own fee statement, router input and floor against
+ * what this returns and refuses on any divergence; only then does it call
+ * `commitPrequoteClaim` with the returned ticket. A refusal in between leaves
+ * the row unclaimed and the quote reusable, which is the whole point of the
+ * split.
  */
-export async function claimSwapExecutionSnapshot(
+export async function readSwapExecutionSnapshot(
   toolId: string,
   sessionId: string,
   params: Record<string, unknown>,
   context: ProtocolExecutionContext,
-  claimedBy: string,
-): Promise<ClaimedSwapSnapshot> {
-  const claimed = await claimPrequoteRow(toolId, sessionId, params, context, claimedBy);
+): Promise<ReadSwapSnapshot> {
+  const claimed = await readPrequoteRow(toolId, sessionId, params, context);
   if (!claimed.ok) return { ok: false, refusal: claimed.refusal };
 
   const restored = restoreRouteSnapshot(claimed.routeRef);
@@ -94,10 +136,11 @@ export async function claimSwapExecutionSnapshot(
     snapshot: restored.snapshot,
     routeSummary: restored.routeSummary,
     vexFee: claimed.vexFee,
+    claim: claimed.ticket,
   };
 }
 
-export type ClaimedUniswapSnapshot =
+export type ReadUniswapSnapshot =
   | {
       readonly ok: true;
       readonly prequoteId: string;
@@ -114,26 +157,27 @@ export type ClaimedUniswapSnapshot =
        * refuses that row first.
        */
       readonly vexFee: VexFeePreview | undefined;
+      /** Hand this to `commitPrequoteClaim` once every comparison has passed. */
+      readonly claim: PrequoteClaimTicket;
     }
   | { readonly ok: false; readonly refusal: SnapshotRefusal };
 
 /**
- * The same claim, restored through the Uniswap codec.
+ * The same read, restored through the Uniswap codec.
  *
  * The row lifecycle is identical - one quote, one execute, newest-wins - and is
  * shared below. What differs is only what a restored snapshot MEANS: KyberSwap
  * restores provider bytes to POST, Uniswap restores the router input, the fee
  * disposition and the floor that the locally built calldata must carry.
  */
-export async function claimUniswapExecutionSnapshot(
+export async function readUniswapExecutionSnapshot(
   toolId: string,
   sessionId: string,
   params: Record<string, unknown>,
   context: ProtocolExecutionContext,
-  claimedBy: string,
-): Promise<ClaimedUniswapSnapshot> {
-  const claimed = await claimPrequoteRow(
-    toolId, sessionId, params, context, claimedBy, UNISWAP_FRESH_QUOTE_TOOL,
+): Promise<ReadUniswapSnapshot> {
+  const claimed = await readPrequoteRow(
+    toolId, sessionId, params, context, UNISWAP_FRESH_QUOTE_TOOL,
   );
   if (!claimed.ok) return { ok: false, refusal: claimed.refusal };
 
@@ -154,34 +198,75 @@ export async function claimUniswapExecutionSnapshot(
     prequoteId: claimed.prequoteId,
     snapshot: restored.snapshot,
     vexFee: claimed.vexFee,
+    claim: claimed.ticket,
   };
 }
 
-type ClaimedRow =
+/**
+ * Consume the row a reader already compared against, atomically.
+ *
+ * Called at the LAST point before anything durable or signable exists, so a
+ * refusal above it costs a quote request and nothing else. Every assertion the
+ * repository makes is carried by the ticket, so this function cannot be talked
+ * into consuming a different row than the one that was read and compared.
+ *
+ * `claimedBy` is the caller's correlation for the audit trail; it is stored on
+ * the row and never used to decide anything.
+ */
+export async function commitPrequoteClaim(
+  ticket: PrequoteClaimTicket,
+  claimedBy: string,
+): Promise<{ readonly ok: true } | { readonly ok: false; readonly refusal: SnapshotRefusal }> {
+  const claimed = await prequoteRepo.claimVerifiedRowForExecute({
+    sessionId: ticket.sessionId,
+    prequoteId: ticket.prequoteId,
+    matchHash: ticket.matchHash,
+    kind: ticket.kind,
+    expectedDisclosure: ticket.expectedDisclosure,
+    claimedBy,
+  });
+  if (claimed !== null) return { ok: true };
+  const reason = await prequoteRepo.diagnoseUnclaimable(
+    ticket.sessionId, ticket.prequoteId, ticket.expectedDisclosure,
+  );
+  return {
+    ok: false,
+    refusal: snapshotRefusal(
+      reason === "missing" ? "missing_snapshot" : reason,
+      ticket.freshQuoteTool,
+    ),
+  };
+}
+
+type ReadRow =
   | {
       readonly ok: true;
       readonly prequoteId: string;
       readonly routeRef: unknown;
       /** The ROW's expiry - the deadline the card stated and the claim enforced. */
       readonly expiresAt: string;
-      /** The claimed row's Vex fee statement, read through the recorder's schema. */
+      /** The row's Vex fee statement, read through the recorder's schema. */
       readonly vexFee: VexFeePreview | undefined;
+      /** What the eventual atomic claim of THIS row will assert. */
+      readonly ticket: PrequoteClaimTicket;
     }
   | { readonly ok: false; readonly refusal: SnapshotRefusal };
 
 /**
  * The venue-independent half: identify the trade, decide WHICH row is the
- * authority, and consume that row atomically. Every refusal names the venue's
- * own quote tool, because a prequote is bound to the provider that answered it.
+ * authority, and read that row WITHOUT consuming it. Every refusal names the
+ * venue's own quote tool, because a prequote is bound to the provider that
+ * answered it.
  *
  * TWO WAYS TO PICK THE ROW, and the difference is the money-path property:
  *
  *   BOUND (`context.approvedQuoteAuthority` present) - a human approved a card
- *   naming one quote, so the claim binds to THAT `prequote_id` and no other. The
- *   repo's claim still requires it to be the current executable row, so a quote
- *   recorded while the card was waiting refuses as `superseded` rather than
- *   becoming the fill. Selecting the newest row here instead is exactly the
- *   substitution the 2026-08-28 review found: approve Q1, execute Q2.
+ *   naming one quote, so the read binds to THAT `prequote_id` and no other, and
+ *   the ticket carries the same identity into the claim. The repo's read and
+ *   claim both require it to be the current executable row, so a quote recorded
+ *   while the card was waiting refuses as `superseded` rather than becoming the
+ *   fill. Selecting the newest row here instead is exactly the substitution the
+ *   2026-08-28 review found: approve Q1, execute Q2.
  *
  *   UNBOUND, no approval in play (a full-permission or autonomous session) - the
  *   newest executable row, exactly as before. There is no card here, so there is
@@ -190,20 +275,38 @@ type ClaimedRow =
  *   UNBOUND, but an approval authorized this dispatch - REFUSED. See the
  *   fail-closed note below.
  */
-async function claimPrequoteRow(
+async function readPrequoteRow(
   toolId: string,
   sessionId: string,
   params: Record<string, unknown>,
   context: ProtocolExecutionContext,
-  claimedBy: string,
   freshQuoteTool?: string,
-): Promise<ClaimedRow> {
-  const refuse = (kind: Parameters<typeof snapshotRefusal>[0]): ClaimedRow =>
+): Promise<ReadRow> {
+  const refuse = (kind: Parameters<typeof snapshotRefusal>[0]): ReadRow =>
     ({ ok: false, refusal: snapshotRefusal(kind, freshQuoteTool) });
 
   const gated = EXECUTE_GATE_TOOLS[toolId];
   if (!gated || gated.kind !== "swap") return refuse("missing_snapshot");
   const { matchHash } = await computeGateMatch(gated, sessionId, params, context);
+
+  const found = (row: SwapPrequote): ReadRow => ({
+    ok: true,
+    prequoteId: row.prequoteId,
+    routeRef: row.routeRef,
+    expiresAt: row.expiresAt,
+    vexFee: vexFeeFromSafetyDetail(row.safetyDetail),
+    ticket: {
+      sessionId,
+      prequoteId: row.prequoteId,
+      matchHash,
+      kind: "swap",
+      // The row's OWN block, carried forward untouched: the caller compares
+      // against what it discloses, and the claim below is conditional on the
+      // very same bytes still being on the row.
+      expectedDisclosure: row.safetyDetail,
+      freshQuoteTool,
+    },
+  });
 
   const authority = context.approvedQuoteAuthority ?? null;
   // FAIL CLOSED (owner decision 2026-08-28). A resume under an approval that
@@ -218,20 +321,21 @@ async function claimPrequoteRow(
     return refuse("unbound_approval");
   }
   if (authority !== null) {
-    const claimed = await prequoteRepo.claimBoundForExecute(
-      sessionId, authority.snapshotId, matchHash, "swap", claimedBy,
+    const bound = await prequoteRepo.findClaimableForExecute(
+      sessionId, authority.snapshotId, matchHash, "swap",
     );
-    if (claimed === null) {
-      const reason = await prequoteRepo.diagnoseUnclaimable(sessionId, authority.snapshotId);
-      return refuse(reason === "missing" ? "missing_snapshot" : reason);
+    if (bound === null) {
+      // The bound row is not claimable. Diagnosis reads the row's own state, so
+      // it is asked with the row's disclosure rather than an expectation the
+      // read never formed - the disclosure fence belongs to the claim, and a
+      // read that found nothing must not report `disclosure_changed`.
+      const latest = await prequoteRepo.findLatestFreshByMatch(sessionId, matchHash, "swap");
+      const reason = await prequoteRepo.diagnoseUnclaimable(
+        sessionId, authority.snapshotId, latest?.safetyDetail ?? {},
+      );
+      return refuse(reason === "missing" || reason === "disclosure_changed" ? "missing_snapshot" : reason);
     }
-    return {
-      ok: true,
-      prequoteId: claimed.prequoteId,
-      routeRef: claimed.routeRef,
-      expiresAt: claimed.expiresAt,
-      vexFee: vexFeeFromSafetyDetail(claimed.safetyDetail),
-    };
+    return found(bound);
   }
 
   const candidate = await prequoteRepo.findLatestExecutableByMatch(sessionId, matchHash, "swap");
@@ -245,19 +349,7 @@ async function claimPrequoteRow(
     if (latest.claimedAt !== null) return refuse("already_claimed");
     return refuse("not_executable");
   }
-
-  const claimed = await prequoteRepo.claimForExecute(sessionId, candidate.prequoteId, claimedBy);
-  if (claimed === null) {
-    const reason = await prequoteRepo.diagnoseUnclaimable(sessionId, candidate.prequoteId);
-    return refuse(reason === "missing" ? "missing_snapshot" : reason);
-  }
-  return {
-    ok: true,
-    prequoteId: claimed.prequoteId,
-    routeRef: claimed.routeRef,
-    expiresAt: claimed.expiresAt,
-    vexFee: vexFeeFromSafetyDetail(claimed.safetyDetail),
-  };
+  return found(candidate);
 }
 
 /**

--- a/src/vex-agent/tools/protocols/prequote/fee-disclosure.ts
+++ b/src/vex-agent/tools/protocols/prequote/fee-disclosure.ts
@@ -120,6 +120,44 @@ const skippedArm = z.object({
  * cannot be believed must not become the authority a person consents to. On the
  * charged arm `feeAmountRaw + netAmountRaw === totalDebitedRaw`; on the skipped
  * arm nothing is taken, so `netAmountRaw === totalDebitedRaw`.
+ *
+ * ## THE FEE LEG PINS THIS STATEMENT (fixed decision, 2026-09-04 round 2)
+ *
+ * A reviewer proposed re-running authoritative fee eligibility a second time,
+ * inside each venue's late fee leg, because that leg signs AFTER the parent
+ * transaction confirms and eligibility is a live oracle read. That was REJECTED
+ * as a behaviour change, and the rejection is the contract every venue is tested
+ * against:
+ *
+ *   THE APPROVED STATEMENT IS THE AUTHORITY FOR THE FEE LEG. Its amount and its
+ *   receiver are fixed at the pre-sign comparison, before anything is signed,
+ *   and the fee leg signs exactly those. Eligibility flipping between the parent
+ *   confirmation and the fee transfer changes NOTHING about what is signed.
+ *
+ * Three reasons, in the order they decide it:
+ *
+ *   1. Re-deriving late can only move the fee AWAY from what a person approved.
+ *      Upward it charges more than was consented to; downward it charges less
+ *      than the card stated on a bridge or swap that already happened. Both are
+ *      a fee nobody agreed to, which is the same defect the pre-sign comparison
+ *      exists to prevent (rule 90: revalidate against the approval, never
+ *      re-derive a new authority).
+ *   2. The parent operation has already confirmed by then. There is no refusal
+ *      available that undoes it, so a late "no" is not a safety outcome - it is
+ *      only missed revenue on an operation the user already received.
+ *   3. The amount and the receiver are already unable to rise: the amount is the
+ *      atomic figure the split fixed and the receiver is a build constant, so
+ *      nothing on that path can raise the fee above the statement.
+ *
+ * What each venue actually signs, pinned by a test per venue:
+ *   Uniswap  - `planUniswapFeeLeg` builds the transfer once from the compared
+ *              `UniswapFeeCharge`; the receiver is `UNISWAP_FEE_RECEIVER_EVM`.
+ *   KyberSwap- no separate leg at all: the fee is inside the router calldata the
+ *              pre-sign guard accepted (`collection: inside_route`).
+ *   Relay    - `runRelayVexFeeLeg` is handed `legs.feeSplit.feeRaw` and the
+ *              origin currency; the receiver is `BRIDGE_FEE_RECEIVER_EVM`.
+ *   Khalani  - the fee leg is a staged leg built with the rest of the plan; the
+ *              runner signs `stagedLegs[feeLegIndex]` and derives nothing.
  */
 export const vexFeePreviewSchema = z
   .discriminatedUnion("charged", [chargedArm, skippedArm])

--- a/src/vex-agent/tools/protocols/quote-authority/refusal.ts
+++ b/src/vex-agent/tools/protocols/quote-authority/refusal.ts
@@ -25,6 +25,7 @@ export type SnapshotRefusalKind =
   | "superseded"
   | "expired"
   | "digest_mismatch"
+  | "disclosure_changed"
   | "unbound_approval";
 
 export interface SnapshotRefusal {
@@ -53,6 +54,14 @@ const REFUSAL_CAUSE: Record<SnapshotRefusalKind, string> = {
   expired: "this quote has expired",
   digest_mismatch:
     "the stored route snapshot no longer matches its own digest, so it cannot be proven to be the route that was approved",
+  // The claim's DISCLOSURE FENCE fired: the executor compared its fee statement
+  // and its route against the block this row carried, and by the time the claim
+  // ran that block was no longer the same. Distinct from `digest_mismatch`
+  // (which is about the route snapshot's own integrity) and from `superseded`
+  // (which is about a newer row), because what moved here is the disclosure a
+  // person read on the row that is still current.
+  disclosure_changed:
+    "the disclosure on the quote authorizing this execute changed between the check and the claim, so what would be signed is no longer what was compared",
   // FAIL-CLOSED, not a fallback. An approval that names no quote cannot say
   // WHICH quote it authorized, and the alternative - executing whichever quote
   // is newest at resume time - is exactly the substitution the binding exists to

--- a/src/vex-agent/tools/protocols/relay/handlers/bridge.ts
+++ b/src/vex-agent/tools/protocols/relay/handlers/bridge.ts
@@ -48,7 +48,7 @@ import { evaluateRelayRouteHealth } from "@tools/relay/health.js";
 import { assertRelayQuoteCorrelation } from "@tools/relay/correlation.js";
 import { classifyRelayBridgeSteps } from "@tools/relay/step-policy.js";
 import { pollRelayIntentStatus, resolveRelayStepClients, type RelayStepClients } from "@tools/relay/execute.js";
-import { BRIDGE_FEE_ACTIVITY_EVENT_ROLE } from "@tools/bridge-fee/index.js";
+import { BRIDGE_FEE_ACTIVITY_EVENT_ROLE, bridgeFeeRefusalData } from "@tools/bridge-fee/index.js";
 import type { RelayQuoteResponse } from "@tools/relay/types.js";
 import { loadConfig } from "@config/store.js";
 import {
@@ -322,7 +322,17 @@ async function relayBridge(
     sessionId,
     derivedNow: relayFeeDisclosure(legs, adapted.currencyIn, tokenIdentity.source),
   });
-  if (feeStatementRefusal !== null) return fail(`${BRIDGE_TOOL_ID} failed: ${feeStatementRefusal}`);
+  if (feeStatementRefusal !== null) {
+    // The TYPED reason travels on the result, not only in the log line above: a
+    // moved fee statement, a missing one and an unregistered gate have three
+    // different remedies, and collapsing them into "bridge failed" leaves an
+    // agent guessing which one it is looking at.
+    return {
+      success: false,
+      output: `${BRIDGE_TOOL_ID} failed: ${feeStatementRefusal.message}`,
+      data: bridgeFeeRefusalData(feeStatementRefusal),
+    };
+  }
 
   // ── Pre-sign gates (fail-closed, hashless failure row, C1) ──
   if (!correlation.ok) {

--- a/src/vex-agent/tools/protocols/relay/handlers/bridge/fee-leg.ts
+++ b/src/vex-agent/tools/protocols/relay/handlers/bridge/fee-leg.ts
@@ -113,7 +113,7 @@ const RELAY_QUOTE_TOOL_NAME = "relay__bridge_quote_get";
  * public result can state WHY rather than collapsing into a generic bridge
  * failure.
  *
- * `not_gated` IS A REFUSAL HERE (round-2 blocker 4). It used to answer `null`,
+ * `not_gated` IS A REFUSAL HERE (review finding, 2026-09-04). It used to answer `null`,
  * which turned the loss of this tool's registry mapping into permission to sign
  * a fee: this handler is gated by construction and its whole fee authority is
  * the prequote row, so an absent registration means the fee cannot be bound to

--- a/src/vex-agent/tools/protocols/relay/handlers/bridge/fee-leg.ts
+++ b/src/vex-agent/tools/protocols/relay/handlers/bridge/fee-leg.ts
@@ -21,9 +21,13 @@ import {
   checkBridgeFeeStatementUnchanged,
   missingBridgeFeeStatementMessage,
   unauthorizedBridgeQuoteMessage,
+  unregisteredBridgeFeeGateMessage,
+  VEX_FEE_GATE_UNREGISTERED_REASON,
+  VEX_FEE_QUOTE_UNAUTHORIZED_REASON,
   VEX_FEE_STATEMENT_CHANGED_REASON,
   VEX_FEE_STATEMENT_MISSING_REASON,
   type BridgeFeeDisclosure,
+  type BridgeFeeRefusal,
 } from "@tools/bridge-fee/index.js";
 import { findFreshMatchedPrequote } from "@vex-agent/tools/protocols/prequote/gate.js";
 import type { RelayQuoteSide } from "@tools/relay/quote.js";
@@ -104,11 +108,16 @@ const RELAY_QUOTE_TOOL_NAME = "relay__bridge_quote_get";
  * did before this check and is equally wrong: it signs a fee nobody was shown.
  * So both are computed and any disagreement REFUSES.
  *
- * Returns the agent-facing refusal, or `null` when this call may proceed.
- * `null` is also the answer when the tool is not prequote-gated at all - there
- * is then no approved statement in existence to contradict, and inventing a
- * refusal for a channel that does not apply would fail bridges for a build
- * fact, not a money fact.
+ * Returns the typed refusal, or `null` when this call may proceed. Every
+ * refusal - including the structural one - carries its bounded reason, so the
+ * public result can state WHY rather than collapsing into a generic bridge
+ * failure.
+ *
+ * `not_gated` IS A REFUSAL HERE (round-2 blocker 4). It used to answer `null`,
+ * which turned the loss of this tool's registry mapping into permission to sign
+ * a fee: this handler is gated by construction and its whole fee authority is
+ * the prequote row, so an absent registration means the fee cannot be bound to
+ * anything anyone approved. Rule 07, fail closed.
  *
  * Nothing here signs, records or reserves anything: it runs BEFORE the intent,
  * the in-flight guard and the signing wallet, so a refusal leaves the world
@@ -120,7 +129,7 @@ export async function relayVexFeeStatementRefusal(input: {
   readonly sessionId: string;
   /** The disposition this call would actually execute on, freshly derived. */
   readonly derivedNow: BridgeFeeDisclosure;
-}): Promise<string | null> {
+}): Promise<BridgeFeeRefusal | null> {
   const matched = await findFreshMatchedPrequote(
     BRIDGE_TOOL_ID,
     input.sessionId,
@@ -128,15 +137,35 @@ export async function relayVexFeeStatementRefusal(input: {
     input.context,
   );
   if (!matched.ok) {
-    // Destructured so the literal narrows: `not_gated` is the one refusal that
-    // is not a refusal at all, it says this tool carries no prequote channel.
+    // Destructured so the literal narrows.
     const { reason, eligibilityKind } = matched;
-    if (reason === "not_gated") return null;
-    return unauthorizedBridgeQuoteMessage({ reason, eligibilityKind }, RELAY_QUOTE_TOOL_NAME);
+    if (reason === "not_gated") {
+      logger.error("relay.bridge.vex_fee_gate_unregistered", {
+        reason: VEX_FEE_GATE_UNREGISTERED_REASON,
+        toolId: BRIDGE_TOOL_ID,
+      });
+      return {
+        reason: VEX_FEE_GATE_UNREGISTERED_REASON,
+        movedFields: [],
+        message: unregisteredBridgeFeeGateMessage(BRIDGE_TOOL_ID),
+        remediation: "Report this build defect; a re-quote cannot clear it.",
+      };
+    }
+    return {
+      reason: VEX_FEE_QUOTE_UNAUTHORIZED_REASON,
+      movedFields: [],
+      message: unauthorizedBridgeQuoteMessage({ reason, eligibilityKind }, RELAY_QUOTE_TOOL_NAME),
+      remediation: `Call ${RELAY_QUOTE_TOOL_NAME} again and approve the fresh quote.`,
+    };
   }
   if (matched.vexFee === undefined) {
     logger.warn("relay.bridge.vex_fee_statement_missing", { reason: VEX_FEE_STATEMENT_MISSING_REASON });
-    return missingBridgeFeeStatementMessage(RELAY_QUOTE_TOOL_NAME);
+    return {
+      reason: VEX_FEE_STATEMENT_MISSING_REASON,
+      movedFields: [],
+      message: missingBridgeFeeStatementMessage(RELAY_QUOTE_TOOL_NAME),
+      remediation: `Call ${RELAY_QUOTE_TOOL_NAME} again and approve the fresh quote.`,
+    };
   }
   const check = checkBridgeFeeStatementUnchanged({
     statedOnCard: matched.vexFee,
@@ -150,7 +179,12 @@ export async function relayVexFeeStatementRefusal(input: {
     reason: VEX_FEE_STATEMENT_CHANGED_REASON,
     field: check.field,
   });
-  return bridgeFeeStatementChangedMessage(check, RELAY_QUOTE_TOOL_NAME);
+  return {
+    reason: VEX_FEE_STATEMENT_CHANGED_REASON,
+    movedFields: [check.field],
+    message: bridgeFeeStatementChangedMessage(check, RELAY_QUOTE_TOOL_NAME),
+    remediation: `Call ${RELAY_QUOTE_TOOL_NAME} again and approve the fresh quote.`,
+  };
 }
 
 /** Disclosure for every path where the bridge did not complete - nothing is ever charged there. */

--- a/src/vex-agent/tools/protocols/uniswap/handlers/swap/activity-recording.ts
+++ b/src/vex-agent/tools/protocols/uniswap/handlers/swap/activity-recording.ts
@@ -38,6 +38,13 @@ export async function failPreBroadcast(
     tokenOut?: UniswapToken;
   },
   err: unknown,
+  /**
+   * A typed refusal disclosure, when this failure has a machine-readable remedy
+   * the generic failure code cannot express (`vexFeeRefusalData`). Merged into
+   * the result's `data` alongside `_executionId`; absent for every other
+   * failure, which keeps the result shape unchanged where nothing typed exists.
+   */
+  refusal?: Record<string, unknown>,
 ): Promise<ToolResult> {
   const failureCode = classifyPreBroadcastFailure(err).failureCode;
   const failureReason = uniswapFailureMessage(err);
@@ -60,7 +67,11 @@ export async function failPreBroadcast(
       failureReason,
     },
   });
-  return { success: false, output: `${TOOL_ID} failed: ${failureReason}.`, data: { _executionId: executionId } };
+  return {
+    success: false,
+    output: `${TOOL_ID} failed: ${failureReason}.`,
+    data: { _executionId: executionId, ...(refusal ?? {}) },
+  };
 }
 
 /**

--- a/src/vex-agent/tools/protocols/uniswap/handlers/swap/execute-handler.ts
+++ b/src/vex-agent/tools/protocols/uniswap/handlers/swap/execute-handler.ts
@@ -54,9 +54,9 @@ import {
   type UniswapFeeLegPlan,
 } from "./fee/index.js";
 import { VexError, ErrorCodes } from "../../../../../../errors.js";
-import { claimUniswapExecutionSnapshot } from "../../../prequote/claim.js";
+import { readUniswapExecutionSnapshot, commitPrequoteClaim } from "../../../prequote/claim.js";
 import { toVexFeePreview } from "../../../prequote/fee-disclosure.js";
-import { revalidateVexFeeStatement } from "@tools/vex-fee/fee-revalidation.js";
+import { revalidateVexFeeStatement, vexFeeRefusalData } from "@tools/vex-fee/fee-revalidation.js";
 import { canonicalWrapPairRefusal } from "../../../wrap-pair-refusal.js";
 import {
   compareUniswapExecutionInputs,
@@ -139,15 +139,19 @@ export async function executeUniswapSwap(
   const wrapPair = canonicalWrapPairRefusal(deployment.chainId, tokenIn, tokenOut, TOOL_ID);
   if (wrapPair) return fail(wrapPair);
 
-  // ── THE APPROVED QUOTE, claimed for exactly one execute ──
+  // ── THE APPROVED QUOTE, READ but not yet consumed ──
   //
-  // Claimed BEFORE this handler quotes anything, so two concurrent executes of
-  // one quote resolve to a single winner before either prices a route. Fresh
-  // pathing below is allowed and expected - Uniswap's pools move - but the
-  // router input, the fee and the floor come from THIS snapshot, never from the
-  // fresh route. Deriving the floor from a fresh route is what let the sibling
-  // venue fill a 313,879.7 quote at 1,190.145 on 2026-08-27 without reverting.
-  const claimed = await claimUniswapExecutionSnapshot(TOOL_ID, sessionId, p, context, `${TOOL_ID}:${sessionId}`);
+  // Read BEFORE this handler quotes anything, because the router input, the fee
+  // and the floor come from THIS snapshot and never from the fresh route. Fresh
+  // pathing below is allowed and expected - Uniswap's pools move - but deriving
+  // the floor from a fresh route is what let the sibling venue fill a 313,879.7
+  // quote at 1,190.145 on 2026-08-27 without reverting.
+  //
+  // The row is CLAIMED further down, after every comparison this execution can
+  // make has passed (round-2 blocker 1). Claiming here burnt the approved quote
+  // on the way out of a correct refusal: the retry the refusal instructed the
+  // agent to make got `already_claimed`.
+  const claimed = await readUniswapExecutionSnapshot(TOOL_ID, sessionId, p, context);
   if (!claimed.ok) {
     return failPreBroadcast(
       p,
@@ -225,6 +229,15 @@ export async function executeUniswapSwap(
         `Refused before signing: ${feeVerdict.summary} is not what the approved quote stated.`,
         `Nothing was signed. Request a fresh ${UNISWAP_FRESH_QUOTE_TOOL} and approve that one.`,
       ),
+      // The TYPED reason, on the result the agent actually reads. Without it a
+      // moved fee statement is indistinguishable from any other swap failure,
+      // and the two have different remedies. Nothing is claimed at this point,
+      // so the remediation it names is a remedy the agent can really take.
+      vexFeeRefusalData({
+        reason: feeVerdict.reason,
+        movedFields: feeVerdict.movedFields,
+        remediation: `Request a fresh ${UNISWAP_FRESH_QUOTE_TOOL} and approve that one.`,
+      }),
     );
   }
 
@@ -243,6 +256,27 @@ export async function executeUniswapSwap(
     );
   }
   quoted = { ...quoted, minAmountOut: approvedMinOut };
+
+  // ── ONLY NOW is the approved quote consumed ──
+  //
+  // Every comparison this execution can make has passed: the router input, the
+  // fee disposition, the card's own fee statement and the approved floor. The
+  // claim is atomic and asserts the row's identity, its claimability and the
+  // disclosure block the checks above were made against, so a row that moved
+  // underneath refuses typed instead of being claimed silently.
+  //
+  // A refusal ABOVE this line leaves `claimed_at` and `claimed_by` null and the
+  // quote reusable; a refusal here means another execute won the same row, which
+  // is the one state where "already claimed" is the truth. Still nothing signed:
+  // the signing wallet is resolved on the next line.
+  const consumed = await commitPrequoteClaim(claimed.claim, `${TOOL_ID}:${sessionId}`);
+  if (!consumed.ok) {
+    return failPreBroadcast(
+      p,
+      { chainId: deployment.chainId, chainSlug: deployment.key, walletAddress, sessionId, tokenIn, tokenOut },
+      new VexError(ErrorCodes.KYBER_PRICE_FLOOR_VIOLATED, consumed.refusal.message),
+    );
+  }
 
   // Per-session signing wallet - resolved only now that dryRun is rejected
   // and the quote succeeded, so a rejected/failed call never decrypts a key.

--- a/src/vex-agent/tools/protocols/uniswap/handlers/swap/execute-handler.ts
+++ b/src/vex-agent/tools/protocols/uniswap/handlers/swap/execute-handler.ts
@@ -148,7 +148,7 @@ export async function executeUniswapSwap(
   // quote at 1,190.145 on 2026-08-27 without reverting.
   //
   // The row is CLAIMED further down, after every comparison this execution can
-  // make has passed (round-2 blocker 1). Claiming here burnt the approved quote
+  // make has passed (review finding, 2026-09-04). Claiming here burnt the approved quote
   // on the way out of a correct refusal: the retry the refusal instructed the
   // agent to make got `already_claimed`.
   const claimed = await readUniswapExecutionSnapshot(TOOL_ID, sessionId, p, context);


### PR DESCRIPTION
## What changes

- **Read, compare, then claim.** Uniswap and KyberSwap claimed the approved prequote row before comparing the re-derived fee statement, so any divergence burned the approval and a retry got `already_claimed`. The row is now read under the same claimable predicate the claim applies, restored and compared, and only then claimed by one `UPDATE` asserting id, session, match hash, kind and the disclosure bytes, immediately before the durable intent. A moved disclosure refuses typed as `disclosure_changed` with `claimed_at` still null; the exactly-one-winner concurrency case is unchanged; Relay and Khalani never claimed and are untouched on this point.
- **`not_gated` refuses on fee-bearing bridge handlers** (Relay fee leg, Khalani fee disclosure) before any signer, nonce reservation, staging or broadcast.
- **The approved statement is the contract.** Pin tests on all four venues flip eligibility after the parent confirms and prove the fee leg signs exactly the statement's amount and receiver; the decision is recorded next to the schema. Re-deriving at signing time was already rejected in the wallet reference audit.
- **Typed divergence reasons reach the tool result** (`vex_fee_statement_changed`, `vex_fee_statement_missing`) on every venue under one typed key with the moved fields and a remediation.

## Live evidence (rule 10, read-only, no funds moved)

KyberSwap, Uniswap and Khalani quotes projected through the recorders: charged 25 bps, fee 25000, net 9975000, total 10000000, `withVexFee` ok, archived with provenance. Relay: `UNAUTHORIZED_QUOTE: Please provide an api key` through the real handler; a same-day capture shows the byte-identical body without `referrer` answers 200. The client attaches `referrer: "vex"` on every quote while `RELAY_API_KEY` is optional and absent, so keyless Relay bridging is currently non-functional. Separate lane.

## Verification

- root vitest across the four venues' handler suites, quote-authority, vex-fee, bridge-fee and the agent-scan adversarial suites: 68 files, 825 tests; Postgres integration `swap-prequotes-claim.int.test.ts`: 31 tests on the real server (divergence leaves the row unclaimed then reusable, stale disclosure refused typed, jsonb key-order insensitivity, supersession precedence, one winner); root tsc, em-dash and unsafe-escapes gates green.
- Growth decision: `relay-handlers/bridge.test.ts` 913 to 1026, grown on purpose (one handler lifecycle behind one hoisted mock topology).

Reference reading: the wallet reference audit (re-derivation at signing rejected), MetaMask `TransactionController.ts` `#approveTransaction` (reservations released in `finally`, a failed attempt leaves the transaction reusable), Rabby `ethSendTransaction` (the approved result is what gets signed).
