### PR TITLE
chore(deps): Sentry Electron 7.18, electron-log 5.4.4, fuses refresh and the Electron dependency audit

### DIFF
--- a/vex-app/docs/dependency-audit-2026-09-09.md
+++ b/vex-app/docs/dependency-audit-2026-09-09.md
@@ -1,0 +1,234 @@
+# Electron dependency audit, 2026-09-09
+
+Context: on 2026-09-09 a new js-yaml advisory (GHSA-2883-xcg3-v3hh) turned the
+production dependency audit red on every open branch through the
+`electron-updater > js-yaml` path. PR #180 moved the existing
+`electron-updater>js-yaml` override pin from 4.3.1 to 4.3.2 and cleared it.
+The owner then asked for a review of every Electron-related dependency in
+`vex-app/package.json`: what upstream changed, and whether to bump.
+
+Three research passes read the upstream release records (GitHub releases,
+package changelogs, the Electron breaking-changes document, the advisory
+database, npm dist-tags) against our own call sites and build configuration.
+Repository facts were re-verified on a main-based worktree; every file:line
+below refers to `vex-app/`.
+
+Decision (owner, 2026-09-09): before the next release only the bumps that are
+easy and cannot interfere with release testing land. Everything else is
+recorded here with the dates that make it urgent.
+
+## Summary
+
+| Package | Pinned | Available | Decision | Reason |
+| --- | --- | --- | --- | --- |
+| `electron` | `42.0.0` | 42.11.3 (42 line), 43.6.0, 44.3.0 | after the release: 42.11.3 | 17 CVE backports, zero breaking changes, no native rebuild; deferred only to keep the binary under manual test stable |
+| `electron-builder` | `~26.8.1` | 26.16.1 (`v26` tag; npm `latest` is 26.15.3) | after the release: 26.16.1 with a three-platform dry run | fixes the AppImage CVE-2026-54672 we currently ship; changes the release pipeline |
+| `electron-updater` | `~6.8.9` | 6.8.9 | current | the shipped `builder-util-runtime` is already 9.7.0 |
+| `@sentry/electron` | `~7.16.0` | 7.18.0 | now | no effect on our configuration, verified below |
+| `electron-log` | `~5.4.3` | 5.4.4 | now | exports map only |
+| `@electron/fuses` | `~2.1.1` | 2.1.3 | now (lockfile refresh inside the range) | no option change |
+| `node-pty` | `1.2.0-beta.15` | same (`beta` tag) | current | the exact version VS Code pins |
+
+Reference: the VS Code checkout in `agents-colab/vscode` (2026-08-18) pins
+`electron` 42.8.1 and `node-pty` `^1.2.0-beta.15`. A production desktop
+product under real load has not moved to Electron 43 or 44.
+
+## Electron
+
+Support policy: the latest three stable majors are supported, eight-week
+cadence. Electron 42 loses support when 45 ships on 2026-10-20.
+
+| Target | Chromium / Node | Released / end of support | Breaking changes that touch us | Native rebuild |
+| --- | --- | --- | --- | --- |
+| 42.11.3 | 148 / 24.19.0 | 2026-09-08 / 2026-10-20 | none | no |
+| 43.6.0 | 150 / 24.17.0 | 2026-06-30 / 2027-01-05 | one behaviour change (dialog default directory) | no |
+| 44.3.0 | 152 / 24.18.1 | 2026-08-25 / 2027-03-02 | clipboard API became asynchronous | no, needs the packaged probe |
+
+### 42.0.0 to 42.11.3, the patch line
+
+Security: 42.4.1 carries CVE-2026-9115 and CVE-2026-9116; 42.11.1 carries
+CVE-2026-15764 through CVE-2026-15778 (15 CVEs). Node moved from 24.15.0 to
+24.19.0, which is newer than the Node base of 43 or 44.
+
+Fixes that land on code we run:
+
+- ASAR integrity with an updater: a browser-process crash in
+  `ValidateIntegrityOrDie` and a spurious preload `ENOENT` when `app.asar` is
+  replaced on disk while the app runs (42.6.2). We flip
+  `EnableEmbeddedAsarIntegrityValidation` and `OnlyLoadAppFromAsar` in
+  `build/afterPack.mjs:392-393` and ship `electron-updater`.
+- utilityProcess: crashes at exit on Windows 11 24H2 and later (42.10.0),
+  faster `utilityProcess.fork()`. We fork the pty host in
+  `src/main/studio/pty-host-starter.ts:551`.
+- safeStorage: `isAsyncEncryptionAvailable()` answered false right after
+  `ready`, and the async encrypt and decrypt calls could crash before
+  initialization (42.4.1). Consumer: `src/main/compose/electron-secret-adapter.ts`.
+- contextBridge: renderer crash on arrays with throwing getters, main and
+  utility crashes on option objects with throwing accessors (42.11.2).
+- Permission handlers received the top-level origin and a null `webContents`
+  for `hid` and `usb` from subframes. We deny everything in
+  `src/main/permissions.ts`, so we were already fail-closed.
+- `protocol.handle` session selection and cross-origin `no-cors` responses,
+  sandbox inheritance for windows opened from sandboxed frames, a Windows
+  process that would not exit after `app.quit()` with a pending Open With
+  dialog, BrowserWindow creation leak, a crash showing a file dialog on a
+  closing window, a Linux D-Bus disconnect crash.
+
+No native rebuild: `NODE_MODULE_VERSION` is fixed for the lifetime of an
+Electron major, and node-pty is consumed as shipped prebuilds
+(`scripts/check-native-artifacts.mjs`).
+
+### 43
+
+Breaking changes in 43 that reach us: dialog methods default `defaultPath` to
+Downloads, and we never set it (`src/main/ipc/images.ts`,
+`src/main/ipc/shell-backdrop.ts`), so both pickers change their starting
+directory. `showHiddenFiles` on Linux was removed; we do not use it. 43 is
+supported only until 2027-01-05 and its breaking set is a strict subset of the
+44 work, so it is not a landing spot.
+
+### 44, the one real migration
+
+The clipboard module was rearchitected onto the W3C Clipboard API (RFC 0019):
+`readText()`, `writeText()`, `read()`, `write()` and `has()` return Promises.
+That lands on the wallet export lease, `src/main/ipc/wallet-export-clipboard-lease.ts`
+(`clipboard.writeText(secret)` at line 111, `clipboard.readText()` at 63,
+`clipboard.clear()` at 65). The lease reads the clipboard, compares a SHA-256
+against the secret it wrote, and clears only content it still owns. Making all
+three calls asynchronous opens a time-of-check to time-of-use window across two
+awaits inside a secret-handling path. This is a lifecycle redesign with its own
+plan, approval and tests, not a mechanical `await` insertion.
+
+Also in 44: `clipboard` removed from the renderer (never exposed by us), 32-bit
+targets removed (we build x64 and arm64 only), `net.request` rejects a frame
+`Sec-Fetch-Dest` without `Sec-Fetch-Mode: navigate` (none of our `net.fetch`
+sites send it), macOS 12 dropped. `webUtils.getPathForFile`, used by
+`src/preload/shell/files.ts` and `src/preload/terminal-clipboard-files.ts`,
+is unchanged since its introduction in Electron 32.
+
+node-pty 1.2.0-beta.15 publishes no Electron compatibility claim. It builds
+against `node-addon-api`, so prebuilds are ABI-stable across majors, but that
+is inferred, not measured: `pnpm run probe:node-pty:packaged` is the gate
+before accepting 43 or 44.
+
+### Recommendation and schedule
+
+1. First change after the release: `electron` 42.11.3. One version string,
+   verified by CI and the packaged payload gates.
+2. Before 2026-10-20: an Electron 44 arc that redesigns the clipboard lease
+   around promise-based calls with the ownership-hash race named in the plan,
+   then runs the packaged node-pty probe on 44.
+
+## electron-builder
+
+### The finding that matters: AppImage CVE-2026-54672
+
+GHSA-7g7r-gx96-252g, CVSS 7.8, `app-builder-lib` below 26.15.0. The generated
+`AppRun` exported `LD_LIBRARY_PATH="${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"`;
+with the variable unset this leaves a trailing colon, an empty path component
+the dynamic linker resolves to the current working directory. The same applies
+to `PATH`, `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR`. We build AppImage
+(`electron-builder.release.yml`, linux targets), so every AppImage published
+from 26.8.1 carries it. There is no backport below 26.15.0. Do not publish
+another AppImage before the bump.
+
+The second advisory, GHSA-p2f4-r6v6-j797 / CVE-2026-54673 in
+`builder-util-runtime` below 9.7.0 (credential leak on cross-origin
+redirects), does not affect the shipped app: `electron-updater` 6.8.9 already
+resolves `builder-util-runtime` 9.7.0 in `pnpm-lock.yaml`. Only the build-time
+copy under `app-builder-lib` 26.8.1 is still 9.5.1.
+
+### Why 26.16.1 and not 26.15.3
+
+npm `latest` points at 26.15.3 because master moved to the 27 alphas; the
+maintained 26 line continues on `release/v26` under the `v26` dist-tag, at
+26.16.1 as of 2026-09-07. Its release notes exist only in the GitHub release
+bodies. The pin must name the version (`~26.16.1`); neither `~26.8.1` nor
+`latest` reaches it.
+
+Versions 26.15.0 through 26.15.5 carry two regressions on our own targets:
+the 7-Zip toolset switch in 26.15.0 dropped `.framework` symlinks from the
+macOS zip and broke Squirrel.Mac update validation until 26.15.2, and NSIS
+failed to extract the main exe and native binaries on x64 and arm64 until
+26.15.6. 26.16.1 also fixes macOS signing with `CSC_LINK` on newer runners
+(`security set-key-partition-list` received the wrong keychain password),
+which is the shape of our release job.
+
+Other changes on our configuration keys, 26.8.2 to 26.16.1: exe regeneration
+when the ASAR header changes so integrity validation matches (26.8.2), Azure
+Trusted Signing preflight removed (26.9.1), `signAndEditExecutable` split
+with a new `signExecutable` flag (26.11.0), deterministic file ordering in
+`latest*.yml` (26.12.0), blockmap and icon generation rewritten in TypeScript
+(26.14.0), `app-builder-bin` removed (26.15.0) and `7zip-bin` removed
+(26.16.0). The comment in `electron-builder.release.yml:227` about
+app-builder-lib 26.8.1 defaults for the Azure timestamp keys goes stale; the
+keys are pinned explicitly, so behaviour does not change.
+
+### What the bump changes for CI
+
+7-Zip, makensis, appimage, fpm and the icon tools are no longer npm packages.
+They are downloaded toolsets with pinned checksums, so all three release jobs
+acquire a build-time network dependency and a cold-cache failure mode.
+The node-module collector was rewritten repeatedly between 26.9 and 26.16;
+our negated `files` globs and `asarUnpack` list are exactly what it decides.
+
+### Release dry run checklist
+
+1. Linux: unpack the AppImage and confirm `AppRun` uses the
+   `${VAR:+:${VAR}}` form for `LD_LIBRARY_PATH`, `PATH`, `XDG_DATA_DIRS`
+   and `GSETTINGS_SCHEMA_DIR`, with no trailing colon. This is the acceptance
+   test for the CVE.
+2. macOS: `codesign -vvv --deep --strict` and `spctl -a -vv` on both
+   architectures, notarization staples, and `unzip -l` of the zip artifact
+   showing the `Electron Framework.framework` symlinks survived. Confirm the
+   `CSC_LINK` job no longer fails on `set-key-partition-list`.
+3. Windows: install the NSIS output on a clean x64 machine and confirm the
+   main exe, the node-pty prebuilds, `spawn-helper`, `vex-mcp.exe` and
+   `vex-pipe-front.exe` are extracted; rerun the Authenticode and timestamp
+   gate and the bridge path gate in `.github/workflows/release.yml`.
+4. ASAR integrity: the fuses set by `build/afterPack.mjs` still validate;
+   `disableAsarIntegrity` stays unset.
+5. Updater metadata: diff `latest.yml`, `latest-mac.yml` and
+   `latest-linux.yml` and the blockmaps against the current release.
+6. Payload: `pnpm run check:package` and `scripts/check-native-artifacts.mjs`
+   stay green after the collector changes.
+7. CI: the toolset downloads succeed on all three runners, or the cache is
+   seeded.
+
+v27 is in alpha (27.0.0-alpha.8) with a `migrate-schema` command; its
+breaking changes rename `azureSignOptions` into a unified `win.sign`, change
+the `asar` option shape and require native ESM with Node 22.12 or later. Not
+a candidate.
+
+## @sentry/electron and electron-log
+
+`@sentry/electron` 7.16.0 to 7.18.0: 7.17.0 pins the Sentry JavaScript SDK
+10.70.0, 7.18.0 pins 10.73.0. The one breaking change in 7.18.0, the
+`electronBreadcrumbs`, `electronNet` and `childProcess` integrations no longer
+emitting logs by default, has no effect on us: `src/main/telemetry/sentry-lifecycle.ts`
+sets `defaultIntegrations: false` and enables only dedupe and linked errors,
+with `sendDefaultPii: false` and `skipOpenTelemetrySetup: true`. The advisory
+database lists nothing against `@sentry/electron`. Verification after the
+bump: the app type check and the `before-send` and `sentry-lifecycle` suites,
+because `before-send.ts` imports the SDK's `Event` and `Breadcrumb` types.
+
+`electron-log` 5.4.3 to 5.4.4: an `exports` map in package.json and a CI-only
+test fix. Our `electron-log/main.js` import stays valid; the file transport,
+rotation and hooks are unchanged.
+
+`@electron/fuses` 2.1.2 replaced `extract-zip` with an internal fork; 2.1.3
+fixes `.app` bundle path detection on macOS. `FuseV1Options` is unchanged.
+
+## Sources
+
+- https://github.com/electron/electron/releases
+- https://www.electronjs.org/docs/latest/breaking-changes
+- https://www.electronjs.org/docs/latest/tutorial/electron-timelines
+- https://github.com/electron/rfcs/blob/main/text/0019-clipboard-rearchitecture.md
+- https://github.com/electron/fuses/releases
+- https://github.com/electron-userland/electron-builder/releases
+- https://github.com/advisories/GHSA-7g7r-gx96-252g
+- https://github.com/advisories/GHSA-p2f4-r6v6-j797
+- https://github.com/advisories/GHSA-2883-xcg3-v3hh
+- https://github.com/getsentry/sentry-electron/blob/master/CHANGELOG.md
+- https://github.com/megahertz/electron-log/releases

