### PR TITLE
chore(deps): pin electron-updater's js-yaml to 4.3.2 for GHSA-2883-xcg3-v3hh

### DIFF
--- a/vex-app/package.json
+++ b/vex-app/package.json
@@ -146,7 +146,7 @@
       "utf-8-validate"
     ],
     "overrides": {
-      "electron-updater>js-yaml": "4.3.1",
+      "electron-updater>js-yaml": "4.3.2",
       "jayson>ws": "7.5.13",
       "rpc-websockets>ws": "8.21.3"
     }

--- a/vex-app/pnpm-lock.yaml
+++ b/vex-app/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  electron-updater>js-yaml: 4.3.1
+  electron-updater>js-yaml: 4.3.2
   jayson>ws: 7.5.13
   rpc-websockets>ws: 8.21.3
 
@@ -2321,8 +2321,8 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5322,7 +5322,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -5797,7 +5797,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
The production dependency audit started refusing js-yaml 4.3.1 on the electron-updater path today: GHSA-2883-xcg3-v3hh (maxTotalMergeKeys does not bound CPU use for empty merge sources, patched in 4.3.2). It turns the `vex-app-build-and-test` and `vex-app-e2e` jobs red on every open PR and on the next main run.

This moves the existing `electron-updater>js-yaml` override pin from 4.3.1 to 4.3.2, inside electron-updater's `^4.1.0` range. Only the two js-yaml lock entries change.

Verified: `pnpm install` regenerated the lockfile; `pnpm run audit:deps` in `vex-app/` passes with the two reviewed exceptions (uuid, stream-json) unchanged and their reachability verifiers green.
