### PR TITLE
fix(ci): keep the launchpads reads green on main under the app tsconfig and without a local keystore

### DIFF
--- a/src/__tests__/vex-agent/tools/protocols/pools/read-depth-handlers.test.ts
+++ b/src/__tests__/vex-agent/tools/protocols/pools/read-depth-handlers.test.ts
@@ -12,7 +12,7 @@
  * the code under test.
  */
 
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 
 import { POOLS_HANDLERS } from "@vex-agent/tools/protocols/pools/handlers.js";
 import { getPoolsFunClient } from "@tools/pools-fun/client.js";
@@ -382,6 +382,14 @@ function stubApiRewards(capture: string) {
 }
 
 describe("pools.holder_rewards", () => {
+  // The handler falls back to the session's selected wallet when no
+  // `walletAddress` is passed. That resolution reads the local keystore config,
+  // which exists on a developer machine and not in CI: pin it here so the
+  // tests exercise the handler, never the environment (CI on main went red on
+  // exactly this after the launchpads integration, 2026-09-05).
+  beforeEach(() => {
+    vi.spyOn(walletResolve, "resolveSelectedAddressForRead").mockReturnValue(WALLET);
+  });
   it("reports the on-chain amounts with their raw units, decimals and a scaled figure", async () => {
     stubSuite(3);
     stubOnChainRewards();

--- a/src/tools/virtuals/candles/geckoterminal.ts
+++ b/src/tools/virtuals/candles/geckoterminal.ts
@@ -163,7 +163,14 @@ function readCandle(raw: unknown): VirtualsCandle | null {
   if (!Array.isArray(raw) || raw.length < 6) return null;
   const ts = raw[0];
   if (typeof ts !== "number" || !Number.isFinite(ts)) return null;
-  const [open, high, low, close, volume] = [raw[1], raw[2], raw[3], raw[4], raw[5]].map(decimal);
+  // Indexed reads are `T | undefined` under the app's stricter tsconfig, so each
+  // member is coalesced to the same `null` a non-decimal value produces.
+  const parts = [raw[1], raw[2], raw[3], raw[4], raw[5]].map(decimal);
+  const open = parts[0] ?? null;
+  const high = parts[1] ?? null;
+  const low = parts[2] ?? null;
+  const close = parts[3] ?? null;
+  const volume = parts[4] ?? null;
   if (open === null || high === null || low === null || close === null || volume === null) {
     return null;
   }


### PR DESCRIPTION
Two follow-ups to #161 found by CI on main: a strict-tsconfig type error in the Virtuals candle parser (vex-app build, e2e and package-payload jobs), and seven pools.holder_rewards tests that resolved the session wallet from the local keystore config, which CI does not have (root-build-and-test). Verified locally: vex-app lint:tsc and the app type ratchet green at baseline; the test file green with an empty VEX_CONFIG_DIR; root build then the test file green in CI order. The macOS job's files-real-fs watcher timeout is outside this arc.