--- a/vex-app/package.json
+++ b/vex-app/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@hookform/resolvers": "~5.2.2",
     "@parcel/watcher": "~2.6.0",
-    "@sentry/electron": "~7.16.0",
+    "@sentry/electron": "~7.18.0",
     "@shikijs/vscode-textmate": "10.0.2",
     "@solana/web3.js": "~1.98.4",
     "@tanstack/react-query": "~5.100.9",
@@ -79,7 +79,7 @@
     "@zxcvbn-ts/language-en": "~4.1.1",
     "class-variance-authority": "~0.7.1",
     "clsx": "~2.1.1",
-    "electron-log": "~5.4.3",
+    "electron-log": "~5.4.4",
     "electron-updater": "~6.8.9",
     "ignore": "~7.0.6",
     "lightweight-charts": "5.2.1",
@@ -97,7 +97,7 @@
     "zustand": "~5.0.13"
   },
   "devDependencies": {
-    "@electron/fuses": "~2.1.1",
+    "@electron/fuses": "~2.1.3",
     "@playwright/test": "1.59.1",
     "@tailwindcss/vite": "~4.2.4",
     "@testcontainers/postgresql": "^11.14.0",

--- a/vex-app/package.json
+++ b/vex-app/package.json
@@ -146,7 +146,7 @@
       "utf-8-validate"
     ],
     "overrides": {
-      "electron-updater>js-yaml": "4.3.1",
+      "electron-updater>js-yaml": "4.3.2",
       "jayson>ws": "7.5.13",
       "rpc-websockets>ws": "8.21.3"
     }

