### PR TITLE
fix(pty-host): reserve the settlement window inside the shutdown bound

### DIFF
--- a/vex-app/docs/PTY_SHUTDOWN_AUDIT.md
+++ b/vex-app/docs/PTY_SHUTDOWN_AUDIT.md
@@ -1,0 +1,71 @@
+# PTY shutdown settlement audit
+
+## Evidence
+
+Both Windows jobs failed in cleanup with `EBUSY` removing a
+`vex-realpty-work-*` directory:
+
+- [Job 102114875908](https://github.com/Vex-Foundation/Vex/actions/jobs/102114875908):
+  the slow-consumer test, with 11,567 other tests passing. Its pause assertion
+  did not fail. Cleanup spent about 5,007 ms in `shutdownAll`, then reported
+  zero surviving shell PIDs before directory removal failed.
+- [Job 102062382075](https://github.com/Vex-Foundation/Vex/actions/jobs/102062382075):
+  the continuous snapshot producer. Its failure was directory removal, not
+  the snapshot assertion. The scoped rerun passed this case in 5,296 ms.
+
+The logs do not identify the process or handle holding the directory.
+
+`PtyHostService.runShutdown` limits the terminal phase to 5,000 ms.
+`TerminalProcess.beginGracefulShutdown` previously spent that same 5,000 ms
+before issuing a forced kill when output kept resetting the quiet-period
+timer. The host could therefore dispose the terminal at the moment of kill,
+removing the native exit listener and resolving the lifecycle promises before
+the native exit. The existing 3,000 ms settlement window was bypassed.
+
+The process now reserves that settlement window inside the unchanged total
+budget. The host watchdog remains for a pty or final cwd probe that never
+settles. No timeout value was increased.
+
+## Reference comparison
+
+Read from the local VS Code checkout:
+
+- `src/vs/platform/terminal/node/terminalProcess.ts`: data accounting,
+  pause/resume, exit debounce, forced shutdown and Windows handling.
+- `src/vs/platform/terminal/common/terminal.ts`: high/low watermarks.
+- `src/vs/platform/terminal/test/node/ptyHostService.test.ts`: listener ownership
+  across host restarts. A search of the requested terminal test subtree found
+  no real-process Windows teardown test to adopt.
+
+Adopted: synchronous producer-side character accounting with hysteresis,
+trailing-output debounce, bounded shutdown, and retained exit subscriptions.
+The production flow-control decision already follows these patterns and needs
+no new transition API for the supplied failures.
+
+Rejected: treating VS Code's kill-then-announce sequence as proof of native
+settlement, or using its fixed Windows kill/spawn throttle to prove a race.
+Vex releases terminal ownership on completion, which requires observing exit.
+
+The installed `node-pty@1.2.0-beta.15` emits Windows `onExit` from the ConPTY
+output socket's close handler. Its console descendant termination also has
+asynchronous work. A root PID disappearing is therefore insufficient evidence
+for removing the fixture directory. The real-process fixture now records
+native exits at spawn, including the Windows canary, and awaits those exits
+in addition to its independent PID leak detector before removal.
+
+## Verification boundary
+
+`shutdown-settlement.test.ts` keeps two native exits under explicit control
+while continuous output forces a kill. It fails against the original code
+because shutdown has already completed before either exit. It also checks that
+a missing exit still respects the existing total shutdown bound.
+
+The slow-consumer integration test gates production on completed replay, holds
+real parser acknowledgements, checks stopped output after delivery drains, and
+requires new output after releasing the acknowledgements. Its existing
+500 ms absence interval remains; it is not the sole proof of ordering.
+
+Linux exercises a real POSIX pty only. Windows CI must prove that native exit
+plus PID disappearance precedes successful directory removal for these
+ConPTY workloads, including its asynchronous descendant cleanup. The logs and
+Linux tests alone cannot prove which Windows handle held the directory.

--- a/vex-app/src/pty-host/__tests__/launch-and-exit.test.ts
+++ b/vex-app/src/pty-host/__tests__/launch-and-exit.test.ts
@@ -215,7 +215,7 @@ describe("exit sequencing", () => {
         pty.emit("still going\r\n");
       }
 
-      // The backstop fired at 5000 ms regardless, which is the whole point.
+      // Continuous output cannot extend the total 5000 ms shutdown budget.
       expect(pty.killed).toBe(true);
       expect(exits).toBe(1);
       expect(TERMINAL_MAXIMUM_SHUTDOWN_MS).toBe(5_000);

--- a/vex-app/src/pty-host/__tests__/real-pty.test.ts
+++ b/vex-app/src/pty-host/__tests__/real-pty.test.ts
@@ -34,12 +34,11 @@
  *
  * ## Cleanup is this suite's own responsibility
  *
- * `await shutdownAll()` does NOT mean the shells are dead: `dispose()` makes a
- * pending `kill()` return early, so the promise can resolve while a process is
- * still exiting. Every test therefore records the pids it spawned and REAPS
- * them - `process.kill(pid, 0)` until it throws ESRCH - rather than trusting
- * the service's own report. A leaked `yes` loop would otherwise outlive the
- * run and burn a core.
+ * Shutdown has a bounded fallback, so cleanup independently observes both the
+ * native pty exit and the spawned shell's disappearance. On Windows, node-pty
+ * emits exit when the ConPTY output socket closes; a dead shell PID alone does
+ * not establish that boundary. Both must precede removing the working directory.
+ * Survivors fail the test even when the detector has to kill them afterwards.
  *
  * EVERY SIGNAL GOES THROUGH `assertSignalablePid`, because "the pid the host
  * reported" and "a process this suite may signal" are not the same set: pid 0
@@ -167,6 +166,8 @@ let spawnedPids: number[];
  * spawner inside it is the production one, unchanged.
  */
 let spawnedPtys: PtyAdapter[];
+/** Native exit observers survive the host's bounded disposal fallback. */
+let ptyExits: Array<{ exited: boolean; dispose: () => void }>;
 let requestCounter = 0;
 
 function recordingSpawner(): PtySpawner {
@@ -174,6 +175,14 @@ function recordingSpawner(): PtySpawner {
   return (executable, args, options) => {
     const adapter = spawn(executable, args, options);
     spawnedPtys.push(adapter);
+    let exited = false;
+    const subscription = adapter.onExit(() => {
+      exited = true;
+    });
+    ptyExits.push({
+      get exited() { return exited; },
+      dispose: () => subscription.dispose(),
+    });
     return adapter;
   };
 }
@@ -642,6 +651,7 @@ beforeEach(async () => {
   services = [];
   spawnedPids = [];
   spawnedPtys = [];
+  ptyExits = [];
   traceWindowsPhase("beforeEach ready");
 });
 
@@ -660,6 +670,15 @@ afterEach(async () => {
   // because the harness did.
   const survivors = await detectSurvivors(spawnedPids);
   traceWindowsPhase(`afterEach survivors ${String(survivors.length)}`);
+  try {
+    await until(
+      () => ptyExits.every((pty) => pty.exited),
+      "every native pty exit (ConPTY output socket close on Windows)",
+      10_000,
+    );
+  } finally {
+    for (const pty of ptyExits) pty.dispose();
+  }
   await fs.rm(snapshotDir, { recursive: true, force: true });
   await fs.rm(workDir, { recursive: true, force: true });
   expect(survivors).toEqual([]);
@@ -712,7 +731,7 @@ describe.runIf(process.platform === "win32")("ConPTY under a vitest fork worker"
 
   it("spawns a real shell, reports a pid once it connects, and reads one line", async () => {
     traceWindowsPhase("canary: start");
-    const spawn = createNodePtySpawner();
+    const spawn = recordingSpawner();
     const pty = spawn(process.env.COMSPEC ?? "cmd.exe", ["/c", "echo VEX_CANARY"], {
       name: "xterm-256color",
       cols: 80,
@@ -1397,45 +1416,75 @@ describe("mirror-paced flow control against a real pty", () => {
     traceWindowsPhase("it: mirror-paced pause");
     const service = buildService();
     const port = new XtermConsumerPort();
-    await send(service, { kind: "attachWindow", windowId: WINDOW, nonce: "n".repeat(32) }, [
-      port,
-    ]);
+    try {
+      await send(service, { kind: "attachWindow", windowId: WINDOW, nonce: "n".repeat(32) }, [
+        port,
+      ]);
 
-    const line = "y".repeat(95);
-    await createTerminal(service, "t1", {
-      args: ["-c", `yes '${line}' | head -n 200000`],
-    });
-    // Armed, so the consumer WOULD ack - if it ever finished a write.
-    port.ackFor("t1");
-    port.stalled = true;
-    port.receive({ kind: "attach", terminalId: "t1" });
+      // ConPTY renders console rows and can coalesce output across the attach.
+      // Keep the marker within one row and gate production on the completed
+      // replay, so the pause belongs to this stalled consumer. The ready line
+      // lets node-pty's Windows first-data gate accept our input.
+      const line = "y".repeat(FLOOD_MARKER_CHARS);
+      await createTerminal(service, "t1", {
+        cols: FLOOD_COLS,
+        args: ["-c", `echo VEX_CONSUMER_READY; read _start; yes '${line}' | head -n 200000; read _hold`],
+      });
+      // Armed, so the consumer WOULD ack - if it ever finished a write.
+      port.ackFor("t1");
+      port.stalled = true;
+      port.receive({ kind: "attach", terminalId: "t1" });
+      await until(
+        () => port.eventsOfKind("replay").some((event) => event.last),
+        "the stalled consumer's attach replay to finish",
+      );
+      expect(await send(service, {
+        kind: "write",
+        terminalId: "t1",
+        windowId: WINDOW,
+        data: "\n",
+      })).toEqual({ ok: true, value: null });
 
-    const terminal = service.terminal("t1");
-    if (terminal === undefined) throw new Error("unreachable");
+      const terminal = service.terminal("t1");
+      if (terminal === undefined) throw new Error("unreachable");
 
-    // The producer is stopped at the source, because the only consumer stopped
-    // reporting progress.
-    await until(
-      () => terminal.process.isPaused,
-      "the pty to pause behind a stalled consumer",
-    );
+      // The producer is stopped at the source, because the only consumer stopped
+      // reporting progress.
+      await until(
+        () => terminal.process.isPaused,
+        "the pty to pause behind a stalled consumer",
+      );
+      const debt = terminal.process.unacknowledged;
+      expect(debt).toBeGreaterThan(TERMINAL_FLOW_HIGH_WATERMARK_CHARS);
+      // Drain the coalescer and real parser while its completion acknowledgements
+      // remain held. Their completion, not a particular ConPTY chunk count,
+      // establishes the stream whose growth is checked below.
+      await until(
+        () => dataOf(port).length === debt && port.outstandingWrites === 0,
+        "all paused output to reach the consumer's held completions",
+      );
 
-    // AND IT STAYS STOPPED. An arrival-time ack would have kept crediting the
-    // host and the stream would have run to completion regardless.
-    const atPause = port.eventsOfKind("data").length;
-    await delay(500);
-    const afterWaiting = port.eventsOfKind("data").length;
-    expect(afterWaiting - atPause).toBeLessThan(5);
+      // AND IT STAYS STOPPED. An arrival-time ack would have kept crediting the
+      // host and the stream would have run to completion regardless.
+      await delay(500);
+      expect(dataOf(port).length).toBe(debt);
+      expect(terminal.process.unacknowledged).toBe(debt);
+      expect(port.eventsOfKind("resyncRequired")).toEqual([]);
 
-    // Releasing the consumer lets the owed acks out and the producer resumes,
-    // so the pause was backpressure and not a deadlock.
-    port.resumeConsumer();
-    await until(
-      () => !terminal.process.isPaused,
-      "the pty to resume once the consumer caught up",
-    );
-
-    port.dispose();
+      // Releasing the consumer lets the owed acks out and the producer resumes,
+      // so the pause was backpressure and not a deadlock.
+      port.resumeConsumer();
+      await until(
+        () => dataOf(port).length > debt,
+        "new producer output after the consumer releases its completions",
+      );
+    } finally {
+      try {
+        await service.shutdownAll();
+      } finally {
+        port.dispose();
+      }
+    }
   }, 120_000);
 });
 

--- a/vex-app/src/pty-host/__tests__/shutdown-settlement.test.ts
+++ b/vex-app/src/pty-host/__tests__/shutdown-settlement.test.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  TERMINAL_MAXIMUM_SHUTDOWN_MS,
+  type TerminalHostMessage,
+} from "@shared/schemas/terminal.js";
+import { PtyHostService } from "../host-service.js";
+import { TerminalSnapshotStore } from "../snapshot-store.js";
+import { fakeProbe, scriptedSpawnerPool, type ScriptedPty } from "./scripted-pty.js";
+
+let directory: string;
+let service: PtyHostService;
+let ptys: ScriptedPty[];
+let messages: TerminalHostMessage[];
+
+beforeEach(async () => {
+  directory = await fs.mkdtemp(path.join(os.tmpdir(), "vex-shutdown-settlement-"));
+  vi.useFakeTimers();
+  const pool = scriptedSpawnerPool();
+  ptys = pool.ptys;
+  messages = [];
+  service = new PtyHostService({
+    spawn: pool.spawn,
+    probe: fakeProbe({
+      directories: ["/project"],
+      files: ["/bin/bash"],
+      executables: { bash: "/bin/bash" },
+    }),
+    baseEnv: { PATH: "/bin" },
+    snapshotStore: new TerminalSnapshotStore(directory),
+    scrollbackRows: 1000,
+    graceMs: 60_000,
+    shortGraceMs: 6_000,
+    sendToMain: (message) => messages.push(message),
+    platform: "win32",
+  });
+});
+
+afterEach(async () => {
+  try {
+    for (const pty of ptys) pty.exit(0);
+    const shutdown = service.shutdownAll();
+    await vi.advanceTimersByTimeAsync(TERMINAL_MAXIMUM_SHUTDOWN_MS);
+    await shutdown;
+  } finally {
+    vi.useRealTimers();
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+async function createTerminal(terminalId: string): Promise<ScriptedPty> {
+  await service.handleMainMessage({
+    requestId: terminalId,
+    request: {
+      kind: "create",
+      terminalId,
+      windowId: "window",
+      projectId: "project",
+      launch: {
+        executable: "bash",
+        args: [],
+        cwd: "/project",
+        projectLabel: "project",
+        cols: 80,
+        rows: 24,
+        env: {},
+      },
+    },
+  }, []);
+  const reply = messages.find((message) =>
+    message.kind === "reply" && message.requestId === terminalId);
+  expect(reply).toMatchObject({ kind: "reply", outcome: { ok: true } });
+  const pty = ptys[ptys.length - 1];
+  if (pty === undefined) throw new Error("create did not spawn a pty");
+  // Windows conpty can finish closing after kill returns. The test owns the
+  // eventual native exit event, independently of the kill request.
+  pty.ignoresKill = true;
+  return pty;
+}
+
+async function produceUntilKilled(producers: readonly ScriptedPty[]): Promise<void> {
+  for (let elapsed = 0; elapsed < TERMINAL_MAXIMUM_SHUTDOWN_MS; elapsed += 100) {
+    for (const pty of producers) pty.emit("still producing\r\n");
+    await vi.advanceTimersByTimeAsync(100);
+    if (producers.every((pty) => pty.killed)) return;
+  }
+  throw new Error("shutdown never killed all continuously producing ptys");
+}
+
+describe("host shutdown waits for conpty settlement", () => {
+  it("retains every continuously producing pty until its controlled native exit", async () => {
+    const first = await createTerminal("first");
+    const second = await createTerminal("second");
+    let completed = false;
+    const shutdown = service.shutdownAll().then(() => { completed = true; });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Output resets the quiet-period debounce, so shutdown must force a kill.
+    // Observing that kill is the gate: no wall-clock race or sampled delay.
+    await produceUntilKilled([first, second]);
+    expect(completed).toBe(false);
+    expect(messages.filter((message) => message.kind === "terminalExit")).toEqual([]);
+
+    first.exit(17);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(completed).toBe(false);
+    expect(messages.filter((message) => message.kind === "terminalExit")).toEqual([
+      { kind: "terminalExit", terminalId: "first", exitCode: 17, signal: null },
+    ]);
+    expect(service.terminal("second")).toBeDefined();
+
+    second.exit(23);
+    await shutdown;
+    expect(messages.filter((message) => message.kind === "terminalExit")).toEqual([
+      { kind: "terminalExit", terminalId: "first", exitCode: 17, signal: null },
+      { kind: "terminalExit", terminalId: "second", exitCode: 23, signal: null },
+    ]);
+    expect(service.terminal("first")).toBeUndefined();
+    expect(service.terminal("second")).toBeUndefined();
+  });
+
+  it("keeps the existing shutdown bound when the native exit never arrives", async () => {
+    const pty = await createTerminal("wedged");
+    let completed = false;
+    const shutdown = service.shutdownAll().then(() => { completed = true; });
+    await vi.advanceTimersByTimeAsync(0);
+    const started = Date.now();
+    await produceUntilKilled([pty]);
+    const remaining = TERMINAL_MAXIMUM_SHUTDOWN_MS - (Date.now() - started);
+    if (remaining > 0) {
+      await vi.advanceTimersByTimeAsync(remaining - 1);
+      expect(completed).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+    }
+    await shutdown;
+    expect(completed).toBe(true);
+    expect(Date.now() - started).toBe(TERMINAL_MAXIMUM_SHUTDOWN_MS);
+    expect(service.terminal("wedged")).toBeUndefined();
+  });
+});

--- a/vex-app/src/pty-host/terminal-process.ts
+++ b/vex-app/src/pty-host/terminal-process.ts
@@ -856,6 +856,10 @@ export class TerminalProcess {
 
   private beginGracefulShutdown(): void {
     this.queueExit();
+    // The host's total shutdown bound includes waiting for the native exit.
+    // Using that whole bound before issuing kill lets the host dispose this
+    // owner just as kill begins, removing the exit listener while ConPTY is
+    // still closing. Reserve the existing settlement window within the bound.
     this.forceKillTimer = setTimeout(() => {
       this.forceKillTimer = null;
       if (this.closeTimer !== null && !this.disposed) {
@@ -863,7 +867,7 @@ export class TerminalProcess {
         this.closeTimer = null;
         void this.kill();
       }
-    }, TERMINAL_MAXIMUM_SHUTDOWN_MS);
+    }, TERMINAL_MAXIMUM_SHUTDOWN_MS - TERMINAL_KILL_SETTLE_MS);
     this.forceKillTimer.unref?.();
   }
 

--- a/vex-app/src/shared/schemas/terminal.ts
+++ b/vex-app/src/shared/schemas/terminal.ts
@@ -174,7 +174,7 @@ export const TERMINAL_DATA_FLUSH_TIMEOUT_MS = 250;
  */
 export const TERMINAL_SNAPSHOT_DRAIN_MS = 1_000;
 
-/** Force-kill backstop for a pty that will not exit on its own. */
+/** Total pty shutdown budget, including the native exit wait after force-kill. */
 export const TERMINAL_MAXIMUM_SHUTDOWN_MS = 5_000;
 
 /**


### PR DESCRIPTION
## Problem

Two Windows CI failures in `vex-app/src/pty-host/__tests__/real-pty.test.ts` (runs 34226677072 and the main run for c8ebc5cb2) both ended in cleanup: `EBUSY: resource busy or locked, rmdir ...vex-realpty-work-...`. The assertions had passed. The host disposed a terminal at the same 5-second deadline its force-kill timer used, removing the exit listener while ConPTY was still closing, so the native exit was never awaited and the temp directory was still held.

## Change

- `terminal-process.ts`: the force kill fires at the shutdown bound minus the existing settlement window, so the native exit is awaited inside the bound.
- `real-pty.test.ts`: awaits the native exit before removing its directory; production is gated on replay and resumed output is verified.
- `shutdown-settlement.test.ts` (new): controlled-clock regressions for the exit and deadline ordering; red when the original timer is restored.
- `terminal.ts` schema and `launch-and-exit.test.ts`: budget comments corrected.
- `vex-app/docs/PTY_SHUTDOWN_AUDIT.md`: evidence and the adopted and rejected patterns from VS Code's pty host flow control.

## Verification

- `pnpm exec vitest run src/pty-host` three times: 150 passed each, one existing Windows-only skip.
- `pnpm run lint` (tsc, ratchet, boundaries), `pnpm run check:em-dash`, `pnpm run test:unsafe-escapes`: passed.
- Windows ConPTY cannot run locally; the Windows CI job is the proof for the flow assertions and the directory removal after native exit.