### PR TITLE
fix(studio): give agents an inline protocol map and correct the instruction and consent text

### DIFF
--- a/src/__tests__/vex-agent/studio/changelog.test.ts
+++ b/src/__tests__/vex-agent/studio/changelog.test.ts
@@ -79,6 +79,15 @@ describe("the shipped change log", () => {
     expect(studioChangelogTag("Thing", entries)).toBe("Changed in Vex 2.0");
   });
 
+  it("removes heading tags once their version leaves the visible history", () => {
+    const entries = Array.from({ length: STUDIO_CHANGELOG_VERSION_LIMIT + 1 }, (_, index) =>
+      entry({ version: `9.${index}`, subject: `Subject ${index}` }));
+    const agedSubject = `Subject ${STUDIO_CHANGELOG_VERSION_LIMIT}`;
+    expect(studioChangelogWindow(entries).some((note) => note.subject === agedSubject)).toBe(false);
+    expect(studioChangelogTag(agedSubject, entries)).toBeNull();
+    expect(studioChangelogTag("Subject 0", entries)).toBe("Added in Vex 9.0");
+  });
+
   it("does NOT tag a heading from a `removed` entry", () => {
     // The thing it names is gone; there is no heading left to label.
     const entries = [entry({ kind: "removed", subject: "GoneTool" })];

--- a/src/__tests__/vex-agent/studio/instruction-corrections.test.ts
+++ b/src/__tests__/vex-agent/studio/instruction-corrections.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  STUDIO_BUG_REPORT_NOTE,
+  STUDIO_COMMON_JOBS_NOTE,
+  renderStudioBlockTitle,
+  renderStudioBuildingAppsNote,
+  renderStudioHowToWorkWithVexMcp,
+  renderStudioProjectIdentity,
+} from "@vex-agent/studio/instructions/project-brief.js";
+import {
+  STUDIO_RULE_QUOTE_FIRST,
+  STUDIO_OUTCOME_WORDS,
+  renderStudioOutcomeVocabulary,
+} from "@vex-agent/studio/instructions/shared-usage.js";
+import { studioOutcomeToCallToolResult } from "@vex-agent/mcp/server-result.js";
+import { STUDIO_TEST_BRIEF } from "./render-fixtures.js";
+
+const prose = (text: string): string => text.replace(/\s+/g, " ");
+
+describe("Studio instruction corrections", () => {
+  it.each(["full", "restricted"] as const)("describes prepared cards and client policy under %s", (permission) => {
+    const text = prose(renderStudioProjectIdentity({ ...STUDIO_TEST_BRIEF, permission }));
+    expect(text).toContain("Wallet Prepare tools return an intent for a separate Confirm call");
+    expect(text).toContain("some protocol Prepare tools automatically hand off to an approval card, including Lighter flows");
+    expect(text).toContain("Vex's permission controls Vex's own execution gate");
+    expect(text).toContain("Follow additional binding client policy");
+    expect(text).not.toContain("satisfies any confirm-before");
+    if (permission === "full") {
+      expect(text).toContain("Supported direct Vex actions within the user's task execute without per-call approval");
+      expect(text).toContain("can still require their own Vex card");
+    }
+  });
+
+  it("requires actual authorization before widening slippage", () => {
+    const text = prose(STUDIO_COMMON_JOBS_NOTE);
+    expect(text).toContain("RE-QUOTE AT THE SAME SLIPPAGE FIRST");
+    expect(text).toContain("only within the user's stated limit or after the user authorizes the new worst-case amount");
+    expect(text).toContain("Announcing a larger bound does not authorize it");
+    expect(text).not.toContain("in the open and confirmed by the card");
+  });
+
+  it("uses current market and position state when no quote or preview exists", () => {
+    expect(STUDIO_RULE_QUOTE_FIRST).toContain("quotes/previews if offered");
+    expect(STUDIO_RULE_QUOTE_FIRST).toContain("read current market/position state");
+    expect(STUDIO_RULE_QUOTE_FIRST).toContain("Disclose effects, amounts, costs, impact and ETA before acting");
+    expect(STUDIO_RULE_QUOTE_FIRST).not.toContain("quote before any");
+  });
+
+  it("distinguishes ordinary provider requests from public image publication", () => {
+    const text = prose(STUDIO_BUG_REPORT_NOTE);
+    expect(text).toContain("Ordinary quotes and research send necessary inputs to their providers");
+    expect(text).toContain("Publication tools, including `launchpads__image_publish`, make content public and require a corresponding user request");
+    expect(text).not.toContain("Calling a Vex tool is not publishing");
+  });
+
+  it("reports expiry before fresh terms and a new approval, on the wire and in the guide", () => {
+    const result = studioOutcomeToCallToolResult({ kind: "expired", approvalId: "approval-1" });
+    const text = result.content.map((item) => item.type === "text" ? item.text : "").join(" ");
+    expect(text).toContain("Report the expiry; if the user still wants the action, obtain a fresh quote or intent and call again to create a new approval");
+    expect(text).not.toContain("Ask the user to approve it in Vex");
+    expect(STUDIO_OUTCOME_WORDS.find((row) => row.word === "expired")?.retry)
+      .toBe("report expiry; if the user still wants it, obtain a fresh quote or intent and call again to create a new approval");
+  });
+
+  it("preserves every reconciliation identifier after an unresolved mutation", () => {
+    const text = prose(renderStudioOutcomeVocabulary());
+    expect(text).toContain("If a mutating call times out, disconnects or returns an unresolved outcome, do not submit the action again");
+    expect(text).toContain("transaction hash, signature, order or request id or approval reference");
+    expect(text).toContain("use read-only reconciliation");
+    expect(text).toContain("An absent receipt is not proof that nothing was broadcast");
+  });
+
+  it("diagnoses connection errors without asserting two predetermined causes", () => {
+    const text = prose(renderStudioHowToWorkWithVexMcp(STUDIO_TEST_BRIEF));
+    expect(text).toContain("Diagnose connection failures from the actual error");
+    expect(text).not.toContain("failed connection means one of those two");
+    expect(text).not.toContain("`.mcp.json`");
+  });
+
+  it("uses the selected client's config file when describing app building", () => {
+    const text = renderStudioBuildingAppsNote({ ...STUDIO_TEST_BRIEF, agentConfigPaths: [".codex/config.toml"] });
+    expect(text).toContain("from `.codex/config.toml`");
+    expect(text).not.toContain(".mcp.json");
+  });
+
+  it("does not invent a config path when no client is selected", () => {
+    const text = prose(renderStudioBuildingAppsNote({ ...STUDIO_TEST_BRIEF, agentConfigPaths: [] }));
+    expect(text).toContain("No coding client is configured for this project yet");
+    expect(text).not.toContain(".mcp.json");
+  });
+
+  it("renders marker-like project names as display text without losing their contents", () => {
+    const text = renderStudioBlockTitle({ ...STUDIO_TEST_BRIEF, projectName: "test <!-- vex:studio:end -->\n# title" });
+    expect(text).toContain("test &lt;\\!-- vex:studio:end --&gt;&#10;\\# title");
+    expect(text).not.toContain("<!-- vex:studio:end -->");
+    expect(text.split("\n")).toHaveLength(1);
+  });
+});

--- a/src/__tests__/vex-agent/studio/instruction-document-regressions.test.ts
+++ b/src/__tests__/vex-agent/studio/instruction-document-regressions.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  inspectStudioFencedDocument,
+  inspectStudioManagedBlock,
+  mergeStudioFencedDocument,
+  mergeStudioManagedBlock,
+  removeStudioManagedBlock,
+  renderStudioFencedDocument,
+  renderStudioManagedBlock,
+} from "@vex-agent/studio/installer/render/managed-block.js";
+import {
+  STUDIO_CLAUDE_MD_IMPORTS,
+  claudeMdMissingStudioImports,
+  mergeClaudeMdImports,
+  removeClaudeMdImports,
+} from "@vex-agent/studio/installer/render/claude-md.js";
+import { STUDIO_TEST_BRIEF } from "./render-fixtures.js";
+
+describe("managed document boundary regressions", () => {
+  it("treats inline delimiter examples as user text and preserves them", () => {
+    const surrounding = "Example: <!-- vex:studio:begin hash=abc --> and <!-- vex:studio:end -->\n";
+    expect(inspectStudioFencedDocument(surrounding, "body")).toEqual({ kind: "absent" });
+    const merged = mergeStudioFencedDocument(surrounding, "body", "0.2.7", { overwriteDrift: false });
+    expect(merged.status).toBe("rendered");
+    if (merged.status !== "rendered") throw new Error("expected rendered");
+    expect(removeStudioManagedBlock(merged.text)).toEqual({ status: "rendered", text: surrounding });
+  });
+
+  it("keeps marker-like project names intact and Repair idempotent", () => {
+    const brief = { ...STUDIO_TEST_BRIEF, projectName: "test <!-- vex:studio:end -->" };
+    const fresh = renderStudioManagedBlock(brief);
+    expect(inspectStudioManagedBlock(fresh, brief)).toEqual({ kind: "intact", upToDate: true });
+    const edited = fresh.replace("This repository is connected", "This repository WAS connected");
+    const repaired = mergeStudioManagedBlock(edited, brief, { overwriteDrift: true });
+    expect(repaired).toEqual({ status: "rendered", text: fresh });
+    if (repaired.status !== "rendered") throw new Error("expected rendered");
+    expect(mergeStudioManagedBlock(repaired.text, brief, { overwriteDrift: true }))
+      .toEqual({ status: "unchanged" });
+  });
+
+  it.each(["second block", "second begin", "second end"])("refuses %s by name even during Repair", (variant) => {
+    const block = renderStudioFencedDocument("body", "0.2.7");
+    const duplicate = variant === "second block" ? block + block
+      : variant === "second begin" ? "<!-- vex:studio:begin hash=abc -->\n" + block
+        : block + "<!-- vex:studio:end -->\n";
+    expect(inspectStudioFencedDocument(duplicate, "body")).toMatchObject({ kind: "malformed" });
+    for (const result of [
+      mergeStudioFencedDocument(duplicate, "body", "0.2.7", { overwriteDrift: true }),
+      removeStudioManagedBlock(duplicate),
+    ]) {
+      expect(result).toMatchObject({ status: "refused", reason: "malformed_managed_block" });
+      if (result.status === "refused") expect(result.detail).toContain("duplicate_managed_block");
+    }
+  });
+
+  it("accepts untouched CRLF content and preserves surrounding bytes through refresh and removal", () => {
+    const before = "# User\r\n  trailing spaces  \r\n";
+    const after = "\r\nUser suffix\r\n";
+    const block = renderStudioFencedDocument("first\nsecond", "0.2.7").replace(/\n/g, "\r\n");
+    const existing = before + block + after;
+    expect(inspectStudioFencedDocument(existing, "first\nsecond"))
+      .toEqual({ kind: "intact", upToDate: true });
+    expect(mergeStudioFencedDocument(existing, "first\nsecond", "0.2.7", { overwriteDrift: false }))
+      .toEqual({ status: "unchanged" });
+    const refresh = mergeStudioFencedDocument(existing, "updated\nbody", "0.2.7", { overwriteDrift: false });
+    expect(refresh.status).toBe("rendered");
+    if (refresh.status !== "rendered") throw new Error("expected rendered");
+    expect(refresh.text.startsWith(before)).toBe(true);
+    expect(refresh.text.endsWith(after)).toBe(true);
+    expect(inspectStudioFencedDocument(refresh.text, "updated\nbody"))
+      .toEqual({ kind: "intact", upToDate: true });
+    expect(removeStudioManagedBlock(refresh.text)).toEqual({ status: "rendered", text: before + after });
+    expect(inspectStudioFencedDocument(existing.replace("second", "edited"), "first\nsecond").kind)
+      .toBe("drifted");
+  });
+});
+
+describe("active Claude imports", () => {
+  it("preserves fenced imports inside a nested list and appends active imports", () => {
+    const example = "- Example:\n    ```md\n    @AGENTS.md\n    @.vex/vex-guide.md\n    ```\n";
+    expect(claudeMdMissingStudioImports(example)).toEqual(STUDIO_CLAUDE_MD_IMPORTS);
+    expect(removeClaudeMdImports(example)).toEqual({ status: "unchanged" });
+    const merged = mergeClaudeMdImports(example);
+    expect(merged.status).toBe("rendered");
+    if (merged.status !== "rendered") throw new Error("expected rendered");
+    expect(claudeMdMissingStudioImports(merged.text)).toEqual([]);
+    expect(removeClaudeMdImports(merged.text)).toEqual({ status: "rendered", text: example });
+  });
+
+  it("refuses to append imports inside an unclosed example", () => {
+    const example = "# Example\n```md\n@AGENTS.md\n";
+    expect(mergeClaudeMdImports(example)).toMatchObject({
+      status: "refused", reason: "malformed_markdown_fence",
+    });
+    expect(removeClaudeMdImports(example)).toEqual({ status: "unchanged" });
+  });
+
+  it.each(["```md", "~~~~markdown", "   ```"])("ignores and preserves examples in %s fences", (opening) => {
+    const marker = opening.trim().startsWith("~") ? "~~~~" : "```";
+    const example = ["# Examples", opening, ...STUDIO_CLAUDE_MD_IMPORTS, marker, ""].join("\r\n");
+    expect(claudeMdMissingStudioImports(example)).toEqual(STUDIO_CLAUDE_MD_IMPORTS);
+    expect(removeClaudeMdImports(example)).toEqual({ status: "unchanged" });
+    const merged = mergeClaudeMdImports(example);
+    expect(merged.status).toBe("rendered");
+    if (merged.status !== "rendered") throw new Error("expected rendered");
+    expect(merged.text.startsWith(example)).toBe(true);
+    expect(claudeMdMissingStudioImports(merged.text)).toEqual([]);
+    expect(removeClaudeMdImports(merged.text)).toEqual({ status: "rendered", text: example });
+  });
+
+  it("does not close a fence on a shorter or different marker", () => {
+    const example = ["````md", "```", "~~~", ...STUDIO_CLAUDE_MD_IMPORTS, "````", ""].join("\n");
+    expect(claudeMdMissingStudioImports(example)).toEqual(STUDIO_CLAUDE_MD_IMPORTS);
+    expect(removeClaudeMdImports(example)).toEqual({ status: "unchanged" });
+  });
+});

--- a/src/__tests__/vex-agent/studio/instructions-extraction.test.ts
+++ b/src/__tests__/vex-agent/studio/instructions-extraction.test.ts
@@ -59,6 +59,11 @@
  *       - A19: the SAME SOURCE sentence tells the reader which other copy exists
  *         and that neither overrides the other.
  *
+ *  4. The 2026-09-08 review replaces the universal quote rule with quotes or
+ *     previews where offered, otherwise current market and position reads.
+ *     Effects and costs are disclosed before acting. APPROVAL is reworded
+ *     without changing its requirements to retain the 512-character bound.
+ *
  * The budget lints in `mcp/instructions.test.ts` continue to own the
  * 512-character prefix and the 2000-byte whole-string bounds.
  */