--- a/vex-app/pnpm-lock.yaml
+++ b/vex-app/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ~2.6.0
         version: 2.6.0
       '@sentry/electron':
-        specifier: ~7.16.0
-        version: 7.16.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
+        specifier: ~7.18.0
+        version: 7.18.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
       '@shikijs/vscode-textmate':
         specifier: 10.0.2
         version: 10.0.2
@@ -80,8 +80,8 @@ importers:
         specifier: ~2.1.1
         version: 2.1.1
       electron-log:
-        specifier: ~5.4.3
-        version: 5.4.3
+        specifier: ~5.4.4
+        version: 5.4.4
       electron-updater:
         specifier: ~6.8.9
         version: 6.8.9
@@ -129,8 +129,8 @@ importers:
         version: 5.0.13(@types/react@19.2.14)(react@19.2.6)
     devDependencies:
       '@electron/fuses':
-        specifier: ~2.1.1
-        version: 2.1.1
+        specifier: ~2.1.3
+        version: 2.1.3
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -202,17 +202,6 @@ packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
-
-  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
-    resolution: {integrity: sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==}
-    engines: {node: '>=18.0.0'}
-
-  '@apm-js-collab/code-transformer@0.18.1':
-    resolution: {integrity: sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==}
-    hasBin: true
-
-  '@apm-js-collab/tracing-hooks@0.13.0':
-    resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -297,8 +286,8 @@ packages:
     resolution: {integrity: sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==}
     hasBin: true
 
