### PR TITLE
fix(relay): send the attribution referrer only when an API key is configured

### DIFF
--- a/src/__tests__/tools/relay/relay-referrer-key-gate.test.ts
+++ b/src/__tests__/tools/relay/relay-referrer-key-gate.test.ts
@@ -24,6 +24,7 @@ vi.mock("@utils/http.js", () => http);
 
 import { RelayClient } from "@tools/relay/client.js";
 import { RELAY_NATIVE_CURRENCY } from "@tools/relay/chains.js";
+import type { RelayQuoteRequest } from "@tools/relay/types.js";
 
 const client = new RelayClient("https://relay.test");
 
@@ -61,6 +62,34 @@ function takeQuote(): Promise<unknown> {
     amount: "5000000",
     tradeType: "EXACT_INPUT",
   });
+}
+
+/**
+ * A quote request that also carries fields no caller is allowed to set: the
+ * attribution `referrer`, a Relay app-fee claim, and a fee-share bps. Merged in
+ * through a `Record<string, unknown>` because TypeScript's excess-property check
+ * only fires on a fresh literal - a request that arrived through `unknown` (a
+ * persisted row, an IPC payload, a model-shaped argument) carries whatever it
+ * carries, and the compiler is not the thing that stops it.
+ */
+function pollutedRequest(): RelayQuoteRequest {
+  const base: RelayQuoteRequest = {
+    user: "0x1111111111111111111111111111111111111111",
+    recipient: "0x1111111111111111111111111111111111111111",
+    refundTo: "0x1111111111111111111111111111111111111111",
+    originChainId: 8453,
+    destinationChainId: 42161,
+    originCurrency: RELAY_NATIVE_CURRENCY,
+    destinationCurrency: RELAY_NATIVE_CURRENCY,
+    amount: "5000000",
+    tradeType: "EXACT_INPUT",
+  };
+  const smuggled: Record<string, unknown> = {
+    referrer: "attacker-supplied",
+    appFees: [{ recipient: "0x9999999999999999999999999999999999999999", fee: "1000" }],
+    referrerFeeBps: "500",
+  };
+  return Object.assign({}, base, smuggled);
 }
 
 /** The body actually put on the wire by the first (only) request. */
