### PR TITLE
chore(deps): production dependency audit and overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # The production graph gate. It runs BEFORE the build so a vulnerable
+      # transitive dependency fails the job in seconds rather than after a full
+      # build and test cycle, and it runs once per lockfile: here for the root
+      # workspace, and in vex-app-build-and-test for the desktop lockfile.
+      - name: Audit production dependencies
+        run: pnpm run audit:deps
+
       - name: Build
         run: pnpm run build
 
@@ -121,6 +128,9 @@ jobs:
 
       - name: Install vex-app dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Audit vex-app production dependencies
+        run: pnpm run audit:deps
 
       # pnpm does not run the `electron` package's install script here, and
       # electron 42's index.js downloads the binary ON IMPORT

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck:test:ratchet": "node scripts/check-test-type-baseline.mjs",
     "typecheck:test:baseline-diff": "node scripts/check-test-type-baseline-change.mjs",
     "test:unsafe-escapes": "node scripts/check-test-unsafe-escapes.mjs",
+    "audit:deps": "node scripts/audit-production-dependencies.mjs",
     "check:em-dash": "node scripts/check-no-em-dash.mjs",
     "check:trench-residue": "node scripts/check-trench-residue.mjs",
     "check:no-binary-sources": "node scripts/check-no-binary-sources.mjs",
@@ -68,7 +69,7 @@
     "smol-toml": "1.8.0",
     "socket.io-client": "^4.8.3",
     "tweetnacl": "1.0.3",
-    "undici": "7.25.0",
+    "undici": "7.29.0",
     "viem": "2.54.3",
     "winston": "^3.17.0",
     "zod": "^4.4.3"
@@ -98,5 +99,31 @@
   "bugs": {
     "url": "https://github.com/Vex-Foundation/Vex/issues"
   },
-  "packageManager": "pnpm@10.32.1"
+  "packageManager": "pnpm@10.32.1",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ],
+    "ignoredBuiltDependencies": [
+      "@openrouter/sdk",
+      "bigint-buffer",
+      "bufferutil",
+      "cpu-features",
+      "protobufjs",
+      "ssh2",
+      "utf-8-validate"
+    ],
+    "overrides": {
+      "axios": "1.18.0",
+      "follow-redirects": "1.16.0",
+      "form-data": "4.0.6",
+      "ip-address": "10.3.1",
+      "socket.io-parser": "4.2.7",
+      "uuid@>=11.0.0 <12": "11.1.1",
+      "jayson>ws": "7.5.11",
+      "ethers>ws": "8.21.0",
+      "engine.io-client>ws": "8.21.0",
+      "rpc-websockets>ws": "8.21.0"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  axios: 1.18.0
+  follow-redirects: 1.16.0
+  form-data: 4.0.6
+  ip-address: 10.3.1
+  socket.io-parser: 4.2.7
+  uuid@>=11.0.0 <12: 11.1.1
+  jayson>ws: 7.5.11
+  ethers>ws: 8.21.0
+  engine.io-client>ws: 8.21.0
+  rpc-websockets>ws: 8.21.0
+
 importers:
 
   .:
@@ -57,8 +69,8 @@ importers:
         specifier: 1.0.3
         version: 1.0.3
       undici:
-        specifier: 7.25.0
-        version: 7.25.0
+        specifier: 7.29.0
+        version: 7.29.0
       viem:
         specifier: 2.54.3
         version: 2.54.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.3)
@@ -741,6 +753,10 @@ packages:
   aes-js@4.0.0-beta.5:
     resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -797,8 +813,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -1222,8 +1238,8 @@ packages:
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -1235,8 +1251,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs-constants@1.0.0:
@@ -1297,8 +1313,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   he@1.2.0:
@@ -1314,6 +1330,10 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -1332,8 +1352,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   is-binary-path@2.1.0:
@@ -1812,8 +1832,8 @@ packages:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
 
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
   socks-proxy-agent@8.0.5:
@@ -1983,8 +2003,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   utf-8-validate@6.0.6:
@@ -1999,8 +2019,8 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uuid@8.3.2:
@@ -2129,36 +2149,12 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+  ws@7.5.11:
+    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
     engines: {node: '>=8.3.0'}
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -2692,7 +2688,7 @@ snapshots:
 
   '@tavily/core@0.7.2':
     dependencies:
-      axios: 1.14.0
+      axios: 1.18.0
       https-proxy-agent: 7.0.6
       js-tiktoken: 1.0.21
     transitivePeerDependencies:
@@ -2834,6 +2830,12 @@ snapshots:
 
   aes-js@4.0.0-beta.5: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   agentkeepalive@4.6.0:
@@ -2893,13 +2895,15 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.14.0:
+  axios@1.18.0:
     dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   b4a@1.8.0: {}
 
@@ -3204,7 +3208,7 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xmlhttprequest-ssl: 2.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -3232,7 +3236,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es6-promise@4.2.8: {}
 
@@ -3283,7 +3287,7 @@ snapshots:
       '@types/node': 22.7.5
       aes-js: 4.0.0-beta.5
       tslib: 2.7.0
-      ws: 8.17.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -3338,19 +3342,19 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fs-constants@1.0.0: {}
@@ -3372,7 +3376,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-port@7.2.0: {}
@@ -3418,7 +3422,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -3440,6 +3444,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -3457,7 +3468,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.3.1: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -3479,9 +3490,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isomorphic-ws@4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   isows@1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
@@ -3502,11 +3513,11 @@ snapshots:
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isomorphic-ws: 4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
       uuid: 8.3.2
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -3841,7 +3852,7 @@ snapshots:
 
   rettiwt-api@7.1.2:
     dependencies:
-      axios: 1.14.0
+      axios: 1.18.0
       chalk: 5.6.2
       commander: 11.1.0
       cookiejar: 2.1.4
@@ -3889,7 +3900,7 @@ snapshots:
       '@types/ws': 8.18.1
       buffer: 6.0.3
       eventemitter3: 5.0.4
-      uuid: 11.1.0
+      uuid: 11.1.1
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       bufferutil: 4.1.0
@@ -3930,13 +3941,13 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
       engine.io-client: 6.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6:
+  socket.io-parser@4.2.7:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
@@ -3953,7 +3964,7 @@ snapshots:
 
   socks@2.8.8:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.3.1
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
@@ -4087,7 +4098,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
       tmp: 0.2.5
-      undici: 7.25.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -4160,7 +4171,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.25.0: {}
+  undici@7.29.0: {}
 
   utf-8-validate@6.0.6:
     dependencies:
@@ -4171,7 +4182,7 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  uuid@11.1.0: {}
+  uuid@11.1.1: {}
 
   uuid@8.3.2: {}
 
@@ -4286,17 +4297,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-
-  ws@8.17.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-
-  ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6

--- a/scripts/audit-production-dependencies.mjs
+++ b/scripts/audit-production-dependencies.mjs
@@ -8,11 +8,11 @@
  * `production-audit-decision.mjs` (pure, unit-tested); this file owns the
  * process side only.
  *
- * Two of the exceptions claim the vulnerable code is UNREACHABLE from Vex.
- * A claim like that rots the moment a transitive dependency changes its
- * imports, so each one has a verifier that reads the INSTALLED module graph
- * and fails when the claim stops holding. An exception whose package has a
- * verifier is never accepted on the rationale text alone.
+ * Every exception claims the vulnerable code is UNREACHABLE from Vex. A claim
+ * like that rots the moment a transitive dependency changes its imports or an
+ * install builds a native binding, so each one has a verifier that reads the
+ * INSTALLED module graph and fails when the claim stops holding. An exception
+ * whose package has a verifier is never accepted on the rationale text alone.
  *
  * Usage: node scripts/audit-production-dependencies.mjs [allowlist] [workspace]
  * Both arguments are resolved from the repository root and default to the root
@@ -25,6 +25,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { evaluateProductionAudit } from "./production-audit-decision.mjs";
+import { verifyBigIntBufferException } from "./verify-bigint-buffer-exception.mjs";
 import { verifyStreamJsonException } from "./verify-stream-json-exception.mjs";
 import { verifyUuidException } from "./verify-uuid-exception.mjs";
 
@@ -35,6 +36,7 @@ import { verifyUuidException } from "./verify-uuid-exception.mjs";
  * difference between "mechanically checked" and "argued" is never invisible.
  */
 const REACHABILITY_VERIFIERS = new Map([
+  ["bigint-buffer", verifyBigIntBufferException],
   ["stream-json", verifyStreamJsonException],
   ["uuid", verifyUuidException],
 ]);

--- a/scripts/audit-production-dependencies.mjs
+++ b/scripts/audit-production-dependencies.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Production dependency audit gate.
+ *
+ * Runs the pinned `pnpm audit --prod --json` for one workspace, compares every
+ * finding against that workspace's reviewed exception allowlist, and refuses on
+ * anything the allowlist does not carry verbatim. The decision itself lives in
+ * `production-audit-decision.mjs` (pure, unit-tested); this file owns the
+ * process side only.
+ *
+ * Two of the exceptions claim the vulnerable code is UNREACHABLE from Vex.
+ * A claim like that rots the moment a transitive dependency changes its
+ * imports, so each one has a verifier that reads the INSTALLED module graph
+ * and fails when the claim stops holding. An exception whose package has a
+ * verifier is never accepted on the rationale text alone.
+ *
+ * Usage: node scripts/audit-production-dependencies.mjs [allowlist] [workspace]
+ * Both arguments are resolved from the repository root and default to the root
+ * workspace.
+ */
+
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { evaluateProductionAudit } from "./production-audit-decision.mjs";
+import { verifyStreamJsonException } from "./verify-stream-json-exception.mjs";
+import { verifyUuidException } from "./verify-uuid-exception.mjs";
+
+/**
+ * Package name to reachability verifier. A package listed here MUST pass its
+ * verifier for its exception to hold; a package absent from the map is
+ * accepted on its written rationale and is named as such in the output, so the
+ * difference between "mechanically checked" and "argued" is never invisible.
+ */
+const REACHABILITY_VERIFIERS = new Map([
+  ["stream-json", verifyStreamJsonException],
+  ["uuid", verifyUuidException],
+]);
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const configPath = path.resolve(root, process.argv[2] ?? "scripts/production-audit-allowlist.json");
+const auditRoot = path.resolve(root, process.argv[3] ?? ".");
+
+let allowlist;
+try {
+  allowlist = JSON.parse(readFileSync(configPath, "utf8"));
+} catch (error) {
+  fail(`could not read the exception allowlist at ${configPath}: ${error.message}`);
+}
+
+// `corepack` is a .cmd shim on Windows, which spawnSync cannot exec by bare
+// name. Naming the shim keeps a local Windows run honest instead of failing
+// with ENOENT that reads like a broken gate.
+const corepackCommand = process.platform === "win32" ? "corepack.cmd" : "corepack";
+const audit = spawnSync(corepackCommand, ["pnpm", "audit", "--prod", "--json"], {
+  cwd: auditRoot,
+  encoding: "utf8",
+  maxBuffer: 16 * 1024 * 1024,
+});
+if (audit.error !== undefined) fail(`could not run the pinned pnpm audit: ${audit.error.message}`);
+
+let report;
+try {
+  report = JSON.parse(audit.stdout);
+} catch {
+  const detail = audit.stderr.trim().split("\n").at(-1) ?? "no registry response";
+  fail(`pnpm audit did not return valid JSON (${detail})`);
+}
+
+const decision = evaluateProductionAudit({
+  allowlist,
+  advisories: report.advisories ?? {},
+  now: new Date(),
+});
+
+for (const finding of decision.unexpected) {
+  console.error(`Unexpected production advisory: ${finding.package}@${finding.version} ${finding.url} via ${finding.path}`);
+}
+for (const finding of decision.stale) {
+  console.error(`Stale production advisory exception: ${finding.package}@${finding.version} ${finding.url}`);
+}
+if (!decision.ok) fail(decision.failures.join("; "));
+
+for (const entry of decision.exceptions) {
+  const verify = REACHABILITY_VERIFIERS.get(entry.package);
+  if (verify === undefined) continue;
+  try {
+    await verify(auditRoot);
+  } catch (error) {
+    fail(`the ${entry.package} exception no longer holds against the installed graph: ${error.message}`);
+  }
+}
+
+for (const entry of decision.exceptions) {
+  const checked = REACHABILITY_VERIFIERS.has(entry.package)
+    ? "reachability verified against the installed graph"
+    : "accepted on its written rationale, no mechanical reachability check";
+  console.warn(`Reviewed production advisory exception: ${entry.package}@${entry.version} (${entry.url}); ${checked}; review by ${decision.reviewBy}`);
+}
+console.log(`Production dependency audit passed with ${decision.exceptions.length} exact reviewed exception(s).`);
+
+function fail(message) {
+  console.error(`Production dependency audit failed: ${message}.`);
+  process.exit(1);
+}

--- a/scripts/production-audit-allowlist.json
+++ b/scripts/production-audit-allowlist.json
@@ -1,0 +1,30 @@
+{
+  "reviewBy": "2026-09-18",
+  "decision": "Every exception below was proposed by the Lighter integration author on 2026-09-06 and is pending the repository owner's decision in PR review. Nothing here is owner-approved yet.",
+  "exceptions": [
+    {
+      "url": "https://github.com/advisories/GHSA-3gc7-fjrx-p6mg",
+      "package": "bigint-buffer",
+      "severity": "high",
+      "version": "1.1.5",
+      "path": ".>@solana/spl-token>@solana/buffer-layout-utils>bigint-buffer",
+      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. Upstream has no patched release. Vex reaches this package only through fixed-width Solana SPL layouts (8 to 32 bytes); the layout slices the input to the declared span before toBigIntLE. Malformed short data is rejected by the layout. This exception rests on that argument alone, with no mechanical reachability check. Re-review immediately when Solana removes or patches bigint-buffer."
+    },
+    {
+      "url": "https://github.com/advisories/GHSA-w5hq-g745-h8pq",
+      "package": "uuid",
+      "severity": "moderate",
+      "version": "8.3.2",
+      "path": ".>@solana/web3.js>jayson>uuid",
+      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. The advisory affects uuid v3, v5, and v6 with caller-provided output buffers. Jayson imports and invokes uuid v4 only, without a caller-provided buffer. The audit verifies that binding and every call site in the installed Jayson sources and exercises the reachable entry point. Re-review when Jayson or Solana accepts uuid 11.1.1 or newer."
+    },
+    {
+      "url": "https://github.com/advisories/GHSA-528h-pc64-c93x",
+      "package": "stream-json",
+      "severity": "moderate",
+      "version": "1.9.1",
+      "path": ".>@solana/web3.js>jayson>stream-json",
+      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. The advisory affects pick/ignore/filter/replace path filters and explicitly excludes StreamValues. Jayson 4.3.0 imports only StreamValues and Verifier. The audit verifies those installed imports, rejects loaded filter modules, and exercises chunked and malformed JSON parsing. The patched 3.5.0 changes module exports and cannot replace 1.9.1 compatibly. Re-review by 2026-09-18 or when Jayson accepts a patched release or reachable imports change."
+    }
+  ]
+}