-  '@electron/fuses@2.1.1':
-    resolution: {integrity: sha512-38ho27/mtUV/LpsZ1LCDJUomKBBSUZDk/qBH4FNNtoN5fmnkmWDcIp5pm1Kv3InqhRjKZKs7Jzx+wWZNMArHrA==}
+  '@electron/fuses@2.1.3':
+    resolution: {integrity: sha512-LoKJUXNiJ4JM8IIrUltSHI+8pkogaGj5wmJx81jE/Wk3g2w1/kfMbTEKNoY5kitGE8hiC12h32R/1SlywFtxXg==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -641,8 +630,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/semantic-conventions@1.40.0':
-    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
 
   '@oxc-project/types@0.128.0':
@@ -876,36 +865,36 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
-  '@sentry/browser-utils@10.67.0':
-    resolution: {integrity: sha512-HUzaf0xAnPAB+OHBkD7N1Py+CTbD5InHulQ/pdhX4JctWtxuwD8odMD1LzdPnW8J6gVHlDVvcVBR8mXMZYSLSw==}
+  '@sentry/browser-utils@10.73.0':
+    resolution: {integrity: sha512-qQygxJZ+RV779+iL1+lrJ4f4sZLgbgW0/JWPNp0YlcEAE62yCsdKbqoTEjB/EugdS4mSjBMX0chZC6rblu2Ycw==}
     engines: {node: '>=18'}
 
-  '@sentry/browser@10.67.0':
-    resolution: {integrity: sha512-/ZhsAvte4rYhg0A0RtSFFgAgXhyMOfQIeOAfMfptN+X6IVSYOfkA9jtrP+Ej4+6vlaUFWRir1HweF56y63dEEA==}
+  '@sentry/browser@10.73.0':
+    resolution: {integrity: sha512-HqTe1S5RrWLufhX2LaFP3yNoMxfNDroh120bq1zdGHZfFDBMJQ0CDXxHO+L4UJfQ5dWdCCzWbXIAiZuWGa/DFQ==}
     engines: {node: '>=18'}
 
   '@sentry/conventions@0.16.0':
     resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
     engines: {node: '>=14'}
 
-  '@sentry/core@10.67.0':
-    resolution: {integrity: sha512-b6U3pJ8AUvN9aouq0vl+VZI8KT8RslBsfGMFuNwRr313zOmdmFJBZqTiUw9VGgJ2jGKxLO9alm9rlxBfX4hf+w==}
+  '@sentry/core@10.73.0':
+    resolution: {integrity: sha512-FLO1UgH19RyasVpofu612WCOgb2nEH0dZy+R72d7p65XU9i0wxlMKm3+sgfwKmiSJp1Qhilaaxs4Jg6BbiM5HA==}
     engines: {node: '>=18'}
 
-  '@sentry/electron@7.16.0':
-    resolution: {integrity: sha512-GgnsAGynr1IKfakRuW5AGlxQsIZi0cFUyzcn9ekrYy1cIyb85piVLN5u7W9pXzSzKopaGrxXBWubPBSRagyXjA==}
+  '@sentry/electron@7.18.0':
+    resolution: {integrity: sha512-0urgVmB4APMVbA8SedNKBghddmWvaRLXlRPUj7PSS4o+fZJBWY7DbqbmjQhe1T2jwNvLZpNb1xkq7MxDdTe3DQ==}
     peerDependencies:
-      '@sentry/node-native': 10.67.0
+      '@sentry/node-native': 10.73.0
     peerDependenciesMeta:
       '@sentry/node-native':
         optional: true
 
-  '@sentry/feedback@10.67.0':
-    resolution: {integrity: sha512-I4ML2/SF3enwikb6ZSoRiqolQrx0zSzTSnUgwCmugICF/jpHW0th1pCray9R+t1Zzibw/Dpj4t/DNXaSDRa2MA==}
+  '@sentry/feedback@10.73.0':
+    resolution: {integrity: sha512-D6nSngX+e46Mae2/oh2bxBvxNK1z2NERbuMAhB5sx9x4xMBWIyGnYYTECehvEqV9+AqGAgxxhOZoYIG3AmRwww==}
     engines: {node: '>=18'}
 
-  '@sentry/node-core@10.67.0':
-    resolution: {integrity: sha512-dBHHRwZyan1pOnFJ+sNBvR8TkXbZAfZU/jpxmALS3JZ2/8AGR7cQKL+b7SleKuJ7iUDZyklN3Nqi0i5JkcA+HA==}
+  '@sentry/node-core@10.73.0':
+    resolution: {integrity: sha512-GHAGUmZPmm6FKfxfv2maVVJ/A99YAmd7oFOuKMDmITI6O/Msl6JB3vPTEpopVAHLW0LYJQBOjddL9C7o+Jt44g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -925,28 +914,28 @@ packages:
       '@opentelemetry/sdk-trace-base':
         optional: true
 
-  '@sentry/node@10.67.0':
-    resolution: {integrity: sha512-SFKpZGqOCEFSmP93NdDP6ikZp4NS7A/JR8+2ofK3jF6Y9Vyox7pX0pxdOnPLpFcPtMybMahfWqSAWJvsFs4RmA==}
+  '@sentry/node@10.73.0':
+    resolution: {integrity: sha512-jiMJ6GgXDw6UMGzJY+o0c8OoeA9OfHqZ/xEpHfDqy75hn+9CEkRkbNGCIdMvsc7wW/Se1Os394hHfTpU+YEskg==}
     engines: {node: '>=18'}
 
-  '@sentry/opentelemetry@10.67.0':
-    resolution: {integrity: sha512-oLTOrAK1rOqmYRktOJZwz37B1seXPx1W2FTMVtzTVNjMFA/LZwGzePeZzhUOgzZgfLHixMd/ceWtGqoxAndcjQ==}
+  '@sentry/opentelemetry@10.73.0':
+    resolution: {integrity: sha512-fQouPQKsH0CQrw6oAn1k0Z2I+tgyochCovifr5qNS69i0OzjknLa03WJyiZ/IuzXc4AVa5jAKfOeE9slABz8Qw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
       '@opentelemetry/core': ^1.30.1 || ^2.1.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
 
-  '@sentry/replay-canvas@10.67.0':
-    resolution: {integrity: sha512-neNA4T6MFtZzMdKYetiR+LZd9BNSd0q2szMn0wk+A15PqHE/IN7a34V6JZc9rCtmzB0wldh0eWGOBb49MSNKjA==}
+  '@sentry/replay-canvas@10.73.0':
+    resolution: {integrity: sha512-sxa2lKkHPfF/j5xFpW7gocthWXRqyoHz8KCPy6yGc8plT477nl57iGSKhQDYsx1Ny10TLjs7YkIuPP1GY/Ax2Q==}
     engines: {node: '>=18'}
 
-  '@sentry/replay@10.67.0':
-    resolution: {integrity: sha512-nkEUgPCR82EcyJkCf3XCE9H0R5KisCqyCAaSGxe7NpAoQbvASHx4MUNgXVAn+D0M494gvPZh6lFH7JgzqTcSqQ==}
+  '@sentry/replay@10.73.0':
+    resolution: {integrity: sha512-nN2wjN/Y0J5BOJV5hqRHUEBfxwUsipp1PKjcDHh6Fpxnrtfldu3Y99E8cQInseo5heFdzEvrOHBBrqWZXOHVKQ==}
     engines: {node: '>=18'}
 
-  '@sentry/server-utils@10.67.0':
-    resolution: {integrity: sha512-GQ9t+RSTx5s3b/aZrLFuL4nrwPLMah5NiZk5cjxJmgmOSgm3nMdO8gdqCedDch5B13F3YsxtaQYjSJnzLz8M5A==}
+  '@sentry/server-utils@10.73.0':
+    resolution: {integrity: sha512-QskripdKFbM/+gipC6mpa2crLwL7+VbkX84IpHg2z9UlYQ1kNKd3aMT+Qk9NLRSw/zu1rSIAvlbWfx4D3rgNAA==}
     engines: {node: '>=18'}
 
   '@shikijs/core@4.4.3':
@@ -1378,16 +1367,6 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
-  acorn-import-attributes@1.9.5:
-    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
-    peerDependencies:
-      acorn: ^8
-
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1462,10 +1441,6 @@ packages:
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
-
-  astring@1.9.0:
-    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
-    hasBin: true
 
   async-exit-hook@2.0.1:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
@@ -1667,8 +1642,8 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
-  cjs-module-lexer@2.2.0:
-    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+  cjs-module-lexer@2.2.1:
+    resolution: {integrity: sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1878,8 +1853,8 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  electron-log@5.4.3:
-    resolution: {integrity: sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==}
+  electron-log@5.4.4:
+    resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
     engines: {node: '>= 14'}
 
   electron-publish@26.8.1:
@@ -1936,6 +1911,9 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
+  es-module-lexer@3.0.2:
+    resolution: {integrity: sha512-BuIB67FngDSyQ/dpQNOZybwdEBDUGJQvOqwWr4ha/ufYiqzuEwPkKO2zLhRAgay28tStRIHUeWmszZAJo3GCOg==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1960,14 +1938,6 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-
-  esquery@1.7.0:
-    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
-    engines: {node: '>=0.10'}
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2080,6 +2050,10 @@ packages:
 
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.4.0:
+    resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -2228,8 +2202,8 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
-  import-in-the-middle@3.0.1:
-    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+  import-in-the-middle@3.5.0:
+    resolution: {integrity: sha512-O6wo8l0lhBuytKz3x8S65TvacFtoopji+gCVeEBbjCaRy75gkk4bCBQoVmY7OEZ63cbFK+yf77pDCTWaadV7hQ==}
     engines: {node: '>=18'}
 
   inflight@1.0.6:
@@ -2497,10 +2471,6 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
-
-  meriyah@6.1.4:
-    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
-    engines: {node: '>=18.0.0'}
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -2963,9 +2933,6 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-
-  semifies@1.0.0:
-    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
@@ -3583,30 +3550,6 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
-  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
-    dependencies:
-      '@apm-js-collab/code-transformer': 0.18.1
-      es-module-lexer: 2.1.0
-      magic-string: 0.30.21
-      module-details-from-path: 1.0.4
-
-  '@apm-js-collab/code-transformer@0.18.1':
-    dependencies:
-      '@types/estree': 1.0.9
-      astring: 1.9.0
-      esquery: 1.7.0
-      meriyah: 6.1.4
-      semifies: 1.0.0
-      source-map: 0.6.1
-
-  '@apm-js-collab/tracing-hooks@0.13.0':
-    dependencies:
-      '@apm-js-collab/code-transformer': 0.18.1
-      debug: 4.4.3
-      module-details-from-path: 1.0.4
-    transitivePeerDependencies:
-      - supports-color
-
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
@@ -3684,7 +3627,7 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  '@electron/fuses@2.1.1': {}
+  '@electron/fuses@2.1.3': {}
 
   '@electron/get@3.1.0':
     dependencies:
@@ -3759,7 +3702,7 @@ snapshots:
     dependencies:
       cross-dirname: 0.1.0
       debug: 4.4.3
-      fs-extra: 11.3.5
+      fs-extra: 11.4.0
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
@@ -4003,13 +3946,13 @@ snapshots:
   '@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.220.0
-      import-in-the-middle: 3.0.1
+      import-in-the-middle: 3.5.0
       require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
@@ -4018,7 +3961,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -4026,16 +3969,16 @@ snapshots:
       '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace': 2.11.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/sdk-trace@2.11.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/semantic-conventions@1.40.0': {}
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-project/types@0.128.0': {}
 
@@ -4188,94 +4131,91 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
-  '@sentry/browser-utils@10.67.0':
+  '@sentry/browser-utils@10.73.0':
     dependencies:
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.67.0
+      '@sentry/core': 10.73.0
 
-  '@sentry/browser@10.67.0':
+  '@sentry/browser@10.73.0':
     dependencies:
-      '@sentry/browser-utils': 10.67.0
+      '@sentry/browser-utils': 10.73.0
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.67.0
-      '@sentry/feedback': 10.67.0
-      '@sentry/replay': 10.67.0
-      '@sentry/replay-canvas': 10.67.0
+      '@sentry/core': 10.73.0
+      '@sentry/feedback': 10.73.0
+      '@sentry/replay': 10.73.0
+      '@sentry/replay-canvas': 10.73.0
 
   '@sentry/conventions@0.16.0': {}
 
-  '@sentry/core@10.67.0':
+  '@sentry/core@10.73.0':
     dependencies:
       '@sentry/conventions': 0.16.0
 
-  '@sentry/electron@7.16.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))':
+  '@sentry/electron@7.18.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@sentry/browser': 10.67.0
-      '@sentry/core': 10.67.0
-      '@sentry/node': 10.67.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/browser': 10.73.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+      '@sentry/node': 10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
     transitivePeerDependencies:
       - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/feedback@10.67.0':
+  '@sentry/feedback@10.73.0':
     dependencies:
-      '@sentry/core': 10.67.0
+      '@sentry/core': 10.73.0
 
-  '@sentry/node-core@10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.67.0
-      '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
-      import-in-the-middle: 3.0.1
+      '@sentry/core': 10.73.0
+      '@sentry/opentelemetry': 10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.5.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
 
-  '@sentry/node@10.67.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node@10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.67.0
-      '@sentry/node-core': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
-      '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
-      '@sentry/server-utils': 10.67.0
-      import-in-the-middle: 3.0.1
+      '@sentry/core': 10.73.0
+      '@sentry/node-core': 10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.73.0
+      import-in-the-middle: 3.5.0
     transitivePeerDependencies:
       - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/opentelemetry@10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
+  '@sentry/opentelemetry@10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.67.0
+      '@sentry/core': 10.73.0
 
-  '@sentry/replay-canvas@10.67.0':
+  '@sentry/replay-canvas@10.73.0':
     dependencies:
-      '@sentry/core': 10.67.0
-      '@sentry/replay': 10.67.0
+      '@sentry/core': 10.73.0
+      '@sentry/replay': 10.73.0
 
-  '@sentry/replay@10.67.0':
+  '@sentry/replay@10.73.0':
     dependencies:
-      '@sentry/browser-utils': 10.67.0
-      '@sentry/core': 10.67.0
+      '@sentry/browser-utils': 10.73.0
+      '@sentry/core': 10.73.0
 
-  '@sentry/server-utils@10.67.0':
+  '@sentry/server-utils@10.73.0':
     dependencies:
-      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.4
-      '@apm-js-collab/tracing-hooks': 0.13.0
       '@sentry/conventions': 0.16.0
-      '@sentry/core': 10.67.0
-    transitivePeerDependencies:
-      - supports-color
+      '@sentry/core': 10.73.0
 
   '@shikijs/core@4.4.3':
     dependencies:
@@ -4723,12 +4663,6 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  acorn-import-attributes@1.9.5(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
-
-  acorn@8.16.0: {}
-
   agent-base@7.1.4: {}
 
   agentkeepalive@4.6.0:
@@ -4844,8 +4778,6 @@ snapshots:
 
   astral-regex@2.0.0:
     optional: true
-
-  astring@1.9.0: {}
 
   async-exit-hook@2.0.1: {}
 
@@ -5051,7 +4983,7 @@ snapshots:
 
   ci-info@4.4.0: {}
 
-  cjs-module-lexer@2.2.0: {}
+  cjs-module-lexer@2.2.1: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -5303,7 +5235,7 @@ snapshots:
       - electron-builder-squirrel-windows
       - supports-color
 
-  electron-log@5.4.3: {}
+  electron-log@5.4.4: {}
 
   electron-publish@26.8.1:
     dependencies:
@@ -5378,6 +5310,8 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
+  es-module-lexer@3.0.2: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -5402,12 +5336,6 @@ snapshots:
 
   escape-string-regexp@4.0.0:
     optional: true
-
-  esquery@1.7.0:
-    dependencies:
-      estraverse: 5.3.0
-
-  estraverse@5.3.0: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -5507,6 +5435,13 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fs-extra@11.4.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -5701,11 +5636,10 @@ snapshots:
 
   ignore@7.0.6: {}
 
-  import-in-the-middle@3.0.1:
+  import-in-the-middle@3.5.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
-      cjs-module-lexer: 2.2.0
+      cjs-module-lexer: 2.2.1
+      es-module-lexer: 3.0.2
       module-details-from-path: 1.0.4
 
   inflight@1.0.6:
@@ -5956,8 +5890,6 @@ snapshots:
       vfile: 6.0.3
 
   mdn-data@2.27.1: {}
-
-  meriyah@6.1.4: {}
 
   micromark-util-character@2.1.1:
     dependencies:
@@ -6436,8 +6368,6 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
-
-  semifies@1.0.0: {}
 
   semver-compare@1.0.0:
     optional: true

--- a/vex-app/pnpm-lock.yaml
+++ b/vex-app/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  electron-updater>js-yaml: 4.3.1
+  electron-updater>js-yaml: 4.3.2
   jayson>ws: 7.5.13
   rpc-websockets>ws: 8.21.3
 
@@ -2321,8 +2321,8 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5322,7 +5322,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.7.0
       fs-extra: 10.1.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -5797,7 +5797,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
Owner decision 2026-09-09: before the next release only the easy bumps land; the rest is recorded in `vex-app/docs/dependency-audit-2026-09-09.md`.

- `@sentry/electron` ~7.16.0 -> ~7.18.0 (Sentry JavaScript SDK 10.73.0). The 7.18.0 breaking change (integrations no longer emit logs by default) has no effect: we set `defaultIntegrations: false` and enable only dedupe and linked errors.
- `electron-log` ~5.4.3 -> ~5.4.4 (package.json exports map only).
- `@electron/fuses` refreshed 2.1.1 -> 2.1.3 inside the existing `~2.1.1` range.
- New doc: the audit of electron, electron-builder, electron-updater, node-pty, Sentry and electron-log against upstream release records, the deferred items (Electron 42.11.3, electron-builder 26.16.1 with the AppImage CVE-2026-54672), the Electron 44 clipboard migration and the release dry run checklist.

Verified in `vex-app/`: telemetry and logger suites (26 tests), `pnpm run lint` (type ratchet and process boundaries), `pnpm run audit:deps` (two reviewed exceptions unchanged).

Stacked on #180; the js-yaml commit disappears from this diff once #180 merges.