@@ -113,6 +142,37 @@ describe("RelayClient - referrer rides only on a keyed quote", () => {
 
     expect("referrer" in sentQuoteBody()).toBe(false);
     expect(sentHeaders()?.["x-api-key"]).toBeUndefined();
+  });
+
+  it("drops a caller-supplied referrer: keyless it never reaches the wire", async () => {
+    // TypeScript's excess-property check only fires on a fresh object literal.
+    // A request that reached the client through `unknown` (a persisted row, an
+    // IPC payload, a model-shaped argument) carries whatever it carries, so the
+    // transport must project the body rather than spread it.
+    delete process.env.RELAY_API_KEY;
+    quoteResponseOnce();
+    await client.getQuote(pollutedRequest());
+
+    const body = sentQuoteBody();
+    expect("referrer" in body).toBe(false);
+    expect(JSON.stringify(body)).not.toContain("attacker-supplied");
+    // Nothing else the caller smuggled survives either.
+    expect("appFees" in body).toBe(false);
+    expect("referrerFeeBps" in body).toBe(false);
+    // The named fields still travel.
+    expect(body.amount).toBe("5000000");
+    expect(body.tradeType).toBe("EXACT_INPUT");
+  });
+
+  it("replaces a caller-supplied referrer with exactly the constant when keyed", async () => {
+    process.env.RELAY_API_KEY = "k-secret";
+    quoteResponseOnce();
+    await client.getQuote(pollutedRequest());
+
+    const body = sentQuoteBody();
+    expect(body.referrer).toBe("vex");
+    expect(JSON.stringify(body)).not.toContain("attacker-supplied");
+    expect("appFees" in body).toBe(false);
   });
 
   it("sends the constant referrer alongside the key when one is configured", async () => {

--- a/src/__tests__/tools/relay/relay-referrer-key-gate.test.ts
+++ b/src/__tests__/tools/relay/relay-referrer-key-gate.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Relay's `referrer` attribution field is key-gated.
+ *
+ * MEASURED 2026-09-04, `POST https://api.relay.link/quote/v2`, two independent
+ * captures (one through the real `relay.quote.get` handler): a keyless body
+ * carrying `referrer: "vex"` answers HTTP 401
+ * `{"message":"Please provide an api key","errorCode":"UNAUTHORIZED_QUOTE"}`,
+ * while the byte-identical body WITHOUT `referrer` answers HTTP 200. The client
+ * used to inject the referrer on EVERY quote, so a keyless deployment could not
+ * take a Relay bridge quote at all.
+ *
+ * The regression this suite catches: re-attaching `referrer` unconditionally
+ * (the old behavior) makes the keyless case red, and dropping it on a keyed
+ * request silently loses attribution.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const http = vi.hoisted(() => ({
+  fetchWithTimeout: vi.fn<(url: string, options?: RequestInit & { headers?: Record<string, string> }) => Promise<Response>>(),
+  readJson: vi.fn<(response: Response) => Promise<unknown>>(),
+}));
+vi.mock("@utils/http.js", () => http);
+
+import { RelayClient } from "@tools/relay/client.js";
+import { RELAY_NATIVE_CURRENCY } from "@tools/relay/chains.js";
+
+const client = new RelayClient("https://relay.test");
+
+/** The live 200 shape, reduced to what the quote schema requires. */
+function quoteResponseOnce(): void {
+  http.fetchWithTimeout.mockResolvedValueOnce(new Response(null, { status: 200 }));
+  http.readJson.mockResolvedValueOnce({
+    requestId: "0xtop",
+    steps: [{
+      id: "deposit",
+      kind: "transaction",
+      items: [{
+        status: "incomplete",
+        data: {
+          from: "0x1111111111111111111111111111111111111111",
+          to: "0x2222222222222222222222222222222222222222",
+          value: "1000",
+          data: "0xabcd",
+          chainId: 8453,
+        },
+      }],
+    }],
+  });
+}
+
+function takeQuote(): Promise<unknown> {
+  return client.getQuote({
+    user: "0x1111111111111111111111111111111111111111",
+    recipient: "0x1111111111111111111111111111111111111111",
+    refundTo: "0x1111111111111111111111111111111111111111",
+    originChainId: 8453,
+    destinationChainId: 42161,
+    originCurrency: RELAY_NATIVE_CURRENCY,
+    destinationCurrency: RELAY_NATIVE_CURRENCY,
+    amount: "5000000",
+    tradeType: "EXACT_INPUT",
+  });
+}
+
+/** The body actually put on the wire by the first (only) request. */
+function sentQuoteBody(): Record<string, unknown> {
+  const call = http.fetchWithTimeout.mock.calls[0];
+  if (!call) throw new Error("fetchWithTimeout was never called");
+  const parsed: unknown = JSON.parse(String(call[1]?.body));
+  if (typeof parsed !== "object" || parsed === null) throw new Error("quote body was not a JSON object");
+  return parsed as Record<string, unknown>;
+}
+
+function sentHeaders(): Record<string, string> | undefined {
+  const call = http.fetchWithTimeout.mock.calls[0];
+  if (!call) throw new Error("fetchWithTimeout was never called");
+  return call[1]?.headers;
+}
+
+describe("RelayClient - referrer rides only on a keyed quote", () => {
+  const original = process.env.RELAY_API_KEY;
+
+  beforeEach(() => {
+    http.fetchWithTimeout.mockReset();
+    http.readJson.mockReset();
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.RELAY_API_KEY;
+    else process.env.RELAY_API_KEY = original;
+  });
+
+  it("sends NO referrer, and no key header, on a keyless quote", async () => {
+    delete process.env.RELAY_API_KEY;
+    quoteResponseOnce();
+    await takeQuote();
+
+    const body = sentQuoteBody();
+    expect("referrer" in body).toBe(false);
+    expect(sentHeaders()?.["x-api-key"]).toBeUndefined();
+    // The rest of the request is untouched by the gate.
+    expect(body.originChainId).toBe(8453);
+    expect(body.destinationChainId).toBe(42161);
+    expect(body.amount).toBe("5000000");
+    expect(body.tradeType).toBe("EXACT_INPUT");
+  });
+
+  it("treats a blank key as no key, so a whitespace env var cannot cost the quote", async () => {
+    process.env.RELAY_API_KEY = "   ";
+    quoteResponseOnce();
+    await takeQuote();
+
+    expect("referrer" in sentQuoteBody()).toBe(false);
+    expect(sentHeaders()?.["x-api-key"]).toBeUndefined();
+  });
+
+  it("sends the constant referrer alongside the key when one is configured", async () => {
+    process.env.RELAY_API_KEY = " k-secret ";
+    quoteResponseOnce();
+    await takeQuote();
+
+    const body = sentQuoteBody();
+    expect(body.referrer).toBe("vex");
+    // Body and header come from ONE key read: attribution never travels
+    // unauthenticated.
+    expect(sentHeaders()?.["x-api-key"]).toBe("k-secret");
+    expect(JSON.stringify(body)).not.toContain("k-secret");
+  });
+});

--- a/src/__tests__/tools/relay/relay.test.ts
+++ b/src/__tests__/tools/relay/relay.test.ts
@@ -65,10 +65,6 @@ describe("RelayClient", () => {
     const requestedUrl = String(http.fetchWithTimeout.mock.calls[0]![0]);
     expect(requestedUrl).toContain("/quote/v2");
     expect(http.fetchWithTimeout.mock.calls[0]![1]).toMatchObject({ method: "POST" });
-    // Relay attribution: every quote body carries the constant `referrer`,
-    // injected by the client — no caller supplies or overrides it.
-    const sentBody = JSON.parse(String((http.fetchWithTimeout.mock.calls[0]![1] as RequestInit).body));
-    expect(sentBody.referrer).toBe("vex");
     expect(q.steps[0]!.kind).toBe("transaction");
     expect(q.steps[0]!.items[0]!.data?.chainId).toBe(8453);
     expect(q.steps[0]!.requestId).toBe("0xreq");

--- a/src/tools/relay/client.ts
+++ b/src/tools/relay/client.ts
@@ -13,6 +13,11 @@
  * FIRST so it survives the agent-facing length cap, and the HTTP status is
  * preserved onto the error so the shared contract classifies from the status.
  *
+ * REFERRER GATE: the `referrer` attribution field is sent on a quote ONLY when
+ * an API key is configured. Measured 2026-09-04: Relay answers 401
+ * UNAUTHORIZED_QUOTE to a keyless quote body that carries one, and 200 to the
+ * same body without it. Details on `RELAY_REFERRER`.
+ *
  * QUOTE MIGRATION (Wave-2 W2): quotes go to `POST /quote/v2` — v1 `POST /quote`
  * is deprecated. v2 adds a top-level `requestId` and per-side USD under
  * `details{}`; the step/status shapes are unchanged, so this is endpoint-path +
@@ -46,7 +51,29 @@ function relayApiKey(): string | undefined {
   return key !== undefined && key.length > 0 ? key : undefined;
 }
 
-/** Relay integration-attribution identifier, sent as `referrer` on every quote. */
+/**
+ * Relay integration-attribution identifier, sent as `referrer` ONLY on a keyed
+ * quote.
+ *
+ * MEASURED 2026-09-04, `POST https://api.relay.link/quote/v2`, two independent
+ * captures (one of them through the real `relay.quote.get` handler): a body
+ * carrying `referrer: "vex"` with no `x-api-key` answers HTTP 401
+ * `{"message":"Please provide an api key","errorCode":"UNAUTHORIZED_QUOTE"}`,
+ * while the byte-identical body WITHOUT `referrer` answers HTTP 200. Relay
+ * treats the field as a registered-integration claim, so an unauthenticated
+ * caller may not make it.
+ *
+ * Relay documents `referrer` only as attribution: the webhook payload "echoes
+ * the value supplied on the originating quote request, or `null` if no referrer
+ * was provided" (docs.relay.link, API Guides > Webhooks), and the key page
+ * calls the key "Optional API key for authentication and higher rate limits"
+ * (docs.relay.link, References > API > Rate Limits and API keys). Nothing Vex
+ * depends on rides on it: the Vex fee is a SEPARATE transfer, never Relay's
+ * `appFees`, and the prequote identity hash binds `referrer` as a stable empty
+ * for Relay (see prequote/identity/relay-bridge.ts). Dropping it keyless
+ * therefore costs attribution on keyless deployments and nothing else, while
+ * keeping it would cost the quote itself.
+ */
 const RELAY_REFERRER = "vex";
 
 /**
@@ -170,19 +197,29 @@ export class RelayClient {
   private async request<T>(
     path: string,
     validate: (raw: unknown) => T,
-    options: { method?: "GET" | "POST"; query?: Record<string, string | undefined>; body?: unknown } = {},
+    options: {
+      method?: "GET" | "POST";
+      query?: Record<string, string | undefined>;
+      /**
+       * Built FROM the same per-request key read that fills `x-api-key`, so a
+       * key-gated body field (see `RELAY_REFERRER`) can never disagree with the
+       * header that authorizes it.
+       */
+      body?: (keyed: boolean) => unknown;
+    } = {},
   ): Promise<T> {
     try {
       const apiKey = relayApiKey();
+      const body = options.body === undefined ? undefined : options.body(apiKey !== undefined);
       const headers: Record<string, string> = {
-        ...(options.body === undefined ? {} : { "Content-Type": "application/json" }),
+        ...(body === undefined ? {} : { "Content-Type": "application/json" }),
         ...(apiKey === undefined ? {} : { "x-api-key": apiKey }),
       };
       const response = await fetchWithTimeout(this.url(path, options.query), {
         method: options.method ?? "GET",
         timeoutMs: REQUEST_TIMEOUT_MS,
         headers: Object.keys(headers).length === 0 ? undefined : headers,
-        body: options.body === undefined ? undefined : JSON.stringify(options.body),
+        body: body === undefined ? undefined : JSON.stringify(body),
       });
       if (!response.ok) {
         throw relayHttpError(response.status, await readErrorBody(response), apiKey !== undefined);
@@ -203,10 +240,13 @@ export class RelayClient {
       method: "POST",
       // `referrer` is Relay's integration-attribution field (their 2026-07-30
       // request): a constant identifier recorded against the quote and the
-      // resulting transaction. Attribution only — it is NOT an app fee and
-      // never a caller/model input, so it is injected here, transport-side,
-      // on EVERY quote rather than trusted to each caller.
-      body: { ...request, referrer: RELAY_REFERRER },
+      // resulting transaction. Attribution only, never an app fee and never a
+      // caller/model input, so it stays transport-injected rather than trusted
+      // to each caller. It rides ONLY on a keyed request: Relay answers 401
+      // UNAUTHORIZED_QUOTE to a keyless body that claims a referrer, so a
+      // keyless deployment would otherwise get no bridge quote at all. See
+      // `RELAY_REFERRER` for the measurement.
+      body: (keyed) => (keyed ? { ...request, referrer: RELAY_REFERRER } : request),
     });
   }
 

--- a/src/tools/relay/client.ts
+++ b/src/tools/relay/client.ts
@@ -35,6 +35,7 @@ import {
   type RelayQuoteRequest,
   type RelayQuoteResponse,
   type RelayStatusResponse,
+  type RelayTradeType,
 } from "./types.js";
 
 const REQUEST_TIMEOUT_MS = 30_000;
@@ -75,6 +76,50 @@ function relayApiKey(): string | undefined {
  * keeping it would cost the quote itself.
  */
 const RELAY_REFERRER = "vex";
+
+/**
+ * The exact field set Vex puts on a `POST /quote/v2` body. `referrer` is
+ * deliberately absent: only `RelayClient.getQuote` adds it, only as the constant
+ * `RELAY_REFERRER`, and only when a key authorizes it.
+ */
+interface RelayQuoteBody {
+  user: string;
+  recipient: string;
+  refundTo: string;
+  originChainId: number;
+  destinationChainId: number;
+  originCurrency: string;
+  destinationCurrency: string;
+  amount: string;
+  tradeType: RelayTradeType;
+  slippageTolerance?: string;
+  ttl?: number;
+}
+
+/**
+ * Project a caller's quote request onto the canonical wire body by naming every
+ * field. Anything the caller carries beyond this list (a `referrer` above all,
+ * which would cost a keyless deployment its quote and would forge attribution on
+ * a keyed one) is dropped by construction rather than by the caller's discipline.
+ * Optional fields are attached only when present, so the keyless body stays
+ * byte-identical to the one measured against the live endpoint.
+ */
+function canonicalQuoteBody(request: RelayQuoteRequest): RelayQuoteBody {
+  const body: RelayQuoteBody = {
+    user: request.user,
+    recipient: request.recipient,
+    refundTo: request.refundTo,
+    originChainId: request.originChainId,
+    destinationChainId: request.destinationChainId,
+    originCurrency: request.originCurrency,
+    destinationCurrency: request.destinationCurrency,
+    amount: request.amount,
+    tradeType: request.tradeType,
+  };
+  if (request.slippageTolerance !== undefined) body.slippageTolerance = request.slippageTolerance;
+  if (request.ttl !== undefined) body.ttl = request.ttl;
+  return body;
+}
 
 /**
  * Canonical Relay intent-status path. Single source of truth: used both to build
@@ -236,17 +281,24 @@ export class RelayClient {
   }
 
   getQuote(request: RelayQuoteRequest): Promise<RelayQuoteResponse> {
+    // The wire body is a FIELD-BY-FIELD projection of the caller's request, not
+    // a spread of it: a caller object carrying an extra `referrer` (or any other
+    // unknown property) cannot reach Relay, because nothing but the named fields
+    // below is copied. TypeScript's excess-property check is a compile-time
+    // convenience and does not survive `unknown` sources or a widened variable,
+    // so the transport, not the type, owns this.
+    const canonical = canonicalQuoteBody(request);
     return this.request("/quote/v2", (raw) => RelayQuoteResponseSchema.parse(raw), {
       method: "POST",
       // `referrer` is Relay's integration-attribution field (their 2026-07-30
       // request): a constant identifier recorded against the quote and the
       // resulting transaction. Attribution only, never an app fee and never a
-      // caller/model input, so it stays transport-injected rather than trusted
-      // to each caller. It rides ONLY on a keyed request: Relay answers 401
+      // caller/model input, so it is added HERE, by the transport, and only as
+      // the constant. It rides ONLY on a keyed request: Relay answers 401
       // UNAUTHORIZED_QUOTE to a keyless body that claims a referrer, so a
       // keyless deployment would otherwise get no bridge quote at all. See
       // `RELAY_REFERRER` for the measurement.
-      body: (keyed) => (keyed ? { ...request, referrer: RELAY_REFERRER } : request),
+      body: (keyed) => (keyed ? { ...canonical, referrer: RELAY_REFERRER } : canonical),
     });
   }
 

--- a/vex-app/src/shared/schemas/api-keys.ts
+++ b/vex-app/src/shared/schemas/api-keys.ts
@@ -8,9 +8,14 @@
  *     to show the form at all).
  *   - TAVILY_API_KEY (optional)
  *   - RETTIWT_API_KEY (optional)
- *   - RELAY_API_KEY (optional) — bridging works fully WITHOUT it; a key only
- *     raises Relay's rate limits. It is deliberately not a tool prerequisite,
- *     so no relay manifest declares it as a required env.
+ *   - RELAY_API_KEY (optional) - bridging works WITHOUT it: a key raises
+ *     Relay's per-key rate limits and, measured 2026-09-04 against
+ *     `POST api.relay.link/quote/v2`, is what lets a quote carry Relay's
+ *     `referrer` attribution field (a keyless body claiming one is answered
+ *     401 UNAUTHORIZED_QUOTE, so keyless quotes are sent without it - see
+ *     `src/tools/relay/client.ts`). Attribution is the only thing a keyless
+ *     deployment gives up; it is deliberately not a tool prerequisite, so no
+ *     relay manifest declares it as a required env.
  */
 
 import { z } from "zod";


### PR DESCRIPTION
## The defect

Every Relay quote body carried `referrer: "vex"` while `RELAY_API_KEY` stayed optional and absent in a normal deployment. Measured live through the real `relay.quote.get` handler: `POST /quote/v2` answers 401 `UNAUTHORIZED_QUOTE: Please provide an api key` for that body and 200 for the byte-identical body without the referrer. Keyless deployments could not take a Relay bridge quote at all.

## What changes

- The quote body is built from the same key read that fills `x-api-key`: with a key the referrer travels as before, without one it is omitted; the two cannot disagree.
- Nothing Vex depends on rides on the referrer: the Vex fee is a separate transfer after the deposit lands (never Relay `appFees`), and the prequote identity hash binds the referrer as a stable empty for Relay. Relay's documentation ([API keys](https://docs.relay.link/references/api/api-keys), [Get Quote](https://docs.relay.link/references/api/get-quote), [Webhooks](https://docs.relay.link/references/api/api_guides/webhooks)) describes `referrer` as optional attribution echoed on webhooks and never states the key requirement the endpoint enforces.
- The schema comment states the measured truth; the assertion that pinned the unconditional referrer is replaced by a suite asserting the outgoing request per key presence (absent, blank, present).

## Verification

- root vitest `src/__tests__/tools/relay`: green after the stale assertion's removal; root tsc, em-dash and unsafe-escapes gates green.
- Live (rule 10, keyless, read-only, one request): Base to Arbitrum 10 USDC quote succeeds through the real handler with the Vex fee disclosure projected (25 bps, fee 25000, bridged 9975000); the same call at the same commit answered 401 before the fix. Archived with provenance.
- Not exercised live: the keyed path (no key available here); it is byte-identical to the shipping request and covered by unit test.

Reference reading: MetaMask `bridge-controller` `utils/fetch.ts` (identity travels as a conditionally-spread header, optional body fields attached conditionally) and `fetch.test.ts` (assert the exact outgoing request per variant).