@@ -77,14 +82,13 @@ import {
 /** Written out by hand. An edit that lands here is an authored decision. */
 const PINNED_INSTRUCTIONS =
   "Vex moves REAL funds. Nothing here is a sandbox or testnet.\n"
-  + "1. APPROVAL: in a restricted project a destructive call BLOCKS "
-  + "until the user answers the card in Vex; the result IS the settled "
-  + "outcome. Never call again while one is unanswered, and never retry "
-  + "an UNKNOWN outcome.\n"
-  + "2. QUOTE FIRST: quote before any swap, bridge, trade or lend, then"
-  + " restate amounts, fees, impact and ETA.\n"
+  + "1. APPROVAL: a restricted destructive call BLOCKS until the user answers "
+  + "Vex's card; the result IS the settled outcome. Never call again while one "
+  + "is unanswered or retry an UNKNOWN outcome.\n"
+  + "2. QUOTE FIRST: use quotes/previews if offered; else read current market/position "
+  + "state. Disclose effects, amounts, costs, impact and ETA before acting.\n"
   + "3. AMOUNTS: units are PER FIELD - human decimals or raw smallest "
-  + "units. Read the field description; never guess.\n"
+  + "units. Read field descriptions; never guess.\n"
   + "\n"
   + "FINDING TOOLS: every tool is in tools/list. vex_ToolSearch (read-"
   + "only) finds one by intent; vex_ToolDescribe returns a tool's whole"

--- a/src/__tests__/vex-agent/studio/instructions-fee-note.test.ts
+++ b/src/__tests__/vex-agent/studio/instructions-fee-note.test.ts
@@ -29,6 +29,8 @@ import { UNISWAP_FEE_BPS } from "@tools/uniswap/fee/constants.js";
 import { BRIDGE_FEE_BPS } from "@tools/bridge-fee/constants.js";
 import { POOLS_FEE_BPS } from "@tools/pools-fun/fee/venue.js";
 import { JUPITER_SWAP_FEE_BPS } from "@tools/solana-ecosystem/jupiter/jupiter-swaps/constants.js";
+import { LIGHTER_FEE_TICK, LIGHTER_PERPS_FEE, LIGHTER_SPOT_FEE } from "@tools/lighter/fee-policy.js";
+import { VIRTUALS_CURVE_FEE_BPS, virtualsCurveSellFeeFromProceeds } from "@tools/virtuals/curve/fee.js";
 import { WALLET_TX_FEE_BPS } from "@vex-agent/tools/internal/wallet/transaction/vex-fee.js";
 
 const REPO_ROOT = resolve(__dirname, "..", "..", "..", "..");
@@ -55,7 +57,7 @@ function importsAFeeModule(directory: string): boolean {
 }
 
 describe("the Vex fee note in the managed block", () => {
-  it("states the ONE rate every charging venue actually uses", () => {
+  it("states the 25 bps rate for each input-fee operation", () => {
     const rates = [
       KYBERSWAP_FEE_BPS,
       UNISWAP_FEE_BPS,
@@ -64,9 +66,8 @@ describe("the Vex fee note in the managed block", () => {
       POOLS_FEE_BPS,
       WALLET_TX_FEE_BPS,
     ];
-    // The note says one number because the code has one number. The day a venue
-    // charges something else, this fails and the note has to name the venue
-    // rather than keep implying they agree.
+    // These input-fee operations share a rate; Lighter and Virtuals sells
+    // have separate checks below for their rate and fee basis.
     expect(new Set(rates).size, `rates disagree: ${rates.join(", ")}`).toBe(1);
     expect(STUDIO_FEE_NOTE).toContain(`${String(rates[0])} bps`);
     expect(STUDIO_FEE_NOTE).toContain("0.25%");
@@ -139,8 +140,10 @@ describe("the Vex fee note in the managed block", () => {
   });
 
   it("says a failed attempt is never charged, and does not conflate gas with the fee", () => {
-    expect(STUDIO_FEE_NOTE).toContain("at the moment the operation");
-    expect(STUDIO_FEE_NOTE).toContain("never on a failed, reverted or never-broadcast");
+    expect(STUDIO_FEE_NOTE).toContain("A refused, reverted or never-broadcast");
+    expect(STUDIO_FEE_NOTE).toContain("operation has no Vex execution fee");
+    expect(STUDIO_FEE_NOTE).toContain("destination delivery is a separate outcome");
+    expect(STUDIO_FEE_NOTE).not.toContain("a bridge that does not");
     expect(STUDIO_FEE_NOTE).toContain("Network gas");
     expect(STUDIO_FEE_NOTE).toContain("NOT Vex's fee");
   });
@@ -153,6 +156,23 @@ describe("the Vex fee note in the managed block", () => {
     // the ordering.
     expect(STUDIO_FEE_NOTE).not.toContain("and only after the operation");
     expect(STUDIO_FEE_NOTE).toContain("inside the route for a swap");
+  });
+
+  it("separates Lighter perpetual and spot rates from exchange fees", () => {
+    const perpsBps = LIGHTER_PERPS_FEE * 10_000 / LIGHTER_FEE_TICK;
+    const spotBps = LIGHTER_SPOT_FEE * 10_000 / LIGHTER_FEE_TICK;
+    expect(STUDIO_FEE_NOTE).toContain(`Lighter: ${perpsBps} bps perpetual and ${spotBps} bps spot`);
+    expect(STUDIO_FEE_NOTE).toContain("on fills, maker and taker");
+    expect(STUDIO_FEE_NOTE).toContain("separate from exchange fees");
+    expect(STUDIO_FEE_NOTE).not.toContain("Vex charges 25 bps (0.25%) of the INPUT asset");
+  });
+
+  it("charges Virtuals sells on proven proceeds, not the sold input", () => {
+    expect(STUDIO_FEE_NOTE).toContain(`Sells: ${VIRTUALS_CURVE_FEE_BPS} bps of proven VIRTUAL proceeds`);
+    expect(STUDIO_FEE_NOTE).toContain("after settlement; a quote's sell fee is an estimate");
+    expect(STUDIO_FEE_NOTE).toContain("No proven proceeds, no fee");
+    expect(virtualsCurveSellFeeFromProceeds(1_000_000n)).toBe(2_500n);
+    expect(virtualsCurveSellFeeFromProceeds(0n)).toBe(0n);
   });
 
   it("makes the Uniswap sentence add up (I-6d)", () => {

--- a/src/__tests__/vex-agent/studio/managed-block.test.ts
+++ b/src/__tests__/vex-agent/studio/managed-block.test.ts
@@ -14,6 +14,8 @@ import { resolve } from "node:path";
 
 import { describe, it, expect } from "vitest";
 
+import { studioDeclaredEnvironmentKeys } from "@vex-agent/studio/instructions/installation-environment.js";
+import { buildStudioInventory } from "@vex-agent/mcp/inventory/index.js";
 import { STUDIO_SAFETY_PREFIX } from "@vex-agent/mcp/instructions.js";
 import {
   STUDIO_PROTOCOLS_DOC_PATH,
@@ -60,6 +62,8 @@ import {
 } from "./render-fixtures.js";
 
 const REPO_ROOT = resolve(__dirname, "..", "..", "..", "..");
+
+const MAXIMUM_ENVIRONMENT = { configuredKeys: studioDeclaredEnvironmentKeys(), missingKeys: [] };
 
 const USER_TEXT_BEFORE = "# Contributing\n\nRun the tests before you push.\n";
 const USER_TEXT_AFTER = "\n## House style\n\nNo em dashes.\n";
@@ -112,15 +116,30 @@ describe("the managed block's content", () => {
     // every agent in the registry selected, eight selected wallets (four per
     // family), and STUDIO_CHANGE_NOTE_LIMIT notes each at the 400-character
     // summary bound the durable row enforces (`project_change_notes.summary`
-    // CHECK, migration 089). Nothing enforces the bound at runtime, so a render
-    // that only fits the fixture would ship an oversized block to exactly the
-    // user with the most in the project - and their client would silently cut
-    // it.
+    // CHECK, migration 089). The runtime also refuses by the named byte bound;
+    // this guard makes sure valid maximum inputs can still render.
     const bytes = Buffer.byteLength(
-      renderStudioManagedBody(longestStudioBrief()),
+      renderStudioManagedBody(longestStudioBrief(), MAXIMUM_ENVIRONMENT),
       "utf8",
     );
     expect(bytes).toBeLessThanOrEqual(STUDIO_MANAGED_BLOCK_MAX_BYTES);
+  });
+
+  it("fits maximum display-escaping expansion without cutting any project text", () => {
+    const longest = { ...longestStudioBrief(), projectName: "&".repeat(PROJECT_NAME_MAX_LENGTH) };
+    const body = renderStudioManagedBody(longest, MAXIMUM_ENVIRONMENT);
+    expect(body).toContain("&amp;".repeat(PROJECT_NAME_MAX_LENGTH));
+    expect(Buffer.byteLength(body, "utf8")).toBeLessThanOrEqual(STUDIO_MANAGED_BLOCK_MAX_BYTES);
+  });
+
+  it("measures the current live inventory in its maximum-input budget fixture", () => {
+    const longest = longestStudioBrief();
+    const live = buildStudioInventory();
+    expect(longest.inventory.alwaysLoadedNames)
+      .toEqual(live.filter((tool) => tool.alwaysLoad).map((tool) => tool.publicName));
+    expect(longest.inventory.searchableCount).toBe(live.filter((tool) => !tool.alwaysLoad).length);
+    expect(longest.inventory.protocols.map((protocol) => protocol.name))
+      .toEqual([...new Set(live.filter((tool) => tool.kind === "protocol").map((tool) => tool.namespace))]);
   });
 
   it("keeps the whole authority core inside the bound, not merely the fixture", () => {
@@ -130,7 +149,10 @@ describe("the managed block's content", () => {
     const longest = longestStudioBrief();
     expect(longest.projectName).toHaveLength(PROJECT_NAME_MAX_LENGTH);
     expect(longest.changeNotes).toHaveLength(STUDIO_CHANGE_NOTE_LIMIT);
-    expect(longest.changeNotes[0]?.summary).toHaveLength(400);
+    expect([...(longest.changeNotes[0]?.summary ?? "")]).toHaveLength(400);
+    expect(Buffer.byteLength(longest.changeNotes[0]?.summary ?? "", "utf8")).toBe(1600);
+    expect(Buffer.byteLength(longest.projectName, "utf8")).toBe(PROJECT_NAME_MAX_LENGTH * 3);
+
     expect(longest.wallets).toHaveLength(8);
     expect(longest.agentNames).toHaveLength(STUDIO_AGENT_LIST.length);
     // And it really is longer than the fixture the goldens use.
@@ -166,7 +188,9 @@ describe("the managed block's content", () => {
 
     expect(body).toContain(STUDIO_VEX_GUIDE_PATH);
     expect(body).toContain(STUDIO_PROTOCOLS_DOC_PATH);
-    expect(body).toContain("READ IT AT THE START OF A SESSION");
+    expect(body).toContain("Read the relevant protocol section before using it unless already in context");
+    expect(body).toContain("Other clients do not load");
+    expect(body).toContain("it automatically; the map above is what they have until they open the guide");
     expect(body).toContain("READ IT ON DEMAND");
     // And it says WHO already has it, so a Claude Code session does not go
     // looking for a file its import already loaded.
@@ -354,7 +378,9 @@ describe("the project-dependent half of the block", () => {
     expect(body).toContain("registered");
     // t1 #7: `.mcp.json` can point at a path that no longer exists, and "start
     // Vex" was then the only diagnosis the agent had, which was wrong.
-    expect(body).toContain("`vex-mcp` path in `.mcp.json` no longer exists");
+    expect(body).toContain("Diagnose connection failures from the actual error");
+    expect(body).toContain("configured bridge command, path and");
+    expect(body).toContain("Do not assume a predetermined cause");
     // A15: what a locked vault looks like from the agent's side.
     expect(body).toContain("locked vault refuses BY NAME");
   });
@@ -471,7 +497,9 @@ describe("the project-dependent half of the block", () => {
     // I-6a, p1.txt lines 7-9. The block forbade what SwapQuote/SwapExecute
     // instruct ("re-quote with a higher slippageBps", "raise it in steps").
     expect(body).toContain("RE-QUOTE AT THE SAME SLIPPAGE FIRST");
-    expect(body).toContain("Raise `slippageBps` only when the");
+    expect(body).toContain("Increase `slippageBps` only within the");
+    expect(body).toContain("user's stated limit or after the user authorizes the new worst-case amount");
+    expect(body).toContain("Announcing a larger bound does not authorize it");
     expect(body).not.toContain("never raise slippage to force a trade through");
     // p1.txt lines 43-45: a literal reading refused every Solana quote.
     expect(body).toContain("on Solana there are no USD figures at all");
@@ -482,12 +510,12 @@ describe("the project-dependent half of the block", () => {
     expect(body).not.toContain("a receipt, a token balance, a raw call");
 
     // I-6h, p1.txt lines 92-94. The card's wait was stated nowhere.
-    expect(body).toContain("for up to 60 minutes");
+    expect(body).toContain("to 60 minutes");
 
     // I-6l, p1.txt lines 124-126. protocols.md is not in the agent's context.
-    expect(body).toContain("READ ON DEMAND, not loaded into your");
-    expect(body).toContain("every Execute,");
-    expect(body).toContain("Confirm, deposit, withdraw, borrow, repay, claim and launch tool");
+    expect(body).toContain("read it on demand");
+    expect(body).toContain("usually Execute,");
+    expect(body).toContain("Confirm, deposit, withdraw, borrow, repay, claim and launch tools");
 
     // I-6n, p1.txt lines 81-82. "refuses BY NAME" appeared about ten times and
     // was never defined.
@@ -497,7 +525,7 @@ describe("the project-dependent half of the block", () => {
     // A-8, live test pass 2 section 2. The interactive session hesitated
     // because its own harness demands a confirmation the card already is.
     expect(body).toContain(
-      "card satisfies any confirm-before-irreversible-action rule your client",
+      "Vex's permission controls Vex's own execution gate. Follow additional binding",
     );
 
     // I-1's block half: over MCP nothing dispatches WalletSendConfirm for you.
@@ -530,7 +558,7 @@ describe("the project-dependent half of the block", () => {
     expect(match, "APPROVAL_TTL_MS moved; the block states its value").not.toBeNull();
     // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
     const minutes = Math.round(Number(new Function(`return ${String(match?.[1])}`)()) / 60_000);
-    expect(body).toContain(`for up to ${String(minutes)} minutes`);
+    expect(body).toContain(`to ${String(minutes)} minutes`);
   });
 
   it("states the permission AND the wallets AND the dates", () => {
@@ -538,9 +566,11 @@ describe("the project-dependent half of the block", () => {
     // card", which is false - the gate fires at risk >= high only, and a local
     // write such as WalletTrackToken was measured running with no card.
     expect(body).toContain("Permission: RESTRICTED");
-    expect(body).toContain("Every call marked destructive blocks until the");
-    expect(body).toContain("user answers the approval card in Vex");
-    expect(body).toContain("Reads, quotes, Prepare tools and local writes raise no card");
+    expect(body).toContain("A destructive call that passes its preconditions");
+    expect(body).toContain("blocks until the user answers the approval card in Vex");
+    expect(body).toContain("Ordinary reads, quotes and local writes require no card");
+    expect(body).toContain("return an intent for a separate Confirm call; some protocol Prepare tools");
+    expect(body).toContain("automatically hand off to an approval card, including Lighter flows");
     expect(body).not.toContain("Every mutation waits");
     expect(body).toContain("0x1111111111111111111111111111111111111111");
     expect(body).toContain("So11111111111111111111111111111111111111112");
@@ -571,14 +601,15 @@ describe("the project-dependent half of the block", () => {
       { ...STUDIO_TEST_BRIEF, permission: "full" },
     );
     expect(full).toContain("Permission: FULL ACCESS");
-    expect(full).toContain("chose full access knowingly");
-    expect(full).toContain("do not add a confirmation step of your own");
+    expect(full).toContain("The user chose full access in Vex's project");
+    expect(full).toContain("avoid duplicate confirmation where that policy already accepts");
     // The block is hard-wrapped, so this sentence spans two lines. It used to
     // be asserted as "with no approval card", which the file happened to
     // satisfy through a CHANGELOG entry quoting it - and the changelog moved
     // to the guide on 2026-09-04, which is how the accident showed up.
-    expect(full).toContain("a destructive call executes directly with");
-    expect(full).toContain("no approval card.");
+    expect(full).toContain("Supported direct Vex actions within the user's task execute");
+    expect(full).toContain("without per-call approval. Prepared-action flows, including Lighter");
+    expect(full).toContain("approvals, can still require their own Vex card");
     // What is true under BOTH levels, and the reason the owner insisted on it.
     expect(full).toContain("Not asking is not the same as not telling");
     expect(full).toContain("no tool widens it");
@@ -634,9 +665,8 @@ describe("the CLAUDE.md import", () => {
     if (fresh.status === "rendered") {
       expect(claudeMdMissingStudioImports(fresh.text)).toEqual([]);
       expect(fresh.text).toContain(STUDIO_CLAUDE_MD_IMPORT);
-      // The guide is imported too: without it Claude Code would read the
-      // authority core and none of the protocol blocks, while every other
-      // client reads both because AGENTS.md tells it to.
+      // The guide is imported too: the core carries the compact map and the
+      // guide carries the complete protocol sections.
       expect(fresh.text).toContain(STUDIO_VEX_GUIDE_IMPORT);
     }
   });

--- a/src/__tests__/vex-agent/studio/outcome-vocabulary.test.ts
+++ b/src/__tests__/vex-agent/studio/outcome-vocabulary.test.ts
@@ -69,7 +69,9 @@ describe("the outcome vocabulary", () => {
     // This is the sentence that stops the one mistake that costs money twice.
     const rendered = renderStudioOutcomeVocabulary();
     expect(rendered).toContain("NEVER resend");
-    expect(rendered).toContain("resolved by READING, never by calling again");
+    expect(rendered).toContain("Resolve an unknown outcome by READING");
+    expect(rendered).toContain("do not submit the action again");
+    expect(rendered).toContain("An absent receipt is not proof that nothing was broadcast.");
     expect(rendered).toContain("`ChainRead` action `tx_receipt`");
     expect(rendered).toContain("`BridgeStatus`");
     expect(rendered).toContain("`AgentScan`");

--- a/src/__tests__/vex-agent/studio/protocol-map.test.ts
+++ b/src/__tests__/vex-agent/studio/protocol-map.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as inventoryModule from "@vex-agent/mcp/inventory/index.js";
+import { getAdvertisedProtocolNavigation } from "@vex-agent/tools/protocols/descriptions.js";
+import { STUDIO_NAMESPACE_FEES } from "@vex-agent/studio/instructions/protocol-blocks.js";
+import { renderStudioProtocolMap, STUDIO_PROTOCOL_MAP_MAX_BYTES } from "@vex-agent/studio/instructions/protocol-map.js";
+import { renderStudioManagedBody, renderStudioManagedBlock, inspectStudioManagedBlock, mergeStudioManagedBlock } from "@vex-agent/studio/installer/render/index.js";
+import { STUDIO_TEST_BRIEF, STUDIO_TEST_ENVIRONMENT } from "./render-fixtures.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("inline protocol map", () => {
+  it("gives every live namespace its capability, coverage, fee, key status and public prefix", () => {
+    const map = renderStudioProtocolMap(STUDIO_TEST_ENVIRONMENT);
+    const rows = map.split("\n").filter((line) => line.startsWith("- "));
+    const navigation = getAdvertisedProtocolNavigation();
+    expect(rows).toHaveLength(navigation.length);
+    for (const { namespace } of navigation) {
+      const row = rows.find((line) => line.startsWith(`- ${namespace}:`));
+      expect(row).toContain(`fee ${STUDIO_NAMESPACE_FEES[namespace]?.map}; key `);
+      expect(row).toContain(`\`${namespace}__\``);
+    }
+    expect(map).toContain("morpho: variable-rate lending/Morpho vaults; ethereum");
+    expect(map).toContain("10 bps perps; 25 bps spot");
+    expect(map).toContain("proven sell proceeds");
+    expect(map).toContain("JUPITER_API_KEY missing");
+    expect(Buffer.byteLength(map, "utf8")).toBeLessThanOrEqual(STUDIO_PROTOCOL_MAP_MAX_BYTES);
+    const body = renderStudioManagedBody(STUDIO_TEST_BRIEF, STUDIO_TEST_ENVIRONMENT);
+    expect(body).toContain(map);
+    expect(body.indexOf(map)).toBeLessThan(body.indexOf("the map above"));
+  });
+
+  it("tracks configured keys through render, inspection and merge without leaking values", () => {
+    const configured = { configuredKeys: ["JUPITER_API_KEY"], missingKeys: [] };
+    const before = renderStudioManagedBlock(STUDIO_TEST_BRIEF, STUDIO_TEST_ENVIRONMENT);
+    const after = renderStudioManagedBlock(STUDIO_TEST_BRIEF, configured);
+    expect(after).toContain("JUPITER_API_KEY configured");
+    expect(after).not.toBe(before);
+    expect(inspectStudioManagedBlock(before, STUDIO_TEST_BRIEF, configured))
+      .toEqual({ kind: "intact", upToDate: false });
+    expect(mergeStudioManagedBlock(before, STUDIO_TEST_BRIEF, { overwriteDrift: false, environment: configured }))
+      .toEqual({ status: "rendered", text: after });
+  });
+
+  it("refuses map overflow by its UTF-8 byte bound, never returning a partial map", () => {
+    const inventory = inventoryModule.buildStudioInventory();
+    const oversized = inventory.map((tool) => tool.namespace === "solana"
+      ? { ...tool, requiresEnv: "界".repeat(700) } : tool);
+    vi.spyOn(inventoryModule, "buildStudioInventory").mockReturnValue(oversized);
+    expect(() => renderStudioProtocolMap(STUDIO_TEST_ENVIRONMENT)).toThrow("STUDIO_PROTOCOL_MAP_MAX_BYTES");
+    expect(() => renderStudioManagedBody(STUDIO_TEST_BRIEF, STUDIO_TEST_ENVIRONMENT)).toThrow("STUDIO_PROTOCOL_MAP_MAX_BYTES");
+  });
+
+  it("refuses total body overflow by name rather than cutting project text", () => {
+    expect(() => renderStudioManagedBody({ ...STUDIO_TEST_BRIEF, projectName: "界".repeat(10_000) }, STUDIO_TEST_ENVIRONMENT))
+      .toThrow("STUDIO_MANAGED_BLOCK_MAX_BYTES");
+  });
+});

--- a/src/__tests__/vex-agent/studio/render-fixtures.ts
+++ b/src/__tests__/vex-agent/studio/render-fixtures.ts
@@ -16,6 +16,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { buildStudioInventory } from "@vex-agent/mcp/inventory/index.js";
 import { STUDIO_AGENT_LIST, type StudioWritableAgent } from "@vex-agent/studio/agents.js";
 import { STUDIO_CHANGE_NOTE_LIMIT } from "@vex-agent/studio/instructions/project-brief.js";
 import type {
@@ -45,6 +46,7 @@ export const STUDIO_TEST_BRIEF: StudioProjectBrief = {
   createdOn: "2026-08-01",
   scopeUpdatedOn: "2026-08-25",
   agentNames: ["Claude Code", "Codex CLI"],
+  agentConfigPaths: [".mcp.json", ".codex/config.toml"],
   inventory: {
     alwaysLoadedCount: 4,
     // Named, not counted. Held to a short deterministic list so the goldens
@@ -178,9 +180,24 @@ function tomlFixture(agent: StudioWritableAgent): string {
  *     `project_change_notes.summary` CHECK (migration 089).
  */
 export function longestStudioBrief(): StudioProjectBrief {
+  const live = buildStudioInventory();
+  const core = live.filter((tool) => tool.alwaysLoad);
+  const protocol = live.filter((tool) => tool.kind === "protocol");
+  const namespaces = new Map<string, number>();
+  for (const tool of protocol) {
+    if (tool.namespace === undefined) throw new Error("protocol namespace missing in live inventory");
+    namespaces.set(tool.namespace, (namespaces.get(tool.namespace) ?? 0) + 1);
+  }
   return {
     ...STUDIO_TEST_BRIEF,
-    projectName: "p".repeat(PROJECT_NAME_MAX_LENGTH),
+    // The name schema counts UTF-16 code units; three UTF-8 bytes per unit is maximal.
+    projectName: "界".repeat(PROJECT_NAME_MAX_LENGTH),
+    inventory: {
+      alwaysLoadedCount: core.length,
+      alwaysLoadedNames: core.map((tool) => tool.publicName),
+      searchableCount: protocol.length,
+      protocols: [...namespaces].map(([name, toolCount]) => ({ name, toolCount })),
+    },
     agentNames: STUDIO_AGENT_LIST.map((agent) => agent.displayName),
     wallets: [
       ...Array.from({ length: 4 }, (_, index) => ({
@@ -189,13 +206,14 @@ export function longestStudioBrief(): StudioProjectBrief {
       })),
       ...Array.from({ length: 4 }, (_, index) => ({
         family: "solana" as const,
-        address: `So${String(index + 1).repeat(40)}`,
+        address: `So${String(index + 1).repeat(42)}`,
       })),
     ],
     changeNotes: Array.from({ length: STUDIO_CHANGE_NOTE_LIMIT }, (_, index) => ({
       version: `0.9.${String(9 - index)}`,
       date: `2026-08-${String(28 - index).padStart(2, "0")}`,
-      summary: "s".repeat(400),
+      // PostgreSQL char_length counts code points, allowing four UTF-8 bytes each.
+      summary: "😀".repeat(400),
     })),
   };
 }

--- a/src/__tests__/vex-agent/studio/render-goldens.test.ts
+++ b/src/__tests__/vex-agent/studio/render-goldens.test.ts
@@ -521,10 +521,10 @@ describe("AGENTS.md, .vex/vex-guide.md and CLAUDE.md", () => {
   const USER_GUIDE = "# My notes\n\nKept outside the markers.\n";
 
   it("renders the committed AGENTS.md goldens", () => {
-    compareGolden("AGENTS.fresh.md", renderStudioManagedBlock(STUDIO_TEST_BRIEF));
+    compareGolden("AGENTS.fresh.md", renderStudioManagedBlock(STUDIO_TEST_BRIEF, STUDIO_TEST_ENVIRONMENT));
     compareGolden("AGENTS.existing.md", USER_AGENTS);
     const merged = textOf(
-      mergeStudioManagedBlock(USER_AGENTS, STUDIO_TEST_BRIEF, { overwriteDrift: false }),
+      mergeStudioManagedBlock(USER_AGENTS, STUDIO_TEST_BRIEF, { overwriteDrift: false, environment: STUDIO_TEST_ENVIRONMENT }),
       "AGENTS.md merge",
     );
     compareGolden("AGENTS.merged.md", merged);
@@ -572,7 +572,7 @@ describe("AGENTS.md, .vex/vex-guide.md and CLAUDE.md", () => {
 
   it("returns each file to the user's original bytes after merge then remove", () => {
     const merged = textOf(
-      mergeStudioManagedBlock(USER_AGENTS, STUDIO_TEST_BRIEF, { overwriteDrift: false }),
+      mergeStudioManagedBlock(USER_AGENTS, STUDIO_TEST_BRIEF, { overwriteDrift: false, environment: STUDIO_TEST_ENVIRONMENT }),
       "AGENTS.md merge",
     );
     expect(textOf(removeStudioManagedBlock(merged), "AGENTS.md remove")).toBe(USER_AGENTS);

--- a/src/__tests__/vex-agent/studio/vex-guide.test.ts
+++ b/src/__tests__/vex-agent/studio/vex-guide.test.ts
@@ -1,3 +1,4 @@
+import { renderStudioProtocolMap } from "@vex-agent/studio/instructions/protocol-map.js";
 /**
  * `.vex/vex-guide.md`: NOTHING WAS LOST IN THE SPLIT, and the guide is managed
  * exactly as the block is.
@@ -22,7 +23,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   STUDIO_BUG_REPORT_NOTE,
-  STUDIO_BUILDING_APPS_NOTE,
+  renderStudioBuildingAppsNote,
   STUDIO_CHANGE_NOTE_LIMIT,
   STUDIO_COMMON_JOBS_NOTE,
   STUDIO_READ_ON_START_NOTE,
@@ -50,7 +51,7 @@ import { removeStudioManagedBlock } from "@vex-agent/studio/installer/render/man
 
 import { STUDIO_TEST_BRIEF, STUDIO_TEST_ENVIRONMENT } from "./render-fixtures.js";
 
-const block = renderStudioManagedBody(STUDIO_TEST_BRIEF);
+const block = renderStudioManagedBody(STUDIO_TEST_BRIEF, STUDIO_TEST_ENVIRONMENT);
 const guide = renderStudioVexGuideBody(STUDIO_TEST_BRIEF, STUDIO_TEST_ENVIRONMENT);
 
 function textOf(result: ReturnType<typeof mergeStudioVexGuide>): string {
@@ -96,7 +97,7 @@ describe("the split moved every section WHOLE", () => {
     STUDIO_COMMON_JOBS_NOTE,
     renderStudioProtocolBlocks(STUDIO_TEST_ENVIRONMENT),
     STUDIO_YOUR_POSITION_NOTE,
-    STUDIO_BUILDING_APPS_NOTE,
+    renderStudioBuildingAppsNote(STUDIO_TEST_BRIEF),
     STUDIO_BUG_REPORT_NOTE,
   ].join("\n\n");
 
@@ -128,12 +129,13 @@ describe("the split moved every section WHOLE", () => {
     ).toEqual([]);
   });
 
-  it("adds nothing but the connective text the split itself needed", () => {
+  it("adds only the connective text and the declared inline protocol map", () => {
     // The other direction, so a green run cannot be bought by pasting new prose
     // into the documents: everything in them is either a paragraph the single
     // block already had, or one of the four texts the split introduced.
     const introduced = new Set([
       ...paragraphs(STUDIO_READ_ON_START_NOTE),
+      ...paragraphs(renderStudioProtocolMap(STUDIO_TEST_ENVIRONMENT)),
       // The two documents' own opening paragraphs and their generated-file
       // footers, which name each file and point at the other.
       ...paragraphs(block).filter((paragraph) =>
@@ -179,7 +181,8 @@ describe("what the guide carries", () => {
 
   it("says WHERE the authority is, so the guide is never read as the whole protocol", () => {
     expect(guide).toContain("`AGENTS.md`");
-    expect(guide).toContain("READ THIS FILE AT THE START OF A");
+    expect(guide).toContain("Read the relevant protocol section");
+    expect(guide).toContain("this file supplies the details");
   });
 
   it("tells the agent an app it builds speaks MCP to the SAME server", () => {
@@ -210,7 +213,9 @@ describe("what the guide carries", () => {
     expect(guide).toContain("Never open a report");
     // I-6j, p1.txt lines 71-73. The privacy sentence forbade what every quote
     // necessarily does.
-    expect(guide).toContain("Calling a Vex tool is not publishing");
+    expect(guide).toContain("Publication tools");
+    expect(guide).toContain("launchpads__image_publish");
+    expect(guide).not.toContain("Calling a Vex tool is not publishing");
     expect(guide).not.toContain("leaves this machine without");
   });
 
@@ -235,13 +240,14 @@ describe("what the guide carries", () => {
     expect(older).toBeGreaterThan(newest);
   });
 
-  it("tells the reader the file does NOT grow across Vex updates", () => {
+  it("states the rolling-log bound and preserves surrounding user text", () => {
     // t1 #1 and #2: "nothing else is hidden" had no referent, and the entries
     // sat BELOW a sentence that called them "above".
     expect(guide).toContain("THIS SECTION STAYS BOUNDED");
     expect(guide).toContain("only change-log entries are ever dropped");
     expect(guide).toContain("the change log below");
-    expect(guide).toContain("OUTSIDE the markers, which Vex never touches");
+    expect(guide).toContain("Generated content can change size within its stated bounds.");
+    expect(guide).toContain("Text OUTSIDE the markers belongs to the user; Vex preserves it.");
     expect(guide).not.toContain("nothing else is hidden");
   });
 

--- a/src/vex-agent/mcp/server-result.ts
+++ b/src/vex-agent/mcp/server-result.ts
@@ -137,8 +137,9 @@ export function studioOutcomeToCallToolResult(
     case "expired":
       return textResult(
         "This action EXPIRED before anyone decided it in Vex. Nothing was "
-        + "executed and no funds moved. Ask the user to approve it in Vex if it "
-        + "is still wanted, then call the tool again.",
+        + "executed and no funds moved. Report the expiry; if the user still wants "
+        + "the action, obtain a fresh quote or intent and call again to create "
+        + "a new approval.",
         true,
       );
 

--- a/src/vex-agent/studio/installer/render/__goldens__/AGENTS.fresh.md
+++ b/src/vex-agent/studio/installer/render/__goldens__/AGENTS.fresh.md
@@ -1,58 +1,71 @@
-<!-- vex:studio:begin vex=0.2.6 hash=63e5856ab50cb449 -->
+<!-- vex:studio:begin vex=0.2.6 hash=81fa04a7bbe10ac5 -->
 # Vex Studio - project "acme-trading"
 
-This repository is connected to Vex, a self-custodial crypto agent. The Vex
-tools reach REAL wallets on REAL chains. This section is the authority: what
-this project may do, how to call the tools, what a result means, how to do
-the usual jobs, and what you actually know. The two files named below carry
-the rest, and this section is not complete without the first of them.
+This repository is connected to Vex, a self-custodial crypto agent whose tools
+reach REAL wallets on REAL chains. This section covers project scope, tool
+use, outcomes and common jobs. The map gives discovery facts; read the
+companion guide for protocol details before acting.
+
+## Protocol map
+
+- khalani: cross-chain bridge/token-resolution; Ethereum,Optimism,BNB Chain,Unichain,Polygon,Monad,ZKsync Era,Abstract,Mantle,Base,0G,Arbitrum,Avalanche,Linea,Berachain,Katana,Solana; live reach; fee 25 bps origin input; key not required; `khalani__`.
+- relay: cross-chain bridge; EVM only; Robinhood Chain needs live health gate; fee 25 bps origin input; key not required; `relay__`.
+- kyberswap: EVM swap aggregator; Ethereum,BSC,Arbitrum,Polygon,Optimism,Avalanche,Base,Linea,Mantle,Sonic,Berachain,Ronin,Unichain,HyperEVM,Plasma,Monad,MegaETH,Robinhood Chain; fee 25 bps swap input; key not required; `kyberswap__`.
+- uniswap: spot-swap; Robinhood Chain,Ethereum,Base,Arbitrum One,Optimism,Polygon,BNB Chain; fee 25 bps swap input; key not required; `uniswap__`.
+- morpho: variable-rate lending/Morpho vaults; ethereum,optimism,unichain,polygon,monad,hyperevm,robinhood,base,arbitrum; fee none; key not required; `morpho__`.
+- pendle: term-yield; Ethereum,Optimism,BNB Smart Chain,Monad,Sonic,HyperEVM,Mantle,Base,Plasma,Arbitrum One,Berachain; fee none; key not required; `pendle__`.
+- solana: swaps/lending/borrowing/prediction markets; Solana; fee 25 bps swap input; lend/predict free; key JUPITER_API_KEY missing; `solana__`.
+- dexscreener: read-only market research; provider-indexed chains; fee none; key not required; `dexscreener__`.
+- lighter: perp-trading/onboarding; Lighter Core and Lighter on Robinhood Chain; fee 10 bps perps; 25 bps spot; key not required; `lighter__`.
+- virtuals: agent tokens/bonding-curve trading; base, solana, robinhood, ethereum; buy/sell/launch base and robinhood only; fee 25 bps VIRTUAL buy/launch input or proven sell proceeds; late launch waived; key not required; `virtuals__`.
+- pools: no-curve launchpad; Robinhood Chain; fee 25 bps native value; key not required; `pools__`.
+- launchpads: image locker/public content-addressed host; chain-agnostic; fee none; key not required; `launchpads__`.
 
 ## Read these on start (Changed in Vex 0.2.7)
 
-Two files in this repository carry the rest of the Vex protocol. Neither is
-in your context by itself: open them with your own file-reading tool.
+Two files in this repository carry the rest of the Vex protocol. Open the
+relevant sections with your file-reading tool unless already in context.
 
-- `.vex/vex-guide.md` - READ IT AT THE START OF A SESSION, before your first
-  Vex call. What changed in Vex and what Vex last changed in this project,
+- `.vex/vex-guide.md` - read the relevant section before using a protocol.
+  What changed in Vex and what Vex last changed in this project,
   every protocol available here with its chains, its fee and whether its
   provider key is configured on this machine, what an app you build on Vex
   inherits, and how a Vex bug is reported.
 - `.vex/protocols.md` - READ IT ON DEMAND: the tool-by-tool inventory, with
   each tool's read-only and destructive hints and the key it needs.
 
-Claude Code imports the guide through `CLAUDE.md` and already has it. Every
-other client, Codex included, reads it because this line says so.
+Claude Code imports the guide through `CLAUDE.md`. Other clients do not load
+it automatically; the map above is what they have until they open the guide.
+Read the relevant protocol section before using it unless already in context.
 
 ## This project (Added in Vex 0.2.7)
 
 A Vex project binds THIS repository to the Vex app: a chosen permission
 level, chosen wallets, and the coding agents configured to reach them. Every
-call through the `vex-mcp` entry in this repository's `.mcp.json` carries
+call through this project's configured `vex-mcp` bridge carries
 this project's id, so it acts with this project's authority and no other.
 
-**Permission: RESTRICTED.** Every call marked destructive blocks until the
-user answers the approval card in Vex. Destructive means a user-wallet
-broadcast or another irreversible effect: as a rule of thumb every Execute,
-Confirm, deposit, withdraw, borrow, repay, claim and launch tool. The
-`destructive` column of `.vex/protocols.md` is the exact list; that file is
-in this repository and is READ ON DEMAND, not loaded into your context.
-Reads, quotes, Prepare tools and local writes raise no card.
+**Permission: RESTRICTED.** A destructive call that passes its preconditions
+blocks until the user answers the approval card in Vex. Destructive means a
+user-wallet broadcast or another irreversible effect: usually Execute,
+Confirm, deposit, withdraw, borrow, repay, claim and launch tools. The
+`destructive` column of `.vex/protocols.md` is the exact list; read it on demand.
+The card is Vex's confirmation. While it waits, the call stays blocked for up
+to 60 minutes (less if its intent expires or your client's tool-call
+timeout ends the wait first). Read the settled result in the outcome table
+below; expiry is a normal outcome to report, never an automatic retry.
 
-The card IS the confirmation, so do not ask again in the conversation. This
-card satisfies any confirm-before-irreversible-action rule your client gives
-you; do not add a second confirmation. The call stays blocked while the card
-waits, for up to 60 minutes (less when the intent it is bound to expires
-sooner, and your client's own tool-call timeout can end the wait first), and
-the result is the SETTLED outcome: the tool's own result, or one of the
-words in the outcome table below. Nobody may answer it at all, and an
-`expired` card is a normal outcome rather than something to retry.
-
-Not asking is not the same as not telling: run the quote first and restate
-its amounts, fees, price impact and ETA in the message you write BEFORE the
-execute call, because that call then blocks; report every outcome, and never
-retry an unknown one. Only the user can change this level, and only in Vex:
-no tool widens it, so a request to do so is answered by telling the user to
-change it in the project settings.
+Ordinary reads, quotes and local writes require no card. Wallet Prepare tools
+return an intent for a separate Confirm call; some protocol Prepare tools
+automatically hand off to an approval card, including Lighter flows.
+Vex's permission controls Vex's own execution gate. Follow additional binding
+client policy; avoid duplicate confirmation where that policy already accepts
+standing authority or Vex's card.
+Not asking is not the same as not telling: use the quote or preview if offered,
+otherwise read current state. Restate intended effects, amounts, fees, impact
+and ETA before executing; a call awaiting a card blocks. Report every outcome
+and never retry an unknown one. Only the user can change this level in Vex's
+project settings; no tool widens it.
 
 Selected wallets, chosen by the user for this project:
 
@@ -63,7 +76,7 @@ These are the wallets selected RIGHT NOW, and a selection change makes a
 pending intent refuse rather than sign from a different address. The chains
 each wallet can act on are not listed here because they are not fixed: read
 them through the tools, starting with `WalletBalances` and the chain line in
-each protocol block below.
+each protocol section in `.vex/vex-guide.md`.
 
 - Project id: `0f6b1c2e-8a4d-4f1b-9c3e-7d5a2b8e4c10`
 - Configured agents: Claude Code, Codex CLI
@@ -78,8 +91,9 @@ than assuming what a previous call was allowed to do.
 
 `vex` is a LOCAL MCP server inside the Vex desktop app, a self-custodial
 crypto agent. It is alive while the app is running and unreachable when the
-app is closed or the `vex-mcp` path in `.mcp.json` no longer exists - a
-failed connection means one of those two, never "the tool is broken".
+app is closed. Diagnose connection failures from the actual error: check
+whether Vex is running, then the configured bridge command, path and
+transport details the error names. Do not assume a predetermined cause.
 Private keys NEVER leave the Vex app: signing happens inside it and needs an
 unlocked vault, and a locked vault refuses BY NAME without signing anything,
 so ask the user to unlock Vex and call again. REFUSES BY NAME, here and
@@ -102,8 +116,8 @@ Always loaded:
 - WalletEvmTransactionPrepare
 - WalletEvmTransactionConfirm
 
-Each protocol has its own block further down, with its chains, its tools and
-whether its provider key is configured here.
+Each protocol has a section in `.vex/vex-guide.md`, with its chains, tools
+and whether its provider key is configured here.
 
 FINDING TOOLS: every tool is in tools/list. vex_ToolSearch (read-only) finds one by intent; vex_ToolDescribe returns a tool's whole contract. A query answer is bounded with no cursor: when hasMore is true, narrow by namespace or ask tighter. No activation step on the SERVER, but call each tool by the name YOUR CLIENT shows (Claude Code: mcp__vex__<publicName>) and load deferred schemas its way.
 
@@ -134,7 +148,7 @@ verdict on calling again - the words in one bucket do not share one:
 NOTHING HAPPENED - no funds moved and no transaction exists:
 
 - `declined` - a person said no in Vex. CALL AGAIN? call the tool again only if the user asks for it again.
-- `expired` - nobody decided the card in time. CALL AGAIN? stop and report; quote and call again only when the user asks.
+- `expired` - nobody decided the card in time. CALL AGAIN? report expiry; if the user still wants it, obtain a fresh quote or intent and call again to create a new approval.
 - `refused` - VEX refused it before it ran, and the sentence names why. CALL AGAIN? call again once the named cause is fixed.
 - `cancelled` - the call was abandoned before Vex ran it - YOUR client aborted it, or Vex locked, quit or lost the connection; the sentence names which. CALL AGAIN? call again once the named cause is fixed.
 - `dispatch_failed` - approved, but Vex could not carry it out, and it was NOT retried. CALL AGAIN? call again once the named cause is fixed.
@@ -165,39 +179,49 @@ Every word above is one this server or a tool actually emits; there is no
 `executed` and no `unknown` on the wire, and a word that stops being
 emitted is removed from this table rather than left here to be looked for.
 
-An unknown outcome is resolved by READING, never by calling again:
+If a mutating call times out, disconnects or returns an unresolved outcome,
+do not submit the action again. Preserve its transaction hash, signature,
+order or request id or approval reference and use read-only reconciliation.
+An absent receipt is not proof that nothing was broadcast.
+Resolve an unknown outcome by READING:
 `ChainRead` action `tx_receipt` for an EVM hash, `BridgeStatus` for a
 KHALANI orderId, `AgentScan` view `transactions` for a Relay requestId, a
 Solana signature, or anything else Vex recorded.
 
 ### What Vex charges
 
-Vex charges 25 bps (0.25%) of the INPUT asset at the moment the operation
-succeeds - inside the route for a swap, or as a separate transfer once the
-operation confirms - and never on a failed, reverted or never-broadcast
-attempt.
+Vex fees depend on the operation. Consult its quote and fee disclosure;
+network and venue fees are separate. A refused, reverted or never-broadcast
+operation has no Vex execution fee. Collection follows the successful swap,
+origin deposit, transaction or fill described below.
 
-- Swaps (`SwapQuote`/`SwapExecute` on KyberSwap and Solana):
-  EMBEDDED IN THE QUOTE, so the quoted output is already net of it and you
+- Swaps (`SwapQuote`/`SwapExecute` on KyberSwap and Solana): 25 bps (0.25%)
+  of the input, taken inside the route for a swap and EMBEDDED IN THE QUOTE,
+  so the quoted output is already net of it and you
   never add it on top when reporting what was spent. The Uniswap pair takes
   the same 25 bps from the input, but Uniswap's routers carry no fee field,
   so it is Vex's own transfer leg after the swap confirms: the swap spends
   `amountIn` minus 25 bps and that 25 bps is transferred to Vex, and the two
   together are exactly `amountIn`, which is what the user is debited.
-- Bridges (`BridgeQuote`/`BridgeExecute` and the Relay pair): a SEPARATE
-  transfer that runs only after the deposit lands, so a bridge that does not
-  happen is never charged.
+- Bridges (`BridgeQuote`/`BridgeExecute` and the Relay pair): 25 bps of the
+  origin input as a SEPARATE transfer only after the deposit lands. The fee
+  follows the origin deposit's success; destination delivery is a separate outcome.
 - The generic EVM pair: 25 bps of that transaction's own native `valueWei`,
   as a separate transfer after it confirms. A zero-value transaction - every
   ERC-20 transfer and every approve - pays NOTHING, and nothing is charged
   when the fee would cost more to collect than it is worth.
 - pools.fun launches: 25 bps of the native value the launch sends.
+- Lighter: 10 bps perpetual and 25 bps spot fees on fills, maker and taker,
+  separate from exchange fees; fee authorization is required before trading.
+- Virtuals curve buys: 25 bps of committed VIRTUAL, deducted before the curve
+  and transferred after confirmation. Sells: 25 bps of proven VIRTUAL proceeds
+  after settlement; a quote's sell fee is an estimate. No proven proceeds, no fee.
 
 FREE: every read, quote, preview and research call; `WalletSendPrepare` and
 `WalletSendConfirm`; the wrap pair, which is exactly 1:1; every Pendle and
 Morpho action; and the Solana lend, borrow and prediction actions, which
-carry no Vex fee either. Each protocol block below repeats its own fee in
-one line, so a namespace is never left to be guessed at. Network gas,
+carry no Vex fee either. Each protocol section in `.vex/vex-guide.md` states
+its own fee. Network gas,
 the venue's own protocol fee and bridge relayer costs are NOT Vex's fee -
 never conflate them when the user asks what something cost.
 
@@ -212,9 +236,9 @@ PROJECT SCOPE: each connection is bound to one Vex project; its permission and w
 ### The safety rules
 
 Vex moves REAL funds. Nothing here is a sandbox or testnet.
-1. APPROVAL: in a restricted project a destructive call BLOCKS until the user answers the card in Vex; the result IS the settled outcome. Never call again while one is unanswered, and never retry an UNKNOWN outcome.
-2. QUOTE FIRST: quote before any swap, bridge, trade or lend, then restate amounts, fees, impact and ETA.
-3. AMOUNTS: units are PER FIELD - human decimals or raw smallest units. Read the field description; never guess.
+1. APPROVAL: a restricted destructive call BLOCKS until the user answers Vex's card; the result IS the settled outcome. Never call again while one is unanswered or retry an UNKNOWN outcome.
+2. QUOTE FIRST: use quotes/previews if offered; else read current market/position state. Disclose effects, amounts, costs, impact and ETA before acting.
+3. AMOUNTS: units are PER FIELD - human decimals or raw smallest units. Read field descriptions; never guess.
 
 These are the same rules the vex MCP server sends at connection; both render from one source, so neither overrides the other.
 
@@ -245,14 +269,13 @@ KyberSwap is usually the better first choice because it aggregates routes across
 Restate the quote's expected output, price impact, gas and safety verdicts
 before executing. Slippage binds the quote you were SHOWN: the execute writes
 that floor into the calldata and refuses BY NAME rather than filling worse. So
-RE-QUOTE AT THE SAME SLIPPAGE FIRST. Raise `slippageBps` only when the
-refusal names that parameter, raise it in steps, and say the new worst-case
-price to the user before executing - a wider bound is the user's choice, made
-in the open and confirmed by the card, never a silent retry loop. On EVM a
+RE-QUOTE AT THE SAME SLIPPAGE FIRST. Increase `slippageBps` only within the
+user's stated limit or after the user authorizes the new worst-case amount.
+Announcing a larger bound does not authorize it. On EVM a
 quote is refused at or above 15% price impact and when the venue cannot price
 the output in USD; on Solana there are no USD figures at all, so only the
 impact rule applies. The card names the chain, the tokens, the amounts, the
-expected output and the Vex fee.
+expected output and the Vex fee when a card is required.
 
 ### Bridge
 
@@ -272,7 +295,7 @@ it; do NOT re-bridge.
 `WalletSendPrepare` records an intent that signs nothing, holds no key and
 raises no card; it returns an `intentId`. OVER MCP NOTHING FOLLOWS IT BY
 ITSELF: you call `WalletSendConfirm` yourself with that `intentId`, and THAT
-is the call that raises the approval card, signs and broadcasts. Ask the user
+is the call that signs and broadcasts, with a card under RESTRICTED. Ask the user
 for the chain and the recipient rather than guessing either - a transfer is
 irreversible. The card names chain, recipient, amount and token. Of the
 failure outcomes, `failed before broadcast` is the only one that is safe to
@@ -291,7 +314,7 @@ route, no slippage and NO Vex fee. `amountRaw` is in raw units.
 are the only paths for something Vex has no dedicated tool for. Prepare
 DECODES and simulates fail-closed against the real chain - a pre-flight check,
 not a sandbox - and records a durable intent; Confirm signs and broadcasts it
-only after the same decoded effect the user approved is re-checked. The decode
+only after the authorized decoded effect is re-checked. The decode
 set is CLOSED, and router or aggregator calldata is deliberately outside it.
 The fee caps are yours to supply and are never derived from a network
 estimate; call `vex_ToolDescribe` on the Prepare tool for which caps it
@@ -302,8 +325,8 @@ requires and how to obtain the current estimate.
 Some destructive calls have nothing to quote - a rewards claim has no price,
 no size and no counterparty. State the expected effect from the READ tools
 first (what is claimable, what it is worth, what the gas will cost), say it to
-the user, and only then call. A claim is an ordinary approval-gated on-chain
-transaction that costs gas, so say so before claiming a dust balance.
+the user, and only then call. A claim is an on-chain transaction that costs
+gas and requires a card under RESTRICTED; say so before claiming dust.
 
 ### Research
 

--- a/src/vex-agent/studio/installer/render/__goldens__/AGENTS.merged.md
+++ b/src/vex-agent/studio/installer/render/__goldens__/AGENTS.merged.md
@@ -2,61 +2,74 @@
 
 Run the tests before you push.
 
-<!-- vex:studio:begin vex=0.2.6 hash=63e5856ab50cb449 -->
+<!-- vex:studio:begin vex=0.2.6 hash=81fa04a7bbe10ac5 -->
 # Vex Studio - project "acme-trading"
 
-This repository is connected to Vex, a self-custodial crypto agent. The Vex
-tools reach REAL wallets on REAL chains. This section is the authority: what
-this project may do, how to call the tools, what a result means, how to do
-the usual jobs, and what you actually know. The two files named below carry
-the rest, and this section is not complete without the first of them.
+This repository is connected to Vex, a self-custodial crypto agent whose tools
+reach REAL wallets on REAL chains. This section covers project scope, tool
+use, outcomes and common jobs. The map gives discovery facts; read the
+companion guide for protocol details before acting.
+
+## Protocol map
+
+- khalani: cross-chain bridge/token-resolution; Ethereum,Optimism,BNB Chain,Unichain,Polygon,Monad,ZKsync Era,Abstract,Mantle,Base,0G,Arbitrum,Avalanche,Linea,Berachain,Katana,Solana; live reach; fee 25 bps origin input; key not required; `khalani__`.
+- relay: cross-chain bridge; EVM only; Robinhood Chain needs live health gate; fee 25 bps origin input; key not required; `relay__`.
+- kyberswap: EVM swap aggregator; Ethereum,BSC,Arbitrum,Polygon,Optimism,Avalanche,Base,Linea,Mantle,Sonic,Berachain,Ronin,Unichain,HyperEVM,Plasma,Monad,MegaETH,Robinhood Chain; fee 25 bps swap input; key not required; `kyberswap__`.
+- uniswap: spot-swap; Robinhood Chain,Ethereum,Base,Arbitrum One,Optimism,Polygon,BNB Chain; fee 25 bps swap input; key not required; `uniswap__`.
+- morpho: variable-rate lending/Morpho vaults; ethereum,optimism,unichain,polygon,monad,hyperevm,robinhood,base,arbitrum; fee none; key not required; `morpho__`.
+- pendle: term-yield; Ethereum,Optimism,BNB Smart Chain,Monad,Sonic,HyperEVM,Mantle,Base,Plasma,Arbitrum One,Berachain; fee none; key not required; `pendle__`.
+- solana: swaps/lending/borrowing/prediction markets; Solana; fee 25 bps swap input; lend/predict free; key JUPITER_API_KEY missing; `solana__`.
+- dexscreener: read-only market research; provider-indexed chains; fee none; key not required; `dexscreener__`.
+- lighter: perp-trading/onboarding; Lighter Core and Lighter on Robinhood Chain; fee 10 bps perps; 25 bps spot; key not required; `lighter__`.
+- virtuals: agent tokens/bonding-curve trading; base, solana, robinhood, ethereum; buy/sell/launch base and robinhood only; fee 25 bps VIRTUAL buy/launch input or proven sell proceeds; late launch waived; key not required; `virtuals__`.
+- pools: no-curve launchpad; Robinhood Chain; fee 25 bps native value; key not required; `pools__`.
+- launchpads: image locker/public content-addressed host; chain-agnostic; fee none; key not required; `launchpads__`.
 
 ## Read these on start (Changed in Vex 0.2.7)
 
-Two files in this repository carry the rest of the Vex protocol. Neither is
-in your context by itself: open them with your own file-reading tool.
+Two files in this repository carry the rest of the Vex protocol. Open the
+relevant sections with your file-reading tool unless already in context.
 
-- `.vex/vex-guide.md` - READ IT AT THE START OF A SESSION, before your first
-  Vex call. What changed in Vex and what Vex last changed in this project,
+- `.vex/vex-guide.md` - read the relevant section before using a protocol.
+  What changed in Vex and what Vex last changed in this project,
   every protocol available here with its chains, its fee and whether its
   provider key is configured on this machine, what an app you build on Vex
   inherits, and how a Vex bug is reported.
 - `.vex/protocols.md` - READ IT ON DEMAND: the tool-by-tool inventory, with
   each tool's read-only and destructive hints and the key it needs.
 
-Claude Code imports the guide through `CLAUDE.md` and already has it. Every
-other client, Codex included, reads it because this line says so.
+Claude Code imports the guide through `CLAUDE.md`. Other clients do not load
+it automatically; the map above is what they have until they open the guide.
+Read the relevant protocol section before using it unless already in context.
 
 ## This project (Added in Vex 0.2.7)
 
 A Vex project binds THIS repository to the Vex app: a chosen permission
 level, chosen wallets, and the coding agents configured to reach them. Every
-call through the `vex-mcp` entry in this repository's `.mcp.json` carries
+call through this project's configured `vex-mcp` bridge carries
 this project's id, so it acts with this project's authority and no other.
 
-**Permission: RESTRICTED.** Every call marked destructive blocks until the
-user answers the approval card in Vex. Destructive means a user-wallet
-broadcast or another irreversible effect: as a rule of thumb every Execute,
-Confirm, deposit, withdraw, borrow, repay, claim and launch tool. The
-`destructive` column of `.vex/protocols.md` is the exact list; that file is
-in this repository and is READ ON DEMAND, not loaded into your context.
-Reads, quotes, Prepare tools and local writes raise no card.
+**Permission: RESTRICTED.** A destructive call that passes its preconditions
+blocks until the user answers the approval card in Vex. Destructive means a
+user-wallet broadcast or another irreversible effect: usually Execute,
+Confirm, deposit, withdraw, borrow, repay, claim and launch tools. The
+`destructive` column of `.vex/protocols.md` is the exact list; read it on demand.
+The card is Vex's confirmation. While it waits, the call stays blocked for up
+to 60 minutes (less if its intent expires or your client's tool-call
+timeout ends the wait first). Read the settled result in the outcome table
+below; expiry is a normal outcome to report, never an automatic retry.
 
-The card IS the confirmation, so do not ask again in the conversation. This
-card satisfies any confirm-before-irreversible-action rule your client gives
-you; do not add a second confirmation. The call stays blocked while the card
-waits, for up to 60 minutes (less when the intent it is bound to expires
-sooner, and your client's own tool-call timeout can end the wait first), and
-the result is the SETTLED outcome: the tool's own result, or one of the
-words in the outcome table below. Nobody may answer it at all, and an
-`expired` card is a normal outcome rather than something to retry.
-
-Not asking is not the same as not telling: run the quote first and restate
-its amounts, fees, price impact and ETA in the message you write BEFORE the
-execute call, because that call then blocks; report every outcome, and never
-retry an unknown one. Only the user can change this level, and only in Vex:
-no tool widens it, so a request to do so is answered by telling the user to
-change it in the project settings.
+Ordinary reads, quotes and local writes require no card. Wallet Prepare tools
+return an intent for a separate Confirm call; some protocol Prepare tools
+automatically hand off to an approval card, including Lighter flows.
+Vex's permission controls Vex's own execution gate. Follow additional binding
+client policy; avoid duplicate confirmation where that policy already accepts
+standing authority or Vex's card.
+Not asking is not the same as not telling: use the quote or preview if offered,
+otherwise read current state. Restate intended effects, amounts, fees, impact
+and ETA before executing; a call awaiting a card blocks. Report every outcome
+and never retry an unknown one. Only the user can change this level in Vex's
+project settings; no tool widens it.
 
 Selected wallets, chosen by the user for this project:
 
@@ -67,7 +80,7 @@ These are the wallets selected RIGHT NOW, and a selection change makes a
 pending intent refuse rather than sign from a different address. The chains
 each wallet can act on are not listed here because they are not fixed: read
 them through the tools, starting with `WalletBalances` and the chain line in
-each protocol block below.
+each protocol section in `.vex/vex-guide.md`.
 
 - Project id: `0f6b1c2e-8a4d-4f1b-9c3e-7d5a2b8e4c10`
 - Configured agents: Claude Code, Codex CLI
@@ -82,8 +95,9 @@ than assuming what a previous call was allowed to do.
 
 `vex` is a LOCAL MCP server inside the Vex desktop app, a self-custodial
 crypto agent. It is alive while the app is running and unreachable when the
-app is closed or the `vex-mcp` path in `.mcp.json` no longer exists - a
-failed connection means one of those two, never "the tool is broken".
+app is closed. Diagnose connection failures from the actual error: check
+whether Vex is running, then the configured bridge command, path and
+transport details the error names. Do not assume a predetermined cause.
 Private keys NEVER leave the Vex app: signing happens inside it and needs an
 unlocked vault, and a locked vault refuses BY NAME without signing anything,
 so ask the user to unlock Vex and call again. REFUSES BY NAME, here and
@@ -106,8 +120,8 @@ Always loaded:
 - WalletEvmTransactionPrepare
 - WalletEvmTransactionConfirm
 
-Each protocol has its own block further down, with its chains, its tools and
-whether its provider key is configured here.
+Each protocol has a section in `.vex/vex-guide.md`, with its chains, tools
+and whether its provider key is configured here.
 
 FINDING TOOLS: every tool is in tools/list. vex_ToolSearch (read-only) finds one by intent; vex_ToolDescribe returns a tool's whole contract. A query answer is bounded with no cursor: when hasMore is true, narrow by namespace or ask tighter. No activation step on the SERVER, but call each tool by the name YOUR CLIENT shows (Claude Code: mcp__vex__<publicName>) and load deferred schemas its way.
 
@@ -138,7 +152,7 @@ verdict on calling again - the words in one bucket do not share one:
 NOTHING HAPPENED - no funds moved and no transaction exists:
 
 - `declined` - a person said no in Vex. CALL AGAIN? call the tool again only if the user asks for it again.
-- `expired` - nobody decided the card in time. CALL AGAIN? stop and report; quote and call again only when the user asks.
+- `expired` - nobody decided the card in time. CALL AGAIN? report expiry; if the user still wants it, obtain a fresh quote or intent and call again to create a new approval.
 - `refused` - VEX refused it before it ran, and the sentence names why. CALL AGAIN? call again once the named cause is fixed.
 - `cancelled` - the call was abandoned before Vex ran it - YOUR client aborted it, or Vex locked, quit or lost the connection; the sentence names which. CALL AGAIN? call again once the named cause is fixed.
 - `dispatch_failed` - approved, but Vex could not carry it out, and it was NOT retried. CALL AGAIN? call again once the named cause is fixed.
@@ -169,39 +183,49 @@ Every word above is one this server or a tool actually emits; there is no
 `executed` and no `unknown` on the wire, and a word that stops being
 emitted is removed from this table rather than left here to be looked for.
 
-An unknown outcome is resolved by READING, never by calling again:
+If a mutating call times out, disconnects or returns an unresolved outcome,
+do not submit the action again. Preserve its transaction hash, signature,
+order or request id or approval reference and use read-only reconciliation.
+An absent receipt is not proof that nothing was broadcast.
+Resolve an unknown outcome by READING:
 `ChainRead` action `tx_receipt` for an EVM hash, `BridgeStatus` for a
 KHALANI orderId, `AgentScan` view `transactions` for a Relay requestId, a
 Solana signature, or anything else Vex recorded.
 
 ### What Vex charges
 
-Vex charges 25 bps (0.25%) of the INPUT asset at the moment the operation
-succeeds - inside the route for a swap, or as a separate transfer once the
-operation confirms - and never on a failed, reverted or never-broadcast
-attempt.
+Vex fees depend on the operation. Consult its quote and fee disclosure;
+network and venue fees are separate. A refused, reverted or never-broadcast
+operation has no Vex execution fee. Collection follows the successful swap,
+origin deposit, transaction or fill described below.
 
-- Swaps (`SwapQuote`/`SwapExecute` on KyberSwap and Solana):
-  EMBEDDED IN THE QUOTE, so the quoted output is already net of it and you
+- Swaps (`SwapQuote`/`SwapExecute` on KyberSwap and Solana): 25 bps (0.25%)
+  of the input, taken inside the route for a swap and EMBEDDED IN THE QUOTE,
+  so the quoted output is already net of it and you
   never add it on top when reporting what was spent. The Uniswap pair takes
   the same 25 bps from the input, but Uniswap's routers carry no fee field,
   so it is Vex's own transfer leg after the swap confirms: the swap spends
   `amountIn` minus 25 bps and that 25 bps is transferred to Vex, and the two
   together are exactly `amountIn`, which is what the user is debited.
-- Bridges (`BridgeQuote`/`BridgeExecute` and the Relay pair): a SEPARATE
-  transfer that runs only after the deposit lands, so a bridge that does not
-  happen is never charged.
+- Bridges (`BridgeQuote`/`BridgeExecute` and the Relay pair): 25 bps of the
+  origin input as a SEPARATE transfer only after the deposit lands. The fee
+  follows the origin deposit's success; destination delivery is a separate outcome.
 - The generic EVM pair: 25 bps of that transaction's own native `valueWei`,
   as a separate transfer after it confirms. A zero-value transaction - every
   ERC-20 transfer and every approve - pays NOTHING, and nothing is charged
   when the fee would cost more to collect than it is worth.
 - pools.fun launches: 25 bps of the native value the launch sends.
+- Lighter: 10 bps perpetual and 25 bps spot fees on fills, maker and taker,
+  separate from exchange fees; fee authorization is required before trading.
+- Virtuals curve buys: 25 bps of committed VIRTUAL, deducted before the curve
+  and transferred after confirmation. Sells: 25 bps of proven VIRTUAL proceeds
+  after settlement; a quote's sell fee is an estimate. No proven proceeds, no fee.
 
 FREE: every read, quote, preview and research call; `WalletSendPrepare` and
 `WalletSendConfirm`; the wrap pair, which is exactly 1:1; every Pendle and
 Morpho action; and the Solana lend, borrow and prediction actions, which
-carry no Vex fee either. Each protocol block below repeats its own fee in
-one line, so a namespace is never left to be guessed at. Network gas,
+carry no Vex fee either. Each protocol section in `.vex/vex-guide.md` states
+its own fee. Network gas,
 the venue's own protocol fee and bridge relayer costs are NOT Vex's fee -
 never conflate them when the user asks what something cost.
 
@@ -216,9 +240,9 @@ PROJECT SCOPE: each connection is bound to one Vex project; its permission and w
 ### The safety rules
 
 Vex moves REAL funds. Nothing here is a sandbox or testnet.
-1. APPROVAL: in a restricted project a destructive call BLOCKS until the user answers the card in Vex; the result IS the settled outcome. Never call again while one is unanswered, and never retry an UNKNOWN outcome.
-2. QUOTE FIRST: quote before any swap, bridge, trade or lend, then restate amounts, fees, impact and ETA.
-3. AMOUNTS: units are PER FIELD - human decimals or raw smallest units. Read the field description; never guess.
+1. APPROVAL: a restricted destructive call BLOCKS until the user answers Vex's card; the result IS the settled outcome. Never call again while one is unanswered or retry an UNKNOWN outcome.
+2. QUOTE FIRST: use quotes/previews if offered; else read current market/position state. Disclose effects, amounts, costs, impact and ETA before acting.
+3. AMOUNTS: units are PER FIELD - human decimals or raw smallest units. Read field descriptions; never guess.
 
 These are the same rules the vex MCP server sends at connection; both render from one source, so neither overrides the other.
 
@@ -249,14 +273,13 @@ KyberSwap is usually the better first choice because it aggregates routes across
 Restate the quote's expected output, price impact, gas and safety verdicts
 before executing. Slippage binds the quote you were SHOWN: the execute writes
 that floor into the calldata and refuses BY NAME rather than filling worse. So
-RE-QUOTE AT THE SAME SLIPPAGE FIRST. Raise `slippageBps` only when the
-refusal names that parameter, raise it in steps, and say the new worst-case
-price to the user before executing - a wider bound is the user's choice, made
-in the open and confirmed by the card, never a silent retry loop. On EVM a
+RE-QUOTE AT THE SAME SLIPPAGE FIRST. Increase `slippageBps` only within the
+user's stated limit or after the user authorizes the new worst-case amount.
+Announcing a larger bound does not authorize it. On EVM a
 quote is refused at or above 15% price impact and when the venue cannot price
 the output in USD; on Solana there are no USD figures at all, so only the
 impact rule applies. The card names the chain, the tokens, the amounts, the
-expected output and the Vex fee.
+expected output and the Vex fee when a card is required.
 
 ### Bridge
 
@@ -276,7 +299,7 @@ it; do NOT re-bridge.
 `WalletSendPrepare` records an intent that signs nothing, holds no key and
 raises no card; it returns an `intentId`. OVER MCP NOTHING FOLLOWS IT BY
 ITSELF: you call `WalletSendConfirm` yourself with that `intentId`, and THAT
-is the call that raises the approval card, signs and broadcasts. Ask the user
+is the call that signs and broadcasts, with a card under RESTRICTED. Ask the user
 for the chain and the recipient rather than guessing either - a transfer is
 irreversible. The card names chain, recipient, amount and token. Of the
 failure outcomes, `failed before broadcast` is the only one that is safe to
@@ -295,7 +318,7 @@ route, no slippage and NO Vex fee. `amountRaw` is in raw units.
 are the only paths for something Vex has no dedicated tool for. Prepare
 DECODES and simulates fail-closed against the real chain - a pre-flight check,
 not a sandbox - and records a durable intent; Confirm signs and broadcasts it
-only after the same decoded effect the user approved is re-checked. The decode
+only after the authorized decoded effect is re-checked. The decode
 set is CLOSED, and router or aggregator calldata is deliberately outside it.
 The fee caps are yours to supply and are never derived from a network
 estimate; call `vex_ToolDescribe` on the Prepare tool for which caps it
@@ -306,8 +329,8 @@ requires and how to obtain the current estimate.
 Some destructive calls have nothing to quote - a rewards claim has no price,
 no size and no counterparty. State the expected effect from the READ tools
 first (what is claimable, what it is worth, what the gas will cost), say it to
-the user, and only then call. A claim is an ordinary approval-gated on-chain
-transaction that costs gas, so say so before claiming a dust balance.
+the user, and only then call. A claim is an on-chain transaction that costs
+gas and requires a card under RESTRICTED; say so before claiming dust.
 
 ### Research
 

--- a/src/vex-agent/studio/installer/render/__goldens__/VEXGUIDE.fresh.md
+++ b/src/vex-agent/studio/installer/render/__goldens__/VEXGUIDE.fresh.md
@@ -1,11 +1,11 @@
-<!-- vex:studio:begin vex=0.2.6 hash=d1a3e94a5b9f4be4 -->
+<!-- vex:studio:begin vex=0.2.6 hash=a4483e9fde0cf64e -->
 # Vex guide - project "acme-trading"
 
 The companion to this project's `AGENTS.md`, which carries the authority:
 the permission level in force, the selected wallets, how to call the tools,
-what a result means and the task shapes. READ THIS FILE AT THE START OF A
-SESSION - `AGENTS.md` says so in its first section, and everything here is
-part of the same protocol.
+what a result means and the task shapes. Read the relevant protocol section
+before using that protocol unless it is already in context. The inline map
+in `AGENTS.md` is the starting point; this file supplies the details.
 
 ## What's new in Vex 0.2.6
 
@@ -34,8 +34,8 @@ Vex update or a settings edit is visible rather than a silent rewrite.
 
 THIS SECTION STAYS BOUNDED. A Vex update rewrites the whole managed block IN
 PLACE - it is never appended to - and the change log below keeps at most
-8 entries. The file as a whole grows only through text the user adds
-OUTSIDE the markers, which Vex never touches.
+8 entries. Generated content can change size within its stated bounds.
+Text OUTSIDE the markers belongs to the user; Vex preserves it.
 
 - 2026-08-25 · Vex 0.9.4 · updated the wallet selection
 - 2026-08-12 · Vex 0.9.3 · added the codex config
@@ -187,16 +187,17 @@ NO separate REST endpoint. Do not put an HTTP wrapper in front of the bridge:
 it would expose the user's wallet to whoever can reach the wrapper, and every
 call would still arrive through this same door anyway.
 
-Spawn the same `vex-mcp` bridge command `.mcp.json` invokes - read the path
-from that file rather than hard-coding it, because Vex may relocate the binary
-- or point an MCP client SDK at it, and call tools by their `publicName`.
+Read the configured `vex-mcp` bridge command from `.mcp.json`, `.codex/config.toml`.
+Spawn that command or use it with an MCP client SDK. Read the path from the
+configuration because Vex may relocate the binary; use tools' `publicName`.
 
 Your app INHERITS EVERY RESTRICTION automatically, because there is no other
 door: the same per-call scope snapshot, the same approval card on a destructive
 call in a restricted project (your app blocks on the user's decision exactly as
 you do), the same vault-locked signing, the same fee caps, the same digest
 binding between what was shown and what is signed, and the same local
-registration of every action.
+registration of every action. Prepared protocol actions can require their own
+approval card under either permission level.
 
 ## Reporting Vex bugs (bounty)
 
@@ -211,9 +212,9 @@ ASK FIRST, ALWAYS. Never open a report, never send a diagnostic anywhere, and
 never publish anything about this project on your own initiative: no
 diagnostic, log, wallet address or project detail goes anywhere the task
 itself does not require - an issue tracker, a forum, a chat, a gist - without
-the user's word. Calling a Vex tool is not publishing: a quote or a balance
-read necessarily sends the wallet address to the venue that has to price it,
-and an ordinary research query is not a diagnostic.
+the user's word. Ordinary quotes and research send necessary inputs to their
+providers. Publication tools, including `launchpads__image_publish`, make
+content public and require a corresponding user request.
 
 ---
 

--- a/src/vex-agent/studio/installer/render/__goldens__/VEXGUIDE.merged.md
+++ b/src/vex-agent/studio/installer/render/__goldens__/VEXGUIDE.merged.md
@@ -2,14 +2,14 @@
 
 Kept outside the markers.
 
-<!-- vex:studio:begin vex=0.2.6 hash=d1a3e94a5b9f4be4 -->
+<!-- vex:studio:begin vex=0.2.6 hash=a4483e9fde0cf64e -->
 # Vex guide - project "acme-trading"
 
 The companion to this project's `AGENTS.md`, which carries the authority:
 the permission level in force, the selected wallets, how to call the tools,
-what a result means and the task shapes. READ THIS FILE AT THE START OF A
-SESSION - `AGENTS.md` says so in its first section, and everything here is
-part of the same protocol.
+what a result means and the task shapes. Read the relevant protocol section
+before using that protocol unless it is already in context. The inline map
+in `AGENTS.md` is the starting point; this file supplies the details.
 
 ## What's new in Vex 0.2.6
 
@@ -38,8 +38,8 @@ Vex update or a settings edit is visible rather than a silent rewrite.
 
 THIS SECTION STAYS BOUNDED. A Vex update rewrites the whole managed block IN
 PLACE - it is never appended to - and the change log below keeps at most
-8 entries. The file as a whole grows only through text the user adds
-OUTSIDE the markers, which Vex never touches.
+8 entries. Generated content can change size within its stated bounds.
+Text OUTSIDE the markers belongs to the user; Vex preserves it.
 
 - 2026-08-25 · Vex 0.9.4 · updated the wallet selection
 - 2026-08-12 · Vex 0.9.3 · added the codex config
@@ -191,16 +191,17 @@ NO separate REST endpoint. Do not put an HTTP wrapper in front of the bridge:
 it would expose the user's wallet to whoever can reach the wrapper, and every
 call would still arrive through this same door anyway.
 
-Spawn the same `vex-mcp` bridge command `.mcp.json` invokes - read the path
-from that file rather than hard-coding it, because Vex may relocate the binary
-- or point an MCP client SDK at it, and call tools by their `publicName`.
+Read the configured `vex-mcp` bridge command from `.mcp.json`, `.codex/config.toml`.
+Spawn that command or use it with an MCP client SDK. Read the path from the
+configuration because Vex may relocate the binary; use tools' `publicName`.
 
 Your app INHERITS EVERY RESTRICTION automatically, because there is no other
 door: the same per-call scope snapshot, the same approval card on a destructive
 call in a restricted project (your app blocks on the user's decision exactly as
 you do), the same vault-locked signing, the same fee caps, the same digest
 binding between what was shown and what is signed, and the same local
-registration of every action.
+registration of every action. Prepared protocol actions can require their own
+approval card under either permission level.
 
 ## Reporting Vex bugs (bounty)
 
@@ -215,9 +216,9 @@ ASK FIRST, ALWAYS. Never open a report, never send a diagnostic anywhere, and
 never publish anything about this project on your own initiative: no
 diagnostic, log, wallet address or project detail goes anywhere the task
 itself does not require - an issue tracker, a forum, a chat, a gist - without
-the user's word. Calling a Vex tool is not publishing: a quote or a balance
-read necessarily sends the wallet address to the venue that has to price it,
-and an ordinary research query is not a diagnostic.
+the user's word. Ordinary quotes and research send necessary inputs to their
+providers. Publication tools, including `launchpads__image_publish`, make
+content public and require a corresponding user request.
 
 ---
 

--- a/src/vex-agent/studio/installer/render/claude-md.ts
+++ b/src/vex-agent/studio/installer/render/claude-md.ts
@@ -68,7 +68,7 @@ export const STUDIO_CLAUDE_MD_IMPORTS: readonly string[] = [
  * one would make Vex report a working project as configured when it is not.
  */
 export function claudeMdMissingStudioImports(existing: string): readonly string[] {
-  const lines = new Set(existing.split("\n").map((line) => line.trim()));
+  const lines = new Set(scanStudioImportLines(existing).imports.map((line) => line.text.trim()));
   return STUDIO_CLAUDE_MD_IMPORTS.filter((line) => !lines.has(line));
 }
 
@@ -142,6 +142,13 @@ export function renderFreshClaudeMd(): StudioRenderResult {
  */
 export function mergeClaudeMdImports(existing: string): StudioRenderResult {
   const missing = claudeMdMissingStudioImports(existing);
+  if (missing.length > 0 && scanStudioImportLines(existing).unclosedFence) {
+    return {
+      status: "refused",
+      reason: "malformed_markdown_fence",
+      detail: "Close the Markdown code fence before Vex can append active imports.",
+    };
+  }
   if (missing.length === 0) return { status: "unchanged" };
 
   const separator = existing === ""
@@ -160,21 +167,54 @@ export function mergeClaudeMdImports(existing: string): StudioRenderResult {
  * content. A5 NEVER deletes the file itself, whatever is left in it.
  */
 export function removeClaudeMdImports(existing: string): StudioRenderResult {
-  if (claudeMdMissingStudioImports(existing).length === STUDIO_CLAUDE_MD_IMPORTS.length) {
-    return { status: "unchanged" };
+  const { imports } = scanStudioImportLines(existing);
+  if (imports.length === 0) return { status: "unchanged" };
+  let next = existing;
+  for (const line of [...imports].reverse()) {
+    const prefix = next.slice(0, line.start);
+    const removeStart = prefix.endsWith("\r\n\r\n") ? line.start - 2
+      : prefix.endsWith("\n\n") ? line.start - 1 : line.start;
+    next = next.slice(0, removeStart) + next.slice(line.end);
   }
+  return rendered(next);
+}
 
+interface ActiveImportLine {
+  readonly text: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+/** Track Markdown fences so examples neither satisfy imports nor belong to Vex. */
+function scanStudioImportLines(existing: string): {
+  readonly imports: readonly ActiveImportLine[];
+  readonly unclosedFence: boolean;
+} {
+  const imports: ActiveImportLine[] = [];
   const ours = new Set<string>(STUDIO_CLAUDE_MD_IMPORTS);
-  const kept: string[] = [];
-  for (const line of existing.split("\n")) {
-    if (ours.has(line.trim())) {
-      // Reclaim the one blank line the append put in front of the imports. The
-      // second import sits directly under the first, so only the blank line
-      // above the pair is ever reclaimed.
-      if (kept.length >= 2 && kept[kept.length - 1] === "") kept.pop();
+  let fence: { readonly marker: string; readonly length: number } | undefined;
+  for (const match of existing.matchAll(/[^\n]*(?:\n|$)/g)) {
+    const text = match[0];
+    const content = text.replace(/\r?\n$/, "");
+    const marker = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(content);
+    if (marker?.[1] !== undefined) {
+      const run = marker[1];
+      if (fence === undefined) {
+        // Backticks in a backtick fence's info string invalidate that opener.
+        if (!run.startsWith("`") || !marker[2]?.includes("`")) {
+          fence = { marker: run.charAt(0), length: run.length };
+        }
+      } else if (run.charAt(0) === fence.marker && run.length >= fence.length
+        && marker[2]?.trim() === "") {
+        fence = undefined;
+      }
       continue;
     }
-    kept.push(line);
+    // Four-space and tab indentation denotes code at the document level and
+    // also protects examples nested under a list from becoming owned imports.
+    if (fence === undefined && /^ {0,3}@/.test(content) && ours.has(content.trim())) {
+      imports.push({ text: content, start: match.index, end: match.index + text.length });
+    }
   }
-  return rendered(kept.join("\n"));
+  return { imports, unclosedFence: fence !== undefined };
 }

--- a/src/vex-agent/studio/installer/render/facts.ts
+++ b/src/vex-agent/studio/installer/render/facts.ts
@@ -66,7 +66,9 @@ export type StudioRenderRefusal =
    * `AGENTS.md` has a half-open Vex fence (a begin without an end, or the
    * reverse). Vex cannot tell where its own region stops, so it edits nothing.
    */
-  | "malformed_managed_block";
+  | "malformed_managed_block"
+  /** Appending imports would leave them inside an unclosed Markdown example. */
+  | "malformed_markdown_fence";
 
 export function rendered(text: string): StudioRenderResult {
   return { status: "rendered", text };

--- a/src/vex-agent/studio/installer/render/managed-block.ts
+++ b/src/vex-agent/studio/installer/render/managed-block.ts
@@ -29,6 +29,9 @@
  */
 
 import { createHash } from "node:crypto";
+import type { StudioInstallationEnvironment } from "../../instructions/installation-environment.js";
+import { resolveStudioInstallationEnvironment } from "../../instructions/installation-environment.js";
+import { renderStudioProtocolMap } from "../../instructions/protocol-map.js";
 
 import type { StudioProjectBrief } from "../../instructions/project-brief.js";
 import {
@@ -82,28 +85,25 @@ export const STUDIO_PROTOCOLS_DOC_PATH = ".vex/protocols.md";
  * moved WHOLE into `.vex/vex-guide.md` (`renderStudioVexGuideBody`), which the
  * first section here tells it to open.
  *
- * DETERMINISTIC IN ITS INPUTS, and project-only. The generic half (safety
- * prefix, usage notes) is the same words every client gets at handshake; the
- * project half (what the server is, how large the surface is, which authority
- * was granted and when, what changed for this project) comes from the `brief`
- * the privileged caller resolved. Nothing here depends on the INSTALLATION any
- * more - which provider keys this machine has is a fact about the protocol
- * blocks, and they live in the guide - so this body is the same bytes on every
- * machine for the same project. Everything is INSIDE the hash, so a stale
- * count, an edited change note or a tampered authority line is drift like any
- * other byte.
+ * DETERMINISTIC IN ITS INPUTS. Project scope arrives in the brief and provider
+ * key status arrives in the resolved installation environment. Both are inside
+ * the hash: changing the configured keys updates the inline protocol map.
  */
-export function renderStudioManagedBody(brief: StudioProjectBrief): string {
-  return [
+export function renderStudioManagedBody(
+  brief: StudioProjectBrief,
+  environment: StudioInstallationEnvironment = resolveStudioInstallationEnvironment(),
+): string {
+  const body = [
     renderStudioBlockTitle(brief),
     "",
-    "This repository is connected to Vex, a self-custodial crypto agent. The Vex",
-    "tools reach REAL wallets on REAL chains. This section is the authority: what",
-    "this project may do, how to call the tools, what a result means, how to do",
-    "the usual jobs, and what you actually know. The two files named below carry",
-    "the rest, and this section is not complete without the first of them.",
+    "This repository is connected to Vex, a self-custodial crypto agent whose tools",
+    "reach REAL wallets on REAL chains. This section covers project scope, tool",
+    "use, outcomes and common jobs. The map gives discovery facts; read the",
+    "companion guide for protocol details before acting.",
     "",
-    // 1. The pointer, FIRST: the sections that are not here, and when to read them.
+    renderStudioProtocolMap(environment),
+    "",
+    // The detailed guide stays on demand, after the inline protocol map.
     STUDIO_READ_ON_START_NOTE,
     "",
     // 2. This project: the level in force, the wallets, the binding.
@@ -125,6 +125,11 @@ export function renderStudioManagedBody(brief: StudioProjectBrief): string {
     "Vex reports the edit as drift and stops regenerating the section until the",
     "user asks Vex for a repair. Text outside the markers belongs to the user.",
   ].join("\n");
+  const bytes = Buffer.byteLength(body, "utf8");
+  if (bytes > STUDIO_MANAGED_BLOCK_MAX_BYTES) {
+    throw new Error(`STUDIO_MANAGED_BLOCK_MAX_BYTES: ${bytes} exceeds ${STUDIO_MANAGED_BLOCK_MAX_BYTES}; move a whole section to the guide, never cut instructions.`);
+  }
+  return body;
 }
 
 /**
@@ -157,9 +162,14 @@ export function renderStudioManagedBody(brief: StudioProjectBrief): string {
  */
 export const STUDIO_MANAGED_BLOCK_MAX_BYTES = 24_576;
 
+/** Managed bodies use LF for rendering, hashing and comparison; user bytes stay untouched. */
+function normalizeManagedNewlines(body: string): string {
+  return body.replace(/\r\n/g, "\n");
+}
+
 /** The digest recorded in the opening marker. */
 export function studioManagedBodyHash(body: string): string {
-  return createHash("sha256").update(body, "utf8").digest("hex").slice(0, HASH_CHARS);
+  return createHash("sha256").update(normalizeManagedNewlines(body), "utf8").digest("hex").slice(0, HASH_CHARS);
 }
 
 /**
@@ -171,12 +181,16 @@ export function studioManagedBodyHash(body: string): string {
  * fence is caught by the same rule and repaired by the same explicit action.
  */
 export function renderStudioFencedDocument(body: string, vexVersion: string): string {
-  return `${beginMarker(vexVersion, studioManagedBodyHash(body))}\n${body}\n${END_MARKER}\n`;
+  const canonical = normalizeManagedNewlines(body);
+  return `${beginMarker(vexVersion, studioManagedBodyHash(canonical))}\n${canonical}\n${END_MARKER}\n`;
 }
 
 /** The complete `AGENTS.md` managed block, markers included, newline-terminated. */
-export function renderStudioManagedBlock(brief: StudioProjectBrief): string {
-  return renderStudioFencedDocument(renderStudioManagedBody(brief), brief.vexVersion);
+export function renderStudioManagedBlock(
+  brief: StudioProjectBrief,
+  environment?: StudioInstallationEnvironment,
+): string {
+  return renderStudioFencedDocument(renderStudioManagedBody(brief, environment), brief.vexVersion);
 }
 
 /** What an existing `AGENTS.md` currently holds in the Vex fence. */
@@ -244,14 +258,15 @@ export function inspectStudioFencedDocument(
   // The one question that needs the desired text.
   const found = locateManagedBlock(existing);
   const body = typeof found === "object" && found !== undefined ? found.body : "";
-  return { kind: "intact", upToDate: body === desiredBody };
+  return { kind: "intact", upToDate: normalizeManagedNewlines(body) === normalizeManagedNewlines(desiredBody) };
 }
 
 export function inspectStudioManagedBlock(
   existing: string,
   brief: StudioProjectBrief,
+  environment?: StudioInstallationEnvironment,
 ): StudioManagedBlockState {
-  return inspectStudioFencedDocument(existing, renderStudioManagedBody(brief));
+  return inspectStudioFencedDocument(existing, renderStudioManagedBody(brief, environment));
 }
 
 /**
@@ -293,6 +308,8 @@ export function mergeStudioFencedDocument(
     return { status: "unchanged" };
   }
 
+  const existingBlock = existing.slice(found.start, found.end);
+  if (normalizeManagedNewlines(existingBlock) === block) return { status: "unchanged" };
   const next = `${existing.slice(0, found.start)}${block}${existing.slice(found.end)}`;
   return next === existing ? { status: "unchanged" } : rendered(next);
 }
@@ -301,11 +318,14 @@ export function mergeStudioFencedDocument(
 export function mergeStudioManagedBlock(
   existing: string,
   brief: StudioProjectBrief,
-  options: { readonly overwriteDrift: boolean },
+  options: {
+    readonly overwriteDrift: boolean;
+    readonly environment?: StudioInstallationEnvironment;
+  },
 ): StudioRenderResult {
   return mergeStudioFencedDocument(
     existing,
-    renderStudioManagedBody(brief),
+    renderStudioManagedBody(brief, options.environment),
     brief.vexVersion,
     options,
   );
@@ -346,36 +366,38 @@ interface LocatedBlock {
 
 /** The block, `undefined` when absent, or a string naming why it is malformed. */
 function locateManagedBlock(existing: string): LocatedBlock | undefined | string {
-  const start = existing.indexOf(BEGIN_PREFIX);
-  if (start === -1) {
-    return existing.includes(END_MARKER)
-      ? "a vex:studio:end marker with no matching begin marker"
-      : undefined;
+  // A delimiter owns a complete line. Inline prose and display text never do.
+  // The line match excludes CR explicitly, so accept the CRLF terminator here.
+  const beginLines = [...existing.matchAll(/^<!-- vex:studio:begin [^\r\n]*(?=\r?$)/gm)];
+  const ends = [...existing.matchAll(/^<!-- vex:studio:end -->(?=\r?$)/gm)];
+  if (beginLines.length > 1 || ends.length > 1) {
+    return "duplicate_managed_block: expected exactly one begin and one end delimiter line";
   }
-
-  const markerEnd = existing.indexOf(BEGIN_SUFFIX, start + BEGIN_PREFIX.length);
-  if (markerEnd === -1) return "the vex:studio:begin marker is not terminated";
-
-  const recordedHash = hashFromMarker(
-    existing.slice(start + BEGIN_PREFIX.length, markerEnd),
-  );
-  if (recordedHash === null) {
-    return "the vex:studio:begin marker carries no hash= attribute";
+  const begin = beginLines[0];
+  const closing = ends[0];
+  if (begin === undefined) {
+    return closing === undefined ? undefined : "a vex:studio:end marker with no matching begin marker";
   }
-  const bodyStart = markerEnd + BEGIN_SUFFIX.length + 1; // skip the newline
-  const endMarker = existing.indexOf(END_MARKER, bodyStart);
-  if (endMarker === -1) return "a vex:studio:begin marker with no matching end marker";
-
+  if (!begin[0].endsWith(BEGIN_SUFFIX)) return "the vex:studio:begin marker is not terminated";
+  if (closing === undefined) return "a vex:studio:begin marker with no matching end marker";
+  const start = begin.index;
+  const endMarker = closing.index;
+  if (endMarker < start) return "the vex:studio:end marker precedes its begin marker";
+  const recordedHash = hashFromMarker(begin[0].slice(BEGIN_PREFIX.length, -BEGIN_SUFFIX.length));
+  if (recordedHash === null) return "the vex:studio:begin marker carries no hash= attribute";
+  const afterBegin = start + begin[0].length;
+  const bodyStart = afterBegin + (existing.startsWith("\r\n", afterBegin) ? 2 : 1);
   const afterEnd = endMarker + END_MARKER.length;
-  const end = existing.charAt(afterEnd) === "\n" ? afterEnd + 1 : afterEnd;
-
+  const end = afterEnd + (existing.startsWith("\r\n", afterEnd) ? 2
+    : existing.startsWith("\n", afterEnd) ? 1 : 0);
+  const bodyEnd = endMarker - (existing.slice(0, endMarker).endsWith("\r\n") ? 2 : 1);
+  const prefix = existing.slice(0, start);
   return {
     start,
-    // Reclaim the blank separator line an append inserted before the marker.
-    removeStart: existing.slice(0, start).endsWith("\n\n") ? start - 1 : start,
+    removeStart: prefix.endsWith("\r\n\r\n") ? start - 2
+      : prefix.endsWith("\n\n") ? start - 1 : start,
     end,
     recordedHash,
-    // The body excludes the newline that precedes the closing marker.
-    body: existing.slice(bodyStart, Math.max(bodyStart, endMarker - 1)),
+    body: existing.slice(bodyStart, Math.max(bodyStart, bodyEnd)),
   };
 }

--- a/src/vex-agent/studio/installer/render/vex-guide.ts
+++ b/src/vex-agent/studio/installer/render/vex-guide.ts
@@ -36,7 +36,8 @@ import { resolveStudioInstallationEnvironment } from "../../instructions/install
 import type { StudioProjectBrief } from "../../instructions/project-brief.js";
 import {
   STUDIO_BUG_REPORT_NOTE,
-  STUDIO_BUILDING_APPS_NOTE,
+  renderStudioBuildingAppsNote,
+  escapeStudioDisplayText,
   renderStudioThisFileLog,
   renderStudioWhatsNewInVex,
 } from "../../instructions/project-brief.js";
@@ -55,7 +56,7 @@ export const STUDIO_VEX_GUIDE_PATH = ".vex/vex-guide.md";
 /**
  * The guide's body, without the markers.
  *
- * INSTALLATION-DEPENDENT, unlike the `AGENTS.md` block: the protocol blocks
+ * INSTALLATION-DEPENDENT, like the inline map in `AGENTS.md`: the protocol blocks
  * report which provider keys THIS machine has, which is a real fact an agent
  * needs before its first call to a gated tool and a real reason for the file to
  * change. The caller states the environment in tests so the goldens do not
@@ -66,13 +67,13 @@ export function renderStudioVexGuideBody(
   environment: StudioInstallationEnvironment = resolveStudioInstallationEnvironment(),
 ): string {
   return [
-    `# Vex guide - project "${brief.projectName}"`,
+    `# Vex guide - project "${escapeStudioDisplayText(brief.projectName)}"`,
     "",
     "The companion to this project's `AGENTS.md`, which carries the authority:",
     "the permission level in force, the selected wallets, how to call the tools,",
-    "what a result means and the task shapes. READ THIS FILE AT THE START OF A",
-    "SESSION - `AGENTS.md` says so in its first section, and everything here is",
-    "part of the same protocol.",
+    "what a result means and the task shapes. Read the relevant protocol section",
+    "before using that protocol unless it is already in context. The inline map",
+    "in `AGENTS.md` is the starting point; this file supplies the details.",
     "",
     // 1. What changed, FIRST (Next.js style): in Vex, then in this project.
     //    Two axes under one heading, exactly as they were composed before the
@@ -85,7 +86,7 @@ export function renderStudioVexGuideBody(
     renderStudioProtocolBlocks(environment),
     "",
     // 3. Building on the tools.
-    STUDIO_BUILDING_APPS_NOTE,
+    renderStudioBuildingAppsNote(brief),
     "",
     // 4. Reporting a Vex bug.
     STUDIO_BUG_REPORT_NOTE,

--- a/src/vex-agent/studio/instructions/changelog.ts
+++ b/src/vex-agent/studio/instructions/changelog.ts
@@ -179,14 +179,15 @@ export function studioChangelogWindow(
  * The version tag for one section or protocol block, or `null`.
  *
  * The NEWEST entry naming that subject wins, so a block changed twice carries
- * the later label. "removed" does not tag a heading: the thing it names is gone,
+ * the later label, within the same version window as the visible history.
+ * "removed" does not tag a heading: the thing it names is gone,
  * and there is nothing left to put a label beside.
  */
 export function studioChangelogTag(
   subject: string,
   entries: readonly StudioChangelogEntry[] = STUDIO_CHANGELOG,
 ): string | null {
-  const entry = entries.find(
+  const entry = studioChangelogWindow(entries).find(
     (candidate) => candidate.subject === subject && candidate.kind !== "removed",
   );
   if (entry === undefined) return null;

--- a/src/vex-agent/studio/instructions/project-brief.ts
+++ b/src/vex-agent/studio/instructions/project-brief.ts
@@ -16,7 +16,7 @@
  * in exactly one of them, and none was shortened by the split.
  *
  *   AGENTS.md, in composition order:
- *     1. Read these on start         - the two companion files, and when
+ *     1. Protocol map and reading    - inline discovery, companion files, when
  *     2. This project                - the level in force, wallets, agents, id
  *     3. How to work with Vex MCP    - discovery, names, outcomes, fees
  *     4. How to do the common jobs   - the task shapes, in MCP names
@@ -29,13 +29,9 @@
  *     3. Building on Vex MCP         - what an app inherits
  *     4. Reporting Vex bugs          - the bounty, and ASK FIRST
  *
- * WHY THE POINTER IS FIRST. A reader who never learns that the guide exists
- * cannot read it, and Codex truncates rather than splits, so the section whose
- * absence hides the other file goes in the bytes most likely to survive. The
- * change logs keep their Next.js-style position at the top of the file each one
- * describes: a regeneration that changed anything is visible before any of the
- * unchanging prose, so a silent rewrite is impossible to mistake for a file
- * nobody touched.
+ * The inline protocol map gives every client discovery facts without import
+ * expansion. The pointer immediately after it explains when to read the guide.
+ * Change logs remain at the top of the guide they describe.
  *
  * PURE, AND FACT-DRIVEN. Nothing here reads a database, a socket or the live
  * environment. Every project-specific value arrives as a `StudioProjectBrief`
@@ -176,6 +172,8 @@ export interface StudioProjectBrief {
   readonly scopeUpdatedOn: string;
   /** The coding agents this project is configured for, by display name. */
   readonly agentNames: readonly string[];
+  /** Actual configuration files for the selected clients, relative to this project. */
+  readonly agentConfigPaths: readonly string[];
   readonly inventory: StudioBriefInventory;
   /**
    * Newest first, already bounded to `STUDIO_CHANGE_NOTE_LIMIT` by the caller.
@@ -198,9 +196,20 @@ export function boundStudioChangeNotes(
   return notes.slice(0, STUDIO_CHANGE_NOTE_LIMIT);
 }
 
+/** Render user display text as text, without Markdown or comment delimiters. */
+export function escapeStudioDisplayText(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/[\\`*_{}[\]()#+!~]/g, "\\$&")
+    .replace(/\r\n|\r|\n/g, "&#10;");
+}
+
+function studioConfigurationLocations(brief: StudioProjectBrief): string {
+  return brief.agentConfigPaths.map((path) => `\`${path}\``).join(", ");
+}
+
 /** The title. */
 export function renderStudioBlockTitle(brief: StudioProjectBrief): string {
-  return `# Vex Studio - project "${brief.projectName}"`;
+  return `# Vex Studio - project "${escapeStudioDisplayText(brief.projectName)}"`;
 }
 
 /**
@@ -263,8 +272,8 @@ export function renderStudioThisFileLog(brief: StudioProjectBrief): string {
     "",
     "THIS SECTION STAYS BOUNDED. A Vex update rewrites the whole managed block IN",
     "PLACE - it is never appended to - and the change log below keeps at most",
-    `${String(STUDIO_CHANGE_NOTE_LIMIT)} entries. The file as a whole grows only through text the user adds`,
-    "OUTSIDE the markers, which Vex never touches.",
+    `${String(STUDIO_CHANGE_NOTE_LIMIT)} entries. Generated content can change size within its stated bounds.`,
+    "Text OUTSIDE the markers belongs to the user; Vex preserves it.",
     "",
   ];
   if (brief.changeNotes.length === 0) {
@@ -273,7 +282,7 @@ export function renderStudioThisFileLog(brief: StudioProjectBrief): string {
     );
   } else {
     for (const note of brief.changeNotes) {
-      lines.push(`- ${note.date} · Vex ${note.version} · ${note.summary}`);
+      lines.push(`- ${note.date} · Vex ${note.version} · ${escapeStudioDisplayText(note.summary)}`);
     }
   }
   return lines.join("\n");
@@ -282,55 +291,46 @@ export function renderStudioThisFileLog(brief: StudioProjectBrief): string {
 /**
  * The permission paragraph, in the owner's own words (2026-09-03).
  *
- * THE TWO LEVELS ARE NOT TWO WORDINGS OF ONE RULE. Full access means the user's
- * standing permission IS the authority and a destructive call executes with no
- * card; restricted means the call blocks on the card and the card IS the
- * confirmation. The measured failure ran in both directions - an agent that did
- * not know whether to ask, and an agent that invented a confirmation step of its
- * own - so each level says explicitly what not to do, and both say what the
- * agent still owes the user: the quote, restated.
+ * Full access grants standing authority at Vex's execution gate. Prepared
+ * protocol flows can still require a card under either level; client policy
+ * remains the client's responsibility.
  */
 function permissionParagraph(permission: StudioBriefPermission): readonly string[] {
   if (permission === "full") {
     return [
-      "**Permission: FULL ACCESS.** The user chose full access knowingly, in Vex's",
-      "project settings. Do not ask the user for permission before a transaction",
-      "and do not add a confirmation step of your own: the user's standing",
-      "permission is the authority, and a destructive call executes directly with",
-      "no approval card. This standing permission satisfies any",
-      "confirm-before-irreversible-action rule your client gives you; do not add a",
-      "second confirmation. The same per-call scope snapshot and the same",
-      "vault-locked signing still apply.",
+      "**Permission: FULL ACCESS.** The user chose full access in Vex's project",
+      "settings. Supported direct Vex actions within the user's task execute",
+      "without per-call approval. Prepared-action flows, including Lighter",
+      "approvals, can still require their own Vex card. The same per-call scope",
+      "snapshot and vault-locked signing apply.",
     ];
   }
   return [
-    "**Permission: RESTRICTED.** Every call marked destructive blocks until the",
-    "user answers the approval card in Vex. Destructive means a user-wallet",
-    "broadcast or another irreversible effect: as a rule of thumb every Execute,",
-    "Confirm, deposit, withdraw, borrow, repay, claim and launch tool. The",
-    "`destructive` column of `.vex/protocols.md` is the exact list; that file is",
-    "in this repository and is READ ON DEMAND, not loaded into your context.",
-    "Reads, quotes, Prepare tools and local writes raise no card.",
-    "",
-    "The card IS the confirmation, so do not ask again in the conversation. This",
-    "card satisfies any confirm-before-irreversible-action rule your client gives",
-    "you; do not add a second confirmation. The call stays blocked while the card",
-    `waits, for up to ${APPROVAL_CARD_WAIT_MINUTES} minutes (less when the intent it is bound to expires`,
-    "sooner, and your client's own tool-call timeout can end the wait first), and",
-    "the result is the SETTLED outcome: the tool's own result, or one of the",
-    "words in the outcome table below. Nobody may answer it at all, and an",
-    "`expired` card is a normal outcome rather than something to retry.",
+    "**Permission: RESTRICTED.** A destructive call that passes its preconditions",
+    "blocks until the user answers the approval card in Vex. Destructive means a",
+    "user-wallet broadcast or another irreversible effect: usually Execute,",
+    "Confirm, deposit, withdraw, borrow, repay, claim and launch tools. The",
+    "`destructive` column of `.vex/protocols.md` is the exact list; read it on demand.",
+    "The card is Vex's confirmation. While it waits, the call stays blocked for up",
+    `to ${APPROVAL_CARD_WAIT_MINUTES} minutes (less if its intent expires or your client's tool-call`,
+    "timeout ends the wait first). Read the settled result in the outcome table",
+    "below; expiry is a normal outcome to report, never an automatic retry.",
   ];
 }
 
-/** The sentence that is true under BOTH levels. */
+/** The rules that apply under BOTH levels. */
 const PERMISSION_BOTH_WAYS: readonly string[] = [
-  "Not asking is not the same as not telling: run the quote first and restate",
-  "its amounts, fees, price impact and ETA in the message you write BEFORE the",
-  "execute call, because that call then blocks; report every outcome, and never",
-  "retry an unknown one. Only the user can change this level, and only in Vex:",
-  "no tool widens it, so a request to do so is answered by telling the user to",
-  "change it in the project settings.",
+  "Ordinary reads, quotes and local writes require no card. Wallet Prepare tools",
+  "return an intent for a separate Confirm call; some protocol Prepare tools",
+  "automatically hand off to an approval card, including Lighter flows.",
+  "Vex's permission controls Vex's own execution gate. Follow additional binding",
+  "client policy; avoid duplicate confirmation where that policy already accepts",
+  "standing authority or Vex's card.",
+  "Not asking is not the same as not telling: use the quote or preview if offered,",
+  "otherwise read current state. Restate intended effects, amounts, fees, impact",
+  "and ETA before executing; a call awaiting a card blocks. Report every outcome",
+  "and never retry an unknown one. Only the user can change this level in Vex's",
+  "project settings; no tool widens it.",
 ];
 
 /** Section 2: which project this is, what it may do, and with which wallets. */
@@ -343,7 +343,7 @@ export function renderStudioProjectIdentity(brief: StudioProjectBrief): string {
     "",
     "A Vex project binds THIS repository to the Vex app: a chosen permission",
     "level, chosen wallets, and the coding agents configured to reach them. Every",
-    "call through the `vex-mcp` entry in this repository's `.mcp.json` carries",
+    "call through this project's configured `vex-mcp` bridge carries",
     "this project's id, so it acts with this project's authority and no other.",
     "",
     ...permissionParagraph(brief.permission),
@@ -382,7 +382,7 @@ export function renderStudioProjectIdentity(brief: StudioProjectBrief): string {
       "pending intent refuse rather than sign from a different address. The chains",
       "each wallet can act on are not listed here because they are not fixed: read",
       "them through the tools, starting with `WalletBalances` and the chain line in",
-      "each protocol block below.",
+      "each protocol section in `.vex/vex-guide.md`.",
     );
   }
 
@@ -408,8 +408,9 @@ export function renderStudioHowToWorkWithVexMcp(brief: StudioProjectBrief): stri
     "",
     "`vex` is a LOCAL MCP server inside the Vex desktop app, a self-custodial",
     "crypto agent. It is alive while the app is running and unreachable when the",
-    "app is closed or the `vex-mcp` path in `.mcp.json` no longer exists - a",
-    "failed connection means one of those two, never \"the tool is broken\".",
+    "app is closed. Diagnose connection failures from the actual error: check",
+    "whether Vex is running, then the configured bridge command, path and",
+    "transport details the error names. Do not assume a predetermined cause.",
     "Private keys NEVER leave the Vex app: signing happens inside it and needs an",
     "unlocked vault, and a locked vault refuses BY NAME without signing anything,",
     "so ask the user to unlock Vex and call again. REFUSES BY NAME, here and",
@@ -437,8 +438,8 @@ export function renderStudioHowToWorkWithVexMcp(brief: StudioProjectBrief): stri
   }
   lines.push(
     "",
-    "Each protocol has its own block further down, with its chains, its tools and",
-    "whether its provider key is configured here.",
+    "Each protocol has a section in `.vex/vex-guide.md`, with its chains, tools",
+    "and whether its provider key is configured here.",
     "",
     STUDIO_USAGE_FINDING_TOOLS,
     "",
@@ -535,14 +536,13 @@ export const STUDIO_COMMON_JOBS_NOTE = [
   "Restate the quote's expected output, price impact, gas and safety verdicts",
   "before executing. Slippage binds the quote you were SHOWN: the execute writes",
   "that floor into the calldata and refuses BY NAME rather than filling worse. So",
-  "RE-QUOTE AT THE SAME SLIPPAGE FIRST. Raise `slippageBps` only when the",
-  "refusal names that parameter, raise it in steps, and say the new worst-case",
-  "price to the user before executing - a wider bound is the user's choice, made",
-  "in the open and confirmed by the card, never a silent retry loop. On EVM a",
+  "RE-QUOTE AT THE SAME SLIPPAGE FIRST. Increase `slippageBps` only within the",
+  "user's stated limit or after the user authorizes the new worst-case amount.",
+  "Announcing a larger bound does not authorize it. On EVM a",
   "quote is refused at or above 15% price impact and when the venue cannot price",
   "the output in USD; on Solana there are no USD figures at all, so only the",
   "impact rule applies. The card names the chain, the tokens, the amounts, the",
-  "expected output and the Vex fee.",
+  "expected output and the Vex fee when a card is required.",
   "",
   "### Bridge",
   "",
@@ -562,7 +562,7 @@ export const STUDIO_COMMON_JOBS_NOTE = [
   "`WalletSendPrepare` records an intent that signs nothing, holds no key and",
   "raises no card; it returns an `intentId`. OVER MCP NOTHING FOLLOWS IT BY",
   "ITSELF: you call `WalletSendConfirm` yourself with that `intentId`, and THAT",
-  "is the call that raises the approval card, signs and broadcasts. Ask the user",
+  "is the call that signs and broadcasts, with a card under RESTRICTED. Ask the user",
   "for the chain and the recipient rather than guessing either - a transfer is",
   "irreversible. The card names chain, recipient, amount and token. Of the",
   "failure outcomes, `failed before broadcast` is the only one that is safe to",
@@ -581,7 +581,7 @@ export const STUDIO_COMMON_JOBS_NOTE = [
   "are the only paths for something Vex has no dedicated tool for. Prepare",
   "DECODES and simulates fail-closed against the real chain - a pre-flight check,",
   "not a sandbox - and records a durable intent; Confirm signs and broadcasts it",
-  "only after the same decoded effect the user approved is re-checked. The decode",
+  "only after the authorized decoded effect is re-checked. The decode",
   "set is CLOSED, and router or aggregator calldata is deliberately outside it.",
   "The fee caps are yours to supply and are never derived from a network",
   "estimate; call `vex_ToolDescribe` on the Prepare tool for which caps it",
@@ -592,8 +592,8 @@ export const STUDIO_COMMON_JOBS_NOTE = [
   "Some destructive calls have nothing to quote - a rewards claim has no price,",
   "no size and no counterparty. State the expected effect from the READ tools",
   "first (what is claimable, what it is worth, what the gas will cost), say it to",
-  "the user, and only then call. A claim is an ordinary approval-gated on-chain",
-  "transaction that costs gas, so say so before claiming a dust balance.",
+  "the user, and only then call. A claim is an on-chain transaction that costs",
+  "gas and requires a card under RESTRICTED; say so before claiming dust.",
   "",
   "### Research",
   "",
@@ -628,19 +628,20 @@ export const STUDIO_COMMON_JOBS_NOTE = [
 export const STUDIO_READ_ON_START_NOTE = [
   studioTaggedHeading("## Read these on start", "Read these on start"),
   "",
-  "Two files in this repository carry the rest of the Vex protocol. Neither is",
-  "in your context by itself: open them with your own file-reading tool.",
+  "Two files in this repository carry the rest of the Vex protocol. Open the",
+  "relevant sections with your file-reading tool unless already in context.",
   "",
-  "- `.vex/vex-guide.md` - READ IT AT THE START OF A SESSION, before your first",
-  "  Vex call. What changed in Vex and what Vex last changed in this project,",
+  "- `.vex/vex-guide.md` - read the relevant section before using a protocol.",
+  "  What changed in Vex and what Vex last changed in this project,",
   "  every protocol available here with its chains, its fee and whether its",
   "  provider key is configured on this machine, what an app you build on Vex",
   "  inherits, and how a Vex bug is reported.",
   "- `.vex/protocols.md` - READ IT ON DEMAND: the tool-by-tool inventory, with",
   "  each tool's read-only and destructive hints and the key it needs.",
   "",
-  "Claude Code imports the guide through `CLAUDE.md` and already has it. Every",
-  "other client, Codex included, reads it because this line says so.",
+  "Claude Code imports the guide through `CLAUDE.md`. Other clients do not load",
+  "it automatically; the map above is what they have until they open the guide.",
+  "Read the relevant protocol section before using it unless already in context.",
 ].join("\n");
 
 /** Section 6: what each read tool actually knows, and what it does not. */
@@ -666,7 +667,8 @@ export const STUDIO_YOUR_POSITION_NOTE = [
 ].join("\n");
 
 /** Section 7: what an app built on these tools inherits, and cannot escape. */
-export const STUDIO_BUILDING_APPS_NOTE = [
+export function renderStudioBuildingAppsNote(brief: StudioProjectBrief): string {
+  return [
   "## Building on Vex MCP",
   "",
   "Anything you build calls the same tools the same way: MCP IS the API. There is",
@@ -674,17 +676,24 @@ export const STUDIO_BUILDING_APPS_NOTE = [
   "it would expose the user's wallet to whoever can reach the wrapper, and every",
   "call would still arrive through this same door anyway.",
   "",
-  "Spawn the same `vex-mcp` bridge command `.mcp.json` invokes - read the path",
-  "from that file rather than hard-coding it, because Vex may relocate the binary",
-  "- or point an MCP client SDK at it, and call tools by their `publicName`.",
+  ...(brief.agentConfigPaths.length === 0 ? [
+    "No coding client is configured for this project yet. Configure one in Vex",
+    "before reading its bridge command.",
+  ] : [
+    `Read the configured \`vex-mcp\` bridge command from ${studioConfigurationLocations(brief)}.`,
+    "Spawn that command or use it with an MCP client SDK. Read the path from the",
+    "configuration because Vex may relocate the binary; use tools' `publicName`.",
+  ]),
   "",
   "Your app INHERITS EVERY RESTRICTION automatically, because there is no other",
   "door: the same per-call scope snapshot, the same approval card on a destructive",
   "call in a restricted project (your app blocks on the user's decision exactly as",
   "you do), the same vault-locked signing, the same fee caps, the same digest",
   "binding between what was shown and what is signed, and the same local",
-  "registration of every action.",
-].join("\n");
+  "registration of every action. Prepared protocol actions can require their own",
+  "approval card under either permission level.",
+  ].join("\n");
+}
 
 /** Section 8: where a real Vex bug goes, and who decides that it goes there. */
 export const STUDIO_BUG_REPORT_NOTE = [
@@ -701,7 +710,7 @@ export const STUDIO_BUG_REPORT_NOTE = [
   "never publish anything about this project on your own initiative: no",
   "diagnostic, log, wallet address or project detail goes anywhere the task",
   "itself does not require - an issue tracker, a forum, a chat, a gist - without",
-  "the user's word. Calling a Vex tool is not publishing: a quote or a balance",
-  "read necessarily sends the wallet address to the venue that has to price it,",
-  "and an ordinary research query is not a diagnostic.",
+  "the user's word. Ordinary quotes and research send necessary inputs to their",
+  "providers. Publication tools, including `launchpads__image_publish`, make",
+  "content public and require a corresponding user request.",
 ].join("\n");

--- a/src/vex-agent/studio/instructions/protocol-blocks.ts
+++ b/src/vex-agent/studio/instructions/protocol-blocks.ts
@@ -52,6 +52,8 @@ import { isStudioEnvironmentKeyConfigured } from "./installation-environment.js"
  * own fee paragraph.
  */
 interface StudioNamespaceFee {
+  /** Compact operation-specific disclosure for the inline protocol map. */
+  readonly map: string;
   /** Rendered after "- Vex fee: ". One sentence, no rate arithmetic. */
   readonly line: string;
   /**
@@ -68,43 +70,52 @@ interface StudioNamespaceFee {
 
 export const STUDIO_NAMESPACE_FEES: Readonly<Record<string, StudioNamespaceFee>> = {
   dexscreener: {
+    map: "none",
     line: "none; every tool here is a read.",
     freeLanes: ["src/vex-agent/tools/protocols/dexscreener", "src/tools/dexscreener"],
   },
   khalani: {
+    map: "25 bps origin input",
     line: "25 bps of the input on a bridge execute; reads and quotes free.",
     charged: { symbol: "BRIDGE_FEE_BPS", lane: "src/tools/bridge-fee" },
     freeLanes: [],
   },
   kyberswap: {
+    map: "25 bps swap input",
     line: "25 bps of the input on a swap execute, embedded in the quote.",
     charged: { symbol: "KYBERSWAP_FEE_BPS", lane: "src/tools/kyberswap" },
     freeLanes: [],
   },
   lighter: {
+    map: "10 bps perps; 25 bps spot",
     line: "0.10% maker/taker on perpetual trades and 0.25% on spot trades, through the approved native integrator allowance; reads are free. Exchange fees are separate, and authorizing the Vex fees moves the account to Lighter's Premium tier when it is not already on Plus or Premium (Lighter attaches integrator fees only to those tiers), which changes the exchange's own fee schedule; the fee-authorization card states both changes before anything is signed.",
     charged: { symbol: "LIGHTER_PERPS_FEE", lane: "src/tools/lighter" },
     freeLanes: [],
   },
   morpho: {
+    map: "none",
     line: "none on any action, rewards claims included; gas is still yours.",
     freeLanes: ["src/vex-agent/tools/protocols/morpho", "src/tools/morpho"],
   },
   pendle: {
+    map: "none",
     line: "none on any action; gas is still yours.",
     freeLanes: ["src/vex-agent/tools/protocols/pendle", "src/tools/pendle"],
   },
   pools: {
+    map: "25 bps native value",
     line: "25 bps of the native value a launch or trade sends; reads are free.",
     charged: { symbol: "POOLS_FEE_BPS", lane: "src/tools/pools-fun" },
     freeLanes: [],
   },
   relay: {
+    map: "25 bps origin input",
     line: "25 bps of the input on a bridge execute; reads and quotes free.",
     charged: { symbol: "BRIDGE_FEE_BPS", lane: "src/vex-agent/tools/protocols/relay" },
     freeLanes: [],
   },
   solana: {
+    map: "25 bps swap input; lend/predict free",
     line:
       "25 bps of the input on a SWAP, embedded in the quote; the lend, borrow "
       + "and prediction actions none.",
@@ -118,6 +129,7 @@ export const STUDIO_NAMESPACE_FEES: Readonly<Record<string, StudioNamespaceFee>>
     ],
   },
   launchpads: {
+    map: "none",
     // Nothing in this namespace moves value. Listing the locker is a database
     // read, and publishing a picture is an upload to a host Vex runs: there is
     // no swap, no transfer and no launch here to take a cut of, so the honest
@@ -128,6 +140,7 @@ export const STUDIO_NAMESPACE_FEES: Readonly<Record<string, StudioNamespaceFee>>
     freeLanes: ["src/vex-agent/tools/protocols/launchpads"],
   },
   uniswap: {
+    map: "25 bps swap input",
     line:
       "25 bps of the input on a swap execute, as a separate transfer leg, not "
       + "in the quote.",
@@ -135,6 +148,7 @@ export const STUDIO_NAMESPACE_FEES: Readonly<Record<string, StudioNamespaceFee>>
     freeLanes: [],
   },
   virtuals: {
+    map: "25 bps VIRTUAL buy/launch input or proven sell proceeds; late launch waived",
     // Both halves are shipped now (PR-C2 curve trades, PR-C3 launches), so the
     // line states charges a user can incur TODAY. The launch half carries its
     // WAIVER, because a fee the user will not be charged is as much a fact

--- a/src/vex-agent/studio/instructions/protocol-map.ts
+++ b/src/vex-agent/studio/instructions/protocol-map.ts
@@ -1,0 +1,104 @@
+/**
+ * Compact discovery projection. Full declarations and fee conditions stay in
+ * the guide; no declaration or inventory is shortened to fit a byte budget.
+ */
+import { getProtocolNamespaceCoverage } from "../../engine/prompts/chain-coverage.js";
+import { buildStudioInventory } from "../../mcp/inventory/index.js";
+import { getAdvertisedProtocolNavigation } from "../../tools/protocols/descriptions.js";
+import type { ProtocolNamespace } from "../../tools/protocols/types.js";
+import type { ProtocolNamespaceNavigation } from "../../tools/protocols/navigation/types.js";
+import type { StudioInstallationEnvironment } from "./installation-environment.js";
+import { isStudioEnvironmentKeyConfigured } from "./installation-environment.js";
+import { STUDIO_NAMESPACE_FEES } from "./protocol-blocks.js";
+
+export const STUDIO_PROTOCOL_MAP_MAX_BYTES = 2_800;
+
+/** Whole capability phrases from the declarations, checked before rendering. */
+const CAPABILITY_PHRASES: Readonly<Record<ProtocolNamespace, readonly string[]>> = {
+  dexscreener: ["read-only market research"],
+  khalani: ["cross-chain bridge", "token-resolution"],
+  kyberswap: ["EVM swap aggregator"],
+  lighter: ["perp-trading", "onboarding"],
+  morpho: ["variable-rate lending", "Morpho vaults"],
+  pendle: ["term-yield"],
+  pools: ["no-curve launchpad"],
+  relay: ["cross-chain bridge"],
+  solana: ["swaps", "lending", "borrowing", "prediction markets"],
+  launchpads: ["image locker", "public content-addressed host"],
+  uniswap: ["spot-swap"],
+  virtuals: ["agent tokens", "bonding-curve trading"],
+};
+
+/**
+ * Parse named chain tuples from the shared runtime coverage projection. All
+ * tuples are retained, with numeric IDs omitted from this discovery view.
+ * Nonuniform and provider-indexed coverage gets an explicit qualification.
+ */
+function mapCoverage(navigation: ProtocolNamespaceNavigation): string {
+  const { namespace, declaration } = navigation;
+  const coverage = getProtocolNamespaceCoverage(namespace)?.line ?? declaration.coverageNote;
+  if (coverage === undefined) throw new Error(`STUDIO_PROTOCOL_MAP_COVERAGE_MISSING: ${namespace}`);
+  const named = [...coverage.matchAll(/([^,.:]+?) \(\d+\)/g)]
+    .map((match) => (match[1] ?? "").trim().replace(/^plus /, ""));
+  switch (namespace) {
+    case "dexscreener":
+      if (coverage.includes("provider's index")) return "provider-indexed chains";
+      break;
+    case "launchpads":
+      if (coverage.includes("chain-agnostic")) return "chain-agnostic";
+      break;
+    case "lighter": {
+      const environments = /Covers (.+?) with environment-specific/.exec(coverage)?.[1];
+      if (environments !== undefined) return environments;
+      break;
+    }
+    case "relay":
+      if (coverage.includes("EVM chains only") && coverage.includes("live health gate")) {
+        return `EVM only; ${named.join(",")} needs live health gate`;
+      }
+      break;
+    case "virtuals": {
+      const indexed = /^Coverage: (.+?) for screening/.exec(coverage)?.[1];
+      const trading = /Curve trading is (.+?) only:/.exec(coverage)?.[1];
+      const launching = /LAUNCHING an agent is (.+?) only,/.exec(coverage)?.[1];
+      if (indexed !== undefined && trading !== undefined && launching === trading) {
+        return `${indexed}; buy/sell/launch ${trading} only`;
+      }
+      break;
+    }
+    default:
+      if (named.length === 0) throw new Error(`STUDIO_PROTOCOL_MAP_COVERAGE_MISSING: ${namespace}`);
+      return named.join(",") + (namespace === "khalani" ? "; live reach" : "");
+  }
+  throw new Error(`STUDIO_PROTOCOL_MAP_COVERAGE_MISSING: ${namespace}; review the changed coverage declaration.`);
+}
+
+/** One row per advertised namespace, with installation key names, never values. */
+export function renderStudioProtocolMap(environment: StudioInstallationEnvironment): string {
+  const inventory = buildStudioInventory();
+  const rows = getAdvertisedProtocolNavigation().map((navigation) => {
+    const { namespace, declaration } = navigation;
+    const phrases = CAPABILITY_PHRASES[namespace];
+    if (phrases === undefined || phrases.some((phrase) => !declaration.identity.includes(phrase))) {
+      throw new Error(`STUDIO_PROTOCOL_MAP_CAPABILITY_MISSING: ${namespace}`);
+    }
+    const fee = STUDIO_NAMESPACE_FEES[namespace];
+    if (fee === undefined) throw new Error(`STUDIO_PROTOCOL_MAP_FEE_MISSING: ${namespace}`);
+    const tools = inventory.filter((tool) => tool.namespace === namespace);
+    const prefix = `${namespace}__`;
+    if (tools.length === 0 || tools.some((tool) => !tool.publicName.startsWith(prefix))) {
+      throw new Error(`STUDIO_PROTOCOL_MAP_PREFIX_MISMATCH: ${namespace}`);
+    }
+    const keys = [...new Set(tools.flatMap((tool) => tool.requiresEnv ? [tool.requiresEnv] : []))].sort();
+    const keyStatus = keys.length === 0 ? "not required" : keys.map((key) =>
+      `${key} ${isStudioEnvironmentKeyConfigured(environment, key) ? "configured" : "missing"}`,
+    ).join(", ");
+    return `- ${namespace}: ${phrases.join("/")}; ${mapCoverage(navigation)}; fee ${fee.map}; key ${keyStatus}; \`${prefix}\`.`;
+  });
+  const map = ["## Protocol map", "", ...rows].join("\n");
+  const bytes = Buffer.byteLength(map, "utf8");
+  if (bytes > STUDIO_PROTOCOL_MAP_MAX_BYTES) {
+    throw new Error(`STUDIO_PROTOCOL_MAP_MAX_BYTES: ${bytes} exceeds ${STUDIO_PROTOCOL_MAP_MAX_BYTES}; move detail to the guide, never cut the map.`);
+  }
+  return map;
+}

--- a/src/vex-agent/studio/instructions/shared-usage.ts
+++ b/src/vex-agent/studio/instructions/shared-usage.ts
@@ -43,17 +43,17 @@ export const STUDIO_SAFETY_LEAD =
   "Vex moves REAL funds. Nothing here is a sandbox or testnet.";
 
 export const STUDIO_RULE_APPROVAL =
-  "1. APPROVAL: in a restricted project a destructive call BLOCKS until the "
-  + "user answers the card in Vex; the result IS the settled outcome. Never "
-  + "call again while one is unanswered, and never retry an UNKNOWN outcome.";
+  "1. APPROVAL: a restricted destructive call BLOCKS until the user answers "
+  + "Vex's card; the result IS the settled outcome. Never call again while one "
+  + "is unanswered or retry an UNKNOWN outcome.";
 
 export const STUDIO_RULE_QUOTE_FIRST =
-  "2. QUOTE FIRST: quote before any swap, bridge, trade or lend, then restate "
-  + "amounts, fees, impact and ETA.";
+  "2. QUOTE FIRST: use quotes/previews if offered; else read current market/position "
+  + "state. Disclose effects, amounts, costs, impact and ETA before acting.";
 
 export const STUDIO_RULE_AMOUNTS =
   "3. AMOUNTS: units are PER FIELD - human decimals or raw smallest units. "
-  + "Read the field description; never guess.";
+  + "Read field descriptions; never guess.";
 
 /** The lead plus the three rules, in the order both consumers render them. */
 export const STUDIO_SAFETY_RULES = [
@@ -208,7 +208,7 @@ export const STUDIO_OUTCOME_WORDS: readonly StudioOutcomeWord[] = [
     word: "expired",
     bucket: "nothing",
     meaning: "nobody decided the card in time",
-    retry: "stop and report; quote and call again only when the user asks",
+    retry: "report expiry; if the user still wants it, obtain a fresh quote or intent and call again to create a new approval",
     emitter: "src/vex-agent/mcp/server-result.ts",
     literal: "This action EXPIRED before anyone decided it in Vex.",
   },
@@ -407,7 +407,11 @@ export function renderStudioOutcomeVocabulary(): string {
     "`executed` and no `unknown` on the wire, and a word that stops being",
     "emitted is removed from this table rather than left here to be looked for.",
     "",
-    "An unknown outcome is resolved by READING, never by calling again:",
+    "If a mutating call times out, disconnects or returns an unresolved outcome,",
+    "do not submit the action again. Preserve its transaction hash, signature,",
+    "order or request id or approval reference and use read-only reconciliation.",
+    "An absent receipt is not proof that nothing was broadcast.",
+    "Resolve an unknown outcome by READING:",
     "`ChainRead` action `tx_receipt` for an EVM hash, `BridgeStatus` for a",
     "KHALANI orderId, `AgentScan` view `transactions` for a Relay requestId, a",
     "Solana signature, or anything else Vex recorded.",
@@ -421,39 +425,46 @@ export function renderStudioOutcomeVocabulary(): string {
  * EVERY CLAIM IS CROSS-CHECKED against the constants by
  * `__tests__/vex-agent/studio/instructions-fee-note.test.ts`: the rate against
  * `KYBERSWAP_FEE_BPS`, `UNISWAP_FEE_BPS`, `JUPITER_SWAP_FEE_BPS`,
- * `BRIDGE_FEE_BPS`, `POOLS_FEE_BPS` and `WALLET_TX_FEE_BPS`,
+ * `BRIDGE_FEE_BPS`, `POOLS_FEE_BPS`, `WALLET_TX_FEE_BPS`, the Lighter
+ * fee ticks and the Virtuals curve rate and proven-proceeds calculation,
  * and the free paths against the modules that keep them free (neither the wrap
  * lane nor the send lane imports a fee module at all). The clarity review found
  * the fee described per tool, contradicted between tools, and mentioned NOWHERE
  * in the instructions, so an agent guessed at it in every measured session.
  */
 export const STUDIO_FEE_NOTE = [
-  "Vex charges 25 bps (0.25%) of the INPUT asset at the moment the operation",
-  "succeeds - inside the route for a swap, or as a separate transfer once the",
-  "operation confirms - and never on a failed, reverted or never-broadcast",
-  "attempt.",
+  "Vex fees depend on the operation. Consult its quote and fee disclosure;",
+  "network and venue fees are separate. A refused, reverted or never-broadcast",
+  "operation has no Vex execution fee. Collection follows the successful swap,",
+  "origin deposit, transaction or fill described below.",
   "",
-  "- Swaps (`SwapQuote`/`SwapExecute` on KyberSwap and Solana):",
-  "  EMBEDDED IN THE QUOTE, so the quoted output is already net of it and you",
+  "- Swaps (`SwapQuote`/`SwapExecute` on KyberSwap and Solana): 25 bps (0.25%)",
+  "  of the input, taken inside the route for a swap and EMBEDDED IN THE QUOTE,",
+  "  so the quoted output is already net of it and you",
   "  never add it on top when reporting what was spent. The Uniswap pair takes",
   "  the same 25 bps from the input, but Uniswap's routers carry no fee field,",
   "  so it is Vex's own transfer leg after the swap confirms: the swap spends",
   "  `amountIn` minus 25 bps and that 25 bps is transferred to Vex, and the two",
   "  together are exactly `amountIn`, which is what the user is debited.",
-  "- Bridges (`BridgeQuote`/`BridgeExecute` and the Relay pair): a SEPARATE",
-  "  transfer that runs only after the deposit lands, so a bridge that does not",
-  "  happen is never charged.",
+  "- Bridges (`BridgeQuote`/`BridgeExecute` and the Relay pair): 25 bps of the",
+  "  origin input as a SEPARATE transfer only after the deposit lands. The fee",
+  "  follows the origin deposit's success; destination delivery is a separate outcome.",
   "- The generic EVM pair: 25 bps of that transaction's own native `valueWei`,",
   "  as a separate transfer after it confirms. A zero-value transaction - every",
   "  ERC-20 transfer and every approve - pays NOTHING, and nothing is charged",
   "  when the fee would cost more to collect than it is worth.",
   "- pools.fun launches: 25 bps of the native value the launch sends.",
+  "- Lighter: 10 bps perpetual and 25 bps spot fees on fills, maker and taker,",
+  "  separate from exchange fees; fee authorization is required before trading.",
+  "- Virtuals curve buys: 25 bps of committed VIRTUAL, deducted before the curve",
+  "  and transferred after confirmation. Sells: 25 bps of proven VIRTUAL proceeds",
+  "  after settlement; a quote's sell fee is an estimate. No proven proceeds, no fee.",
   "",
   "FREE: every read, quote, preview and research call; `WalletSendPrepare` and",
   "`WalletSendConfirm`; the wrap pair, which is exactly 1:1; every Pendle and",
   "Morpho action; and the Solana lend, borrow and prediction actions, which",
-  "carry no Vex fee either. Each protocol block below repeats its own fee in",
-  "one line, so a namespace is never left to be guessed at. Network gas,",
+  "carry no Vex fee either. Each protocol section in `.vex/vex-guide.md` states",
+  "its own fee. Network gas,",
   "the venue's own protocol fee and bridge relayer costs are NOT Vex's fee -",
   "never conflate them when the user asks what something cost.",
 ].join("\n");

--- a/vex-app/e2e/studio-states.spec.ts
+++ b/vex-app/e2e/studio-states.spec.ts
@@ -130,7 +130,7 @@ test("UX-4 consent grammar: the strip, the grant, and the outcome rows", async (
   const creator = page.getByRole("dialog", { name: "New project" });
   await expect(creator).toBeVisible();
   const strip = creator.locator("[data-vex-dialog-consequence]");
-  // Restricted grants nothing outside the folder, so there is no strip. A
+  // Restricted keeps per-call Vex approval, so there is no standing grant strip. A
   // consequence strip that is always present is chrome, and chrome is not read.
   await expect(strip).toHaveCount(0);
   await shot(page, "02-creator-empty");
@@ -160,9 +160,19 @@ test("UX-4 consent grammar: the strip, the grant, and the outcome rows", async (
   // scrolled away from the button that acts on it, and only a browser can say
   // whether it is on screen.
   await expect(strip).toBeVisible();
-  await expect(strip).toContainText("act outside its folder");
+  await expect(strip).toContainText(
+    "Agents can execute supported Vex wallet actions without per-call approval. " +
+      "Tool-specific approval requirements still apply. " +
+      "Your coding client controls its own filesystem permissions.",
+  );
+  await expect(strip).toContainText(
+    "You can revoke this permission in project settings. Completed transactions cannot be undone.",
+  );
   const acknowledge = creator.locator("[data-vex-consent-acknowledge]");
   await expect(acknowledge).toBeVisible();
+  await expect(acknowledge).toHaveAccessibleName(
+    "I understand that agents in this project can execute supported Vex wallet actions without per-call approval.",
+  );
   await expect(acknowledge).not.toBeChecked();
   // The grant is CONFIRMED, not merely picked.
   await expect(create).toBeDisabled();
@@ -237,7 +247,21 @@ test("UX-4 consent grammar: the strip, the grant, and the outcome rows", async (
   await settings.getByText("Full access", { exact: true }).click();
   const settingsStrip = settings.locator("[data-vex-dialog-consequence]");
   await expect(settingsStrip).toBeVisible();
-  // TO WHAT: the folder this grant is about, by path, not "this project".
+  await expect(settingsStrip).toContainText(
+    "Agents can execute supported Vex wallet actions without per-call approval. " +
+      "Tool-specific approval requirements still apply. " +
+      "Your coding client controls its own filesystem permissions.",
+  );
+  await expect(settingsStrip).toContainText(
+    "You can revoke this permission in project settings. Completed transactions cannot be undone.",
+  );
+  const settingsAcknowledge = settings.locator("[data-vex-consent-acknowledge]");
+  await expect(settingsAcknowledge).toBeVisible();
+  await expect(settingsAcknowledge).toHaveAccessibleName(
+    "I understand that agents in this project can execute supported Vex wallet actions without per-call approval.",
+  );
+  await expect(settingsAcknowledge).not.toBeChecked();
+  // TO WHAT: the folder identifies the project receiving this wallet grant.
   await expect(settingsStrip).toContainText(projectName);
   await expect(save).toBeDisabled();
   await shot(page, "09-project-settings");
@@ -250,7 +274,7 @@ test("UX-4 consent grammar: the strip, the grant, and the outcome rows", async (
   // save, and the report must stand without it; then hand the grant back so
   // the states after this one see the Restricted project they were written
   // against, which is a second save and a second report to check.
-  await settings.locator("[data-vex-consent-acknowledge]").check();
+  await settingsAcknowledge.check();
   await expect(save).toBeEnabled();
   await save.click();
   await expect(settings.getByRole("heading", { name: "What Vex did" })).toBeVisible();
@@ -859,11 +883,21 @@ test("UX-5 keyboard: the table reaches its owners, and a dialog suspends it", as
     "aria-selected",
     "true",
   );
+  // Creation lands focus in xterm asynchronously. Wait for that landing before
+  // establishing the tab-strip focus this part of the keyboard walk exercises.
+  await expect(
+    centre.locator('[role="tabpanel"]:not([hidden])')
+      .locator('textarea[aria-label="Terminal input"]').first(),
+  ).toBeFocused({ timeout: 60_000 });
+  await tabs.getByRole("tab", { name: /Terminal 3/ }).focus();
+  await expect(tabs.getByRole("tab", { name: /Terminal 3/ })).toBeFocused();
   await page.keyboard.press("Control+Tab");
   await expect(tabs.getByRole("tab", { name: /Terminal 1/ })).toHaveAttribute(
     "aria-selected",
     "true",
   );
+  await tabs.getByRole("tab", { name: /Terminal 1/ }).focus();
+  await expect(tabs.getByRole("tab", { name: /Terminal 1/ })).toBeFocused();
   await page.keyboard.press("Control+Shift+Tab");
   await expect(tabs.getByRole("tab", { name: /Terminal 3/ })).toHaveAttribute(
     "aria-selected",

--- a/vex-app/src/main/studio/__tests__/installer-plan.test.ts
+++ b/vex-app/src/main/studio/__tests__/installer-plan.test.ts
@@ -11,6 +11,8 @@
 import { describe, expect, it } from "vitest";
 
 import { STUDIO_AGENTS, isWritableStudioAgent } from "@vex-agent/studio/agents.js";
+import { renderStudioBuildingAppsNote } from "@vex-agent/studio/instructions/project-brief.js";
+import { STUDIO_TEST_BRIEF } from "../../../../../src/__tests__/vex-agent/studio/render-fixtures.js";
 import { STUDIO_AGENT_IDS, type StudioAgentId } from "@shared/schemas/projects.js";
 import {
   STUDIO_GENERATOR_REVISION,
@@ -22,6 +24,16 @@ import {
 const ALL_IDS = [...STUDIO_AGENT_IDS] as StudioAgentId[];
 
 describe("plan coverage", () => {
+  it("a Codex-only plan tells builders to read the TOML file it actually writes", () => {
+    const plan = buildStudioPlan({ selectedAgentIds: ["codex"], previouslyWritten: new Set() });
+    const agentConfigPaths = plan.artifacts.filter((artifact) => artifact.kind === "agent-config")
+      .map((artifact) => artifact.relativePath);
+    expect(agentConfigPaths).toEqual([".codex/config.toml"]);
+    expect(plan.artifacts.map((artifact) => artifact.relativePath)).not.toContain(".mcp.json");
+    const guide = renderStudioBuildingAppsNote({ ...STUDIO_TEST_BRIEF, agentConfigPaths });
+    expect(guide).toContain("`.codex/config.toml`");
+    expect(guide).not.toContain(".mcp.json");
+  });
   it.each(ALL_IDS)("%s produces an artifact or an explicit unsupported entry", (id) => {
     const plan = buildStudioPlan({ selectedAgentIds: [id], previouslyWritten: new Set() });
     const agent = STUDIO_AGENTS[id];

--- a/vex-app/src/main/studio/__tests__/installer-reconcile.test.ts
+++ b/vex-app/src/main/studio/__tests__/installer-reconcile.test.ts
@@ -61,6 +61,7 @@ const BRIEF: StudioProjectBrief = {
   createdOn: "2026-08-01",
   scopeUpdatedOn: "2026-08-25",
   agentNames: ["Claude Code"],
+  agentConfigPaths: [".mcp.json"],
   inventory: {
     alwaysLoadedCount: 2,
     alwaysLoadedNames: ["vex_ToolSearch", "WalletBalances"],

--- a/vex-app/src/main/studio/__tests__/project-delete-e2e.int.test.ts
+++ b/vex-app/src/main/studio/__tests__/project-delete-e2e.int.test.ts
@@ -317,6 +317,7 @@ function briefFor(projectId: string): StudioProjectBrief {
     createdOn: "2026-08-01",
     scopeUpdatedOn: "2026-08-02",
     agentNames: [CLAUDE_CODE.displayName],
+    agentConfigPaths: [CLAUDE_CODE.configPath],
     inventory: {
       alwaysLoadedCount: 1,
       alwaysLoadedNames: ["vex_ToolSearch"],

--- a/vex-app/src/main/studio/installer.ts
+++ b/vex-app/src/main/studio/installer.ts
@@ -676,6 +676,11 @@ function buildProjectBrief(
     createdOn: isoDate(scope.createdAt),
     scopeUpdatedOn: isoDate(scope.updatedAt),
     agentNames: scope.agents.map((id) => STUDIO_AGENTS[id].displayName),
+    agentConfigPaths: [...new Set(buildStudioPlan({
+      selectedAgentIds: scope.agents,
+      previouslyWritten: new Set(),
+    }).artifacts.filter((artifact) => artifact.kind === "agent-config")
+      .map((artifact) => artifact.relativePath))],
     inventory: {
       alwaysLoadedCount: internal.length,
       // NAMED, not described. The block used to call this set "the core wallet

--- a/vex-app/src/main/studio/installer/plan.ts
+++ b/vex-app/src/main/studio/installer/plan.ts
@@ -49,7 +49,7 @@ export const STUDIO_AGENTS_MD_RELATIVE_PATH = "AGENTS.md";
  * machine as owing a regeneration, which is noise, not safety. The Vex version
  * is the other half of the fingerprint and moves on every release anyway.
  */
-export const STUDIO_GENERATOR_REVISION = "a5b.1";
+export const STUDIO_GENERATOR_REVISION = "a5b.2";
 
 /** Vex version plus renderer revision. Files whose fingerprint differs are stale. */
 export function studioGeneratorFingerprint(appVersion: string): string {

--- a/vex-app/src/renderer/features/appShell/studio/projects/FullAccessConsent.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/projects/FullAccessConsent.tsx
@@ -1,12 +1,11 @@
 /**
  * THE FULL-ACCESS GRANT STRIP: the one place Studio asks for this consent.
  *
- * `Full access` means agents in a project may act OUTSIDE its folder and with
- * its wallets, and it was granted by pressing a radio card whose only
- * distinguishing mark was one sentence of caution in the same register as the
- * option beside it (audit finding B2). Nothing separated granting it from
- * picking Restricted, on a self-custodial product where the grant reaches the
- * user's disk and their keys.
+ * `Full access` controls Vex MCP's execution gate: supported wallet actions
+ * can execute without per-call approval, while tool-specific approval
+ * requirements still apply. The coding client controls its own filesystem
+ * permissions. The grant can be revoked; completed transactions cannot be
+ * undone.
  *
  * Owner decision, 2026-09-02: the grant is CONFIRMED, not merely picked. This
  * component is the confirmation, and both surfaces that can make the grant - the

--- a/vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectCreator.test.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectCreator.test.tsx
@@ -40,9 +40,6 @@ import {
 } from "../studio-agent-catalogue.js";
 import {
   ARTIFACT_STATE_SENTENCES,
-  FULL_ACCESS_ACKNOWLEDGEMENT,
-  FULL_ACCESS_CONSEQUENCE_UNDO,
-  FULL_ACCESS_CONSEQUENCE_WHAT,
   fullAccessFolderLine,
   fullAccessWalletsLine,
   PROJECT_FILES_REPAIR_ACTION,
@@ -608,18 +605,20 @@ describe("the Full-access consent gate", () => {
     renderCreator();
     typeName("atlas");
     expect(consentCheckbox()).toBeNull();
+    expect(screen.getByText("Vex asks for approval before executing wallet actions with the wallets you select below. Your coding client controls its own filesystem permissions.")).not.toBeNull();
+    expect(screen.getByText("Agents can execute supported Vex wallet actions without per-call approval. Tool-specific approval requirements still apply.")).not.toBeNull();
 
     pickFullAccess();
     const strip = document.querySelector('[data-vex-consent="full-access"]');
     expect(strip).not.toBeNull();
     const text = strip?.textContent ?? "";
-    expect(text).toContain(FULL_ACCESS_CONSEQUENCE_WHAT);
+    expect(text).toContain("Agents can execute supported Vex wallet actions without per-call approval. Tool-specific approval requirements still apply. Your coding client controls its own filesystem permissions.");
     // TO WHAT. The creator has no path yet - the directory is claimed by the
     // create itself - so it says that rather than printing nothing.
     expect(text).toContain(fullAccessFolderLine(null));
     expect(text).toContain(fullAccessWalletsLine([]));
-    expect(text).toContain(FULL_ACCESS_CONSEQUENCE_UNDO);
-    expect(text).toContain(FULL_ACCESS_ACKNOWLEDGEMENT);
+    expect(text).toContain("You can revoke this permission in project settings. Completed transactions cannot be undone.");
+    expect(text).toContain("I understand that agents in this project can execute supported Vex wallet actions without per-call approval.");
   });
 
   it("keeps Create disabled with a valid name until the grant is acknowledged", () => {

--- a/vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectSettingsDialog.test.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectSettingsDialog.test.tsx
@@ -34,9 +34,6 @@ import {
 } from "../../__tests__/studio-fixtures.js";
 import { ProjectSettingsDialog } from "../ProjectSettingsDialog.js";
 import {
-  FULL_ACCESS_ACKNOWLEDGEMENT,
-  FULL_ACCESS_CONSEQUENCE_UNDO,
-  FULL_ACCESS_CONSEQUENCE_WHAT,
   fullAccessWalletsLine,
   PROJECT_SCOPE_CONFLICT_RELOAD,
   PROJECT_SCOPE_CONFLICT_RELOADING,
@@ -327,11 +324,11 @@ describe("the Full-access consent gate", () => {
     fireEvent.click(screen.getByRole("radio", { name: /Full access/ }));
     const strip = document.querySelector('[data-vex-consent="full-access"]');
     expect(strip).not.toBeNull();
-    expect(strip?.textContent).toContain(FULL_ACCESS_CONSEQUENCE_WHAT);
-    expect(strip?.textContent).toContain(FULL_ACCESS_ACKNOWLEDGEMENT);
+    expect(strip?.textContent).toContain("Agents can execute supported Vex wallet actions without per-call approval. Tool-specific approval requirements still apply. Your coding client controls its own filesystem permissions.");
+    expect(strip?.textContent).toContain("I understand that agents in this project can execute supported Vex wallet actions without per-call approval.");
     // WHAT, TO WHAT, and whether it can be undone: all three, always.
     expect(strip?.textContent).toContain(STORED.displayPath);
-    expect(strip?.textContent).toContain(FULL_ACCESS_CONSEQUENCE_UNDO);
+    expect(strip?.textContent).toContain("You can revoke this permission in project settings. Completed transactions cannot be undone.");
   });
 
   it("keeps Save disabled until the grant is acknowledged", async () => {

--- a/vex-app/src/renderer/features/appShell/studio/projects/projects-copy.ts
+++ b/vex-app/src/renderer/features/appShell/studio/projects/projects-copy.ts
@@ -68,12 +68,12 @@ import type {
 /* --- the grant: Full access, in the creator and in the settings editor --- */
 
 export const FULL_ACCESS_CONSEQUENCE_WHAT =
-  "Agents in this project will be able to act outside its folder and to use its wallets.";
+  "Agents can execute supported Vex wallet actions without per-call approval. Tool-specific approval requirements still apply. Your coding client controls its own filesystem permissions.";
 
 /**
- * Which folder the grant is about. The creator has no path yet - the directory
- * is claimed by the create itself - and says so rather than printing an empty
- * line or guessing at a path Vex has not derived.
+ * Which project folder the grant belongs to. The creator has no path yet -
+ * the directory is claimed by the create itself - and says so rather than
+ * printing an empty line or guessing at a path Vex has not derived.
  */
 export function fullAccessFolderLine(displayPath: string | null): string {
   return displayPath === null
@@ -100,7 +100,7 @@ export function fullAccessWalletsLine(
 }
 
 export const FULL_ACCESS_CONSEQUENCE_UNDO =
-  "This can be undone: change the permission back in this project's settings at any time.";
+  "You can revoke this permission in project settings. Completed transactions cannot be undone.";
 
 /**
  * THE ACKNOWLEDGEMENT, and it is required rather than decorative.
@@ -112,7 +112,7 @@ export const FULL_ACCESS_CONSEQUENCE_UNDO =
  * project says nothing about the next one.
  */
 export const FULL_ACCESS_ACKNOWLEDGEMENT =
-  "I understand that agents in this project can act outside its folder and can use its wallets.";
+  "I understand that agents in this project can execute supported Vex wallet actions without per-call approval.";
 
 /* --------------------------------- delete -------------------------------- */
 
@@ -171,7 +171,7 @@ export const PROJECT_PERMISSION_OPTIONS = [
     index: "01",
     title: "Restricted",
     description:
-      "Agents in this project may act inside the project folder and the wallets you select below.",
+      "Vex asks for approval before executing wallet actions with the wallets you select below. Your coding client controls its own filesystem permissions.",
     caution: false,
   },
   {
@@ -179,7 +179,7 @@ export const PROJECT_PERMISSION_OPTIONS = [
     index: "02",
     title: "Full access",
     description:
-      "Agents in this project may act outside the project folder. Grant this only when you know why you need it.",
+      "Agents can execute supported Vex wallet actions without per-call approval. Tool-specific approval requirements still apply.",
     caution: true,
   },
 ] as const;
@@ -643,6 +643,7 @@ export const REFUSAL_REASON_SENTENCES: Readonly<
   malformed_toml: "The existing file is not valid TOML, so Vex would have had to guess what to keep.",
   toml_multiline_string:
     "The existing TOML uses multi-line strings, which Vex cannot edit section by section without risking the rest of the file.",
+  malformed_markdown_fence: "Close the Markdown code fence in CLAUDE.md, then retry.",
   malformed_managed_block:
     "The Vex block in this file has a start marker without an end, or the reverse, so Vex cannot tell where its own content stops.",
   provenance_collision:

--- a/vex-app/src/shared/schemas/studio-installer.ts
+++ b/vex-app/src/shared/schemas/studio-installer.ts
@@ -69,6 +69,7 @@ export const studioRefusalReasonSchema = z.enum([
   "toml_multiline_string",
   /** `AGENTS.md` has a begin marker with no end, or the reverse. */
   "malformed_managed_block",
+  "malformed_markdown_fence",
   // ── from the confined filesystem contract ──────────────────────────────
   /** An entry already sits at the Vex path and provenance does not prove it is ours. */
   "provenance_collision",


### PR DESCRIPTION
## Why

An independent review of the files Vex Studio writes into a project (`agents-colab/agents_dm/studio-codex-review-2026-09-08.md`) found that Codex, which reads `AGENTS.md` and has no import expansion, received only a sentence telling it to open `.vex/vex-guide.md`, so the protocol inventory reached it late or never; that several sentences in the generated text were false or dangerous (FULL ACCESS claims, slippage widening by announcement, a universal 25 bps fee, a universal quote rule, "calling a tool is not publishing", the expired-card order); that the managed-block generator could be corrupted by a project name containing a delimiter, treated CRLF as drift, and mistook fenced import examples for real imports; and that the Full access consent described a folder boundary Vex does not enforce while calling completed transactions undoable.

## What

- A generated protocol map inside the managed block (12 namespaces, about 2 KB, bounded at 2,800 bytes and refused by name on overflow; the whole managed body stays under the 24,576-byte bound with the live inventory and maximum inputs, measured), plus honest delivery wording. Detailed guide and full inventory stay on demand.
- Text corrections as listed in the commit message, each as a before/after pair in the generator source; goldens regenerated through the repository mechanism and proven stable.
- Generator fixes with red-on-old-code tests: complete-line delimiters, safe display text, exactly one fence, repair idempotence, CRLF policy, import detection that ignores fenced examples, live-inventory budget test.
- Consent copy: "Agents can execute supported Vex wallet actions without per-call approval. Tool-specific approval requirements still apply. Your coding client controls its own filesystem permissions." and "You can revoke this permission in project settings. Completed transactions cannot be undone."

## Verification

Root: `tsc --noEmit`, studio and mcp vitest suites (956 tests), doc generators `--check`, `check:em-dash`, `test:unsafe-escapes`. App: `pnpm run lint`, studio projects and main studio suites (1,189 tests). Rendered `AGENTS.md` for the deterministic fixture: 20,552 to 23,284 bytes.

Note: at maximum escaped inputs the managed body has 37 bytes of headroom under Codex's budget; the live-inventory budget test fails the build before a future protocol addition could ship a render that refuses.