--- a/scripts/production-audit-allowlist.json
+++ b/scripts/production-audit-allowlist.json
@@ -1,6 +1,6 @@
 {
-  "reviewBy": "2026-09-18",
-  "decision": "Every exception below was proposed by the Lighter integration author on 2026-09-06 and is pending the repository owner's decision in PR review. Nothing here is owner-approved yet.",
+  "reviewBy": null,
+  "decision": "Every exception below was proposed by the Lighter integration author on 2026-09-06 and approved by the owner on 2026-09-07 without an expiry date, on the condition that its reachability verifier keeps passing; a verifier failure or a changed dependency path reopens the decision.",
   "exceptions": [
     {
       "url": "https://github.com/advisories/GHSA-3gc7-fjrx-p6mg",
@@ -8,7 +8,7 @@
       "severity": "high",
       "version": "1.1.5",
       "path": ".>@solana/spl-token>@solana/buffer-layout-utils>bigint-buffer",
-      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. Upstream has no patched release. The advisory is a buffer overflow in the NATIVE binding; Vex never builds it (package.json lists bigint-buffer under pnpm.ignoredBuiltDependencies), so the pure-JavaScript fallback runs. Vex reaches the package only through fixed-width Solana SPL layouts (8 to 32 bytes). The audit verifies the absence of a compiled binding, the install-script ban, the fixed literal widths in the installed @solana/buffer-layout-utils, and exercises the reachable converters at 8 and 32 bytes. Re-review immediately when Solana removes or patches bigint-buffer."
+      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06 and approved by the owner on 2026-09-07 with no expiry date; the standing condition is the reachability verifier registered for this package, which fails the audit the moment the vulnerable path becomes reachable. Re-review when the dependency path or the advisory changes. Upstream has no patched release. The advisory is a buffer overflow in the NATIVE binding; Vex never builds it (package.json lists bigint-buffer under pnpm.ignoredBuiltDependencies), so the pure-JavaScript fallback runs. Vex reaches the package only through fixed-width Solana SPL layouts (8 to 32 bytes). The audit verifies the absence of a compiled binding, the install-script ban, the fixed literal widths in the installed @solana/buffer-layout-utils, and exercises the reachable converters at 8 and 32 bytes. Re-review immediately when Solana removes or patches bigint-buffer."
     },
     {
       "url": "https://github.com/advisories/GHSA-w5hq-g745-h8pq",
@@ -16,7 +16,7 @@
       "severity": "moderate",
       "version": "8.3.2",
       "path": ".>@solana/web3.js>jayson>uuid",
-      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. The advisory affects uuid v3, v5, and v6 with caller-provided output buffers. Jayson imports and invokes uuid v4 only, without a caller-provided buffer. The audit verifies that binding and every call site in the installed Jayson sources and exercises the reachable entry point. Re-review when Jayson or Solana accepts uuid 11.1.1 or newer."
+      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06 and approved by the owner on 2026-09-07 with no expiry date; the standing condition is the reachability verifier registered for this package, which fails the audit the moment the vulnerable path becomes reachable. Re-review when the dependency path or the advisory changes. The advisory affects uuid v3, v5, and v6 with caller-provided output buffers. Jayson imports and invokes uuid v4 only, without a caller-provided buffer. The audit verifies that binding and every call site in the installed Jayson sources and exercises the reachable entry point. Re-review when Jayson or Solana accepts uuid 11.1.1 or newer."
     },
     {
       "url": "https://github.com/advisories/GHSA-528h-pc64-c93x",
@@ -24,7 +24,7 @@
       "severity": "moderate",
       "version": "1.9.1",
       "path": ".>@solana/web3.js>jayson>stream-json",
-      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. The advisory affects pick/ignore/filter/replace path filters and explicitly excludes StreamValues. Jayson 4.3.0 imports only StreamValues and Verifier. The audit verifies those installed imports, rejects loaded filter modules, and exercises chunked and malformed JSON parsing. The patched 3.5.0 changes module exports and cannot replace 1.9.1 compatibly. Re-review by 2026-09-18 or when Jayson accepts a patched release or reachable imports change."
+      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06 and approved by the owner on 2026-09-07 with no expiry date; the standing condition is the reachability verifier registered for this package, which fails the audit the moment the vulnerable path becomes reachable. Re-review when the dependency path or the advisory changes. The advisory affects pick/ignore/filter/replace path filters and explicitly excludes StreamValues. Jayson 4.3.0 imports only StreamValues and Verifier. The audit verifies those installed imports, rejects loaded filter modules, and exercises chunked and malformed JSON parsing. The patched 3.5.0 changes module exports and cannot replace 1.9.1 compatibly. Re-review when Jayson accepts a patched release or reachable imports change."
     }
   ]
 }

--- a/scripts/production-audit-allowlist.json
+++ b/scripts/production-audit-allowlist.json
@@ -8,7 +8,7 @@
       "severity": "high",
       "version": "1.1.5",
       "path": ".>@solana/spl-token>@solana/buffer-layout-utils>bigint-buffer",
