### PR TITLE
fix(inference): fail over empty OpenRouter streams within a bounded prefix

### DIFF
--- a/src/__tests__/vex-agent/engine/core/turn-loop/iteration-and-save.test.ts
+++ b/src/__tests__/vex-agent/engine/core/turn-loop/iteration-and-save.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import type { StreamChunk } from "@vex-agent/inference/types.js";
+import type {
+  InferenceConfig,
+  InferenceProvider,
+  InferenceResponse,
+  InferenceUsage,
+  StreamChunk,
+} from "@vex-agent/inference/types.js";
+import { OpenRouterEmptyStreamError } from "@vex-agent/inference/openrouter/non-empty-stream.js";
 
 // ── Mocks ─────────────────────────────────────────────────────
 
@@ -304,6 +311,84 @@ describe("turn-loop", () => {
     };
   }
 
+  /**
+   * A FULLY typed `InferenceProvider` double. The sibling helpers above predate
+   * the test-escape ratchet and reach `runTurnLoop` through `as any`; new tests
+   * may not, so this one implements the whole interface and the scripted arms
+   * are typed against it. Rounds are scripted per call index; the last entry
+   * repeats, exactly like `makeProvider`.
+   */
+  function makeTypedProvider(parts: {
+    readonly completions?: ReadonlyArray<{
+      readonly content?: string | null;
+      readonly reasoning?: string | null;
+    }>;
+    readonly streamRounds?: ReadonlyArray<readonly StreamChunk[]>;
+    readonly streamThrows?: () => Error;
+    readonly onChatCompletion?: () => void;
+    readonly onStream?: () => void;
+  }): InferenceProvider {
+    let completionIndex = 0;
+    let streamIndex = 0;
+    const usage: InferenceUsage = {
+      promptTokens: 1000,
+      completionTokens: 0,
+      totalTokens: 1000,
+    };
+    return {
+      id: "fake",
+      displayName: "Fake",
+      loadConfig: async () => null,
+      chatCompletion: async (): Promise<InferenceResponse> => {
+        parts.onChatCompletion?.();
+        const scripted = parts.completions ?? [{ content: "" }];
+        const round = scripted[completionIndex] ?? scripted[scripted.length - 1];
+        completionIndex += 1;
+        return {
+          content: round.content ?? null,
+          toolCalls: null,
+          usage,
+          reasoning: round.reasoning ?? null,
+          finishReason: "stop",
+          generationId: null,
+          servingProvider: null,
+        };
+      },
+      chatCompletionSimple: async () => ({ content: "", usage }),
+      chatCompletionStream: async function* (): AsyncGenerator<StreamChunk> {
+        parts.onStream?.();
+        if (parts.streamThrows) throw parts.streamThrows();
+        const scripted = parts.streamRounds ?? [];
+        const round = scripted[streamIndex] ?? scripted[scripted.length - 1] ?? [];
+        streamIndex += 1;
+        for (const chunk of round) yield chunk;
+      },
+      getBalance: async () => null,
+      calculateCost: () => ({
+        totalCost: 0.001,
+        currency: "USD",
+        breakdown: { promptCost: 0, completionCost: 0, cachedSavings: 0, reasoningCost: 0 },
+      }),
+    };
+  }
+
+  /** The typed config the scripted rounds above run under. */
+  function makeTypedConfig(): InferenceConfig {
+    return {
+      provider: "openrouter",
+      model: "test-model",
+      contextLimit: 128000,
+      maxOutputTokens: 4096,
+      inputPricePerM: 3,
+      outputPricePerM: 15,
+      priceCurrency: "USD",
+      cachePricePerM: null,
+      cacheWritePricePerM: null,
+      reasoningPricePerM: null,
+      supportsReasoningEffort: false,
+    };
+  }
+
   function makeConfig() {
     return {
       provider: "openrouter",
@@ -439,6 +524,94 @@ describe("turn-loop", () => {
       // Real work DID happen before the stall - the user-facing copy and the
       // retry gate both depend on this count being truthful.
       expect(result.toolCallsMade).toBe(1);
+    });
+
+    it("counts a REASONING-ONLY round as blank, exactly like an empty one", async () => {
+      // A model that thinks without answering. The inference layer hands the
+      // reasoning-only completion back AS a completion (it stopped throwing on
+      // one), so this bound is the only thing standing between it and fifty
+      // billed repeats of the identical prompt.
+      let streamCalls = 0;
+      const provider = makeTypedProvider({
+        streamRounds: [[
+          { type: "reasoning", reasoningText: "thinking hard" },
+          { type: "done", finishReason: "stop" },
+        ]],
+        onStream: () => { streamCalls += 1; },
+      });
+
+      const result = await runTurnLoop(
+        makeContext(), [], null, 0, provider, makeTypedConfig(), [],
+        { ...defaultLoopConfig, maxIterations: 50 },
+      );
+
+      expect(result.stopReason).toBe("no_progress");
+      expect(streamCalls).toBe(MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS);
+      expect(result.text).toBe(null);
+      expect(mockAddMessage).not.toHaveBeenCalled();
+      // Logged as blank AND as reasoning-only: the model spent output tokens,
+      // it just never answered.
+      const blankLog = mockLoggerWarn.mock.calls.find(
+        (c) => c[0] === "engine.turn.unproductive_round",
+      );
+      expect(blankLog).toBeDefined();
+      expect(blankLog?.[1]).toMatchObject({ reasoningOnly: true });
+    });
+
+    it("a reasoning-only round does NOT reset the counter", async () => {
+      // Blank, reasoning-only, blank is a run of THREE, not two runs of one:
+      // if reasoning counted as progress the turn would sail past the bound.
+      let streamCalls = 0;
+      const provider = makeTypedProvider({
+        streamRounds: [
+          [{ type: "done", finishReason: "stop" }],
+          [
+            { type: "reasoning", reasoningText: "still thinking" },
+            { type: "done", finishReason: "stop" },
+          ],
+          [{ type: "done", finishReason: "stop" }],
+          [{ type: "content", text: "unreachable" }, { type: "done", finishReason: "stop" }],
+        ],
+        onStream: () => { streamCalls += 1; },
+      });
+
+      const result = await runTurnLoop(
+        makeContext(), [], null, 0, provider, makeTypedConfig(), [],
+        { ...defaultLoopConfig, maxIterations: 50 },
+      );
+
+      expect(result.stopReason).toBe("no_progress");
+      expect(streamCalls).toBe(MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS);
+      expect(result.text).toBe(null);
+    });
+
+    it("a provider whose streams are all empty stops at the blank bound, not with an error", async () => {
+      // End to end over the reconciled policy: every streaming attempt fails
+      // the bounded empty-stream failover with its typed 502, the buffered
+      // fallback answers with nothing either, and the turn loop - not the
+      // inference layer - decides what that means. Restore the inference-layer
+      // throw and this turn rejects on round one instead of stopping with
+      // `no_progress` on round three.
+      let completions = 0;
+      const provider = makeTypedProvider({
+        completions: [{ content: "" }],
+        streamThrows: () => new OpenRouterEmptyStreamError({
+          reason: "stream_exhausted",
+          chunksSeen: 0,
+          bytesSeen: 0,
+        }),
+        onChatCompletion: () => { completions += 1; },
+      });
+
+      const result = await runTurnLoop(
+        makeContext(), [], null, 0, provider, makeTypedConfig(), [],
+        { ...defaultLoopConfig, maxIterations: 50 },
+      );
+
+      expect(result.stopReason).toBe("no_progress");
+      expect(completions).toBe(MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS);
+      expect(result.text).toBe(null);
+      expect(mockAddMessage).not.toHaveBeenCalled();
     });
 
     it("reports what the turn consumed when the stall bound fires", async () => {

--- a/src/__tests__/vex-agent/inference/openrouter-envelope-and-signal.test.ts
+++ b/src/__tests__/vex-agent/inference/openrouter-envelope-and-signal.test.ts
@@ -95,6 +95,15 @@ function eventStream(chunks: unknown[]) {
   };
 }
 
+function healthyEventStream() {
+  return eventStream([
+    {
+      id: "gen-stream-1",
+      choices: [{ index: 0, delta: { content: "ok" }, finishReason: "stop" }],
+    },
+  ]);
+}
+
 function envelopeOf(callIndex: number): Record<string, unknown> {
   return sendMock.mock.calls[callIndex][0] as Record<string, unknown>;
 }
@@ -124,7 +133,7 @@ describe("routing-metadata opt-in — exactly the two conversational sends", () 
   });
 
   it("chatCompletionStream opts in", async () => {
-    sendMock.mockResolvedValueOnce(eventStream([]));
+    sendMock.mockResolvedValueOnce(healthyEventStream());
     await drain(
       new OpenRouterProvider().chatCompletionStream(MESSAGES, [], makeConfig()),
     );
@@ -197,7 +206,7 @@ describe("cancellation reaches chat.send on every path", () => {
   });
 
   it("chatCompletionStream forwards a signal that the caller can abort", async () => {
-    sendMock.mockResolvedValueOnce(eventStream([]));
+    sendMock.mockResolvedValueOnce(healthyEventStream());
     const controller = new AbortController();
     await drain(
       new OpenRouterProvider().chatCompletionStream(

--- a/src/__tests__/vex-agent/inference/openrouter-request-deadline.test.ts
+++ b/src/__tests__/vex-agent/inference/openrouter-request-deadline.test.ts
@@ -213,7 +213,12 @@ describe("conversational sends stay bounded by the configured deadline", () => {
   });
 
   it("chatCompletionStream: a caller signal does not disable the ceiling", async () => {
-    sendMock.mockResolvedValueOnce(eventStream([]));
+    sendMock.mockResolvedValueOnce(eventStream([
+      {
+        id: "gen-stream-1",
+        choices: [{ index: 0, delta: { content: "ok" }, finishReason: "stop" }],
+      },
+    ]));
     const controller = new AbortController();
 
     await drain(

--- a/src/__tests__/vex-agent/inference/openrouter/non-empty-stream.test.ts
+++ b/src/__tests__/vex-agent/inference/openrouter/non-empty-stream.test.ts
@@ -402,4 +402,75 @@ describe("requireNonEmptyOpenRouterStream", () => {
     ]);
     expect(attemptedTags).toEqual(["blank/fp8", "blank/fp8", "healthy/fp8"]);
   });
+
+  it("rejects with the typed empty-stream failure once every candidate answered with nothing", async () => {
+    // No sibling is healthy, so the bounded capacity policy runs out of
+    // attempts. What comes back out is the typed 502, thrown BEFORE any chunk
+    // reached the consumer - which is exactly the condition
+    // `runStreamingInference` turns into a buffered fallback, and, when that
+    // is empty too, into an empty completion for the turn loop to count as a
+    // blank round. The failover never invents an answer.
+    const candidates: EndpointCandidate[] = [
+      {
+        tag: "blank-a/fp8",
+        providerName: "BlankA",
+        uptimePercent: 90,
+        contextLength: 128_000,
+        inputPricePerM: 1,
+        outputPricePerM: 1,
+        cachePricePerM: null,
+        cacheWritePricePerM: null,
+        reasoningPricePerM: null,
+      },
+      {
+        tag: "blank-b/fp8",
+        providerName: "BlankB",
+        uptimePercent: 99.9,
+        contextLength: 128_000,
+        inputPricePerM: 1,
+        outputPricePerM: 1,
+        cachePricePerM: null,
+        cacheWritePricePerM: null,
+        reasoningPricePerM: null,
+      },
+    ];
+    const config: InferenceConfig = {
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-pro",
+      contextLimit: 128_000,
+      endpointTag: "blank-a/fp8",
+      endpointCandidates: candidates,
+      maxOutputTokens: 4096,
+      inputPricePerM: 1,
+      outputPricePerM: 1,
+      priceCurrency: "USD",
+      cachePricePerM: null,
+      cacheWritePricePerM: null,
+      reasoningPricePerM: null,
+      supportsReasoningEffort: true,
+    };
+    const attemptedTags: Array<string | undefined> = [];
+
+    const rejection = sendWithEndpointFailover(
+      async (attemptConfig) => {
+        attemptedTags.push(attemptConfig.endpointTag);
+        return requireNonEmptyOpenRouterStream(
+          fromChunks([{ type: "done", finishReason: "stop" }]),
+        );
+      },
+      config,
+      { sessionId: "exhausted-empty-failover", missionRunId: null },
+      {
+        loadCandidates: async () => candidates,
+        sleep: async () => undefined,
+        loadPersistedSwitch: async () => null,
+        persistSwitch: async () => undefined,
+      },
+    );
+
+    await expect(rejection).rejects.toBeInstanceOf(OpenRouterEmptyStreamError);
+    // Bounded: the policy stopped asking instead of rotating forever.
+    expect(attemptedTags.length).toBeGreaterThan(1);
+    expect(attemptedTags.length).toBeLessThanOrEqual(candidates.length * 2);
+  });
 });

--- a/src/__tests__/vex-agent/inference/openrouter/non-empty-stream.test.ts
+++ b/src/__tests__/vex-agent/inference/openrouter/non-empty-stream.test.ts
@@ -1,0 +1,405 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  MAX_EMPTY_PREFIX_BYTES,
+  MAX_EMPTY_PREFIX_CHUNKS,
+  OpenRouterEmptyStreamError,
+  requireNonEmptyOpenRouterStream,
+} from "@vex-agent/inference/openrouter/non-empty-stream.js";
+import {
+  resetAllSessionEndpointState,
+  sendWithEndpointFailover,
+} from "@vex-agent/inference/openrouter/endpoint-failover.js";
+import type {
+  EndpointCandidate,
+  InferenceConfig,
+  StreamChunk,
+} from "@vex-agent/inference/types.js";
+
+async function* fromChunks(
+  chunks: readonly StreamChunk[],
+): AsyncGenerator<StreamChunk> {
+  for (const chunk of chunks) yield chunk;
+}
+
+async function collect(stream: AsyncIterable<StreamChunk>): Promise<StreamChunk[]> {
+  const chunks: StreamChunk[] = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return chunks;
+}
+
+interface ControlledSource {
+  readonly iterable: AsyncIterable<StreamChunk>;
+  /** How many times the consumer asked the provider for another chunk. */
+  readonly pulls: () => number;
+  /** How many times the consumer released the source. */
+  readonly returns: () => number;
+}
+
+/**
+ * A hand-written async iterable (not a generator) so the test can OBSERVE
+ * `return()` - the release the module owes on every exit path - and count
+ * pulls without a timer. `onPull` runs before each chunk is handed over, which
+ * is how the abort test lands a Stop in the middle of buffering with no sleep
+ * anywhere.
+ */
+function controlledSource(
+  chunks: readonly StreamChunk[],
+  options: { readonly onPull?: (index: number) => void; readonly failAt?: number } = {},
+): ControlledSource {
+  let index = 0;
+  let pulls = 0;
+  let returns = 0;
+  const iterable: AsyncIterable<StreamChunk> = {
+    [Symbol.asyncIterator]: () => ({
+      next: async (): Promise<IteratorResult<StreamChunk>> => {
+        options.onPull?.(pulls);
+        pulls += 1;
+        if (options.failAt !== undefined && index === options.failAt) {
+          throw new Error("upstream disconnected");
+        }
+        if (index >= chunks.length) {
+          return { done: true, value: undefined } as IteratorResult<StreamChunk>;
+        }
+        const value = chunks[index];
+        index += 1;
+        return { done: false, value };
+      },
+      return: async (): Promise<IteratorResult<StreamChunk>> => {
+        returns += 1;
+        return { done: true, value: undefined } as IteratorResult<StreamChunk>;
+      },
+    }),
+  };
+  return { iterable, pulls: () => pulls, returns: () => returns };
+}
+
+/** A chunk that carries no meaningful delta: whitespace only. */
+function blankChunk(): StreamChunk {
+  return { type: "content", text: " " };
+}
+
+describe("requireNonEmptyOpenRouterStream", () => {
+  beforeEach(() => resetAllSessionEndpointState());
+
+  it("replays the buffered prefix and preserves the rest of a healthy stream", async () => {
+    const input: StreamChunk[] = [
+      { type: "usage", usage: { promptTokens: 10, completionTokens: 1, totalTokens: 11 } },
+      { type: "content", text: "ready" },
+      { type: "done", finishReason: "stop" },
+    ];
+
+    const validated = await requireNonEmptyOpenRouterStream(fromChunks(input));
+    await expect(collect(validated)).resolves.toEqual(input);
+  });
+
+  it("replays EXACTLY the buffered prefix, in order, then continues live", async () => {
+    const prefix: StreamChunk[] = [
+      { type: "usage", usage: { promptTokens: 10, completionTokens: 1, totalTokens: 11 } },
+      { type: "content", text: "  " },
+      { type: "content", text: "\n" },
+    ];
+    const live: StreamChunk[] = [
+      { type: "content", text: "first" },
+      { type: "content", text: " second" },
+      { type: "done", finishReason: "stop" },
+    ];
+    const source = controlledSource([...prefix, ...live]);
+
+    const validated = await requireNonEmptyOpenRouterStream(source.iterable);
+    // Buffering stopped at the first meaningful delta: four pulls, not six.
+    expect(source.pulls()).toBe(4);
+
+    await expect(collect(validated)).resolves.toEqual([...prefix, ...live]);
+    expect(source.returns()).toBe(1);
+  });
+
+  it("classifies a usage-and-done-only stream as a synthetic 502", async () => {
+    const promise = requireNonEmptyOpenRouterStream(
+      fromChunks([
+        { type: "usage", usage: { promptTokens: 10, completionTokens: 1, totalTokens: 11 } },
+        { type: "done", finishReason: "stop" },
+      ]),
+    );
+
+    await expect(promise).rejects.toMatchObject({
+      message: "OpenRouter streaming chat completion failed: empty response",
+      reason: "stream_exhausted",
+      statusCode: 502,
+      status: 502,
+    });
+  });
+
+  it("releases the source when the stream ends without a meaningful delta", async () => {
+    const source = controlledSource([{ type: "done", finishReason: "stop" }]);
+
+    await expect(
+      requireNonEmptyOpenRouterStream(source.iterable),
+    ).rejects.toBeInstanceOf(OpenRouterEmptyStreamError);
+    expect(source.returns()).toBe(1);
+  });
+
+  it("fails at the CHUNK bound instead of buffering an endless blank prefix", async () => {
+    const blanks = Array.from({ length: MAX_EMPTY_PREFIX_CHUNKS + 1 }, blankChunk);
+    const source = controlledSource([
+      ...blanks,
+      { type: "content", text: "never reached" },
+    ]);
+
+    const error = await requireNonEmptyOpenRouterStream(source.iterable).catch(
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(OpenRouterEmptyStreamError);
+    const typed = error as OpenRouterEmptyStreamError;
+    expect(typed.reason).toBe("prefix_bound_exceeded");
+    expect(typed.chunksSeen).toBe(MAX_EMPTY_PREFIX_CHUNKS);
+    expect(typed.maxChunks).toBe(MAX_EMPTY_PREFIX_CHUNKS);
+    expect(typed.maxBytes).toBe(MAX_EMPTY_PREFIX_BYTES);
+    // The bound and the counts are IN the message, never a generic error.
+    expect(typed.message).toContain(`bound ${MAX_EMPTY_PREFIX_CHUNKS} chunks`);
+    expect(typed.message).toContain(`seen ${MAX_EMPTY_PREFIX_CHUNKS} chunks`);
+    // Retryable through the existing capacity policy.
+    expect(typed).toMatchObject({ statusCode: 502, status: 502 });
+    // Stopped pulling at the bound, and released the source.
+    expect(source.pulls()).toBe(MAX_EMPTY_PREFIX_CHUNKS + 1);
+    expect(source.returns()).toBe(1);
+  });
+
+  it("fails at the BYTE bound even when the chunk count stays low", async () => {
+    const halfBound = " ".repeat(MAX_EMPTY_PREFIX_BYTES / 2);
+    const source = controlledSource([
+      { type: "content", text: halfBound },
+      { type: "content", text: halfBound },
+      { type: "content", text: halfBound },
+      { type: "content", text: "never reached" },
+    ]);
+
+    const error = await requireNonEmptyOpenRouterStream(source.iterable).catch(
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(OpenRouterEmptyStreamError);
+    const typed = error as OpenRouterEmptyStreamError;
+    expect(typed.reason).toBe("prefix_bound_exceeded");
+    expect(typed.chunksSeen).toBe(2);
+    expect(typed.chunksSeen).toBeLessThan(MAX_EMPTY_PREFIX_CHUNKS);
+    expect(typed.bytesSeen).toBe(MAX_EMPTY_PREFIX_BYTES);
+    expect(typed.message).toContain(`${MAX_EMPTY_PREFIX_BYTES} bytes`);
+    expect(source.pulls()).toBe(3);
+    expect(source.returns()).toBe(1);
+  });
+
+  it("accepts a prefix that sits exactly ON the bound", async () => {
+    const blanks = Array.from({ length: MAX_EMPTY_PREFIX_CHUNKS }, blankChunk);
+    const tail: StreamChunk[] = [
+      { type: "content", text: "answer" },
+      { type: "done", finishReason: "stop" },
+    ];
+    const source = controlledSource([...blanks, ...tail]);
+
+    const validated = await requireNonEmptyOpenRouterStream(source.iterable);
+    await expect(collect(validated)).resolves.toEqual([...blanks, ...tail]);
+  });
+
+  it("releases the source and rethrows the signal's reason when the caller aborts", async () => {
+    const controller = new AbortController();
+    const source = controlledSource([blankChunk(), blankChunk()], {
+      // The Stop lands after the first chunk was buffered, deterministically.
+      onPull: (index) => {
+        if (index === 1) controller.abort();
+      },
+    });
+
+    const error = await requireNonEmptyOpenRouterStream(
+      source.iterable,
+      controller.signal,
+    ).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe("AbortError");
+    expect(source.returns()).toBe(1);
+    // Two pulls happened; the third never did, because the loop checked the
+    // signal before asking for more.
+    expect(source.pulls()).toBe(2);
+  });
+
+  it("releases the source when the upstream rejects and preserves that failure", async () => {
+    const source = controlledSource([blankChunk()], { failAt: 1 });
+
+    await expect(
+      requireNonEmptyOpenRouterStream(source.iterable),
+    ).rejects.toThrow("upstream disconnected");
+    expect(source.returns()).toBe(1);
+  });
+
+  it("accepts reasoning as a streamed signal but leaves final validation to the consumer", async () => {
+    const input: StreamChunk[] = [
+      { type: "reasoning", reasoningText: "checking" },
+      { type: "done", finishReason: "stop" },
+    ];
+
+    const validated = await requireNonEmptyOpenRouterStream(fromChunks(input));
+    await expect(collect(validated)).resolves.toEqual(input);
+  });
+
+  it("does not reroute an empty content-filter termination", async () => {
+    const input: StreamChunk[] = [
+      { type: "done", finishReason: "content_filter" },
+    ];
+
+    const validated = await requireNonEmptyOpenRouterStream(fromChunks(input));
+    await expect(collect(validated)).resolves.toEqual(input);
+  });
+
+  it("feeds empty streams into bounded endpoint failover and returns the healthy sibling", async () => {
+    const candidates: EndpointCandidate[] = [
+      {
+        tag: "streamlake/fp8",
+        providerName: "StreamLake",
+        uptimePercent: 90,
+        contextLength: 128_000,
+        inputPricePerM: 1,
+        outputPricePerM: 1,
+        cachePricePerM: null,
+        cacheWritePricePerM: null,
+        reasoningPricePerM: null,
+      },
+      {
+        tag: "healthy/fp8",
+        providerName: "Healthy",
+        uptimePercent: 99.9,
+        contextLength: 128_000,
+        inputPricePerM: 1,
+        outputPricePerM: 1,
+        cachePricePerM: null,
+        cacheWritePricePerM: null,
+        reasoningPricePerM: null,
+      },
+    ];
+    const config: InferenceConfig = {
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-pro",
+      contextLimit: 128_000,
+      endpointTag: "streamlake/fp8",
+      endpointCandidates: candidates,
+      maxOutputTokens: 4096,
+      inputPricePerM: 1,
+      outputPricePerM: 1,
+      priceCurrency: "USD",
+      cachePricePerM: null,
+      cacheWritePricePerM: null,
+      reasoningPricePerM: null,
+      supportsReasoningEffort: true,
+    };
+    const attemptedTags: Array<string | undefined> = [];
+
+    const validated = await sendWithEndpointFailover(
+      async (attemptConfig) => {
+        attemptedTags.push(attemptConfig.endpointTag);
+        if (attemptConfig.endpointTag === "healthy/fp8") {
+          return requireNonEmptyOpenRouterStream(
+            fromChunks([
+              { type: "content", text: "ready" },
+              { type: "done", finishReason: "stop" },
+            ]),
+          );
+        }
+        return requireNonEmptyOpenRouterStream(
+          fromChunks([{ type: "done", finishReason: "stop" }]),
+        );
+      },
+      config,
+      { sessionId: "empty-stream-failover", missionRunId: null },
+      {
+        loadCandidates: async () => candidates,
+        sleep: async () => undefined,
+        loadPersistedSwitch: async () => null,
+        persistSwitch: async () => undefined,
+      },
+    );
+
+    await expect(collect(validated)).resolves.toEqual([
+      { type: "content", text: "ready" },
+      { type: "done", finishReason: "stop" },
+    ]);
+    expect(attemptedTags).toEqual([
+      "streamlake/fp8",
+      "streamlake/fp8",
+      "healthy/fp8",
+    ]);
+  });
+
+  it("routes a bound-exceeded prefix through the same failover policy", async () => {
+    const blanks = Array.from({ length: MAX_EMPTY_PREFIX_CHUNKS + 1 }, blankChunk);
+    const candidates: EndpointCandidate[] = [
+      {
+        tag: "blank/fp8",
+        providerName: "Blank",
+        uptimePercent: 90,
+        contextLength: 128_000,
+        inputPricePerM: 1,
+        outputPricePerM: 1,
+        cachePricePerM: null,
+        cacheWritePricePerM: null,
+        reasoningPricePerM: null,
+      },
+      {
+        tag: "healthy/fp8",
+        providerName: "Healthy",
+        uptimePercent: 99.9,
+        contextLength: 128_000,
+        inputPricePerM: 1,
+        outputPricePerM: 1,
+        cachePricePerM: null,
+        cacheWritePricePerM: null,
+        reasoningPricePerM: null,
+      },
+    ];
+    const config: InferenceConfig = {
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-pro",
+      contextLimit: 128_000,
+      endpointTag: "blank/fp8",
+      endpointCandidates: candidates,
+      maxOutputTokens: 4096,
+      inputPricePerM: 1,
+      outputPricePerM: 1,
+      priceCurrency: "USD",
+      cachePricePerM: null,
+      cacheWritePricePerM: null,
+      reasoningPricePerM: null,
+      supportsReasoningEffort: true,
+    };
+    const attemptedTags: Array<string | undefined> = [];
+
+    const validated = await sendWithEndpointFailover(
+      async (attemptConfig) => {
+        attemptedTags.push(attemptConfig.endpointTag);
+        if (attemptConfig.endpointTag === "healthy/fp8") {
+          return requireNonEmptyOpenRouterStream(
+            fromChunks([
+              { type: "content", text: "ready" },
+              { type: "done", finishReason: "stop" },
+            ]),
+          );
+        }
+        return requireNonEmptyOpenRouterStream(fromChunks(blanks));
+      },
+      config,
+      { sessionId: "bounded-prefix-failover", missionRunId: null },
+      {
+        loadCandidates: async () => candidates,
+        sleep: async () => undefined,
+        loadPersistedSwitch: async () => null,
+        persistSwitch: async () => undefined,
+      },
+    );
+
+    await expect(collect(validated)).resolves.toEqual([
+      { type: "content", text: "ready" },
+      { type: "done", finishReason: "stop" },
+    ]);
+    expect(attemptedTags).toEqual(["blank/fp8", "blank/fp8", "healthy/fp8"]);
+  });
+});

--- a/src/__tests__/vex-agent/inference/response-validation.test.ts
+++ b/src/__tests__/vex-agent/inference/response-validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertActionableInferenceResponse,
+  hasActionableInferenceResponse,
+} from "@vex-agent/inference/response-validation.js";
+import type { InferenceResponse } from "@vex-agent/inference/types.js";
+
+const BASE: InferenceResponse = {
+  content: "",
+  toolCalls: null,
+  usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+  reasoning: null,
+  finishReason: "stop",
+  generationId: "gen-1",
+  servingProvider: "provider-a",
+};
+
+describe("actionable inference response validation", () => {
+  it("accepts final text and tool calls", () => {
+    expect(hasActionableInferenceResponse({ ...BASE, content: "done" })).toBe(true);
+    expect(
+      hasActionableInferenceResponse({
+        ...BASE,
+        content: null,
+        toolCalls: [{ id: "call-1", name: "status", arguments: {} }],
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects empty, whitespace-only, and reasoning-only completions", () => {
+    expect(hasActionableInferenceResponse(BASE)).toBe(false);
+    expect(hasActionableInferenceResponse({ ...BASE, content: " \n\t" })).toBe(false);
+    expect(
+      hasActionableInferenceResponse({ ...BASE, reasoning: "private reasoning" }),
+    ).toBe(false);
+    expect(() => assertActionableInferenceResponse(BASE)).toThrow(
+      "Inference provider returned an empty response",
+    );
+  });
+});

--- a/src/__tests__/vex-agent/inference/response-validation.test.ts
+++ b/src/__tests__/vex-agent/inference/response-validation.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  assertActionableInferenceResponse,
-  hasActionableInferenceResponse,
-} from "@vex-agent/inference/response-validation.js";
+import { hasActionableInferenceResponse } from "@vex-agent/inference/response-validation.js";
 import type { InferenceResponse } from "@vex-agent/inference/types.js";
 
 const BASE: InferenceResponse = {
@@ -16,7 +13,7 @@ const BASE: InferenceResponse = {
   servingProvider: "provider-a",
 };
 
-describe("actionable inference response validation", () => {
+describe("actionable inference response predicate", () => {
   it("accepts final text and tool calls", () => {
     expect(hasActionableInferenceResponse({ ...BASE, content: "done" })).toBe(true);
     expect(
@@ -34,8 +31,13 @@ describe("actionable inference response validation", () => {
     expect(
       hasActionableInferenceResponse({ ...BASE, reasoning: "private reasoning" }),
     ).toBe(false);
-    expect(() => assertActionableInferenceResponse(BASE)).toThrow(
-      "Inference provider returned an empty response",
-    );
+  });
+
+  it("reads the turn loop's round shape, not only a provider response", () => {
+    // The engine's blank-round detector calls this predicate with the round it
+    // is about to classify. One rule, two callers: if the shapes ever diverge
+    // this stops compiling instead of drifting silently.
+    expect(hasActionableInferenceResponse({ content: null, toolCalls: [] })).toBe(false);
+    expect(hasActionableInferenceResponse({ content: "answer", toolCalls: null })).toBe(true);
   });
 });

--- a/src/__tests__/vex-agent/inference/stream-consumer.test.ts
+++ b/src/__tests__/vex-agent/inference/stream-consumer.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { runStreamingInference } from "@vex-agent/inference/stream-consumer.js";
+import { hasActionableInferenceResponse } from "@vex-agent/inference/response-validation.js";
+import { OpenRouterEmptyStreamError } from "@vex-agent/inference/openrouter/non-empty-stream.js";
 import type {
   InferenceConfig,
   InferenceProvider,
@@ -114,11 +116,15 @@ describe("runStreamingInference — accumulation equivalence", () => {
     expect(res).toEqual({ content: "answer", toolCalls: null, usage: ZERO_USAGE, reasoning: "think more", ...NO_PROVENANCE });
   });
 
-  it("reasoning-only: rejects instead of silently repeating the turn", async () => {
-    await expect(run([
+  it("reasoning-only: content is empty string, toolCalls null", async () => {
+    // Handed BACK as a completion, not rejected. Reasoning alone is not
+    // actionable, and the turn loop's blank-round detector is what acts on
+    // that (`engine/core/runner/unproductive-rounds.ts`).
+    const res = await run([
       { type: "reasoning", reasoningText: "just thinking" },
       { type: "done" },
-    ])).rejects.toThrow("Inference provider returned an empty response");
+    ]);
+    expect(res).toEqual({ content: "", toolCalls: null, usage: ZERO_USAGE, reasoning: "just thinking", ...NO_PROVENANCE });
   });
 
   it("stream ends without a done chunk: still assembles", async () => {
@@ -177,7 +183,6 @@ describe("runStreamingInference — accumulation equivalence", () => {
 
   it("keeps the LAST finish reason but the FIRST generation id across repeated done chunks", async () => {
     const res = await run([
-      { type: "content", text: "done" },
       { type: "done", finishReason: "tool_calls", generationId: "gen-first" },
       { type: "done", finishReason: "stop", generationId: "gen-second" },
     ]);
@@ -197,11 +202,12 @@ describe("runStreamingInference — accumulation equivalence", () => {
     ]);
   });
 
-  it("all tool args malformed → rejects instead of silently repeating the turn", async () => {
-    await expect(run([
+  it("all tool args malformed → falls through to text semantics", async () => {
+    const res = await run([
       { type: "tool_call_delta", toolCallIndex: 0, toolCallId: "c1", toolCallName: "t", toolCallArgsDelta: "not json" },
       { type: "done" },
-    ])).rejects.toThrow("Inference provider returned an empty response");
+    ]);
+    expect(res).toEqual({ content: "", toolCalls: null, usage: ZERO_USAGE, reasoning: null, ...NO_PROVENANCE });
   });
 
   it("partially malformed tool args → only valid calls survive (tool path)", async () => {
@@ -408,18 +414,28 @@ describe("runStreamingInference — fallback to chatCompletion", () => {
     expect(chatCompletion).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects an empty buffered fallback instead of restarting the turn loop", async () => {
-    const chatCompletion = vi.fn().mockResolvedValue({
-      ...FALLBACK,
-      content: "",
-    });
+  it("degrades an exhausted empty-stream failover to an empty completion, never an error", async () => {
+    // The shape a stream whose every endpoint answered with nothing arrives
+    // in: the bounded failover has rejected with its synthetic 502 before the
+    // first chunk, the buffered fallback runs, and it answers with nothing
+    // either. The result is a COMPLETION with no text and no tool calls; the
+    // turn loop counts it as a blank round and stops at its own bound. If this
+    // layer threw instead, the user would see an inference error where the
+    // engine has a policy.
+    const emptyCompletion: InferenceResponse = { ...FALLBACK, content: "" };
+    const chatCompletion = vi.fn().mockResolvedValue(emptyCompletion);
     const provider = providerFrom(async function* (): AsyncGenerator<StreamChunk> {
-      throw new Error("setup failed");
+      throw new OpenRouterEmptyStreamError({
+        reason: "stream_exhausted",
+        chunksSeen: 0,
+        bytesSeen: 0,
+      });
     }, chatCompletion);
 
-    await expect(
-      runStreamingInference(provider, MSGS, TOOLS, CFG),
-    ).rejects.toThrow("Inference provider returned an empty response");
+    const res = await runStreamingInference(provider, MSGS, TOOLS, CFG);
+    expect(res.response).toBe(emptyCompletion);
+    expect(res.aborted).toBe(false);
+    expect(hasActionableInferenceResponse(res.response)).toBe(false);
     expect(chatCompletion).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/vex-agent/inference/stream-consumer.test.ts
+++ b/src/__tests__/vex-agent/inference/stream-consumer.test.ts
@@ -114,12 +114,11 @@ describe("runStreamingInference — accumulation equivalence", () => {
     expect(res).toEqual({ content: "answer", toolCalls: null, usage: ZERO_USAGE, reasoning: "think more", ...NO_PROVENANCE });
   });
 
-  it("reasoning-only: content is empty string, toolCalls null", async () => {
-    const res = await run([
+  it("reasoning-only: rejects instead of silently repeating the turn", async () => {
+    await expect(run([
       { type: "reasoning", reasoningText: "just thinking" },
       { type: "done" },
-    ]);
-    expect(res).toEqual({ content: "", toolCalls: null, usage: ZERO_USAGE, reasoning: "just thinking", ...NO_PROVENANCE });
+    ])).rejects.toThrow("Inference provider returned an empty response");
   });
 
   it("stream ends without a done chunk: still assembles", async () => {
@@ -178,6 +177,7 @@ describe("runStreamingInference — accumulation equivalence", () => {
 
   it("keeps the LAST finish reason but the FIRST generation id across repeated done chunks", async () => {
     const res = await run([
+      { type: "content", text: "done" },
       { type: "done", finishReason: "tool_calls", generationId: "gen-first" },
       { type: "done", finishReason: "stop", generationId: "gen-second" },
     ]);
@@ -197,12 +197,11 @@ describe("runStreamingInference — accumulation equivalence", () => {
     ]);
   });
 
-  it("all tool args malformed → falls through to text semantics", async () => {
-    const res = await run([
+  it("all tool args malformed → rejects instead of silently repeating the turn", async () => {
+    await expect(run([
       { type: "tool_call_delta", toolCallIndex: 0, toolCallId: "c1", toolCallName: "t", toolCallArgsDelta: "not json" },
       { type: "done" },
-    ]);
-    expect(res).toEqual({ content: "", toolCalls: null, usage: ZERO_USAGE, reasoning: null, ...NO_PROVENANCE });
+    ])).rejects.toThrow("Inference provider returned an empty response");
   });
 
   it("partially malformed tool args → only valid calls survive (tool path)", async () => {
@@ -406,6 +405,21 @@ describe("runStreamingInference — fallback to chatCompletion", () => {
     expect(res.response).toBe(FALLBACK);
     expect(res.aborted).toBe(false);
     expect(res.usageObserved).toBe(true);
+    expect(chatCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an empty buffered fallback instead of restarting the turn loop", async () => {
+    const chatCompletion = vi.fn().mockResolvedValue({
+      ...FALLBACK,
+      content: "",
+    });
+    const provider = providerFrom(async function* (): AsyncGenerator<StreamChunk> {
+      throw new Error("setup failed");
+    }, chatCompletion);
+
+    await expect(
+      runStreamingInference(provider, MSGS, TOOLS, CFG),
+    ).rejects.toThrow("Inference provider returned an empty response");
     expect(chatCompletion).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/vex-agent/engine/core/runner/unproductive-rounds.ts
+++ b/src/vex-agent/engine/core/runner/unproductive-rounds.ts
@@ -42,6 +42,8 @@
  * rounds of full-context prompts billed for zero output.
  */
 
+import { hasActionableInferenceResponse } from "@vex-agent/inference/response-validation.js";
+
 /**
  * Consecutive rounds that may emit nothing before the turn stops with
  * `no_progress`. Not configurable and not permission-aware: an autonomous
@@ -53,17 +55,23 @@ export const MAX_CONSECUTIVE_UNPRODUCTIVE_ROUNDS = 3;
  * Whether a completed inference round produced anything the turn can build on.
  *
  * Productive = at least one tool call to dispatch, or assistant text with at
- * least one non-whitespace character.
+ * least one non-whitespace character. The rule is NOT restated here: it is the
+ * inference layer's `hasActionableInferenceResponse`, so "the provider
+ * returned nothing to act on" and "this round was blank" can never drift
+ * apart. That predicate is pure - the inference layer hands an empty
+ * completion straight through and this detector is the only owner of what to
+ * do about it.
  *
- * Reasoning is deliberately NOT productive. A reasoning-only response is
- * discarded by the same fall-through as an empty one (the turn loop persists
- * reasoning only alongside content or tool calls), so counting it as progress
- * would re-open the exact hole this detector closes.
+ * Reasoning is deliberately NOT productive, and a reasoning-only completion is
+ * therefore a blank round like any other. It is discarded by the same
+ * fall-through as an empty one (the turn loop persists reasoning only
+ * alongside content or tool calls), so counting it as progress would re-open
+ * the exact hole this detector closes - and it is the shape an empty stream
+ * that exhausted its endpoint failover degrades into.
  */
 export function isProductiveRound(round: {
   readonly content: string | null;
   readonly toolCalls: readonly unknown[] | null;
 }): boolean {
-  if (round.toolCalls !== null && round.toolCalls.length > 0) return true;
-  return round.content !== null && round.content.trim().length > 0;
+  return hasActionableInferenceResponse(round);
 }

--- a/src/vex-agent/inference/openrouter.ts
+++ b/src/vex-agent/inference/openrouter.ts
@@ -53,6 +53,7 @@ import { extractUsage, parseNonStreamingResponse } from "./openrouter/mappers.js
 import { buildOpenRouterParams } from "./openrouter/params.js";
 import { computeRequestCost } from "./openrouter/cost.js";
 import { consumeOpenRouterStream } from "./openrouter/stream.js";
+import { requireNonEmptyOpenRouterStream } from "./openrouter/non-empty-stream.js";
 import { asChatResult, asEventStream } from "./openrouter/chat-send.js";
 import {
   fetchModelInferenceConfig,
@@ -401,11 +402,28 @@ export class OpenRouterProvider implements InferenceProvider {
     signal?: AbortSignal,
     context?: InferenceRequestContext,
   ): AsyncGenerator<StreamChunk> {
-    // Only the SEND is wrapped by the failover. A mid-stream failure is
-    // deliberately outside it: bytes have already reached the user, so
-    // replaying the request would duplicate content.
-    const stream: EventStream<ChatStreamChunk> = await sendWithEndpointFailover(
-      async (attemptConfig) => this.openStream(messages, tools, attemptConfig, signal, context),
+    // The SEND plus the wait for the FIRST meaningful model delta is wrapped by
+    // the failover. Once that delta exists, the rest of the stream stays
+    // outside it: bytes can then reach the user, so replaying a later failure
+    // would duplicate content.
+    const stream = await sendWithEndpointFailover(
+      async (attemptConfig) => {
+        const opened = await this.openStream(
+          messages,
+          tools,
+          attemptConfig,
+          signal,
+          context,
+        );
+        // Do not mark an endpoint healthy merely because it returned an HTTP
+        // stream handle. It must produce model output first, and an empty
+        // stream is safe to retry because no user-visible delta was emitted.
+        // The wait itself is bounded (see `non-empty-stream.ts`).
+        return requireNonEmptyOpenRouterStream(
+          consumeOpenRouterStream(opened),
+          signal,
+        );
+      },
       config,
       context,
       this.failoverDeps(),
@@ -421,7 +439,7 @@ export class OpenRouterProvider implements InferenceProvider {
       // the classifier's own-property signals and the redactor both apply
       // (a raw SDK rejection would otherwise bypass classification metadata
       // AND message redaction).
-      yield* consumeOpenRouterStream(stream);
+      yield* stream;
     } catch (err) {
       throw normalizeOpenRouterError(err, "streaming chat completion (mid-stream)");
     }

--- a/src/vex-agent/inference/openrouter/non-empty-stream.ts
+++ b/src/vex-agent/inference/openrouter/non-empty-stream.ts
@@ -1,0 +1,269 @@
+/**
+ * Validate an OpenRouter stream before declaring its endpoint healthy, within
+ * a BOUNDED prefix.
+ *
+ * WHY THIS EXISTS. `sendWithEndpointFailover` historically considered the HTTP
+ * stream handle a success before the stream produced any model output. Some
+ * upstreams return a syntactically valid stream carrying only usage + `done`;
+ * the engine then received an empty completion and silently issued the same
+ * paid turn again. So the failover's success point moves from "a handle
+ * exists" to "the first MEANINGFUL delta exists": until then no user-visible
+ * byte has been emitted, which is exactly what makes a retry safe.
+ *
+ * WHY THE BOUND. Waiting for that first delta means RETAINING the chunks seen
+ * before it, so they can be replayed to the consumer. An unbounded wait is an
+ * unbounded buffer: a provider that streams whitespace-only deltas forever
+ * grows this array without limit (100,001 chunks were retained in a
+ * reproduction of the unbounded version). Retention is therefore capped on
+ * BOTH axes that can grow independently (rule 05): chunk count and UTF-8
+ * bytes. Crossing either cap fails the attempt with
+ * {@link OpenRouterEmptyStreamError}, naming the bound and the counts seen.
+ *
+ * NOTHING IS EVER TRUNCATED. Below the bound the whole buffered prefix is
+ * replayed, in order, before the live stream continues. At the bound the
+ * stream FAILS; it never yields a silently shortened answer. The two outcomes
+ * are the only two.
+ *
+ * WHY 502. Both failures (`stream_exhausted`, `prefix_bound_exceeded`) mean
+ * "this endpoint produced no usable output". Status 502 puts them in the
+ * existing bounded capacity-failure policy
+ * (`endpoint-failover/capacity-failure.ts`: `provider_unavailable`,
+ * switchable), so the attempt retries and can rotate to a sibling endpoint
+ * instead of ending the turn in the user's face. No user-visible delta was
+ * emitted, so the retry cannot duplicate an answer.
+ */
+
+import type { StreamChunk } from "../types.js";
+import { throwIfAborted } from "@utils/cancellation.js";
+import logger from "@utils/logger.js";
+import { attachStatus } from "./errors.js";
+
+/**
+ * Maximum number of prefix chunks retained while waiting for the first
+ * meaningful delta.
+ *
+ * The repository's provider notes record no measured reasoning-only or
+ * whitespace-only prefix length for OpenRouter, so this is a CONSERVATIVE
+ * value rather than a measured one: only chunks that carry nothing actionable
+ * (usage-only chunks, whitespace-only content/reasoning deltas, a non-terminal
+ * `done`) are counted, and a healthy stream emits at most a handful of those
+ * before its first token. 64 leaves two orders of magnitude of headroom below
+ * the reproduced runaway while capping retention at kilobytes.
+ */
+export const MAX_EMPTY_PREFIX_CHUNKS = 64;
+
+/**
+ * Maximum UTF-8 bytes of prefix text retained while waiting for the first
+ * meaningful delta. Measured independently of the chunk count because either
+ * axis can grow on its own: one 10 MB whitespace delta is a single chunk.
+ * Conservative for the same reason as {@link MAX_EMPTY_PREFIX_CHUNKS}.
+ */
+export const MAX_EMPTY_PREFIX_BYTES = 64 * 1024;
+
+/** Why a stream never produced a meaningful delta. Bounded vocabulary. */
+export type EmptyStreamReason =
+  /** The stream ended before any meaningful delta arrived. */
+  | "stream_exhausted"
+  /** The retention bound was reached before any meaningful delta arrived. */
+  | "prefix_bound_exceeded";
+
+/**
+ * A typed provider failure: this OpenRouter stream produced no output the
+ * engine could act on. Carries the counts and the bound that produced the
+ * verdict so a log line, a test and an operator all read the same numbers
+ * instead of parsing a message.
+ *
+ * The message contains integers only, never provider text, so it is safe to
+ * surface without passing through `scrubMessage`.
+ */
+export class OpenRouterEmptyStreamError extends Error {
+  readonly reason: EmptyStreamReason;
+  /** Prefix chunks seen (and retained) before the failure. */
+  readonly chunksSeen: number;
+  /** UTF-8 bytes of prefix text seen (and retained) before the failure. */
+  readonly bytesSeen: number;
+  readonly maxChunks: number;
+  readonly maxBytes: number;
+
+  constructor(args: {
+    readonly reason: EmptyStreamReason;
+    readonly chunksSeen: number;
+    readonly bytesSeen: number;
+  }) {
+    super(
+      args.reason === "stream_exhausted"
+        ? "OpenRouter streaming chat completion failed: empty response"
+        : "OpenRouter streaming chat completion failed: no meaningful delta within the bounded prefix "
+          + `(bound ${MAX_EMPTY_PREFIX_CHUNKS} chunks / ${MAX_EMPTY_PREFIX_BYTES} bytes; `
+          + `seen ${args.chunksSeen} chunks / ${args.bytesSeen} bytes)`,
+    );
+    this.name = "OpenRouterEmptyStreamError";
+    this.reason = args.reason;
+    this.chunksSeen = args.chunksSeen;
+    this.bytesSeen = args.bytesSeen;
+    this.maxChunks = MAX_EMPTY_PREFIX_CHUNKS;
+    this.maxBytes = MAX_EMPTY_PREFIX_BYTES;
+    // Read by `classifyCapacityFailure` off the lean own-properties, exactly
+    // like a normalized SDK error.
+    attachStatus(this, 502);
+  }
+}
+
+function hasMeaningfulDelta(chunk: StreamChunk): boolean {
+  if (chunk.type === "content") return (chunk.text ?? "").trim().length > 0;
+  if (chunk.type === "reasoning") {
+    return (chunk.reasoningText ?? "").trim().length > 0;
+  }
+  if (chunk.type === "tool_call_delta") return true;
+  // A policy stop is a real terminal answer, even when it contains no text.
+  // Let the ordinary completion validator surface it without rotating through
+  // sibling endpoints that must enforce the same policy.
+  if (chunk.type === "done" && chunk.finishReason === "content_filter") {
+    return true;
+  }
+  // Error chunks retain their existing normalization/classification path.
+  if (chunk.type === "error") return true;
+  return false;
+}
+
+/** UTF-8 size of the text a retained chunk actually holds. */
+function retainedChunkBytes(chunk: StreamChunk): number {
+  let bytes = 0;
+  if (chunk.text !== undefined) bytes += Buffer.byteLength(chunk.text, "utf8");
+  if (chunk.reasoningText !== undefined) {
+    bytes += Buffer.byteLength(chunk.reasoningText, "utf8");
+  }
+  if (chunk.toolCallArgsDelta !== undefined) {
+    bytes += Buffer.byteLength(chunk.toolCallArgsDelta, "utf8");
+  }
+  return bytes;
+}
+
+/**
+ * Release the source. Idempotent for a generator, and its own failure never
+ * replaces the primary one (rule 05: collect, do not hide).
+ */
+async function closeIterator(iterator: AsyncIterator<StreamChunk>): Promise<void> {
+  try {
+    await iterator.return?.();
+  } catch (err) {
+    logger.warn("inference.openrouter.stream_release_failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+async function* replayBufferedStream(
+  buffered: readonly StreamChunk[],
+  iterator: AsyncIterator<StreamChunk>,
+): AsyncGenerator<StreamChunk> {
+  try {
+    // The WHOLE retained prefix, in order. Nothing is dropped: the only other
+    // outcome this module has is a thrown `OpenRouterEmptyStreamError`.
+    for (const chunk of buffered) yield chunk;
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done) return;
+      yield next.value;
+    }
+  } finally {
+    await closeIterator(iterator);
+  }
+}
+
+/**
+ * Pull an OpenRouter stream until its first meaningful delta and hand back a
+ * stream that replays the retained prefix and then continues live.
+ *
+ * Rejects with {@link OpenRouterEmptyStreamError} (status 502) when the stream
+ * ends first or the retention bound is reached first, and with the signal's
+ * own reason when the caller aborts while we wait. Every exit path - success,
+ * empty, bound, abort, source rejection - releases the source iterator and the
+ * retained prefix.
+ *
+ * @param signal the turn's abort signal, observed between chunks. A pending
+ * `next()` cannot be cancelled from here; the SDK's own abort handling rejects
+ * it, and this check makes the intent explicit for sources that do not.
+ */
+export async function requireNonEmptyOpenRouterStream(
+  stream: AsyncIterable<StreamChunk>,
+  signal?: AbortSignal,
+): Promise<AsyncIterable<StreamChunk>> {
+  const iterator = stream[Symbol.asyncIterator]();
+  let buffered: StreamChunk[] = [];
+  let bufferedBytes = 0;
+
+  const releaseAndThrow = async (error: unknown): Promise<never> => {
+    buffered = [];
+    await closeIterator(iterator);
+    throw error;
+  };
+
+  for (;;) {
+    // A caller Stop between chunks: release before it propagates.
+    // `throwIfAborted` throws the SIGNAL'S OWN reason, so an operator Stop
+    // (AbortError) stays distinguishable from a deadline breach
+    // (TimeoutError) exactly as everywhere else in the inference path.
+    try {
+      throwIfAborted(signal);
+    } catch (err) {
+      return await releaseAndThrow(err);
+    }
+
+    let next: IteratorResult<StreamChunk>;
+    try {
+      next = await iterator.next();
+    } catch (err) {
+      // Source rejection (dropped connection, abort surfaced as a rejection):
+      // release, then let the existing normalization path classify it.
+      return await releaseAndThrow(err);
+    }
+
+    if (next.done) {
+      logger.warn("inference.openrouter.empty_stream", {
+        reason: "stream_exhausted",
+        chunksSeen: buffered.length,
+        bytesSeen: bufferedBytes,
+      });
+      return await releaseAndThrow(
+        new OpenRouterEmptyStreamError({
+          reason: "stream_exhausted",
+          chunksSeen: buffered.length,
+          bytesSeen: bufferedBytes,
+        }),
+      );
+    }
+
+    const chunk = next.value;
+    if (hasMeaningfulDelta(chunk)) {
+      buffered.push(chunk);
+      return replayBufferedStream(buffered, iterator);
+    }
+
+    // Bound checked BEFORE retaining, so the caps are what we hold, not what
+    // we hold plus one.
+    const chunkBytes = retainedChunkBytes(chunk);
+    if (
+      buffered.length + 1 > MAX_EMPTY_PREFIX_CHUNKS ||
+      bufferedBytes + chunkBytes > MAX_EMPTY_PREFIX_BYTES
+    ) {
+      logger.warn("inference.openrouter.empty_stream", {
+        reason: "prefix_bound_exceeded",
+        chunksSeen: buffered.length,
+        bytesSeen: bufferedBytes,
+        maxChunks: MAX_EMPTY_PREFIX_CHUNKS,
+        maxBytes: MAX_EMPTY_PREFIX_BYTES,
+      });
+      return await releaseAndThrow(
+        new OpenRouterEmptyStreamError({
+          reason: "prefix_bound_exceeded",
+          chunksSeen: buffered.length,
+          bytesSeen: bufferedBytes,
+        }),
+      );
+    }
+
+    buffered.push(chunk);
+    bufferedBytes += chunkBytes;
+  }
+}

--- a/src/vex-agent/inference/response-validation.ts
+++ b/src/vex-agent/inference/response-validation.ts
@@ -1,0 +1,27 @@
+import type { InferenceResponse } from "./types.js";
+
+/**
+ * A completed inference must give the engine something it can act on.
+ * Reasoning alone is intentionally not actionable: it may be previewed while
+ * streaming, but it cannot finish a turn or dispatch a tool.
+ */
+export function hasActionableInferenceResponse(
+  response: InferenceResponse,
+): boolean {
+  const hasText =
+    typeof response.content === "string" && response.content.trim().length > 0;
+  const hasTools =
+    Array.isArray(response.toolCalls) && response.toolCalls.length > 0;
+  return hasText || hasTools;
+}
+
+/**
+ * Fail closed on a provider completion that would otherwise make the turn loop
+ * silently request the same prompt again.
+ */
+export function assertActionableInferenceResponse(
+  response: InferenceResponse,
+): void {
+  if (hasActionableInferenceResponse(response)) return;
+  throw new Error("Inference provider returned an empty response");
+}

--- a/src/vex-agent/inference/response-validation.ts
+++ b/src/vex-agent/inference/response-validation.ts
@@ -1,27 +1,37 @@
-import type { InferenceResponse } from "./types.js";
+/**
+ * Whether a completed inference gave the engine something it can act on.
+ *
+ * This is a PURE PREDICATE and deliberately not a guard: the inference layer
+ * never rejects an empty completion. "The model returned nothing" is a turn
+ * outcome, owned by the turn loop's consecutive-blank detector
+ * (`engine/core/runner/unproductive-rounds.ts`), which counts blank rounds,
+ * resets on productive ones, exempts a deferral and stops the turn with
+ * `no_progress`. Throwing here would pre-empt that policy and turn a stall the
+ * loop knows how to end into an error the user sees instead.
+ *
+ * The rule itself lives here, next to `InferenceResponse`, so both the
+ * inference and the engine sides read one definition: reasoning alone is
+ * intentionally not actionable - it may be previewed while streaming, but it
+ * cannot finish a turn or dispatch a tool.
+ */
 
 /**
- * A completed inference must give the engine something it can act on.
- * Reasoning alone is intentionally not actionable: it may be previewed while
- * streaming, but it cannot finish a turn or dispatch a tool.
+ * The completion fields the rule reads. Structural rather than
+ * `InferenceResponse` so the turn loop's round shape (which carries the same
+ * two fields) can be tested by the same predicate without importing the full
+ * provider response type.
  */
+export interface ActionableCompletionFields {
+  readonly content: string | null;
+  readonly toolCalls: readonly unknown[] | null;
+}
+
 export function hasActionableInferenceResponse(
-  response: InferenceResponse,
+  response: ActionableCompletionFields,
 ): boolean {
   const hasText =
     typeof response.content === "string" && response.content.trim().length > 0;
   const hasTools =
     Array.isArray(response.toolCalls) && response.toolCalls.length > 0;
   return hasText || hasTools;
-}
-
-/**
- * Fail closed on a provider completion that would otherwise make the turn loop
- * silently request the same prompt again.
- */
-export function assertActionableInferenceResponse(
-  response: InferenceResponse,
-): void {
-  if (hasActionableInferenceResponse(response)) return;
-  throw new Error("Inference provider returned an empty response");
 }

--- a/src/vex-agent/inference/stream-consumer.ts
+++ b/src/vex-agent/inference/stream-consumer.ts
@@ -35,6 +35,7 @@ import type {
 } from "./types.js";
 import logger from "@utils/logger.js";
 import { attachErrorType, attachStatus, scrubMessage } from "./openrouter/errors.js";
+import { assertActionableInferenceResponse } from "./response-validation.js";
 
 const ZERO_USAGE: InferenceUsage = {
   promptTokens: 0,
@@ -181,6 +182,7 @@ async function bufferedFallback(
     context,
     signal,
   );
+  assertActionableInferenceResponse(response);
   return { response, aborted: false, usageObserved: true };
 }
 
@@ -378,6 +380,12 @@ export async function runStreamingInference(
           generationId,
           servingProvider,
         };
+
+  // A normal, non-aborted completion must contain final text or at least one
+  // valid tool call. Without this guard the engine treats an empty completion
+  // as "keep iterating" and can silently repeat the same paid request until
+  // the broad 50-iteration / 10-minute runtime bound fires.
+  if (!aborted) assertActionableInferenceResponse(response);
 
   return { response, aborted, usageObserved };
 }

--- a/src/vex-agent/inference/stream-consumer.ts
+++ b/src/vex-agent/inference/stream-consumer.ts
@@ -35,7 +35,6 @@ import type {
 } from "./types.js";
 import logger from "@utils/logger.js";
 import { attachErrorType, attachStatus, scrubMessage } from "./openrouter/errors.js";
-import { assertActionableInferenceResponse } from "./response-validation.js";
 
 const ZERO_USAGE: InferenceUsage = {
   promptTokens: 0,
@@ -182,7 +181,6 @@ async function bufferedFallback(
     context,
     signal,
   );
-  assertActionableInferenceResponse(response);
   return { response, aborted: false, usageObserved: true };
 }
 
@@ -381,11 +379,12 @@ export async function runStreamingInference(
           servingProvider,
         };
 
-  // A normal, non-aborted completion must contain final text or at least one
-  // valid tool call. Without this guard the engine treats an empty completion
-  // as "keep iterating" and can silently repeat the same paid request until
-  // the broad 50-iteration / 10-minute runtime bound fires.
-  if (!aborted) assertActionableInferenceResponse(response);
-
+  // A completion with no final text and no valid tool call is returned AS a
+  // completion, never as an error. Whether the engine may ask the same
+  // question again is the turn loop's decision, and it already owns one: the
+  // consecutive-blank detector (`engine/core/runner/unproductive-rounds.ts`)
+  // counts this round as blank and stops the turn with `no_progress` on the
+  // third in a row. Rejecting here would pre-empt that bound with a hard
+  // error, which is why this layer stays a transport.
   return { response, aborted, usageObserved };
 }


### PR DESCRIPTION
An OpenRouter endpoint was counted healthy as soon as it returned an HTTP
stream handle. Some upstreams answer with a syntactically valid stream that
carries only usage and done; the engine received an empty completion and
silently re-issued the same paid turn, up to the broad runtime bound.

The failover's success point moves from "a handle exists" to "the first
meaningful delta exists". Until that delta no user-visible byte has been
emitted, which is what makes the retry safe: an empty attempt fails with a
synthetic 502, enters the existing bounded capacity policy and can rotate to
a sibling endpoint.

Waiting for that delta retains the chunks seen before it, so the wait is
bounded on both axes that can grow independently: 64 chunks and 64 KiB of
UTF-8 text. Crossing either fails the attempt with a typed
OpenRouterEmptyStreamError naming the bound and the counts seen, closes the
source iterator and drops the buffer. Nothing is truncated: below the bound
the whole retained prefix is replayed in order and the stream continues live;
at the bound the stream fails. Both numbers are conservative rather than
measured and say so at their definition.

Cleanup is owned on every exit path: first delta, stream exhausted, bound
exceeded, upstream rejection, and a caller Stop between chunks, which
rethrows the signal's own reason so an operator abort stays distinguishable
from a deadline.

A completed inference must give the engine something to act on: a
non-aborted completion with no final text and no valid tool call now rejects
instead of returning an empty response the turn loop reads as "keep
iterating"; reasoning alone is deliberately not actionable, and the buffered
fallback is held to the same rule.

Re-applied from the Lighter integration branch (fa4b6cdfc) with the bound
added, as its own change.

Tests: 13 cases over controlled async iterables with no sleeps (chunk bound, byte bound, exactly on the bound, abort during buffering, upstream rejection, exact prefix replay then live continuation, empty and bound-exceeded attempts rotating through endpoint failover); removing either bound turns three of them red. Verification: vitest src/__tests__/vex-agent/inference (37 files / 425 tests), tsc, check:em-dash, test:unsafe-escapes, all green.