### PR TITLE
fix(lighter): show an account whose trading key lives in another vault instead of no account

### DIFF
--- a/src/__tests__/lighter/lighter-onboarding-workflows.test.ts
+++ b/src/__tests__/lighter/lighter-onboarding-workflows.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   LIGHTER_ONBOARDING_WORKFLOW_STATES,
+  hasRecordedLighterTradingKeyRegistration,
   ensureLighterOnboardingWorkflowEnabledWith,
   transitionLighterOnboardingWorkflowWith,
   type LighterOnboardingWorkflowState,
@@ -101,6 +102,20 @@ describe("Lighter onboarding workflow foundation", () => {
       "ambiguous",
       "failed",
     ]);
+  });
+
+  it.each(LIGHTER_ONBOARDING_WORKFLOW_STATES)("distinguishes generated from verified registration in %s", (workflowState) => {
+    expect(hasRecordedLighterTradingKeyRegistration({
+      workflowState, lastStableState: workflowState, apiKeyIndex: 4,
+      publicKeyFingerprint: "test-public-fingerprint",
+    })).toBe(["key_verified", "nonce_synchronized", "ready_to_trade"].includes(workflowState));
+  });
+
+  it("retains verified registration evidence through an ambiguous workflow", () => {
+    expect(hasRecordedLighterTradingKeyRegistration({
+      workflowState: "ambiguous", lastStableState: "key_verified", apiKeyIndex: 4,
+      publicKeyFingerprint: "test-public-fingerprint",
+    })).toBe(true);
   });
 
   it("creates one lower-cased wallet workflow at activation", async () => {

--- a/src/__tests__/vex-agent/tools/lighter-handlers.test.ts
+++ b/src/__tests__/vex-agent/tools/lighter-handlers.test.ts
@@ -85,6 +85,7 @@ const mocks = vi.hoisted(() => ({
     withSessionControlLocks: vi.fn(),
   },
   onboarding: {
+    getWorkflow: vi.fn(),
     buildReaders: vi.fn(),
     resolveStatus: vi.fn(),
   },
@@ -172,6 +173,11 @@ vi.mock("@vex-agent/db/repos/approval-intents.js", () => ({
 vi.mock("@vex-agent/engine/runtime/lease-and-status/session-control-lock.js", () => ({
   withSessionControlLock: mocks.sessionLock.withSessionControlLock,
   withSessionControlLocks: mocks.sessionLock.withSessionControlLocks,
+}));
+
+vi.mock("@vex-agent/db/repos/lighter-onboarding-workflows.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@vex-agent/db/repos/lighter-onboarding-workflows.js")>()),
+  getLighterOnboardingWorkflow: mocks.onboarding.getWorkflow,
 }));
 
 vi.mock("@tools/lighter/wallet-funding/onboarding-readers.js", () => ({
@@ -567,6 +573,7 @@ beforeEach(() => {
   mocks.ocoIntentsRepo.listUnresolved.mockResolvedValue([]);
   mocks.approvalsRepo.getByIdForSession.mockResolvedValue(approvalQueueRow());
   mocks.approvalIntentsRepo.getByApprovalId.mockResolvedValue(approvalIntentAuditRow());
+  mocks.onboarding.getWorkflow.mockResolvedValue(null);
   mocks.onboarding.buildReaders.mockReturnValue({ marker: "onboarding-readers" });
   mocks.lifecycleIntentsRepo.listStreamWatchable.mockResolvedValue([]);
   mocks.lifecycleIntentsRepo.listStatusCandidates.mockResolvedValue([]);
@@ -1139,6 +1146,73 @@ describe("Lighter agent read handlers", () => {
     });
 
     expect(readManagedReadiness).toHaveBeenCalledWith("rhc", 42);
+    expect(data.managedTradingAccessActive).toBe(false);
+    expect(data.tradingAccessRoute).toEqual({
+      kind: "prepare_key_registration_approval",
+      toolId: "lighter.key.register.prepare",
+      params: { environment: "rhc" },
+    });
+    expect(data.userGuidance).toContain("Immediately call lighter.key.register.prepare");
+    expect(data.userGuidance).toContain('environment "rhc"');
+    expect(data.userGuidance).toContain("generates and encrypts the credential locally");
+    expect(data.userGuidance).toContain("Never call lighter.key.register directly");
+  });
+
+  it.each([
+    { tradingKeyRegistered: true, workflowAccount: 42, apiKeyIndex: 4, fingerprint: "test-public-fingerprint", recorded: true },
+    { tradingKeyRegistered: false, workflowAccount: 42, apiKeyIndex: 4, fingerprint: "test-public-fingerprint", recorded: true },
+    { tradingKeyRegistered: false, workflowAccount: 43, apiKeyIndex: 4, fingerprint: "test-public-fingerprint", recorded: false },
+    { tradingKeyRegistered: false, workflowAccount: 42, apiKeyIndex: null, fingerprint: "test-public-fingerprint", recorded: false },
+    { tradingKeyRegistered: false, workflowAccount: 42, apiKeyIndex: 4, fingerprint: null, recorded: false },
+  ])("explains only matching, recorded registration metadata: %j", async ({ tradingKeyRegistered, workflowAccount, apiKeyIndex, fingerprint, recorded }) => {
+    const readManagedReadiness = vi.fn(async () => ({
+      ready: false,
+      reason: "active_managed_credential_missing" as const,
+      activeManagedCredential: false,
+      durableActivation: false,
+      exactPublicKeyMatch: false,
+      clientCheckPassed: false,
+      nonceSynchronized: false,
+      nonceReservable: false,
+    }));
+    configureLighterManagedTradingReadinessResolver({ read: readManagedReadiness });
+    mocks.onboarding.resolveStatus.mockResolvedValue({
+      environment: "rhc",
+      walletAddress: "0xacee6141f6171491d34699c9266cb06a41faa43c",
+      walletSettlementUnits: "948401",
+      walletCanAcquireSettlement: false,
+      accountExists: true,
+      accountIndex: 42,
+      accountCollateralUnits: "1000000",
+      tradingKeyRegistered,
+      requiredCollateralUnits: "1000000",
+      minimumDepositUnits: "1000000",
+      plan: {
+        legs: tradingKeyRegistered ? [] : [{ kind: "register_trading_key", reason: "secure setup" }],
+        ready: false,
+        blocked: null,
+        depositUnits: null,
+        acquireUnits: null,
+      },
+    });
+
+    mocks.onboarding.getWorkflow.mockResolvedValue({
+      environment: "rhc", walletAddress: "0xacee6141f6171491d34699c9266cb06a41faa43c",
+      workflowState: "ready_to_trade", lastStableState: "ready_to_trade", resolvedAccountIndex: workflowAccount,
+      apiKeyIndex, publicKeyFingerprint: fingerprint,
+    });
+    const data = await callJson("lighter.account.onboarding.status", {
+      environment: "rhc",
+      walletAddress: "0xacee6141f6171491d34699c9266cb06a41faa43c",
+    });
+
+    expect(mocks.onboarding.getWorkflow).toHaveBeenCalledWith("rhc", "0xacee6141f6171491d34699c9266cb06a41faa43c");
+    expect(data.plan).toMatchObject({ ready: false, legs: [{ kind: "register_trading_key",
+      reason: recorded
+        ? "This account has a registered trading key from another Vex installation (or an earlier vault), but this machine holds no credential for it. Registering a new trading key here uses another unused key slot without invalidating the existing key."
+        : "Create and register locally encrypted Vex trading access before any order can be signed.",
+    }] });
+    expect(data.userGuidance.includes("this machine holds no credential")).toBe(recorded);
     expect(data.managedTradingAccessActive).toBe(false);
     expect(data.tradingAccessRoute).toEqual({
       kind: "prepare_key_registration_approval",

--- a/src/__tests__/vex-agent/tools/lighter-points-database-listing.test.ts
+++ b/src/__tests__/vex-agent/tools/lighter-points-database-listing.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readLighterPointsForWallets } from "@vex-agent/tools/protocols/lighter/points.js";
+import { configureLighterReadOnlyAccountAuthOutcomeResolver } from "@vex-agent/tools/protocols/lighter/read-account-auth.js";
+import { POINTS_FIXTURE } from "../../lighter/points-fixture.js";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  leaderboard: vi.fn(),
+  live: vi.fn(),
+  referral: vi.fn(),
+}));
+vi.mock("@vex-agent/db/client.js", () => ({ query: mocks.query, queryOne: vi.fn() }));
+vi.mock("@tools/lighter/client.js", () => ({ getLighterClient: () => ({
+  getLeaderboard: mocks.leaderboard,
+  getLivePointsTotal: mocks.live,
+  getReferralPoints: mocks.referral,
+}) }));
+
+const WALLET = "0x1111111111111111111111111111111111111111";
+const OTHER = "0x2222222222222222222222222222222222222222";
+let dispose: (() => void) | undefined;
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.leaderboard.mockResolvedValue(POINTS_FIXTURE.anonymousAllForWallet);
+  mocks.live.mockResolvedValue(POINTS_FIXTURE.livePoints);
+  mocks.referral.mockResolvedValue(POINTS_FIXTURE.referralPoints);
+});
+afterEach(() => { dispose?.(); });
+
+describe("points database listing joined to local authorization", () => {
+  it("uses every resolved workflow, joining by environment and account independently", async () => {
+    mocks.query.mockResolvedValue([
+      { environment: "rhc", wallet_address: WALLET, resolved_account_index: "123",
+        api_key_index: 4, public_key_fingerprint: "test-public-fingerprint", workflow_state: "ready_to_trade", last_stable_state: "ready_to_trade", total_count: "3" },
+      { environment: "core", wallet_address: WALLET, resolved_account_index: "123",
+        api_key_index: 5, public_key_fingerprint: "test-public-fingerprint", workflow_state: "ready_to_trade", last_stable_state: "ready_to_trade", total_count: "3" },
+      { environment: "rhc", wallet_address: OTHER, resolved_account_index: "456",
+        api_key_index: null, public_key_fingerprint: null, workflow_state: "account_resolved", last_stable_state: "account_resolved", total_count: "3" },
+    ]);
+    const resolveAuth = vi.fn(async (environment: string, accountIndex: number) =>
+      environment === "core"
+        ? { kind: "auth" as const, auth: { token: "test-read-authorization", accountIndex } }
+        : { kind: "unavailable" as const, reason: "no_credential" as const, detail: "No local credential." });
+    dispose = configureLighterReadOnlyAccountAuthOutcomeResolver(resolveAuth);
+
+    const report = await readLighterPointsForWallets({ signal: new AbortController().signal });
+
+    expect(report.walletCount).toBe(3);
+    expect(report.rows).toMatchObject([
+      { kind: "credential_missing_here", environment: "rhc", accountIndex: 123,
+        apiKeyIndex: 4, tradingKeyRegistered: true, walletAddress: WALLET },
+      { kind: "points", environment: "core", accountIndex: 123, walletAddress: WALLET },
+      { kind: "credential_missing_here", environment: "rhc", accountIndex: 456,
+        apiKeyIndex: null, tradingKeyRegistered: false, walletAddress: OTHER },
+    ]);
+    expect(resolveAuth.mock.calls).toEqual([["rhc", 123], ["core", 123], ["rhc", 456]]);
+    expect(mocks.leaderboard).toHaveBeenCalledTimes(2);
+    expect(mocks.live).toHaveBeenCalledTimes(1);
+    expect(mocks.referral).toHaveBeenCalledTimes(1);
+    const query = mocks.query.mock.calls[0];
+    expect(query?.[0]).toContain("WHERE resolved_account_index IS NOT NULL");
+    expect(query?.[0]).not.toContain("workflow_state =");
+    expect(query?.[1]).toEqual([100]);
+    for (const row of report.rows) expect(row).not.toHaveProperty("publicKeyFingerprint");
+  });
+
+  it("reports empty only when the database has no resolved accounts", async () => {
+    mocks.query.mockResolvedValue([]);
+    const resolveAuth = vi.fn();
+    dispose = configureLighterReadOnlyAccountAuthOutcomeResolver(resolveAuth);
+    const report = await readLighterPointsForWallets({ signal: new AbortController().signal });
+    expect(report).toMatchObject({ rows: [], walletCount: 0 });
+    expect(resolveAuth).not.toHaveBeenCalled();
+    expect(mocks.leaderboard).not.toHaveBeenCalled();
+  });
+
+  it("propagates unavailable database state instead of returning an empty list", async () => {
+    mocks.query.mockRejectedValue(new Error("Test database unavailable."));
+    await expect(readLighterPointsForWallets({ signal: new AbortController().signal }))
+      .rejects.toThrow("Test database unavailable.");
+    expect(mocks.leaderboard).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid persisted key indexes before local authorization", async () => {
+    mocks.query.mockResolvedValue([{ environment: "rhc", wallet_address: WALLET,
+      resolved_account_index: "123", api_key_index: 255,
+      public_key_fingerprint: "test-public-fingerprint", workflow_state: "ready_to_trade", last_stable_state: "ready_to_trade", total_count: "1" }]);
+    const resolveAuth = vi.fn();
+    dispose = configureLighterReadOnlyAccountAuthOutcomeResolver(resolveAuth);
+    await expect(readLighterPointsForWallets({ signal: new AbortController().signal }))
+      .rejects.toThrow("api_key_index is not a safe integer");
+    expect(resolveAuth).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/vex-agent/tools/lighter-points-read-model.test.ts
+++ b/src/__tests__/vex-agent/tools/lighter-points-read-model.test.ts
@@ -43,6 +43,8 @@ const WALLET_ROW: LighterPointsWallet = {
   walletAddress: WALLET,
   environment: "rhc",
   accountIndex: ACCOUNT_INDEX,
+  apiKeyIndex: 4,
+  tradingKeyRegistered: true,
 };
 
 /**
@@ -254,6 +256,30 @@ describe("reading the campaign for every registered wallet", () => {
     expect(row.observedAt).toBe(OBSERVED_AT);
   });
 
+  it("keeps a registered account missing its local key beside a readable sibling", async () => {
+    const missing = { ...WALLET_ROW, accountIndex: 123, walletAddress: "0x1111111111111111111111111111111111111111" };
+    const { deps: mixed, signals } = deps({
+      wallets: [missing, WALLET_ROW],
+      auth: async (_environment, accountIndex) => accountIndex === missing.accountIndex
+        ? { kind: "unavailable", reason: "no_credential", detail: "No local credential." }
+        : { kind: "auth", auth: { token: "test-read-authorization", accountIndex } },
+    });
+    const report = await readLighterPointsForWallets({ signal: new AbortController().signal, deps: mixed });
+    expect(report.walletCount).toBe(2);
+    expect(report.rows[0]).toEqual({ ...missing, kind: "credential_missing_here", observedAt: OBSERVED_AT });
+    expect(report.rows[1]).toMatchObject({ kind: "points", accountIndex: ACCOUNT_INDEX });
+    expect(signals).toHaveLength(4);
+  });
+
+  it("does not invent a registered key for an account still awaiting registration", async () => {
+    const wallet = { ...WALLET_ROW, apiKeyIndex: null, tradingKeyRegistered: false };
+    const { deps: missing } = deps({ wallets: [wallet], auth: async () => ({
+      kind: "unavailable", reason: "no_credential", detail: "No local credential.",
+    }) });
+    const report = await readLighterPointsForWallets({ signal: new AbortController().signal, deps: missing });
+    expect(report.rows).toEqual([{ ...wallet, kind: "credential_missing_here", observedAt: OBSERVED_AT }]);
+  });
+
   it("lists a wallet whose vault is locked, with the reason, instead of dropping it", async () => {
     const { deps: locked } = deps({
       auth: async () => ({
@@ -373,6 +399,8 @@ describe("reading the campaign for every registered wallet", () => {
       walletAddress: "0x1111111111111111111111111111111111111111",
       environment: "core",
       accountIndex: 7,
+      apiKeyIndex: null,
+      tradingKeyRegistered: false,
     };
     const { deps: two } = deps({ script, wallets: [WALLET_ROW, second] });
     const report = await readLighterPointsForWallets({
@@ -427,6 +455,17 @@ describe("reading the campaign for every registered wallet", () => {
       }),
     ).rejects.toMatchObject({ name: "AbortError" });
     expect(listWallets).not.toHaveBeenCalled();
+  });
+
+  it("keeps cancellation during local authorization from publishing a missing row", async () => {
+    const controller = new AbortController();
+    const { deps: cancelling, signals } = deps({ auth: async () => {
+      controller.abort();
+      return { kind: "unavailable", reason: "no_credential", detail: "No local credential." };
+    } });
+    await expect(readLighterPointsForWallets({ signal: controller.signal, deps: cancelling }))
+      .rejects.toMatchObject({ name: "AbortError" });
+    expect(signals).toHaveLength(0);
   });
 
   it("hands every provider read a signal that carries both the caller and the deadline", async () => {

--- a/src/tools/lighter/Lighter.md
+++ b/src/tools/lighter/Lighter.md
@@ -226,6 +226,20 @@ The privileged execution sequence is intentionally ordered:
    the database lifecycle ready and promote the vault marker to
    `key_registered_active`.
 
+Two Vex installations can share Postgres while keeping separate encrypted vaults,
+for example WSL development and the Windows app. The onboarding workflow records
+account and key registration, including `ready_to_trade`, but does not transfer
+credentials between those vaults. Settings lists every database workflow with a
+resolved account, joined to the current vault by environment and account: no
+resolved account shows the existing setup message; an absent local credential
+shows `credential_missing_here` with the recorded account and API-key index;
+a locally available credential reads points normally. Locked vaults and failed
+reads keep their own unavailable reasons, and a missing key never hides sibling
+wallets. Onboarding status explains an already recorded key missing here as
+registration from another installation or an earlier vault. Lighter supports
+multiple indexed keys: registration into another proven unused slot leaves the
+existing slot valid, subject to the normal registration approval and preflight.
+
 Pending keys use `key_generated_pending_registration` and are excluded from
 trading credential listing and order-signing reads.
 

--- a/src/vex-agent/db/repos/lighter-onboarding-workflows.ts
+++ b/src/vex-agent/db/repos/lighter-onboarding-workflows.ts
@@ -113,6 +113,18 @@ export interface LighterOnboardingResolvedAccount {
   readonly environment: LighterEnvironment;
   readonly walletAddress: string;
   readonly accountIndex: number;
+  readonly apiKeyIndex: number | null;
+  readonly tradingKeyRegistered: boolean;
+}
+
+/** Generated key metadata alone does not prove that registration completed. */
+export function hasRecordedLighterTradingKeyRegistration(
+  workflow: Pick<LighterOnboardingWorkflowRow,
+    "apiKeyIndex" | "publicKeyFingerprint" | "workflowState" | "lastStableState">,
+): boolean {
+  return workflow.apiKeyIndex !== null && Boolean(workflow.publicKeyFingerprint)
+    && [workflow.workflowState, workflow.lastStableState].some((state) =>
+      state === "key_verified" || state === "nonce_synchronized" || state === "ready_to_trade");
 }
 
 /** Default page for the resolved-account listing; also its documented bound. */
@@ -141,11 +153,19 @@ export async function listLighterOnboardingResolvedAccounts(
     readonly environment: LighterEnvironment;
     readonly wallet_address: string;
     readonly resolved_account_index: string | number;
+    readonly api_key_index: number | null;
+    readonly public_key_fingerprint: string | null;
+    readonly workflow_state: LighterOnboardingWorkflowState;
+    readonly last_stable_state: LighterOnboardingWorkflowState | null;
     readonly total_count: string | number;
   }>(
     `SELECT environment,
             wallet_address,
             resolved_account_index,
+            api_key_index,
+            public_key_fingerprint,
+            workflow_state,
+            last_stable_state,
             COUNT(*) OVER () AS total_count
        FROM lighter_onboarding_workflows
       WHERE resolved_account_index IS NOT NULL
@@ -159,6 +179,13 @@ export async function listLighterOnboardingResolvedAccounts(
       environment: row.environment,
       walletAddress: row.wallet_address,
       accountIndex: readSafeInteger(row.resolved_account_index, "resolved_account_index", 0),
+      apiKeyIndex: readNullableSafeInteger(row.api_key_index, "api_key_index", 4, 254),
+      tradingKeyRegistered: hasRecordedLighterTradingKeyRegistration({
+        apiKeyIndex: row.api_key_index,
+        publicKeyFingerprint: row.public_key_fingerprint,
+        workflowState: row.workflow_state,
+        lastStableState: row.last_stable_state,
+      }),
     })),
     totalCount: first === undefined
       ? 0

--- a/src/vex-agent/tools/protocols/lighter/handlers/read.ts
+++ b/src/vex-agent/tools/protocols/lighter/handlers/read.ts
@@ -37,6 +37,11 @@ import {
 } from "@tools/lighter/wallet-funding/onboarding-status.js";
 import { getLighterFundingDeployment } from "@tools/lighter/wallet-funding/deployments.js";
 import * as lighterOrderPreviewsRepo from "@vex-agent/db/repos/lighter-order-previews.js";
+import {
+  getLighterOnboardingWorkflow,
+  hasRecordedLighterTradingKeyRegistration,
+  type LighterOnboardingWorkflowRow,
+} from "@vex-agent/db/repos/lighter-onboarding-workflows.js";
 import { describeFailureForAgent, describeFailureForLog } from "../../runtime/errors.js";
 import {
   defaultLighterOrderRepairDeps,
@@ -530,11 +535,14 @@ export async function resolvePreviewApiKeyIndex(
 
 function managedReadinessRecoveryLeg(
   readiness: LighterManagedTradingReadiness,
+  workflow: LighterOnboardingWorkflowRow | null,
 ): { readonly kind: string; readonly reason: string } {
   if (readiness.reason === "active_managed_credential_missing") {
     return {
       kind: "register_trading_key",
-      reason: "Create and register locally encrypted Vex trading access before any order can be signed.",
+      reason: workflow !== null && hasRecordedLighterTradingKeyRegistration(workflow)
+        ? "This account has a registered trading key from another Vex installation (or an earlier vault), but this machine holds no credential for it. Registering a new trading key here uses another unused key slot without invalidating the existing key."
+        : "Create and register locally encrypted Vex trading access before any order can be signed.",
     };
   }
   if (
@@ -663,16 +671,23 @@ export const LIGHTER_READ_HANDLERS: Record<string, ProtocolHandler> = {
         : await readLighterManagedTradingReadiness(environment.value, status.accountIndex);
       const managedTradingAccessActive = status.tradingKeyRegistered
         && managedTradingReadiness?.ready === true;
+      const workflow = managedTradingReadiness?.reason === "active_managed_credential_missing"
+        ? await getLighterOnboardingWorkflow(environment.value, walletAddress)
+        : null;
       const readinessRecoveryLeg = managedTradingReadiness?.ready === false
-        ? managedReadinessRecoveryLeg(managedTradingReadiness)
+        ? managedReadinessRecoveryLeg(
+            managedTradingReadiness,
+            workflow?.resolvedAccountIndex === status.accountIndex ? workflow : null,
+          )
         : null;
       const plan = !managedTradingAccessActive
-        && !status.plan.legs.some((leg) => leg.kind === "register_trading_key")
+        && (managedTradingReadiness?.reason === "active_managed_credential_missing"
+          || !status.plan.legs.some((leg) => leg.kind === "register_trading_key"))
         ? {
             ...status.plan,
             ready: false,
             legs: [
-              ...status.plan.legs,
+              ...status.plan.legs.filter((leg) => leg.kind !== "register_trading_key"),
               readinessRecoveryLeg ?? {
                 kind: "register_trading_key",
                 reason: "Create and register locally encrypted Vex trading access before any order can be signed.",
@@ -774,7 +789,7 @@ export const LIGHTER_READ_HANDLERS: Record<string, ProtocolHandler> = {
             : fundingAssessment.decision === "below_lighter_deposit_minimum"
               ? `Do not prepare a deposit and do not round the top-up upward. The current Lighter collateral is not enough for the requested trade, but the exact required top-up ${fundingAssessment.collateralShortfallDisplay} is below Lighter's live minimum deposit ${fundingAssessment.minimumDepositDisplay}. Show the user these live values in a compact table: requested collateral ${fundingAssessment.requiredCollateralDisplay}; current Lighter collateral ${fundingAssessment.lighterCollateralDisplay}; Vex wallet ${settlementAsset} ${fundingAssessment.walletSettlementDisplay}; combined ${settlementAsset} ${fundingAssessment.combinedSettlementDisplay}; required top-up ${fundingAssessment.collateralShortfallDisplay}; Lighter minimum deposit ${fundingAssessment.minimumDepositDisplay}. Explain that Vex will not move extra funds beyond the requested top-up; the user must choose a trade or funding amount whose required deposit meets the live minimum.`
             : tradingAccessRoute.kind === "prepare_key_registration_approval"
-              ? `Funding and wallet-owned account creation are proven on ${fundingDeployment.settlementNetworkName}, but secure Vex trading access is not active yet. Immediately call lighter.key.register.prepare in this same turn with environment "${environment.value}" so Vex generates and encrypts the credential locally and the host shows a separate key-registration approval card. Do not ask whether to prepare it and do not ask for another chat confirmation; the approval card is the user's consent. Never call lighter.key.register directly and never ask the user for a key, account index, API-key index, nonce, or fingerprint.`
+              ? `Funding and wallet-owned account creation are proven on ${fundingDeployment.settlementNetworkName}, but secure Vex trading access is not active yet. ${readinessRecoveryLeg?.reason ?? ""} Immediately call lighter.key.register.prepare in this same turn with environment "${environment.value}" so Vex generates and encrypts the credential locally and the host shows a separate key-registration approval card. Do not ask whether to prepare it and do not ask for another chat confirmation; the approval card is the user's consent. Never call lighter.key.register directly and never ask the user for a key, account index, API-key index, nonce, or fingerprint.`
             : feeAuthorizationReadiness?.status === "needs_approval"
               ? `The account is funded and its local trading key is active. Immediately call lighter.fees.approve.prepare with environment "${environment.value}" to show the VEX trading-fee approval in this chat. VEX supplies the recipient, 0.10% perpetual fee, 0.25% spot fee and any disclosed account-tier change. The host card is consent; do not ask for another chat confirmation or technical account details. Continue the requested trade only after provider state confirms the authorization. If the user rejects it, stop fee setup until they request it again.`
             : feeAuthorizationReadiness?.status === "blocked"

--- a/src/vex-agent/tools/protocols/lighter/points.ts
+++ b/src/vex-agent/tools/protocols/lighter/points.ts
@@ -77,9 +77,15 @@ export interface LighterPointsWallet {
   readonly walletAddress: string;
   readonly environment: LighterEnvironment;
   readonly accountIndex: number;
+  readonly apiKeyIndex: number | null;
+  readonly tradingKeyRegistered: boolean;
 }
 
 export type LighterPointsRow =
+  | (LighterPointsWallet & {
+      readonly kind: "credential_missing_here";
+      readonly observedAt: string;
+    })
   | {
       readonly kind: "points";
       readonly walletAddress: string;
@@ -96,7 +102,7 @@ export type LighterPointsRow =
       readonly walletAddress: string;
       readonly environment: LighterEnvironment;
       readonly accountIndex: number;
-      readonly reason: LighterReadOnlyAccountAuthUnavailableReason;
+      readonly reason: Exclude<LighterReadOnlyAccountAuthUnavailableReason, "no_credential">;
       readonly detail: string;
       readonly observedAt: string;
     };
@@ -148,6 +154,8 @@ function defaultLighterPointsDeps(): LighterPointsDeps {
           walletAddress: row.walletAddress,
           environment: row.environment,
           accountIndex: row.accountIndex,
+          apiKeyIndex: row.apiKeyIndex,
+          tradingKeyRegistered: row.tradingKeyRegistered,
         })),
         totalCount: listed.totalCount,
       };
@@ -318,12 +326,28 @@ export async function readLighterPointsForWallets(
   request.signal.throwIfAborted();
 
   const listed = await deps.listWallets(maxWallets);
+  request.signal.throwIfAborted();
   const rows: LighterPointsRow[] = [];
   for (const wallet of listed.rows) {
     request.signal.throwIfAborted();
     const observedAt = deps.now().toISOString();
     const outcome = await deps.resolveAuth(wallet.environment, wallet.accountIndex);
+    request.signal.throwIfAborted();
     if (outcome.kind === "unavailable") {
+      // The privileged resolver checks vault lock before looking up this exact
+      // environment/account scope. Only an unlocked, absent scope means missing here.
+      if (outcome.reason === "no_credential") {
+        rows.push({
+          kind: "credential_missing_here",
+          walletAddress: wallet.walletAddress,
+          environment: wallet.environment,
+          accountIndex: wallet.accountIndex,
+          apiKeyIndex: wallet.apiKeyIndex,
+          tradingKeyRegistered: wallet.tradingKeyRegistered,
+          observedAt,
+        });
+        continue;
+      }
       rows.push({
         kind: "unavailable",
         walletAddress: wallet.walletAddress,

--- a/vex-app/src/main/ipc/__tests__/settings-lighter-points.test.ts
+++ b/vex-app/src/main/ipc/__tests__/settings-lighter-points.test.ts
@@ -14,7 +14,7 @@
  *    `internal.cancelled`, not as a failure.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { defaultPreferences, type Preferences } from "@shared/schemas/preferences.js";
 import type { LighterPointsResult } from "@shared/schemas/lighter-points.js";
@@ -75,6 +75,8 @@ vi.mock("@vex-agent/tools/protocols/lighter/points.js", () => ({
 }));
 
 const { registerSettingsHandlers } = await import("../settings.js");
+const { registerCancelHandler } = await import("../cancel.js");
+const disposers: Array<() => void> = [];
 const { CH } = await import("@shared/ipc/channels.js");
 
 const HEALTHY = "0x33eF6673BD80cB11fcC41b82Bc2181E65cC4d2fA";
@@ -144,7 +146,11 @@ beforeEach(() => {
   mocks.ensureEngineDbUrl.mockResolvedValue({ ok: true, data: undefined });
   mocks.getPrimaryEvmAddress.mockReturnValue(HEALTHY);
   mocks.readLighterPointsForWallets.mockResolvedValue(report());
-  registerSettingsHandlers();
+  disposers.push(...registerSettingsHandlers(), registerCancelHandler());
+});
+
+afterEach(() => {
+  for (const dispose of disposers.splice(0)) dispose();
 });
 
 describe("vex:settings:lighterPoints", () => {
@@ -153,6 +159,57 @@ describe("vex:settings:lighterPoints", () => {
 
     expect(result.ok).toBe(true);
     expect(result.data).toEqual(report());
+  });
+
+  it("returns a registered wallet missing here beside healthy points", async () => {
+    const expected = report();
+    const rows = [...expected.rows, {
+      kind: "credential_missing_here", walletAddress: "0x1111111111111111111111111111111111111111",
+      environment: "rhc", accountIndex: 123, apiKeyIndex: 4,
+      tradingKeyRegistered: true, observedAt: OBSERVED_AT,
+    }];
+    mocks.readLighterPointsForWallets.mockResolvedValue({ ...expected, rows, walletCount: 3 });
+    expect(await call({})).toMatchObject({ ok: true, data: { rows, walletCount: 3 } });
+  });
+
+  it.each([
+    { apiKeyIndex: -1 }, { apiKeyIndex: 255 }, { apiKeyIndex: null },
+    { apiKeyIndex: 4.5 }, { unexpected: "field" }, { tradingKeyRegistered: "yes" },
+  ])("rejects invalid missing-credential metadata %j", async (invalid) => {
+    mocks.readLighterPointsForWallets.mockResolvedValue({
+      rows: [{ kind: "credential_missing_here", walletAddress: REFUSED, environment: "rhc",
+        accountIndex: 123, apiKeyIndex: 4, tradingKeyRegistered: true,
+        observedAt: OBSERVED_AT, ...invalid }], walletCount: 1, observedAt: OBSERVED_AT,
+    });
+    expect(await call({})).toMatchObject({ ok: false, error: { code: "internal.contract_violation" } });
+  });
+
+  it("refuses a trusted-origin subframe before reading wallets", async () => {
+    const frame = sender.senderFrame;
+    const result = await call({}, { ...sender,
+      senderFrame: { url: frame.url, parent: frame, top: frame } });
+    expect(result).toMatchObject({ ok: false, error: { code: "validation.invalid_sender" } });
+    expect(mocks.readLighterPointsForWallets).not.toHaveBeenCalled();
+  });
+
+  it("cancels an in-flight read through the registered cancellation channel", async () => {
+    const started = Promise.withResolvers<AbortSignal>();
+    mocks.readLighterPointsForWallets.mockImplementation(({ signal }: { signal: AbortSignal }) => {
+      started.resolve(signal);
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    });
+    const reading = call({});
+    const signal = await started.promise;
+    const cancel = handlers.get(CH.cancel);
+    if (cancel === undefined) throw new Error("Cancel handler not registered.");
+    expect(await cancel(sender, {
+      requestId: "00000000-0000-4000-8000-000000000902",
+      payload: { correlationId: "00000000-0000-4000-8000-000000000901" },
+    })).toMatchObject({ ok: true, data: { cancelled: true } });
+    expect(signal.aborted).toBe(true);
+    expect(await reading).toMatchObject({ ok: false, error: { code: "internal.cancelled" } });
   });
 
   it("refuses an untrusted sender before doing any provider work", async () => {

--- a/vex-app/src/main/ipc/settings.ts
+++ b/vex-app/src/main/ipc/settings.ts
@@ -218,6 +218,7 @@ export function registerSettingsHandlers(): Array<() => void> {
         const dbUrlOutcome = await ensureEngineDbUrl(ctx.requestId);
         if (!dbUrlOutcome.ok) return dbUrlOutcome;
         try {
+          ctx.signal.throwIfAborted();
           const { readLighterPointsForWallets } = await import(
             "@vex-agent/tools/protocols/lighter/points.js"
           );

--- a/vex-app/src/preload/__tests__/lighter-points.test.ts
+++ b/vex-app/src/preload/__tests__/lighter-points.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LighterPointsResult } from "../../shared/schemas/lighter-points.js";
+
+const invoke = vi.hoisted(() => vi.fn());
+vi.mock("electron", () => ({ ipcRenderer: { invoke } }));
+const { settings } = await import("../shell/settings.js");
+const { CH } = await import("../../shared/ipc/channels.js");
+
+const report: LighterPointsResult = {
+  rows: [{ kind: "credential_missing_here", environment: "rhc",
+    walletAddress: "0x1111111111111111111111111111111111111111",
+    accountIndex: 123, apiKeyIndex: 4, tradingKeyRegistered: true,
+    observedAt: "2026-09-09T00:00:00.000Z" }],
+  walletCount: 1, observedAt: "2026-09-09T00:00:00.000Z",
+};
+beforeEach(() => { invoke.mockReset(); invoke.mockResolvedValue({ ok: true, data: report }); });
+
+describe("Lighter points preload contract", () => {
+  it("preserves local-credential state through the typed, payload-free method", async () => {
+    expect(await settings.lighterPoints().promise).toEqual({ ok: true, data: report });
+    expect(invoke).toHaveBeenCalledWith(CH.settings.lighterPoints, {
+      requestId: expect.any(String), payload: {},
+    });
+  });
+
+  it("sends cancellation once for this points request", () => {
+    const reading = settings.lighterPoints();
+    const envelope = invoke.mock.calls[0]?.[1];
+    reading.cancel();
+    reading.cancel();
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenLastCalledWith(CH.cancel, {
+      requestId: expect.any(String), payload: { correlationId: envelope.requestId },
+    });
+  });
+});

--- a/vex-app/src/renderer/features/appShell/screens/SettingsScreen/LighterPointsSection.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/SettingsScreen/LighterPointsSection.tsx
@@ -27,7 +27,6 @@ const ENVIRONMENT_LABEL: Readonly<Record<"core" | "rhc", string>> = {
 };
 
 const AUTH_REASON_COPY: Readonly<Record<string, string>> = {
-  no_credential: "No Lighter trading credential is saved for this account on this machine.",
   vault_locked: "Vex is locked, so the saved credential could not be read.",
   signer_failed: "Vex could not derive a read-only authorization from the saved credential.",
   unknown: "Vex could not derive a read-only authorization and was not told why.",
@@ -153,7 +152,20 @@ function WalletCard({ row }: { readonly row: LighterPointsRow }): JSX.Element {
           {ENVIRONMENT_LABEL[row.environment]} - account {row.accountIndex}
         </span>
       </div>
-      {row.kind === "unavailable" ? (
+      {row.kind === "credential_missing_here" ? (
+        <div className="mt-3 text-[13px] leading-[20px] text-warning">
+          <p>
+            {row.tradingKeyRegistered
+              ? "The trading key was registered from another Vex installation (or an earlier vault). Points need a trading key on this machine."
+              : "This wallet has a Lighter account. Points need a trading key on this machine."}
+          </p>
+          <p className="mt-2">
+            {row.tradingKeyRegistered
+              ? "Register a trading key on this machine in the Lighter panel; the key registered elsewhere stays valid"
+              : "Register a trading key on this machine in the Lighter panel."}
+          </p>
+        </div>
+      ) : row.kind === "unavailable" ? (
         <p
           className="mt-3 text-[13px] leading-[20px] text-warning"
           data-vex-lighter-points-unavailable={row.reason}

--- a/vex-app/src/renderer/features/appShell/screens/__tests__/LighterPointsSection.test.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/__tests__/LighterPointsSection.test.tsx
@@ -170,6 +170,32 @@ describe("LighterPointsSection", () => {
     expect(screen.getByText(/Vex is locked, so the saved credential/)).not.toBeNull();
   });
 
+  it("shows an account registered elsewhere with its local-key remedy beside healthy points", async () => {
+    render(<LighterPointsSection />);
+    await settle(0, result([
+      { kind: "credential_missing_here", walletAddress: OTHER, environment: "rhc",
+        accountIndex: 123, apiKeyIndex: 4, tradingKeyRegistered: true, observedAt: OBSERVED_AT },
+      healthyRow(),
+    ]));
+    const card = screen.getByText(OTHER).closest("li");
+    expect(card?.textContent).toContain("account 123");
+    expect(card?.textContent).toContain("The trading key was registered from another Vex installation (or an earlier vault). Points need a trading key on this machine.");
+    expect(card?.textContent).toContain("Register a trading key on this machine in the Lighter panel; the key registered elsewhere stays valid");
+    expect(screen.queryByText(/No wallet has a Lighter account registered/)).toBeNull();
+    expect(screen.getByText(/rank 22,146/)).not.toBeNull();
+  });
+
+  it("does not claim registration elsewhere when the account has no recorded key", async () => {
+    render(<LighterPointsSection />);
+    await settle(0, result([{ kind: "credential_missing_here", walletAddress: OTHER,
+      environment: "rhc", accountIndex: 123, apiKeyIndex: null,
+      tradingKeyRegistered: false, observedAt: OBSERVED_AT }]));
+    expect(screen.getByText(/account 123/)).not.toBeNull();
+    expect(screen.getByText(/Points need a trading key on this machine/)).not.toBeNull();
+    expect(screen.queryByText(/was registered from another Vex installation/)).toBeNull();
+    expect(screen.queryByText(/No wallet has a Lighter account registered/)).toBeNull();
+  });
+
   it("points a user with no registered wallet at the Lighter setup", async () => {
     render(<LighterPointsSection />);
     await settle(0, result([]));

--- a/vex-app/src/shared/schemas/lighter-points.ts
+++ b/vex-app/src/shared/schemas/lighter-points.ts
@@ -19,7 +19,6 @@ const lighterPointsWalletAddressSchema = z
 
 /** Why the read-only authorization for one wallet could not be minted. */
 const lighterPointsAuthUnavailableReasonSchema = z.enum([
-  "no_credential",
   "vault_locked",
   "signer_failed",
   "unknown",
@@ -78,6 +77,17 @@ const lighterPointsReferralSchema = z.discriminatedUnion("kind", [
 ]);
 
 const lighterPointsRowSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("credential_missing_here"),
+    walletAddress: lighterPointsWalletAddressSchema,
+    environment: lighterIntegrationEnvironmentSchema,
+    accountIndex: z.number().int().nonnegative(),
+    apiKeyIndex: z.number().int().min(4).max(254).nullable(),
+    tradingKeyRegistered: z.boolean(),
+    observedAt: z.string().datetime(),
+  }).strict().refine((row) => !row.tradingKeyRegistered || row.apiKeyIndex !== null, {
+    message: "A recorded trading key requires its API-key index.",
+  }),
   z
     .object({
       kind: z.literal("points"),


### PR DESCRIPTION
When a database row says a Lighter account is registered but this machine's unlocked vault holds no credential for it (a vault restored or reset, or two Vex installations pointed at one database), the points read used to drop the wallet and Settings claimed that no wallet was registered at all. Rule 90 forbids collapsing unavailable into empty.

- Points read model: every wallet with a resolved account is listed; a wallet without a local credential becomes a strict `credential_missing_here` row carrying the recorded account and api key index (no secrets).
- Settings > Lighter Points: three states (no account; account registered but no credential here, with the remedy that registering a key here adds a slot without invalidating the existing key; credential present).
- `lighter.account.onboarding.status`: the `register_trading_key` recovery leg names the same fact.
- Docs: the separate-vault paragraph in `src/tools/lighter/Lighter.md`.

Verified: root 1,017 tests, app 1,196 tests, lint, em-dash and unsafe-escape checks. Known limitation, left as is: with one database shared by two installations the registration workflow still refuses to prepare a second key from `ready_to_trade`; the owner's real setup uses one database per installation, where a second key registers normally (measured 2026-09-09: account 24226 holds key slots 4 and 5).