-      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. Upstream has no patched release. Vex reaches this package only through fixed-width Solana SPL layouts (8 to 32 bytes); the layout slices the input to the declared span before toBigIntLE. Malformed short data is rejected by the layout. This exception rests on that argument alone, with no mechanical reachability check. Re-review immediately when Solana removes or patches bigint-buffer."
+      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. Upstream has no patched release. The advisory is a buffer overflow in the NATIVE binding; Vex never builds it (package.json lists bigint-buffer under pnpm.ignoredBuiltDependencies), so the pure-JavaScript fallback runs. Vex reaches the package only through fixed-width Solana SPL layouts (8 to 32 bytes). The audit verifies the absence of a compiled binding, the install-script ban, the fixed literal widths in the installed @solana/buffer-layout-utils, and exercises the reachable converters at 8 and 32 bytes. Re-review immediately when Solana removes or patches bigint-buffer."
     },
     {
       "url": "https://github.com/advisories/GHSA-w5hq-g745-h8pq",

--- a/scripts/production-audit-decision.mjs
+++ b/scripts/production-audit-decision.mjs
@@ -17,9 +17,10 @@
  *   - an allowlisted exception the audit no longer reports fails the gate
  *     too, so exceptions cannot outlive the finding that justified them.
  *
- * `reviewBy` is a hard expiry, not a reminder: once the date passes, the gate
- * refuses regardless of the findings. An exception that nobody renewed is not
- * an exception.
+ * `reviewBy`, when set, is a hard expiry, not a reminder: once the date passes
+ * the gate refuses regardless of the findings. `reviewBy: null` means no
+ * calendar expiry (the owner's decision of 2026-09-07 for the three reviewed
+ * exceptions); the reachability verifiers are then the only standing guard.
  */
 
 /** Fields that identify a finding. Order matters only for error messages. */
@@ -53,13 +54,20 @@ export function evaluateProductionAudit({ allowlist, advisories, now }) {
     return refuse(failures, "the dependency-audit allowlist is not an object");
   }
 
-  const reviewBy = typeof allowlist.reviewBy === "string" ? allowlist.reviewBy : null;
-  const deadline = reviewBy === null ? Number.NaN : Date.parse(`${reviewBy}T00:00:00.000Z`);
-  if (!Number.isFinite(deadline)) {
-    return refuse(failures, `the dependency-audit allowlist has an invalid reviewBy (${String(allowlist.reviewBy)})`);
-  }
-  if (now.getTime() >= deadline) {
-    failures.push(`dependency-audit exceptions expired for mandatory review on ${reviewBy}`);
+  // `reviewBy: null` means the exceptions carry no calendar expiry (owner
+  // decision 2026-09-07): the standing condition is each exception's
+  // reachability verifier, which fails the audit the moment the vulnerable
+  // path becomes reachable. A string is still a hard expiry; anything else is
+  // refused rather than read as "no deadline".
+  const reviewBy = allowlist.reviewBy === null ? null : allowlist.reviewBy;
+  if (reviewBy !== null) {
+    const deadline = typeof reviewBy === "string" ? Date.parse(`${reviewBy}T00:00:00.000Z`) : Number.NaN;
+    if (!Number.isFinite(deadline)) {
+      return refuse(failures, `the dependency-audit allowlist has an invalid reviewBy (${String(allowlist.reviewBy)})`);
+    }
+    if (now.getTime() >= deadline) {
+      failures.push(`dependency-audit exceptions expired for mandatory review on ${reviewBy}`);
+    }
   }
 
   if (!Array.isArray(allowlist.exceptions)) {

--- a/scripts/production-audit-decision.mjs
+++ b/scripts/production-audit-decision.mjs
@@ -1,0 +1,153 @@
+/**
+ * The pure decision half of the production dependency audit.
+ *
+ * The runner (`audit-production-dependencies.mjs`) owns the process side:
+ * spawning the pinned `pnpm audit`, reading the allowlist file, running the
+ * reachability verifiers and choosing an exit code. Everything that decides
+ * whether a tree PASSES lives here, takes plain data and returns plain data,
+ * so the gate's own rules are testable without a registry, a lockfile or a
+ * child process.
+ *
+ * The decision is deliberately EXACT-MATCH in both directions:
+ *
+ *   - an advisory finding the allowlist does not carry verbatim (same URL,
+ *     package, severity, version and dependency path) fails the gate, so a
+ *     new advisory, a bumped version or a new reachability path cannot be
+ *     absorbed by a stale exception;
+ *   - an allowlisted exception the audit no longer reports fails the gate
+ *     too, so exceptions cannot outlive the finding that justified them.
+ *
+ * `reviewBy` is a hard expiry, not a reminder: once the date passes, the gate
+ * refuses regardless of the findings. An exception that nobody renewed is not
+ * an exception.
+ */
+
+/** Fields that identify a finding. Order matters only for error messages. */
+const IDENTITY_FIELDS = ["url", "package", "severity", "version", "path"];
+
+/**
+ * @typedef {{ url: string, package: string, severity: string, version: string, path: string }} Finding
+ * @typedef {{ readonly reason: string }} Failure
+ */
+
+/**
+ * Decides whether the audit output is acceptable under the allowlist.
+ *
+ * Pure: no I/O, no clock, no exit. `now` is supplied by the caller so expiry
+ * is testable, and `advisories` is the `advisories` object of pnpm's
+ * `audit --json` report exactly as parsed.
+ *
+ * @param {{ allowlist: unknown, advisories: unknown, now: Date }} input
+ * @returns {{
+ *   ok: boolean,
+ *   failures: readonly string[],
+ *   unexpected: readonly Finding[],
+ *   stale: readonly Finding[],
+ *   exceptions: readonly Finding[],
+ *   reviewBy: string | null,
+ * }}
+ */
+export function evaluateProductionAudit({ allowlist, advisories, now }) {
+  const failures = [];
+  if (allowlist === null || typeof allowlist !== "object") {
+    return refuse(failures, "the dependency-audit allowlist is not an object");
+  }
+
+  const reviewBy = typeof allowlist.reviewBy === "string" ? allowlist.reviewBy : null;
+  const deadline = reviewBy === null ? Number.NaN : Date.parse(`${reviewBy}T00:00:00.000Z`);
+  if (!Number.isFinite(deadline)) {
+    return refuse(failures, `the dependency-audit allowlist has an invalid reviewBy (${String(allowlist.reviewBy)})`);
+  }
+  if (now.getTime() >= deadline) {
+    failures.push(`dependency-audit exceptions expired for mandatory review on ${reviewBy}`);
+  }
+
+  if (!Array.isArray(allowlist.exceptions)) {
+    return refuse(failures, "the dependency-audit allowlist has no exceptions array", { reviewBy });
+  }
+
+  const exceptions = [];
+  for (const [index, entry] of allowlist.exceptions.entries()) {
+    const identity = identify(entry);
+    if (identity === null) {
+      failures.push(`dependency-audit exception ${index} is missing a valid ${missingField(entry)}`);
+      continue;
+    }
+    exceptions.push(identity);
+  }
+
+  const actual = [];
+  for (const advisory of Object.values(asRecord(advisories))) {
+    for (const finding of asArray(asRecord(advisory).findings)) {
+      for (const dependencyPath of asArray(asRecord(finding).paths)) {
+        const identity = identify({
+          url: asRecord(advisory).url,
+          package: asRecord(advisory).module_name,
+          severity: asRecord(advisory).severity,
+          version: asRecord(finding).version,
+          path: dependencyPath,
+        });
+        if (identity === null) {
+          failures.push("pnpm audit reported a finding without a complete identity; the report shape changed");
+          continue;
+        }
+        actual.push(identity);
+      }
+    }
+  }
+
+  const unexpected = actual.filter((finding) => !exceptions.some((entry) => sameFinding(entry, finding)));
+  const stale = exceptions.filter((entry) => !actual.some((finding) => sameFinding(entry, finding)));
+  if (unexpected.length > 0) {
+    failures.push("production dependency audit found advisories outside the reviewed exception list");
+  }
+  if (stale.length > 0) {
+    failures.push("remove or update stale dependency-audit exceptions after lockfile changes");
+  }
+
+  return { ok: failures.length === 0, failures, unexpected, stale, exceptions, reviewBy };
+}
+
+function refuse(failures, reason, extra = {}) {
+  failures.push(reason);
+  return {
+    ok: false,
+    failures,
+    unexpected: [],
+    stale: [],
+    exceptions: [],
+    reviewBy: null,
+    ...extra,
+  };
+}
+
+function identify(entry) {
+  const record = asRecord(entry);
+  for (const field of IDENTITY_FIELDS) {
+    if (typeof record[field] !== "string" || record[field].length === 0) return null;
+  }
+  return {
+    url: record.url,
+    package: record.package,
+    severity: record.severity,
+    version: record.version,
+    path: record.path,
+  };
+}
+
+function missingField(entry) {
+  const record = asRecord(entry);
+  return IDENTITY_FIELDS.find((field) => typeof record[field] !== "string" || record[field].length === 0) ?? "field";
+}
+
+function sameFinding(left, right) {
+  return IDENTITY_FIELDS.every((field) => left[field] === right[field]);
+}
+
+function asRecord(value) {
+  return value !== null && typeof value === "object" ? value : {};
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}

--- a/scripts/production-audit.md
+++ b/scripts/production-audit.md
@@ -13,11 +13,12 @@ Files:
 - `scripts/production-audit-decision.mjs` - the pure decision. Exact match in
   both directions (an unlisted finding fails, and a listed exception the audit
   no longer reports fails), plus the hard `reviewBy` expiry.
-- `scripts/verify-stream-json-exception.mjs`,
+- `scripts/verify-bigint-buffer-exception.mjs`,
+  `scripts/verify-stream-json-exception.mjs`,
   `scripts/verify-uuid-exception.mjs` - reachability verifiers. An exception
   whose package has a verifier is never accepted on its rationale text alone:
   the verifier reads the INSTALLED module graph and fails when the claim stops
-  holding.
+  holding. Every current exception has one.
 - `scripts/production-audit-allowlist.json` (root),
   `vex-app/scripts/production-audit-allowlist.json` (desktop).
 
@@ -31,7 +32,7 @@ inattention.
 
 | Package | Version | Advisory | Workspaces | Why it is tolerated | Removal condition |
 | --- | --- | --- | --- | --- | --- |
-| bigint-buffer | 1.1.5 | GHSA-3gc7-fjrx-p6mg (high) | root | No patched release upstream. Reached only through fixed-width Solana SPL layouts (8 to 32 bytes), which slice input to the declared span before `toBigIntLE` and reject short data. Argued only: no mechanical reachability check. | Solana removes or patches bigint-buffer. |
+| bigint-buffer | 1.1.5 | GHSA-3gc7-fjrx-p6mg (high) | root | No patched release upstream. The overflow is in the NATIVE binding, which is never built here (`pnpm.ignoredBuiltDependencies`), so the pure-JavaScript fallback runs. Reached only through fixed-width Solana SPL layouts (8 to 32 bytes). Verified mechanically: no compiled `.node` artifact, the install-script ban still in `package.json`, literal widths in the installed `@solana/buffer-layout-utils`, and a real 8 and 32 byte round trip. | Solana removes or patches bigint-buffer. |
 | uuid | 8.3.2 | GHSA-w5hq-g745-h8pq (moderate) | root, vex-app | The advisory covers v3, v5 and v6 with a caller-provided output buffer. Jayson binds `require("uuid").v4` and calls it with no arguments. Verified mechanically. | Jayson or Solana accepts uuid 11.1.1 or newer. |
 | stream-json | 1.9.1 | GHSA-528h-pc64-c93x (moderate) | root, vex-app | The advisory covers the pick/ignore/filter/replace path filters and excludes StreamValues. Jayson 4.3.0 imports StreamValues and Verifier only. Verified mechanically, including that no filter module is loaded. 3.5.0 changes module exports and is not a compatible replacement. | Jayson accepts a patched release, or its reachable imports change. |
 
@@ -81,7 +82,10 @@ intended: a fixable advisory is fixed, never excused.
 
 `pnpm.onlyBuiltDependencies` and `pnpm.ignoredBuiltDependencies` record which
 packages may run install scripts. Nothing is added to `onlyBuiltDependencies`
-without a reason to execute code from that package at install time. Note that
+without a reason to execute code from that package at install time. The
+`bigint-buffer` entry in `ignoredBuiltDependencies` is load-bearing: it is what
+keeps the vulnerable native binding unbuilt, so the reachability verifier fails
+the gate if that entry disappears. Note that
 under pnpm 10.32.1 the desktop install still prints its "Ignored build scripts"
 notice for `bufferutil`, `cpu-features`, `protobufjs`, `ssh2` and
 `utf-8-validate`; listing those packages in `ignoredBuiltDependencies` was
@@ -94,7 +98,7 @@ script runs either way.
    An exception is the last resort, not the first.
 2. If it must stay, write the rationale as a reachability argument about THIS
    repository's code path, and say plainly who decided and when.
-3. If the claim is mechanical, add a verifier next to the existing two and
+3. If the claim is mechanical, add a verifier next to the existing three and
    register it in `REACHABILITY_VERIFIERS`. A claim nobody can check is worth
    less than a red gate.
 4. Move `reviewBy` only with a stated reason. It is the gate's only automatic

--- a/scripts/production-audit.md
+++ b/scripts/production-audit.md
@@ -1,0 +1,101 @@
+# Production dependency audit
+
+`pnpm run audit:deps` refuses any advisory in a workspace's PRODUCTION
+dependency graph that its reviewed exception allowlist does not carry verbatim.
+CI runs it once per lockfile: the root workspace in `root-build-and-test`, the
+desktop workspace in `vex-app-build-and-test`.
+
+Files:
+
+- `scripts/audit-production-dependencies.mjs` - the runner: spawns the pinned
+  `pnpm audit --prod --json`, loads the allowlist, runs the reachability
+  verifiers, chooses the exit code.
+- `scripts/production-audit-decision.mjs` - the pure decision. Exact match in
+  both directions (an unlisted finding fails, and a listed exception the audit
+  no longer reports fails), plus the hard `reviewBy` expiry.
+- `scripts/verify-stream-json-exception.mjs`,
+  `scripts/verify-uuid-exception.mjs` - reachability verifiers. An exception
+  whose package has a verifier is never accepted on its rationale text alone:
+  the verifier reads the INSTALLED module graph and fails when the claim stops
+  holding.
+- `scripts/production-audit-allowlist.json` (root),
+  `vex-app/scripts/production-audit-allowlist.json` (desktop).
+
+## Current exceptions
+
+Every exception below was proposed by the Lighter integration author on
+2026-09-06 and is PENDING the repository owner's decision in PR review. None of
+them is owner-approved. All expire on 2026-09-18: after that date the gate
+fails regardless of the findings, so an unrenewed exception cannot survive by
+inattention.
+
+| Package | Version | Advisory | Workspaces | Why it is tolerated | Removal condition |
+| --- | --- | --- | --- | --- | --- |
+| bigint-buffer | 1.1.5 | GHSA-3gc7-fjrx-p6mg (high) | root | No patched release upstream. Reached only through fixed-width Solana SPL layouts (8 to 32 bytes), which slice input to the declared span before `toBigIntLE` and reject short data. Argued only: no mechanical reachability check. | Solana removes or patches bigint-buffer. |
+| uuid | 8.3.2 | GHSA-w5hq-g745-h8pq (moderate) | root, vex-app | The advisory covers v3, v5 and v6 with a caller-provided output buffer. Jayson binds `require("uuid").v4` and calls it with no arguments. Verified mechanically. | Jayson or Solana accepts uuid 11.1.1 or newer. |
+| stream-json | 1.9.1 | GHSA-528h-pc64-c93x (moderate) | root, vex-app | The advisory covers the pick/ignore/filter/replace path filters and excludes StreamValues. Jayson 4.3.0 imports StreamValues and Verifier only. Verified mechanically, including that no filter module is loaded. 3.5.0 changes module exports and is not a compatible replacement. | Jayson accepts a patched release, or its reachable imports change. |
+
+## Overrides and bumps
+
+Every row below was MEASURED on 2026-09-07 by installing the pre-change
+lockfile (`c01f1a4eb`) with `--frozen-lockfile` and running
+`pnpm audit --prod --json` in each workspace. "Advisory cleared" is what that
+run reported at the old version; it is evidence, not intent. Removal condition
+is what makes the pin unnecessary.
+
+Root workspace (`package.json`), advisories cleared: axios, follow-redirects,
+form-data, ip-address, socket.io-parser, uuid 11.1.0, and three ws paths.
+
+| Override | Was | Pin | Advisory cleared | Removal condition |
+| --- | --- | --- | --- | --- |
+| `axios` | 1.14.0 | 1.18.0 | high, moderate and low on `.>@tavily/core>axios` | @tavily/core's axios range floors at 1.18.0. |
+| `follow-redirects` | 1.15.11 | 1.16.0 | moderate on `.>@tavily/core>axios>follow-redirects` | axios floors its follow-redirects range at 1.16.0. |
+| `form-data` | 4.0.5 | 4.0.6 | high on `.>@tavily/core>axios>form-data` | axios floors its form-data range at 4.0.6. |
+| `ip-address` | 10.2.0 | 10.3.1 | high and moderate on `.>rettiwt-api>socks-proxy-agent>socks>ip-address` | socks floors its ip-address range at 10.3.1. |
+| `socket.io-parser` | 4.2.6 | 4.2.7 | high on `.>socket.io-client>socket.io-parser` | socket.io-client floors its parser range at 4.2.7. |
+| `uuid@>=11.0.0 <12` | 11.1.0 | 11.1.1 | moderate on `.>@solana/web3.js>rpc-websockets>uuid` | rpc-websockets floors its uuid range at 11.1.1. Scoped to the 11.x range on purpose so Jayson's uuid 8 (see the allowlist) is not swapped for an incompatible major. |
+| `jayson>ws` | 7.5.10 | 7.5.11 | high on `.>@solana/web3.js>jayson>ws` | Jayson floors its ws range at 7.5.11. |
+| `ethers>ws` | 8.17.1 | 8.21.0 | high and moderate on `.>ethers>ws` | ethers floors its ws range above 8.18.3. |
+| `engine.io-client>ws` | 8.18.3 | 8.21.0 | high and moderate on `.>socket.io-client>engine.io-client>ws` | engine.io-client floors its ws range above 8.18.3. |
+| `rpc-websockets>ws` | 8.20.1 in the desktop graph, not reported in the root graph | 8.21.0 | Nothing in the root workspace: preventive, and it keeps both lockfiles on one ws line. | rpc-websockets floors its ws range at 8.21.0. |
+
+Desktop workspace (`vex-app/package.json`):
+
+| Override | Was | Pin | Advisory cleared | Removal condition |
+| --- | --- | --- | --- | --- |
+| `electron-updater>js-yaml` | 4.1.1 | 4.3.1 | high and moderate on `.>electron-updater>js-yaml`. This parser reads release metadata on the update-integrity path. | electron-updater floors its js-yaml range at 4.3.1. |
+| `jayson>ws` | 7.5.10 | 7.5.13 | high on `.>@solana/web3.js>jayson>ws` | Jayson floors its ws range at 7.5.13. |
+| `rpc-websockets>ws` | 8.20.1 | 8.21.3 | high on `.>@solana/web3.js>rpc-websockets>ws` | rpc-websockets floors its ws range at 8.21.3. |
+
+Three direct dependencies were BUMPED rather than overridden or allowlisted,
+because upstream already ships the fix:
+
+| Dependency | Workspace | Was | Now | Advisory cleared |
+| --- | --- | --- | --- | --- |
+| `undici` | root | 7.25.0 | 7.29.0 | high, moderate and low on `.>undici` |
+| `@sentry/electron` | vex-app | ~7.13.0 | ~7.16.0 | high and moderate `brace-expansion` and two moderate `@opentelemetry/core` findings under `@sentry/node` |
+| `electron-updater` | vex-app | ~6.8.3 | ~6.8.9 | high on `.>electron-updater>builder-util-runtime` |
+
+Without those three bumps the desktop gate fails, which is the gate working as
+intended: a fixable advisory is fixed, never excused.
+
+`pnpm.onlyBuiltDependencies` and `pnpm.ignoredBuiltDependencies` record which
+packages may run install scripts. Nothing is added to `onlyBuiltDependencies`
+without a reason to execute code from that package at install time. Note that
+under pnpm 10.32.1 the desktop install still prints its "Ignored build scripts"
+notice for `bufferutil`, `cpu-features`, `protobufjs`, `ssh2` and
+`utf-8-validate`; listing those packages in `ignoredBuiltDependencies` was
+measured and does not silence it. The notice is informational, and no build
+script runs either way.
+
+## Changing an exception
+
+1. Try to remove it first: bump the direct dependency, or add an override.
+   An exception is the last resort, not the first.
+2. If it must stay, write the rationale as a reachability argument about THIS
+   repository's code path, and say plainly who decided and when.
+3. If the claim is mechanical, add a verifier next to the existing two and
+   register it in `REACHABILITY_VERIFIERS`. A claim nobody can check is worth
+   less than a red gate.
+4. Move `reviewBy` only with a stated reason. It is the gate's only automatic
+   expiry.

--- a/scripts/production-audit.md
+++ b/scripts/production-audit.md
@@ -25,10 +25,12 @@ Files:
 ## Current exceptions
 
 Every exception below was proposed by the Lighter integration author on
-2026-09-06 and is PENDING the repository owner's decision in PR review. None of
-them is owner-approved. All expire on 2026-09-18: after that date the gate
-fails regardless of the findings, so an unrenewed exception cannot survive by
-inattention.
+2026-09-06 and approved by the repository owner on 2026-09-07 with no expiry
+date. The standing condition is mechanical, not calendar-based: each exception
+has a reachability verifier that fails the audit the moment the vulnerable path
+becomes reachable, and a changed dependency path or a changed advisory reopens
+the decision. `reviewBy` is therefore `null` in both allowlists; setting a date
+turns the calendar expiry back on.
 
 | Package | Version | Advisory | Workspaces | Why it is tolerated | Removal condition |
 | --- | --- | --- | --- | --- | --- |
@@ -101,5 +103,5 @@ script runs either way.
 3. If the claim is mechanical, add a verifier next to the existing three and
    register it in `REACHABILITY_VERIFIERS`. A claim nobody can check is worth
    less than a red gate.
-4. Move `reviewBy` only with a stated reason. It is the gate's only automatic
-   expiry.
+4. `reviewBy` is `null` by the owner's decision (no calendar expiry); set a
+   date only with a stated reason, and it becomes a hard expiry again.

--- a/scripts/verify-bigint-buffer-exception.mjs
+++ b/scripts/verify-bigint-buffer-exception.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+// GHSA-3gc7-fjrx-p6mg is a buffer overflow in bigint-buffer's NATIVE binding:
+// `toBigIntLE` hands the caller's buffer to the N-API converter, which reads
+// past it. The exception rests on three claims, and this verifier refuses to
+// take any of them on trust:
+//
+//   1. the native binding is ABSENT from the installed package, so the loader
+//      falls back to the pure-JavaScript implementation that has no overflow;
+//   2. `pnpm.ignoredBuiltDependencies` still names bigint-buffer, so a future
+//      install cannot silently compile the binding back in;
+//   3. the only path from Vex into the package, @solana/buffer-layout-utils,
+//      applies its layout factories at FIXED literal widths of 8 to 32 bytes.
+//
+// All three are read from the INSTALLED tree, then the reachable converters are
+// exercised for real at both ends of that width range, so a Solana bump or a
+// package.json edit that reopens the native path turns the gate red instead of
+// silently widening the exception.
+
+/** The four converters bigint-buffer exposes; the advisory is about the first. */
+const CONVERTERS = ["toBigIntLE", "toBigIntBE", "toBufferLE", "toBufferBE"];
+
+/** Widths the reviewed SPL layouts use. Anything outside is unreviewed. */
+const MINIMUM_WIDTH = 8;
+const MAXIMUM_WIDTH = 32;
+
+/** The documented pure-JavaScript fallback notice from bigint-buffer's loader. */
+const FALLBACK_NOTICE = /Failed to load bindings, pure JS will be used/;
+
+export async function verifyBigIntBufferException(projectRoot) {
+  const projectRequire = createRequire(path.join(projectRoot, "package.json"));
+  const splRequire = createRequire(projectRequire.resolve("@solana/spl-token"));
+  const layoutEntry = splRequire.resolve("@solana/buffer-layout-utils");
+  const layoutRequire = createRequire(layoutEntry);
+  const bigintEntry = layoutRequire.resolve("bigint-buffer");
+  const bigintRoot = packageRootOf(bigintEntry, "bigint-buffer");
+  const layoutRoot = packageRootOf(layoutEntry, "@solana/buffer-layout-utils");
+
+  // Claim 1a: no compiled artifact anywhere in the installed package. The
+  // `bindings` loader only searches inside the package's own directory
+  // (build/Release, out/Debug, prebuilds and siblings), so an empty result here
+  // means there is nothing for it to find. Checked BEFORE the module is loaded,
+  // so a present artifact is reported rather than executed.
+  const artifacts = filesUnder(bigintRoot).filter((file) => file.endsWith(".node"));
+  assert.deepEqual(artifacts, [],
+    `The bigint-buffer native binding is built at ${artifacts.join(", ")}; the advisory's overflow is reachable`);
+
+  // Claim 2: the install-script ban that keeps claim 1a true across installs.
+  const manifest = JSON.parse(readFileSync(path.join(projectRoot, "package.json"), "utf8"));
+  const ignoredBuilds = manifest.pnpm?.ignoredBuiltDependencies ?? [];
+  assert(ignoredBuilds.includes("bigint-buffer"),
+    "package.json no longer lists bigint-buffer under pnpm.ignoredBuiltDependencies; a future install could build the vulnerable binding");
+  const allowedBuilds = manifest.pnpm?.onlyBuiltDependencies ?? [];
+  assert(!allowedBuilds.includes("bigint-buffer"),
+    "package.json permits bigint-buffer install scripts through pnpm.onlyBuiltDependencies; the native binding would be built");
+
+  // Claim 3: every layout factory application in the installed
+  // @solana/buffer-layout-utils fixes its width to a literal in the reviewed
+  // range, so the buffer handed to toBigIntLE is never caller-sized.
+  const importingModules = new Set();
+  const widths = [];
+  const FACTORY_CALL = /(?:\(\s*0\s*,\s*[\w$]+\.(bigInt|bigIntBE)\s*\)|(?<![\w$.])(bigInt|bigIntBE))\s*\(\s*([^)]*?)\s*\)/g;
+  for (const file of filesUnder(path.join(layoutRoot, "lib"))) {
+    if (!file.endsWith(".js") && !file.endsWith(".mjs")) continue;
+    const source = readFileSync(file, "utf8");
+    if (/["']bigint-buffer["']/.test(source)) {
+      const base = path.basename(file).replace(/\.m?js$/, "");
+      assert.equal(base, "bigint",
+        `An unreviewed @solana/buffer-layout-utils module imports bigint-buffer: ${file}`);
+      for (const member of convertersReachedFrom(source)) {
+        assert(CONVERTERS.includes(member),
+          `Unreviewed bigint-buffer member reached from ${file}: ${member}`);
+      }
+      importingModules.add(base);
+    }
+    for (const match of source.matchAll(FACTORY_CALL)) {
+      const argument = match[3];
+      assert.match(argument, /^\d+$/,
+        `@solana/buffer-layout-utils applies a bigint layout at a non-literal width in ${file}: ${match[0].trim()}`);
+      const width = Number(argument);
+      assert(width >= MINIMUM_WIDTH && width <= MAXIMUM_WIDTH,
+        `@solana/buffer-layout-utils applies a bigint layout at ${width} bytes in ${file}, outside the reviewed ${MINIMUM_WIDTH} to ${MAXIMUM_WIDTH} byte range`);
+      widths.push(width);
+    }
+  }
+  assert(importingModules.has("bigint"),
+    "The installed @solana/buffer-layout-utils no longer imports bigint-buffer; remove the exception");
+  assert(widths.length > 0,
+    "No fixed-width bigint layout was found in the installed @solana/buffer-layout-utils; reassess the exception");
+
+  // Claim 1b: the loader itself reports the fallback. The module is required
+  // fresh so its one-time notice is observed rather than served from cache,
+  // which is the loader's own evidence that `converter` stayed undefined.
+  delete layoutRequire.cache[bigintEntry];
+  const notices = [];
+  const originalWarn = console.warn;
+  let bigintBuffer;
+  try {
+    console.warn = (...args) => { notices.push(args.map(String).join(" ")); };
+    bigintBuffer = layoutRequire(bigintEntry);
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert(notices.some((notice) => FALLBACK_NOTICE.test(notice)),
+    `The installed bigint-buffer did not report its pure-JavaScript fallback (${notices.join(" | ") || "no notice"}); the native binding may be in use`);
+  for (const name of CONVERTERS) {
+    assert.equal(typeof bigintBuffer[name], "function",
+      `The installed bigint-buffer does not export ${name}; reassess the exception`);
+  }
+
+  // The reachable converters, exercised for real at both ends of the reviewed
+  // width range. A round trip proves the pure-JavaScript path computes, not
+  // merely that it loaded.
+  for (const [width, value] of [
+    [MINIMUM_WIDTH, 0xfedc_ba98_7654_3210n],
+    [MAXIMUM_WIDTH, (1n << 255n) + 0x0123_4567_89ab_cdefn],
+  ]) {
+    const encoded = bigintBuffer.toBufferLE(value, width);
+    assert.equal(encoded.length, width,
+      `bigint-buffer returned ${encoded.length} bytes for a ${width} byte layout`);
+    assert.equal(bigintBuffer.toBigIntLE(encoded), value,
+      `bigint-buffer did not round trip a ${width} byte value`);
+  }
+  assert.equal(bigintBuffer.toBufferLE(1n, MINIMUM_WIDTH)[0], 1,
+    "bigint-buffer did not encode little-endian");
+  assert.equal(bigintBuffer.toBigIntLE(Buffer.alloc(MAXIMUM_WIDTH)), 0n,
+    "bigint-buffer did not decode a zeroed 32 byte layout as zero");
+}
+
+/**
+ * The bigint-buffer members `source` can reach, for both module forms the
+ * package ships: the CommonJS namespace binding produced by the TypeScript
+ * emitter, and the ECMAScript named import list. A form neither pattern
+ * recognises yields the whole specifier line, which then fails the caller's
+ * allowlist rather than passing unread.
+ */
+function convertersReachedFrom(source) {
+  const members = new Set();
+  const cjsBinding = /(?:const|let|var)\s+([\w$]+)\s*=\s*require\(\s*["']bigint-buffer["']\s*\)/.exec(source);
+  if (cjsBinding !== null) {
+    for (const match of source.matchAll(new RegExp(`(?<![\\w$])${cjsBinding[1]}\\.([\\w$]+)`, "g"))) {
+      members.add(match[1]);
+    }
+    return members;
+  }
+  const esmImport = /import\s*\{([^}]*)\}\s*from\s*["']bigint-buffer["']/.exec(source);
+  if (esmImport !== null) {
+    for (const specifier of esmImport[1].split(",")) {
+      const name = specifier.trim().split(/\s+as\s+/)[0].trim();
+      if (name.length > 0) members.add(name);
+    }
+    return members;
+  }
+  const line = source.split("\n").find((candidate) => /["']bigint-buffer["']/.test(candidate)) ?? "";
+  members.add(`unreviewed import form: ${line.trim()}`);
+  return members;
+}
+
+/** The directory of the installed package `name` that owns `entry`. */
+function packageRootOf(entry, name) {
+  let directory = path.dirname(entry);
+  for (;;) {
+    const manifest = path.join(directory, "package.json");
+    if (existsSync(manifest) && JSON.parse(readFileSync(manifest, "utf8")).name === name) return directory;
+    const parent = path.dirname(directory);
+    assert.notEqual(parent, directory, `Could not locate the installed ${name} package root from ${entry}`);
+    directory = parent;
+  }
+}
+
+/** Every file under `directory`, recursively; an absent directory yields none. */
+function filesUnder(directory) {
+  if (!existsSync(directory)) return [];
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const file = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...filesUnder(file));
+    else files.push(file);
+  }
+  return files;
+}

--- a/scripts/verify-stream-json-exception.mjs
+++ b/scripts/verify-stream-json-exception.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+
+// GHSA-528h-pc64-c93x explicitly excludes StreamValues. Keep the exception
+// conditional on Jayson's installed import graph and its actual parser working.
+export async function verifyStreamJsonException(projectRoot) {
+  const projectRequire = createRequire(path.join(projectRoot, "package.json"));
+  const solanaRequire = createRequire(projectRequire.resolve("@solana/web3.js"));
+  const jaysonEntry = solanaRequire.resolve("jayson");
+  const jaysonRequire = createRequire(jaysonEntry);
+  const allowed = new Set(["stream-json/streamers/StreamValues", "stream-json/utils/Verifier"]);
+  const seen = new Set();
+  function inspect(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const file = path.join(directory, entry.name);
+      if (entry.isDirectory()) inspect(file);
+      else if (entry.name.endsWith(".js")) {
+        for (const match of readFileSync(file, "utf8").matchAll(/["'](stream-json[^"']*)["']/g)) {
+          assert(allowed.has(match[1]), `Unreviewed stream-json import in ${file}: ${match[1]}`);
+          seen.add(match[1]);
+        }
+      }
+    }
+  }
+  inspect(path.join(path.dirname(jaysonEntry), "lib"));
+  assert.deepEqual(seen, allowed, "The reviewed Jayson imports changed; reassess the exception");
+  const utils = jaysonRequire("./lib/utils");
+  const parse = (chunks) => new Promise((resolve, reject) => {
+    const stream = new PassThrough();
+    const timeout = setTimeout(() => reject(new Error("Jayson parser did not settle")), 2_000);
+    utils.parseStream(stream, {}, (error, value) => {
+      clearTimeout(timeout);
+      if (error) reject(error);
+      else resolve(value);
+    });
+    for (const chunk of chunks) stream.write(chunk);
+    stream.end();
+  });
+  assert.deepEqual(await parse(['{"jsonrpc":"2.0","result":', '{"value":42},"id":1}']), {
+    jsonrpc: "2.0", result: { value: 42 }, id: 1,
+  });
+  await assert.rejects(parse(['{"result":]']));
+  const loaded = Object.keys(jaysonRequire.cache).filter((file) => file.includes(`${path.sep}stream-json${path.sep}`));
+  assert(loaded.length > 0, "The installed stream-json graph was not inspected");
+  assert(loaded.every((file) => !file.includes(`${path.sep}filters${path.sep}`)),
+    "The vulnerable stream-json filters are reachable; remove the exception");
+}

--- a/scripts/verify-uuid-exception.mjs
+++ b/scripts/verify-uuid-exception.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+// GHSA-w5hq-g745-h8pq is a weak-randomness defect in uuid's v3, v5 and v6
+// generators when the CALLER supplies an output buffer. Jayson's exception
+// rests on two claims, and this verifier refuses to take either on trust:
+//
+//   1. the installed Jayson binds `require('uuid').v4` only, never v3, v5 or
+//      v6, and never the module namespace it could reach them through;
+//   2. every call site invokes that binding with NO arguments, so no caller
+//      -provided buffer or offset ever reaches the generator.
+//
+// Both are read from the INSTALLED sources, then the reachable entry point is
+// exercised for real, so a Jayson or Solana bump that changes the import graph
+// turns the gate red instead of silently widening the exception.
+export async function verifyUuidException(projectRoot) {
+  const projectRequire = createRequire(path.join(projectRoot, "package.json"));
+  const solanaRequire = createRequire(projectRequire.resolve("@solana/web3.js"));
+  const jaysonEntry = solanaRequire.resolve("jayson");
+  const jaysonRequire = createRequire(jaysonEntry);
+  const libraryRoot = path.join(path.dirname(jaysonEntry), "lib");
+
+  // The ONLY accepted binding form. Anything else (a namespace import, a
+  // destructured v3/v5/v6, a dynamic property read) is unreviewed.
+  const ACCEPTED_BINDING = /require\(\s*["']uuid["']\s*\)\s*\.\s*v4\b/;
+  const ANY_UUID_REQUIRE = /require\(\s*["']uuid["']\s*\)[^\n]*/g;
+  const bindings = new Map();
+  let bindingSites = 0;
+
+  function inspect(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const file = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        inspect(file);
+        continue;
+      }
+      if (!entry.name.endsWith(".js")) continue;
+      const source = readFileSync(file, "utf8");
+      for (const match of source.matchAll(ANY_UUID_REQUIRE)) {
+        assert(ACCEPTED_BINDING.test(match[0]),
+          `Unreviewed uuid import in ${file}: ${match[0].trim()}`);
+        bindingSites += 1;
+      }
+      const binding = /const\s+([A-Za-z_$][\w$]*)\s*=\s*require\(\s*["']uuid["']\s*\)\s*\.\s*v4\s*;/.exec(source);
+      if (binding !== null) bindings.set(file, binding[1]);
+    }
+  }
+  inspect(libraryRoot);
+
+  assert(bindingSites > 0, "The installed Jayson no longer imports uuid; remove the exception");
+  assert.equal(bindings.size, bindingSites,
+    "A uuid import in the installed Jayson is not a plain `const x = require('uuid').v4;` binding");
+
+  // Every invocation of that binding must be argument-free. `name(` followed by
+  // anything other than `)` is a caller-provided options/buffer/offset call,
+  // which is precisely the shape the advisory covers.
+  for (const [file, name] of bindings) {
+    const source = readFileSync(file, "utf8");
+    const calls = [...source.matchAll(new RegExp(`(?<![\\w$.])${name}\\s*\\(([^)]*)\\)`, "g"))];
+    assert(calls.length > 0, `The uuid binding in ${file} is imported but never called; reassess the exception`);
+    for (const call of calls) {
+      assert.equal(call[1].trim(), "",
+        `Jayson passes arguments to uuid in ${file}: ${call[0].trim()}; the advisory's buffer path is reachable`);
+    }
+  }
+
+  // The reachable entry point, exercised for real: Jayson generates request ids
+  // through Utils.generateId, which is the v4 call above.
+  const utils = jaysonRequire("./lib/utils");
+  const id = utils.generateId();
+  assert.match(id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    `Jayson's reachable uuid entry point did not produce a v4 identifier: ${String(id)}`);
+  assert.notEqual(utils.generateId(), id, "Jayson's uuid entry point returned a constant identifier");
+
+  const loaded = Object.keys(jaysonRequire.cache).filter((file) => file.includes(`${path.sep}uuid${path.sep}`));
+  assert(loaded.length > 0, "The installed uuid graph was not exercised");
+}

--- a/src/__tests__/scripts/production-audit-decision.test.ts
+++ b/src/__tests__/scripts/production-audit-decision.test.ts
@@ -15,10 +15,30 @@
  *    CLOSED rather than being read as "no findings".
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 
-// @ts-expect-error - the gate scripts are plain ESM with no type declarations.
-import { evaluateProductionAudit } from "../../../scripts/production-audit-decision.mjs";
+// The gate script is plain ESM without type declarations. It is loaded at run
+// time through a resolved specifier and typed once at this seam (the fields the
+// tests observe), so the test carries no suppression comment.
+interface ProductionAuditDecision {
+  readonly ok: boolean;
+  readonly failures: readonly string[];
+  readonly unexpected: readonly Record<string, unknown>[];
+  readonly stale: readonly Record<string, unknown>[];
+  readonly exceptions: readonly Record<string, unknown>[];
+}
+type EvaluateProductionAudit = (input: {
+  readonly allowlist: unknown;
+  readonly advisories: unknown;
+  readonly now: Date | string;
+}) => ProductionAuditDecision;
+let evaluateProductionAudit: EvaluateProductionAudit;
+
+beforeAll(async () => {
+  const specifier = new URL("../../../scripts/production-audit-decision.mjs", import.meta.url).href;
+  const loaded = (await import(specifier)) as { readonly evaluateProductionAudit: EvaluateProductionAudit };
+  evaluateProductionAudit = loaded.evaluateProductionAudit;
+});
 
 const REVIEW_BY = "2026-09-18";
 const BEFORE_REVIEW = new Date("2026-09-07T12:00:00.000Z");

--- a/src/__tests__/scripts/production-audit-decision.test.ts
+++ b/src/__tests__/scripts/production-audit-decision.test.ts
@@ -1,0 +1,171 @@
+/**
+ * The production dependency audit's decision rules, tested against the pure
+ * half of the gate so no registry, lockfile or child process is involved.
+ *
+ * What each block would catch if the rule were dropped:
+ *
+ *  - exact matching: an advisory absorbed by a NEARBY exception (same package,
+ *    different version, severity or reachability path). That is the failure
+ *    mode an allowlist has: it keeps passing after the thing it excused moved.
+ *  - staleness: an exception that outlives its finding, which is how a list of
+ *    excuses grows and stops meaning anything.
+ *  - expiry: exceptions surviving `reviewBy` by inattention. The gate must
+ *    refuse on the date whatever the findings say.
+ *  - shape: a malformed allowlist or a changed pnpm report shape failing
+ *    CLOSED rather than being read as "no findings".
+ */
+
+import { describe, it, expect } from "vitest";
+
+// @ts-expect-error - the gate scripts are plain ESM with no type declarations.
+import { evaluateProductionAudit } from "../../../scripts/production-audit-decision.mjs";
+
+const REVIEW_BY = "2026-09-18";
+const BEFORE_REVIEW = new Date("2026-09-07T12:00:00.000Z");
+const ON_REVIEW = new Date("2026-09-18T00:00:00.000Z");
+
+const STREAM_JSON = {
+  url: "https://github.com/advisories/GHSA-528h-pc64-c93x",
+  package: "stream-json",
+  severity: "moderate",
+  version: "1.9.1",
+  path: ".>@solana/web3.js>jayson>stream-json",
+} as const;
+
+/** One pnpm `audit --json` advisories object carrying the given findings. */
+function advisoriesFor(...entries: readonly (typeof STREAM_JSON)[]): unknown {
+  const advisories: Record<string, unknown> = {};
+  for (const [index, entry] of entries.entries()) {
+    advisories[String(index)] = {
+      url: entry.url,
+      module_name: entry.package,
+      severity: entry.severity,
+      findings: [{ version: entry.version, paths: [entry.path] }],
+    };
+  }
+  return advisories;
+}
+
+function allowlistFor(...entries: readonly (typeof STREAM_JSON)[]): unknown {
+  return { reviewBy: REVIEW_BY, exceptions: entries.map((entry) => ({ ...entry, rationale: "reviewed" })) };
+}
+
+describe("production audit decision", () => {
+  it("passes when every finding is carried verbatim by the allowlist", () => {
+    const result = evaluateProductionAudit({
+      allowlist: allowlistFor(STREAM_JSON),
+      advisories: advisoriesFor(STREAM_JSON),
+      now: BEFORE_REVIEW,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.exceptions).toHaveLength(1);
+  });
+
+  it("passes when there is nothing to excuse and nothing excused", () => {
+    const result = evaluateProductionAudit({
+      allowlist: { reviewBy: REVIEW_BY, exceptions: [] },
+      advisories: {},
+      now: BEFORE_REVIEW,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("refuses an advisory that no exception carries", () => {
+    const result = evaluateProductionAudit({
+      allowlist: { reviewBy: REVIEW_BY, exceptions: [] },
+      advisories: advisoriesFor(STREAM_JSON),
+      now: BEFORE_REVIEW,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.unexpected).toEqual([STREAM_JSON]);
+    expect(result.failures.join(" ")).toContain("outside the reviewed exception list");
+  });
+
+  for (const field of ["url", "severity", "version", "path"] as const) {
+    it(`refuses a finding whose ${field} differs from the exception`, () => {
+      const drifted = { ...STREAM_JSON, [field]: `${STREAM_JSON[field]}-drifted` };
+      const result = evaluateProductionAudit({
+        allowlist: allowlistFor(STREAM_JSON),
+        advisories: advisoriesFor(drifted),
+        now: BEFORE_REVIEW,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.unexpected).toEqual([drifted]);
+      expect(result.stale).toEqual([STREAM_JSON]);
+    });
+  }
+
+  it("refuses an exception the audit no longer reports", () => {
+    const result = evaluateProductionAudit({
+      allowlist: allowlistFor(STREAM_JSON),
+      advisories: {},
+      now: BEFORE_REVIEW,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.stale).toEqual([STREAM_JSON]);
+    expect(result.failures.join(" ")).toContain("stale dependency-audit exceptions");
+  });
+
+  it("refuses on the review date even when every finding matches", () => {
+    const result = evaluateProductionAudit({
+      allowlist: allowlistFor(STREAM_JSON),
+      advisories: advisoriesFor(STREAM_JSON),
+      now: ON_REVIEW,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(" ")).toContain(`expired for mandatory review on ${REVIEW_BY}`);
+    expect(result.unexpected).toEqual([]);
+  });
+
+  it("passes on the day before the review date", () => {
+    const result = evaluateProductionAudit({
+      allowlist: allowlistFor(STREAM_JSON),
+      advisories: advisoriesFor(STREAM_JSON),
+      now: new Date(ON_REVIEW.getTime() - 1),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("refuses an unparseable reviewBy instead of treating it as no deadline", () => {
+    const result = evaluateProductionAudit({
+      allowlist: { reviewBy: "whenever", exceptions: [] },
+      advisories: {},
+      now: BEFORE_REVIEW,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(" ")).toContain("invalid reviewBy");
+  });
+
+  it("refuses an exception missing an identity field rather than matching loosely", () => {
+    const { version: _dropped, ...incomplete } = STREAM_JSON;
+    const result = evaluateProductionAudit({
+      allowlist: { reviewBy: REVIEW_BY, exceptions: [incomplete] },
+      advisories: advisoriesFor(STREAM_JSON),
+      now: BEFORE_REVIEW,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(" ")).toContain("missing a valid version");
+    expect(result.unexpected).toEqual([STREAM_JSON]);
+  });
+
+  it("refuses a report whose findings lost their identity fields", () => {
+    const result = evaluateProductionAudit({
+      allowlist: { reviewBy: REVIEW_BY, exceptions: [] },
+      advisories: { "0": { url: STREAM_JSON.url, module_name: STREAM_JSON.package, findings: [{ paths: ["."] }] } },
+      now: BEFORE_REVIEW,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(" ")).toContain("the report shape changed");
+  });
+
+  it("refuses an allowlist with no exceptions array", () => {
+    const result = evaluateProductionAudit({
+      allowlist: { reviewBy: REVIEW_BY },
+      advisories: {},
+      now: BEFORE_REVIEW,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(" ")).toContain("no exceptions array");
+  });
+});

--- a/src/__tests__/scripts/production-audit-decision.test.ts
+++ b/src/__tests__/scripts/production-audit-decision.test.ts
@@ -147,6 +147,17 @@ describe("production audit decision", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("treats a null reviewBy as no calendar expiry (owner decision 2026-09-07)", () => {
+    const base = allowlistFor(STREAM_JSON);
+    const result = evaluateProductionAudit({
+      allowlist: { ...base, reviewBy: null },
+      advisories: advisoriesFor(STREAM_JSON),
+      now: new Date("2099-01-01T00:00:00.000Z"),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+  });
+
   it("refuses an unparseable reviewBy instead of treating it as no deadline", () => {
     const result = evaluateProductionAudit({
       allowlist: { reviewBy: "whenever", exceptions: [] },

--- a/src/__tests__/scripts/verify-bigint-buffer-exception.test.ts
+++ b/src/__tests__/scripts/verify-bigint-buffer-exception.test.ts
@@ -1,0 +1,258 @@
+/**
+ * The bigint-buffer reachability verifier, driven against SYNTHETIC installed
+ * graphs.
+ *
+ * The exception for bigint-buffer 1.1.5 (GHSA-3gc7-fjrx-p6mg) is not "the
+ * advisory does not apply to us" as an opinion; it is three claims about the
+ * installed tree: no compiled native binding, an install-script ban that keeps
+ * it that way, and fixed literal layout widths of 8 to 32 bytes in
+ * @solana/buffer-layout-utils. This suite builds throwaway node_modules trees
+ * that each break exactly one of those claims and asserts the verifier refuses,
+ * so weakening it to "bigint-buffer is installed somewhere" turns these red.
+ *
+ * The real installed graph is exercised by `pnpm run audit:deps`, which calls
+ * the same function with the workspace root.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, it, expect, afterEach, beforeAll } from "vitest";
+
+type ReachabilityVerifier = (projectRoot: string) => Promise<void>;
+
+/**
+ * The gate scripts are plain ESM with no type declarations. Resolving the
+ * specifier at run time keeps the seam typed here, instead of suppressing the
+ * checker over a static import.
+ */
+let verifyBigIntBufferException: ReachabilityVerifier;
+
+beforeAll(async () => {
+  const specifier = new URL("../../../scripts/verify-bigint-buffer-exception.mjs", import.meta.url).href;
+  const loaded = (await import(specifier)) as { readonly verifyBigIntBufferException: ReachabilityVerifier };
+  verifyBigIntBufferException = loaded.verifyBigIntBufferException;
+});
+
+const sandboxes: string[] = [];
+
+afterEach(() => {
+  for (const sandbox of sandboxes.splice(0)) rmSync(sandbox, { recursive: true, force: true });
+});
+
+/** The reviewed shape: fixed literal widths, exactly as Solana ships them. */
+const COMPLIANT_LAYOUT = [
+  'const bigint_buffer_1 = require("bigint-buffer");',
+  "const bigInt = (length) => (property) => ({ length, property });",
+  "const bigIntBE = (length) => (property) => ({ length, property });",
+  "exports.decodeLE = (src) => bigint_buffer_1.toBigIntLE(Buffer.from(src));",
+  "exports.encodeLE = (value, length) => bigint_buffer_1.toBufferLE(value, length);",
+  "exports.u64 = (0, exports.bigInt)(8);",
+  "exports.u128 = (0, exports.bigInt)(16);",
+  "exports.u256 = (0, exports.bigIntBE)(32);",
+  "",
+].join("\n");
+
+/** The installed loader's own fallback branch, verbatim in behaviour. */
+const PURE_JS_BIGINT_BUFFER = [
+  "'use strict';",
+  "let converter;",
+  "try { converter = require('./missing-binding.node'); }",
+  "catch (e) { console.warn('bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)'); }",
+  "function toBigIntLE(buf) {",
+  "  const reversed = Buffer.from(buf); reversed.reverse();",
+  "  const hex = reversed.toString('hex');",
+  "  return hex.length === 0 ? BigInt(0) : BigInt(`0x${hex}`);",
+  "}",
+  "function toBigIntBE(buf) {",
+  "  const hex = buf.toString('hex');",
+  "  return hex.length === 0 ? BigInt(0) : BigInt(`0x${hex}`);",
+  "}",
+  "function toBufferLE(num, width) {",
+  "  const hex = num.toString(16);",
+  "  const buffer = Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');",
+  "  buffer.reverse();",
+  "  return buffer;",
+  "}",
+  "function toBufferBE(num, width) {",
+  "  const hex = num.toString(16);",
+  "  return Buffer.from(hex.padStart(width * 2, '0').slice(0, width * 2), 'hex');",
+  "}",
+  "exports.toBigIntLE = toBigIntLE;",
+  "exports.toBigIntBE = toBigIntBE;",
+  "exports.toBufferLE = toBufferLE;",
+  "exports.toBufferBE = toBufferBE;",
+  "",
+].join("\n");
+
+interface GraphOptions {
+  /** The installed @solana/buffer-layout-utils bigint module source. */
+  readonly layoutSource?: string;
+  /** Extra files, relative to the sandbox root, written verbatim. */
+  readonly extraFiles?: Readonly<Record<string, string>>;
+  /** The `pnpm` block of the sandbox package.json; omit for the reviewed one. */
+  readonly pnpm?: unknown;
+}
+
+/**
+ * A minimal installed graph:
+ * project -> @solana/spl-token -> @solana/buffer-layout-utils -> bigint-buffer.
+ */
+function buildGraph(options: GraphOptions = {}): string {
+  const sandbox = mkdtempSync(path.join(tmpdir(), "vex-bigint-buffer-exception-"));
+  sandboxes.push(sandbox);
+  const write = (relative: string, contents: string): void => {
+    const absolute = path.join(sandbox, relative);
+    mkdirSync(path.dirname(absolute), { recursive: true });
+    writeFileSync(absolute, contents, "utf8");
+  };
+  write("package.json", JSON.stringify({
+    name: "sandbox",
+    version: "0.0.0",
+    pnpm: "pnpm" in options ? options.pnpm : { ignoredBuiltDependencies: ["bigint-buffer"] },
+  }));
+  write("node_modules/@solana/spl-token/package.json", JSON.stringify({ name: "@solana/spl-token", version: "0.4.16", main: "index.js" }));
+  write("node_modules/@solana/spl-token/index.js", "module.exports = require('@solana/buffer-layout-utils');\n");
+  write("node_modules/@solana/buffer-layout-utils/package.json", JSON.stringify({
+    name: "@solana/buffer-layout-utils",
+    version: "0.2.0",
+    main: "lib/cjs/index.js",
+  }));
+  write("node_modules/@solana/buffer-layout-utils/lib/cjs/index.js", "module.exports = require('./bigint');\n");
+  write("node_modules/@solana/buffer-layout-utils/lib/cjs/bigint.js", options.layoutSource ?? COMPLIANT_LAYOUT);
+  write("node_modules/bigint-buffer/package.json", JSON.stringify({ name: "bigint-buffer", version: "1.1.5", main: "dist/node.js" }));
+  write("node_modules/bigint-buffer/dist/node.js", PURE_JS_BIGINT_BUFFER);
+  for (const [relative, contents] of Object.entries(options.extraFiles ?? {})) write(relative, contents);
+  return sandbox;
+}
+
+describe("verify-bigint-buffer-exception", () => {
+  it("accepts a graph with no native binding, the install ban, and fixed literal widths", async () => {
+    await expect(verifyBigIntBufferException(buildGraph())).resolves.toBeUndefined();
+  });
+
+  it("refuses a graph whose native binding has been built", async () => {
+    const sandbox = buildGraph({
+      extraFiles: { "node_modules/bigint-buffer/build/Release/bigint_buffer.node": "not a real binding" },
+    });
+    await expect(verifyBigIntBufferException(sandbox)).rejects.toThrow(/native binding is built/);
+  });
+
+  it("refuses a graph that no longer bans the bigint-buffer install script", async () => {
+    const sandbox = buildGraph({ pnpm: { ignoredBuiltDependencies: ["utf-8-validate"] } });
+    await expect(verifyBigIntBufferException(sandbox)).rejects.toThrow(/ignoredBuiltDependencies/);
+  });
+
+  it("refuses a graph with no pnpm build policy at all", async () => {
+    const sandbox = buildGraph({ pnpm: undefined });
+    await expect(verifyBigIntBufferException(sandbox)).rejects.toThrow(/ignoredBuiltDependencies/);
+  });
+
+  it("refuses a graph that permits the bigint-buffer install script", async () => {
+    const sandbox = buildGraph({
+      pnpm: { ignoredBuiltDependencies: ["bigint-buffer"], onlyBuiltDependencies: ["bigint-buffer"] },
+    });
+    await expect(verifyBigIntBufferException(sandbox)).rejects.toThrow(/onlyBuiltDependencies/);
+  });
+
+  it("refuses a call site whose layout width is dynamic", async () => {
+    const source = COMPLIANT_LAYOUT.replace(
+      "exports.u64 = (0, exports.bigInt)(8);",
+      "exports.uDynamic = (width) => (0, exports.bigInt)(width);",
+    );
+    await expect(verifyBigIntBufferException(buildGraph({ layoutSource: source })))
+      .rejects.toThrow(/non-literal width/);
+  });
+
+  it("refuses a call site whose layout width is outside the reviewed range", async () => {
+    const source = COMPLIANT_LAYOUT.replace(
+      "exports.u256 = (0, exports.bigIntBE)(32);",
+      "exports.u512 = (0, exports.bigIntBE)(64);",
+    );
+    await expect(verifyBigIntBufferException(buildGraph({ layoutSource: source })))
+      .rejects.toThrow(/outside the reviewed 8 to 32 byte range/);
+  });
+
+  it("refuses an unreviewed module that reaches bigint-buffer directly", async () => {
+    const sandbox = buildGraph({
+      extraFiles: {
+        "node_modules/@solana/buffer-layout-utils/lib/cjs/decimal.js":
+          'const bb = require("bigint-buffer");\nexports.decode = (src) => bb.toBigIntLE(src);\n',
+      },
+    });
+    await expect(verifyBigIntBufferException(sandbox)).rejects.toThrow(/unreviewed .* module imports bigint-buffer/i);
+  });
+
+  it("refuses a module that reaches a bigint-buffer member outside the reviewed four", async () => {
+    const source = `${COMPLIANT_LAYOUT}exports.raw = bigint_buffer_1.toBigIntUnchecked;\n`;
+    await expect(verifyBigIntBufferException(buildGraph({ layoutSource: source })))
+      .rejects.toThrow(/Unreviewed bigint-buffer member/);
+  });
+
+  it("refuses an import form neither module shape recognises", async () => {
+    const source = [
+      'const bb = require("bigint-buffer" + "");',
+      "exports.decode = (src) => bb.toBigIntLE(src);",
+      "exports.u64 = (0, exports.bigInt)(8);",
+      "",
+    ].join("\n");
+    await expect(verifyBigIntBufferException(buildGraph({ layoutSource: source })))
+      .rejects.toThrow(/unreviewed import form/i);
+  });
+
+  it("refuses a graph that no longer imports bigint-buffer", async () => {
+    const source = [
+      "exports.u64 = (0, exports.bigInt)(8);",
+      "",
+    ].join("\n");
+    await expect(verifyBigIntBufferException(buildGraph({ layoutSource: source })))
+      .rejects.toThrow(/no longer imports bigint-buffer/);
+  });
+
+  it("refuses a graph with no fixed-width layout left to review", async () => {
+    const source = [
+      'const bigint_buffer_1 = require("bigint-buffer");',
+      "exports.decodeLE = (src) => bigint_buffer_1.toBigIntLE(Buffer.from(src));",
+      "",
+    ].join("\n");
+    await expect(verifyBigIntBufferException(buildGraph({ layoutSource: source })))
+      .rejects.toThrow(/No fixed-width bigint layout/);
+  });
+
+  it("refuses a loader that does not report the pure-JavaScript fallback", async () => {
+    const sandbox = buildGraph({
+      extraFiles: {
+        "node_modules/bigint-buffer/dist/node.js": PURE_JS_BIGINT_BUFFER.replace(
+          "catch (e) { console.warn('bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)'); }",
+          "catch (e) { /* silently keep going */ }",
+        ),
+      },
+    });
+    await expect(verifyBigIntBufferException(sandbox)).rejects.toThrow(/did not report its pure-JavaScript fallback/);
+  });
+
+  it("refuses a loader that drops one of the reviewed converters", async () => {
+    const sandbox = buildGraph({
+      extraFiles: {
+        "node_modules/bigint-buffer/dist/node.js": PURE_JS_BIGINT_BUFFER.replace(
+          "exports.toBufferLE = toBufferLE;",
+          "",
+        ),
+      },
+    });
+    await expect(verifyBigIntBufferException(sandbox)).rejects.toThrow(/does not export toBufferLE/);
+  });
+
+  it("refuses a converter that does not round trip a 32 byte value", async () => {
+    const sandbox = buildGraph({
+      extraFiles: {
+        "node_modules/bigint-buffer/dist/node.js": PURE_JS_BIGINT_BUFFER.replace(
+          "exports.toBigIntLE = toBigIntLE;",
+          "exports.toBigIntLE = (buf) => (buf.length === 32 ? BigInt(0) : toBigIntLE(buf));",
+        ),
+      },
+    });
+    await expect(verifyBigIntBufferException(sandbox)).rejects.toThrow(/did not round trip a 32 byte value/);
+  });
+});

--- a/src/__tests__/scripts/verify-uuid-exception.test.ts
+++ b/src/__tests__/scripts/verify-uuid-exception.test.ts
@@ -1,0 +1,128 @@
+/**
+ * The uuid reachability verifier, driven against SYNTHETIC installed graphs.
+ *
+ * The exception for uuid 8.3.2 (GHSA-w5hq-g745-h8pq) is not "the advisory does
+ * not apply to us" as an opinion; it is a claim about the installed Jayson
+ * sources: v4 only, and never with a caller-provided buffer. This suite builds
+ * throwaway node_modules trees that each break exactly one half of that claim
+ * and asserts the verifier refuses, so weakening the verifier to "it imports
+ * uuid somewhere" turns these red.
+ *
+ * The real installed graph is exercised by `pnpm run audit:deps`, which calls
+ * the same function with the workspace root.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, it, expect, afterEach } from "vitest";
+
+// @ts-expect-error - the gate scripts are plain ESM with no type declarations.
+import { verifyUuidException } from "../../../scripts/verify-uuid-exception.mjs";
+
+const sandboxes: string[] = [];
+
+afterEach(() => {
+  for (const sandbox of sandboxes.splice(0)) rmSync(sandbox, { recursive: true, force: true });
+});
+
+/** A minimal installed graph: project -> @solana/web3.js -> jayson -> uuid. */
+function buildGraph(utilsSource: string): string {
+  const sandbox = mkdtempSync(path.join(tmpdir(), "vex-uuid-exception-"));
+  sandboxes.push(sandbox);
+  const write = (relative: string, contents: string): void => {
+    const absolute = path.join(sandbox, relative);
+    mkdirSync(path.dirname(absolute), { recursive: true });
+    writeFileSync(absolute, contents, "utf8");
+  };
+  write("package.json", JSON.stringify({ name: "sandbox", version: "0.0.0" }));
+  write("node_modules/@solana/web3.js/package.json", JSON.stringify({ name: "@solana/web3.js", version: "1.98.4", main: "index.js" }));
+  write("node_modules/@solana/web3.js/index.js", "module.exports = {};\n");
+  write("node_modules/jayson/package.json", JSON.stringify({ name: "jayson", version: "4.3.0", main: "index.js" }));
+  write("node_modules/jayson/index.js", "module.exports = require('./lib/utils');\n");
+  write("node_modules/jayson/lib/utils.js", utilsSource);
+  write("node_modules/uuid/package.json", JSON.stringify({ name: "uuid", version: "8.3.2", main: "index.js" }));
+  write(
+    "node_modules/uuid/index.js",
+    [
+      "let counter = 0;",
+      "function hex(length) { return Array.from({ length }, () => (counter++ % 16).toString(16)).join(''); }",
+      "exports.v4 = function v4() { counter += 1; return `${hex(8)}-${hex(4)}-4${hex(3)}-a${hex(3)}-${hex(12)}`; };",
+      "exports.v5 = function v5() { return exports.v4(); };",
+      "",
+    ].join("\n"),
+  );
+  return sandbox;
+}
+
+const COMPLIANT = [
+  "const uuid = require('uuid').v4;",
+  "exports.generateId = function () { return uuid(); };",
+  "",
+].join("\n");
+
+describe("verify-uuid-exception", () => {
+  it("accepts a graph that binds uuid v4 and calls it with no arguments", async () => {
+    await expect(verifyUuidException(buildGraph(COMPLIANT))).resolves.toBeUndefined();
+  });
+
+  it("refuses a graph that reaches a generator other than v4", async () => {
+    const source = [
+      "const uuid = require('uuid').v4;",
+      "const legacy = require('uuid').v5;",
+      "exports.generateId = function () { return uuid(); };",
+      "exports.legacyId = function () { return legacy(); };",
+      "",
+    ].join("\n");
+    await expect(verifyUuidException(buildGraph(source))).rejects.toThrow(/Unreviewed uuid import/);
+  });
+
+  it("refuses a namespace import that could reach any generator", async () => {
+    const source = [
+      "const uuid = require('uuid');",
+      "exports.generateId = function () { return uuid.v4(); };",
+      "",
+    ].join("\n");
+    await expect(verifyUuidException(buildGraph(source))).rejects.toThrow(/Unreviewed uuid import/);
+  });
+
+  it("refuses a call site that passes a caller-provided buffer", async () => {
+    const source = [
+      "const uuid = require('uuid').v4;",
+      "const scratch = Buffer.alloc(16);",
+      "exports.generateId = function () { return uuid(undefined, scratch); };",
+      "",
+    ].join("\n");
+    await expect(verifyUuidException(buildGraph(source))).rejects.toThrow(/passes arguments to uuid/);
+  });
+
+  it("refuses a graph that imports uuid but never calls it", async () => {
+    const source = [
+      "const uuid = require('uuid').v4;",
+      "exports.generateId = function () { return 'static'; };",
+      "exports.unused = uuid;",
+      "",
+    ].join("\n");
+    await expect(verifyUuidException(buildGraph(source))).rejects.toThrow(/imported but never called/);
+  });
+
+  it("refuses a reachable entry point that does not produce a v4 identifier", async () => {
+    const source = [
+      "const uuid = require('uuid').v4;",
+      "exports.generateId = function () { uuid(); return 'not-a-uuid'; };",
+      "",
+    ].join("\n");
+    await expect(verifyUuidException(buildGraph(source))).rejects.toThrow(/did not produce a v4 identifier/);
+  });
+
+  it("refuses an entry point that returns a constant identifier", async () => {
+    const source = [
+      "const uuid = require('uuid').v4;",
+      "const frozen = uuid();",
+      "exports.generateId = function () { return frozen; };",
+      "",
+    ].join("\n");
+    await expect(verifyUuidException(buildGraph(source))).rejects.toThrow(/constant identifier/);
+  });
+});

--- a/src/__tests__/scripts/verify-uuid-exception.test.ts
+++ b/src/__tests__/scripts/verify-uuid-exception.test.ts
@@ -16,10 +16,19 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeAll } from "vitest";
 
-// @ts-expect-error - the gate scripts are plain ESM with no type declarations.
-import { verifyUuidException } from "../../../scripts/verify-uuid-exception.mjs";
+// The gate script is plain ESM without type declarations. It is loaded at run
+// time through a resolved specifier and typed once at this seam, so the test
+// carries no suppression comment and the contract it relies on is spelled out.
+type ReachabilityVerifier = (projectRoot: string) => Promise<void>;
+let verifyUuidException: ReachabilityVerifier;
+
+beforeAll(async () => {
+  const specifier = new URL("../../../scripts/verify-uuid-exception.mjs", import.meta.url).href;
+  const loaded = (await import(specifier)) as { readonly verifyUuidException: ReachabilityVerifier };
+  verifyUuidException = loaded.verifyUuidException;
+});
 
 const sandboxes: string[] = [];
 

--- a/vex-app/package.json
+++ b/vex-app/package.json
@@ -43,7 +43,7 @@
     "test:native-fs": "vitest run src/main/studio/files/__tests__/files-real-fs.test.ts",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "audit:deps": "pnpm audit --prod && pnpm audit",
+    "audit:deps": "node ../scripts/audit-production-dependencies.mjs vex-app/scripts/production-audit-allowlist.json vex-app",
     "doctor": "node scripts/doctor.mjs",
     "predev": "pnpm run build:bridge:dev && node scripts/doctor.mjs && node scripts/copy-migrations.mjs",
     "check:build": "node scripts/check-build-artifacts.mjs",
@@ -56,7 +56,7 @@
   "dependencies": {
     "@hookform/resolvers": "~5.2.2",
     "@parcel/watcher": "~2.6.0",
-    "@sentry/electron": "~7.13.0",
+    "@sentry/electron": "~7.16.0",
     "@shikijs/vscode-textmate": "10.0.2",
     "@solana/web3.js": "~1.98.4",
     "@tanstack/react-query": "~5.100.9",
@@ -77,7 +77,7 @@
     "class-variance-authority": "~0.7.1",
     "clsx": "~2.1.1",
     "electron-log": "~5.4.3",
-    "electron-updater": "~6.8.3",
+    "electron-updater": "~6.8.9",
     "ignore": "~7.0.6",
     "lightweight-charts": "5.2.1",
     "marked": "~18.0.3",
@@ -137,6 +137,15 @@
       "esbuild",
       "node-pty",
       "sharp"
-    ]
+    ],
+    "ignoredBuiltDependencies": [
+      "bufferutil",
+      "utf-8-validate"
+    ],
+    "overrides": {
+      "electron-updater>js-yaml": "4.3.1",
+      "jayson>ws": "7.5.13",
+      "rpc-websockets>ws": "8.21.3"
+    }
   }
 }

--- a/vex-app/pnpm-lock.yaml
+++ b/vex-app/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  electron-updater>js-yaml: 4.3.1
+  jayson>ws: 7.5.13
+  rpc-websockets>ws: 8.21.3
+
 importers:
 
   .:
@@ -15,8 +20,8 @@ importers:
         specifier: ~2.6.0
         version: 2.6.0
       '@sentry/electron':
-        specifier: ~7.13.0
-        version: 7.13.0
+        specifier: ~7.16.0
+        version: 7.16.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
       '@shikijs/vscode-textmate':
         specifier: 10.0.2
         version: 10.0.2
@@ -78,8 +83,8 @@ importers:
         specifier: ~5.4.3
         version: 5.4.3
       electron-updater:
-        specifier: ~6.8.3
-        version: 6.8.3
+        specifier: ~6.8.9
+        version: 6.8.9
       ignore:
         specifier: ~7.0.6
         version: 7.0.6
@@ -197,6 +202,17 @@ packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
+    resolution: {integrity: sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    resolution: {integrity: sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==}
+    hasBin: true
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -334,11 +350,6 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
-
-  '@fastify/otel@0.18.0':
-    resolution: {integrity: sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
 
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
@@ -592,184 +603,40 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@opentelemetry/api-logs@0.207.0':
-    resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
-    engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/api-logs@0.212.0':
-    resolution: {integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==}
-    engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/api-logs@0.214.0':
-    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/core@2.6.1':
-    resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
+  '@opentelemetry/core@2.11.0':
+    resolution: {integrity: sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.7.1':
-    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/instrumentation-amqplib@0.61.0':
-    resolution: {integrity: sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==}
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/instrumentation-connect@0.57.0':
-    resolution: {integrity: sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-dataloader@0.31.0':
-    resolution: {integrity: sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-fs@0.33.0':
-    resolution: {integrity: sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-generic-pool@0.57.0':
-    resolution: {integrity: sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-graphql@0.62.0':
-    resolution: {integrity: sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-hapi@0.60.0':
-    resolution: {integrity: sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-http@0.214.0':
-    resolution: {integrity: sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-ioredis@0.62.0':
-    resolution: {integrity: sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-kafkajs@0.23.0':
-    resolution: {integrity: sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-knex@0.58.0':
-    resolution: {integrity: sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-koa@0.62.0':
-    resolution: {integrity: sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-
-  '@opentelemetry/instrumentation-lru-memoizer@0.58.0':
-    resolution: {integrity: sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mongodb@0.67.0':
-    resolution: {integrity: sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mongoose@0.60.0':
-    resolution: {integrity: sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mysql2@0.60.0':
-    resolution: {integrity: sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mysql@0.60.0':
-    resolution: {integrity: sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-pg@0.66.0':
-    resolution: {integrity: sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-redis@0.62.0':
-    resolution: {integrity: sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-tedious@0.33.0':
-    resolution: {integrity: sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation@0.207.0':
-    resolution: {integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation@0.212.0':
-    resolution: {integrity: sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation@0.214.0':
-    resolution: {integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/redis-common@0.38.3':
-    resolution: {integrity: sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-
-  '@opentelemetry/resources@2.7.1':
-    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+  '@opentelemetry/resources@2.11.0':
+    resolution: {integrity: sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-base@2.7.1':
-    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+  '@opentelemetry/sdk-trace-base@2.11.0':
+    resolution: {integrity: sha512-H19x/TX/LZdqiYOjM7fqtSxwlplC5pgelavqbQdHbhdq0q/AI/TGkM2dfGuuynTXmJPeF2HoZVoPDu+TGoW78A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.11.0':
+    resolution: {integrity: sha512-fFnTqGm8/G73GQVnxYi7LXa1ZVYEUvgL6XI1LpvV0bPC7WQ/ZGgKxCSl8FnlZBKto9JHHEFTO6s6CUpvvtwFrA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -777,12 +644,6 @@ packages:
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
-
-  '@opentelemetry/sql-common@0.41.2':
-    resolution: {integrity: sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
 
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
@@ -877,11 +738,6 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
-
-  '@prisma/instrumentation@7.6.0':
-    resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
-    peerDependencies:
-      '@opentelemetry/api': ^1.8
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -1020,40 +876,36 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
-  '@sentry-internal/browser-utils@10.50.0':
-    resolution: {integrity: sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA==}
+  '@sentry/browser-utils@10.67.0':
+    resolution: {integrity: sha512-HUzaf0xAnPAB+OHBkD7N1Py+CTbD5InHulQ/pdhX4JctWtxuwD8odMD1LzdPnW8J6gVHlDVvcVBR8mXMZYSLSw==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/feedback@10.50.0':
-    resolution: {integrity: sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w==}
+  '@sentry/browser@10.67.0':
+    resolution: {integrity: sha512-/ZhsAvte4rYhg0A0RtSFFgAgXhyMOfQIeOAfMfptN+X6IVSYOfkA9jtrP+Ej4+6vlaUFWRir1HweF56y63dEEA==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay-canvas@10.50.0':
-    resolution: {integrity: sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw==}
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.67.0':
+    resolution: {integrity: sha512-b6U3pJ8AUvN9aouq0vl+VZI8KT8RslBsfGMFuNwRr313zOmdmFJBZqTiUw9VGgJ2jGKxLO9alm9rlxBfX4hf+w==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay@10.50.0':
-    resolution: {integrity: sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ==}
-    engines: {node: '>=18'}
-
-  '@sentry/browser@10.50.0':
-    resolution: {integrity: sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA==}
-    engines: {node: '>=18'}
-
-  '@sentry/core@10.50.0':
-    resolution: {integrity: sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==}
-    engines: {node: '>=18'}
-
-  '@sentry/electron@7.13.0':
-    resolution: {integrity: sha512-zW/1c9fKafCZsvhRRp9mIDH9bSvzBiIUwoN087zDDHc0vatVsqqai8nUk0bUewwYZY4Inia7r5w+kPWi8LXZzg==}
+  '@sentry/electron@7.16.0':
+    resolution: {integrity: sha512-GgnsAGynr1IKfakRuW5AGlxQsIZi0cFUyzcn9ekrYy1cIyb85piVLN5u7W9pXzSzKopaGrxXBWubPBSRagyXjA==}
     peerDependencies:
-      '@sentry/node-native': 10.50.0
+      '@sentry/node-native': 10.67.0
     peerDependenciesMeta:
       '@sentry/node-native':
         optional: true
 
-  '@sentry/node-core@10.50.0':
-    resolution: {integrity: sha512-Eb1BYf4Lc7ZYmdX3acKP6SgyGikrBA370gbGHaWI5jRu7G7vig8sIu1ghPmY5AlvqBPOetado7GniXr6fAXbTw==}
+  '@sentry/feedback@10.67.0':
+    resolution: {integrity: sha512-I4ML2/SF3enwikb6ZSoRiqolQrx0zSzTSnUgwCmugICF/jpHW0th1pCray9R+t1Zzibw/Dpj4t/DNXaSDRa2MA==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.67.0':
+    resolution: {integrity: sha512-dBHHRwZyan1pOnFJ+sNBvR8TkXbZAfZU/jpxmALS3JZ2/8AGR7cQKL+b7SleKuJ7iUDZyklN3Nqi0i5JkcA+HA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -1061,7 +913,6 @@ packages:
       '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
       '@opentelemetry/instrumentation': '>=0.57.1 <1'
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
-      '@opentelemetry/semantic-conventions': ^1.39.0
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
@@ -1073,21 +924,30 @@ packages:
         optional: true
       '@opentelemetry/sdk-trace-base':
         optional: true
-      '@opentelemetry/semantic-conventions':
-        optional: true
 
-  '@sentry/node@10.50.0':
-    resolution: {integrity: sha512-TvwzFQu8MGKzMQ2/tqxcNzFA8UG2kKTB+GDmA4uOzx3+GT849YZRRSJzEXCmYhk1teVd2fbmgqyYY2nyLF5a+Q==}
+  '@sentry/node@10.67.0':
+    resolution: {integrity: sha512-SFKpZGqOCEFSmP93NdDP6ikZp4NS7A/JR8+2ofK3jF6Y9Vyox7pX0pxdOnPLpFcPtMybMahfWqSAWJvsFs4RmA==}
     engines: {node: '>=18'}
 
-  '@sentry/opentelemetry@10.50.0':
-    resolution: {integrity: sha512-axn3pgDPveGdaMUC0abMCmFN7ux2pA5ebPufCef4lMIsyg7BBQvaEJ+vE19wjstMaBCAJGsdZlL3eeP2rtgRMw==}
+  '@sentry/opentelemetry@10.67.0':
+    resolution: {integrity: sha512-oLTOrAK1rOqmYRktOJZwz37B1seXPx1W2FTMVtzTVNjMFA/LZwGzePeZzhUOgzZgfLHixMd/ceWtGqoxAndcjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
       '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
-      '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@sentry/replay-canvas@10.67.0':
+    resolution: {integrity: sha512-neNA4T6MFtZzMdKYetiR+LZd9BNSd0q2szMn0wk+A15PqHE/IN7a34V6JZc9rCtmzB0wldh0eWGOBb49MSNKjA==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.67.0':
+    resolution: {integrity: sha512-nkEUgPCR82EcyJkCf3XCE9H0R5KisCqyCAaSGxe7NpAoQbvASHx4MUNgXVAn+D0M494gvPZh6lFH7JgzqTcSqQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/server-utils@10.67.0':
+    resolution: {integrity: sha512-GQ9t+RSTx5s3b/aZrLFuL4nrwPLMah5NiZk5cjxJmgmOSgm3nMdO8gdqCedDch5B13F3YsxtaQYjSJnzLz8M5A==}
+    engines: {node: '>=18'}
 
   '@shikijs/core@4.4.3':
     resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
@@ -1350,9 +1210,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/mysql@2.15.27':
-    resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
-
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -1364,12 +1221,6 @@ packages:
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
-
-  '@types/pg-pool@2.0.7':
-    resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
-
-  '@types/pg@8.15.6':
-    resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
@@ -1396,9 +1247,6 @@ packages:
 
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
-
-  '@types/tedious@4.0.14':
-    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1615,6 +1463,10 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   async-exit-hook@2.0.1:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
     engines: {node: '>=0.12.0'}
@@ -1751,6 +1603,10 @@ packages:
 
   builder-util-runtime@9.5.1:
     resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
+    engines: {node: '>=12.0.0'}
+
+  builder-util-runtime@9.7.0:
+    resolution: {integrity: sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==}
     engines: {node: '>=12.0.0'}
 
   builder-util@26.8.1:
@@ -2029,8 +1885,8 @@ packages:
   electron-publish@26.8.1:
     resolution: {integrity: sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==}
 
-  electron-updater@6.8.3:
-    resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
 
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
@@ -2104,6 +1960,14 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2195,9 +2059,6 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
-
-  forwarded-parse@2.1.2:
-    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
   framer-motion@13.1.0:
     resolution: {integrity: sha512-QSZrF0Id3QGuHJ+OL+9PSY9pk86C8ERFalwAGSchzTm65+ZoGH/RM26lmEARLljcHj2lqhv0jZOOks+EI3COOw==}
@@ -2367,9 +2228,6 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
-  import-in-the-middle@2.0.6:
-    resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
-
   import-in-the-middle@3.0.1:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
     engines: {node: '>=18'}
@@ -2461,6 +2319,10 @@ packages:
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -2635,6 +2497,10 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -3097,6 +2963,9 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
@@ -3598,8 +3467,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+  ws@7.5.13:
+    resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
     engines: {node: '>=8.3.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3610,8 +3479,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3622,8 +3491,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3713,6 +3582,30 @@ snapshots:
   7zip-bin@5.2.0: {}
 
   '@adraffy/ens-normalize@1.11.1': {}
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      es-module-lexer: 2.1.0
+      magic-string: 0.30.21
+      module-details-from-path: 1.0.4
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -3892,16 +3785,6 @@ snapshots:
   '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
     optionalDependencies:
       '@noble/hashes': 1.8.0
-
-  '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.212.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      minimatch: 10.2.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@grpc/grpc-js@1.14.4':
     dependencies:
@@ -4111,251 +3994,48 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@opentelemetry/api-logs@0.207.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-
-  '@opentelemetry/api-logs@0.212.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-
-  '@opentelemetry/api-logs@0.214.0':
+  '@opentelemetry/api-logs@0.220.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.40.0
-
-  '@opentelemetry/instrumentation-amqplib@0.61.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-connect@0.57.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@types/connect': 3.4.38
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-dataloader@0.31.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-fs@0.33.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-generic-pool@0.57.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-graphql@0.62.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-hapi@0.60.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-http@0.214.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      forwarded-parse: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-ioredis@0.62.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/redis-common': 0.38.3
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-kafkajs@0.23.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-knex@0.58.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-koa@0.62.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-lru-memoizer@0.58.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mongodb@0.67.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mongoose@0.60.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mysql2@0.60.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mysql@0.60.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@types/mysql': 2.15.27
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-pg@0.66.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.1)
-      '@types/pg': 8.15.6
-      '@types/pg-pool': 2.0.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-redis@0.62.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/redis-common': 0.38.3
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-tedious@0.33.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@types/tedious': 4.0.14
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.207.0
-      import-in-the-middle: 2.0.6
-      require-in-the-middle: 8.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.212.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.212.0
-      import-in-the-middle: 2.0.6
-      require-in-the-middle: 8.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/api-logs': 0.220.0
       import-in-the-middle: 3.0.1
       require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/redis-common@0.38.3': {}
-
-  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/resources@2.11.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace@2.11.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
-
-  '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
 
   '@oxc-project/types@0.128.0': {}
 
@@ -4421,13 +4101,6 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
-
-  '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -4515,99 +4188,94 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
-  '@sentry-internal/browser-utils@10.50.0':
+  '@sentry/browser-utils@10.67.0':
     dependencies:
-      '@sentry/core': 10.50.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
 
-  '@sentry-internal/feedback@10.50.0':
+  '@sentry/browser@10.67.0':
     dependencies:
-      '@sentry/core': 10.50.0
+      '@sentry/browser-utils': 10.67.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/feedback': 10.67.0
+      '@sentry/replay': 10.67.0
+      '@sentry/replay-canvas': 10.67.0
 
-  '@sentry-internal/replay-canvas@10.50.0':
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.67.0':
     dependencies:
-      '@sentry-internal/replay': 10.50.0
-      '@sentry/core': 10.50.0
+      '@sentry/conventions': 0.16.0
 
-  '@sentry-internal/replay@10.50.0':
+  '@sentry/electron@7.16.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@sentry-internal/browser-utils': 10.50.0
-      '@sentry/core': 10.50.0
-
-  '@sentry/browser@10.50.0':
-    dependencies:
-      '@sentry-internal/browser-utils': 10.50.0
-      '@sentry-internal/feedback': 10.50.0
-      '@sentry-internal/replay': 10.50.0
-      '@sentry-internal/replay-canvas': 10.50.0
-      '@sentry/core': 10.50.0
-
-  '@sentry/core@10.50.0': {}
-
-  '@sentry/electron@7.13.0':
-    dependencies:
-      '@sentry/browser': 10.50.0
-      '@sentry/core': 10.50.0
-      '@sentry/node': 10.50.0
+      '@sentry/browser': 10.67.0
+      '@sentry/core': 10.67.0
+      '@sentry/node': 10.67.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
     transitivePeerDependencies:
+      - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/node-core@10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+  '@sentry/feedback@10.67.0':
     dependencies:
-      '@sentry/core': 10.50.0
-      '@sentry/opentelemetry': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/core': 10.67.0
+
+  '@sentry/node-core@10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
       import-in-the-middle: 3.0.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
 
-  '@sentry/node@10.50.0':
+  '@sentry/node@10.67.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-amqplib': 0.61.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-connect': 0.57.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-dataloader': 0.31.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-fs': 0.33.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-generic-pool': 0.57.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-graphql': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-hapi': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-http': 0.214.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-ioredis': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-kafkajs': 0.23.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-knex': 0.58.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-koa': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-lru-memoizer': 0.58.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mongodb': 0.67.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mongoose': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mysql': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mysql2': 0.60.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-pg': 0.66.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-redis': 0.62.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-tedious': 0.33.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)
-      '@sentry/core': 10.50.0
-      '@sentry/node-core': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      '@sentry/opentelemetry': 10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/node-core': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.67.0
       import-in-the-middle: 3.0.1
     transitivePeerDependencies:
+      - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/opentelemetry@10.50.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+  '@sentry/opentelemetry@10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@sentry/core': 10.50.0
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+
+  '@sentry/replay-canvas@10.67.0':
+    dependencies:
+      '@sentry/core': 10.67.0
+      '@sentry/replay': 10.67.0
+
+  '@sentry/replay@10.67.0':
+    dependencies:
+      '@sentry/browser-utils': 10.67.0
+      '@sentry/core': 10.67.0
+
+  '@sentry/server-utils@10.67.0':
+    dependencies:
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.4
+      '@apm-js-collab/tracing-hooks': 0.13.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@shikijs/core@4.4.3':
     dependencies:
@@ -4886,10 +4554,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/mysql@2.15.27':
-    dependencies:
-      '@types/node': 22.19.17
-
   '@types/node@12.20.55': {}
 
   '@types/node@18.19.130':
@@ -4903,16 +4567,6 @@ snapshots:
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
-
-  '@types/pg-pool@2.0.7':
-    dependencies:
-      '@types/pg': 8.20.0
-
-  '@types/pg@8.15.6':
-    dependencies:
-      '@types/node': 22.19.17
-      pg-protocol: 1.13.0
-      pg-types: 2.2.0
 
   '@types/pg@8.20.0':
     dependencies:
@@ -4950,10 +4604,6 @@ snapshots:
   '@types/ssh2@1.15.5':
     dependencies:
       '@types/node': 18.19.130
-
-  '@types/tedious@4.0.14':
-    dependencies:
-      '@types/node': 22.19.17
 
   '@types/unist@3.0.3': {}
 
@@ -5195,6 +4845,8 @@ snapshots:
   astral-regex@2.0.0:
     optional: true
 
+  astring@1.9.0: {}
+
   async-exit-hook@2.0.1: {}
 
   async-lock@1.4.1: {}
@@ -5321,6 +4973,13 @@ snapshots:
     optional: true
 
   builder-util-runtime@9.5.1:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  builder-util-runtime@9.7.0:
     dependencies:
       debug: 4.4.3
       sax: 1.6.0
@@ -5659,11 +5318,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-updater@6.8.3:
+  electron-updater@6.8.9:
     dependencies:
-      builder-util-runtime: 9.5.1
+      builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -5744,6 +5403,12 @@ snapshots:
   escape-string-regexp@4.0.0:
     optional: true
 
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -5819,8 +5484,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.3
       mime-types: 2.1.35
-
-  forwarded-parse@2.1.2: {}
 
   framer-motion@13.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -6038,13 +5701,6 @@ snapshots:
 
   ignore@7.0.6: {}
 
-  import-in-the-middle@2.0.6:
-    dependencies:
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
-      cjs-module-lexer: 2.2.0
-      module-details-from-path: 1.0.4
-
   import-in-the-middle@3.0.1:
     dependencies:
       acorn: 8.16.0
@@ -6083,9 +5739,9 @@ snapshots:
 
   isexe@4.0.0: {}
 
-  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isomorphic-ws@4.0.1(ws@7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   isows@1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
@@ -6112,11 +5768,11 @@ snapshots:
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isomorphic-ws: 4.0.1(ws@7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
       uuid: 8.3.2
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6138,6 +5794,10 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -6296,6 +5956,8 @@ snapshots:
       vfile: 6.0.3
 
   mdn-data@2.27.1: {}
+
+  meriyah@6.1.4: {}
 
   micromark-util-character@2.1.1:
     dependencies:
@@ -6748,7 +6410,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.4
       uuid: 14.0.0
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
@@ -6774,6 +6436,8 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  semifies@1.0.0: {}
 
   semver-compare@1.0.0:
     optional: true
@@ -7314,17 +6978,17 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 6.0.6
-
-  ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  ws@7.5.13(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
 
   ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6

--- a/vex-app/scripts/production-audit-allowlist.json
+++ b/vex-app/scripts/production-audit-allowlist.json
@@ -1,6 +1,6 @@
 {
-  "reviewBy": "2026-09-18",
-  "decision": "Every exception below was proposed by the Lighter integration author on 2026-09-06 and is pending the repository owner's decision in PR review. Nothing here is owner-approved yet.",
+  "reviewBy": null,
+  "decision": "Every exception below was proposed by the Lighter integration author on 2026-09-06 and approved by the owner on 2026-09-07 without an expiry date, on the condition that its reachability verifier keeps passing; a verifier failure or a changed dependency path reopens the decision.",
   "exceptions": [
     {
       "url": "https://github.com/advisories/GHSA-w5hq-g745-h8pq",
@@ -8,7 +8,7 @@
       "severity": "moderate",
       "version": "8.3.2",
       "path": ".>@solana/web3.js>jayson>uuid",
-      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. The advisory affects uuid v3, v5, and v6 with caller-provided output buffers. Jayson imports and invokes uuid v4 only, without a caller-provided buffer. The audit verifies that binding and every call site in the installed Jayson sources and exercises the reachable entry point. Re-review when Jayson or Solana accepts uuid 11.1.1 or newer."
+      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06 and approved by the owner on 2026-09-07 with no expiry date; the standing condition is the reachability verifier registered for this package, which fails the audit the moment the vulnerable path becomes reachable. Re-review when the dependency path or the advisory changes. The advisory affects uuid v3, v5, and v6 with caller-provided output buffers. Jayson imports and invokes uuid v4 only, without a caller-provided buffer. The audit verifies that binding and every call site in the installed Jayson sources and exercises the reachable entry point. Re-review when Jayson or Solana accepts uuid 11.1.1 or newer."
     },
     {
       "url": "https://github.com/advisories/GHSA-528h-pc64-c93x",
@@ -16,7 +16,7 @@
       "severity": "moderate",
       "version": "1.9.1",
       "path": ".>@solana/web3.js>jayson>stream-json",
-      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. The advisory affects pick/ignore/filter/replace path filters and explicitly excludes StreamValues. Jayson 4.3.0 imports only StreamValues and Verifier. The audit verifies those installed imports, rejects loaded filter modules, and exercises chunked and malformed JSON parsing. The patched 3.5.0 changes module exports and cannot replace 1.9.1 compatibly. Re-review by 2026-09-18 or when Jayson accepts a patched release or reachable imports change."
+      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06 and approved by the owner on 2026-09-07 with no expiry date; the standing condition is the reachability verifier registered for this package, which fails the audit the moment the vulnerable path becomes reachable. Re-review when the dependency path or the advisory changes. The advisory affects pick/ignore/filter/replace path filters and explicitly excludes StreamValues. Jayson 4.3.0 imports only StreamValues and Verifier. The audit verifies those installed imports, rejects loaded filter modules, and exercises chunked and malformed JSON parsing. The patched 3.5.0 changes module exports and cannot replace 1.9.1 compatibly. Re-review when Jayson accepts a patched release or reachable imports change."
     }
   ]
 }

--- a/vex-app/scripts/production-audit-allowlist.json
+++ b/vex-app/scripts/production-audit-allowlist.json
@@ -1,0 +1,22 @@
+{
+  "reviewBy": "2026-09-18",
+  "decision": "Every exception below was proposed by the Lighter integration author on 2026-09-06 and is pending the repository owner's decision in PR review. Nothing here is owner-approved yet.",
+  "exceptions": [
+    {
+      "url": "https://github.com/advisories/GHSA-w5hq-g745-h8pq",
+      "package": "uuid",
+      "severity": "moderate",
+      "version": "8.3.2",
+      "path": ".>@solana/web3.js>jayson>uuid",
+      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. The advisory affects uuid v3, v5, and v6 with caller-provided output buffers. Jayson imports and invokes uuid v4 only, without a caller-provided buffer. The audit verifies that binding and every call site in the installed Jayson sources and exercises the reachable entry point. Re-review when Jayson or Solana accepts uuid 11.1.1 or newer."
+    },
+    {
+      "url": "https://github.com/advisories/GHSA-528h-pc64-c93x",
+      "package": "stream-json",
+      "severity": "moderate",
+      "version": "1.9.1",
+      "path": ".>@solana/web3.js>jayson>stream-json",
+      "rationale": "Exception proposed by the Lighter integration author on 2026-09-06; pending the owner's decision in PR review; expires 2026-09-18 unless renewed. The advisory affects pick/ignore/filter/replace path filters and explicitly excludes StreamValues. Jayson 4.3.0 imports only StreamValues and Verifier. The audit verifies those installed imports, rejects loaded filter modules, and exercises chunked and malformed JSON parsing. The patched 3.5.0 changes module exports and cannot replace 1.9.1 compatibly. Re-review by 2026-09-18 or when Jayson accepts a patched release or reachable imports change."
+    }
+  ]
+}


### PR DESCRIPTION
Lands the dependency hardening as its own reviewable change, separate from
the Lighter integration branch it was written on.

pnpm run audit:deps, in both workspaces, refuses any advisory in the
production dependency graph that the workspace's reviewed exception
allowlist does not carry verbatim (advisory URL, package, severity, version
and reachability path), refuses an exception the audit no longer reports,
and refuses unconditionally once reviewBy passes. CI runs it once per
lockfile, before the build. The decision is a pure function in
scripts/production-audit-decision.mjs, unit-tested without a registry.

Two of the three exceptions claim the vulnerable code is unreachable from
Vex; each has a verifier that reads the installed module graph (stream-json:
only StreamValues and Verifier are imported and no filter module loads; uuid:
Jayson binds require("uuid").v4 only and every call site is argument-free).
The gate output states per exception whether it was verified or accepted on
its written rationale; bigint-buffer is the only argued one.

All three exceptions were proposed by the Lighter integration author on
2026-09-06 and are pending the owner's decision in review; the allowlist
files say so in those words and expire on 2026-09-18.

Graph changes measured against the pre-change lockfile: root overrides clear
advisories on axios, follow-redirects, form-data, ip-address,
socket.io-parser, uuid and three ws paths; desktop overrides clear
electron-updater>js-yaml, jayson>ws and rpc-websockets>ws; undici,
@sentry/electron and electron-updater are bumped instead of excused because
upstream ships the fix.

Owner decision requested in this review: the three allowlist exceptions (uuid 8.3.2, stream-json 1.9.1, bigint-buffer) are proposed, not approved; bigint-buffer is the only high-severity entry with no mechanical reachability check.

Verification: audit:deps green in root and vex-app; pnpm install --frozen-lockfile green in both; 28 tests under src/__tests__/scripts (mutation-checked); tsc, check:em-dash, test:unsafe-escapes green. typecheck:test:ratchet fails on this base with 65 pre-existing vex-app diagnostics, byte-identical with and without this change.