### PR TITLE
fix(studio): pty host bound to main, orphan reaper, named folder holders and a rail cleanup notice

### DIFF
--- a/vex-app/docs/PTY_SHUTDOWN_AUDIT.md
+++ b/vex-app/docs/PTY_SHUTDOWN_AUDIT.md
@@ -69,3 +69,150 @@ Linux exercises a real POSIX pty only. Windows CI must prove that native exit
 plus PID disappearance precedes successful directory removal for these
 ConPTY workloads, including its asynchronous descendant cleanup. The logs and
 Linux tests alone cannot prove which Windows handle held the directory.
+
+## Hard main-process death and project cleanup (2026-09-09)
+
+The owner's Windows measurements identified two orphaned utility processes,
+one from September 4 and one from September 8. Their main processes had died;
+a surviving cmd.exe held the deleted project's directory as its cwd. Every
+file could be opened exclusively, but the directory could not be renamed.
+Killing the orphan trees released it. Neither folder size, path length nor
+Recycle Bin configuration explained this incident.
+
+The orderly main-side `PtyHostStarter.dispose` ladder remains primary.
+`pty-host/parent-lifetime.ts` adds a child-side existence check at the existing
+5,000 ms heartbeat cadence. Main passes its PID and the exact
+`--vex-pty-host` marker in both fork arguments and `execArgv`. Electron 42 sends
+regular arguments over Mojo; `execArgv` also reaches the OS command line.
+Only the utility host receives this marker. No shell environment carries it.
+
+On parent loss the host closes admission, disposes every owned terminal and
+exits. This path deliberately skips snapshot capture so disk work cannot delay
+termination. The normal shutdown still captures snapshots first. Windows
+terminal termination runs System32/taskkill.exe with `/PID <shell> /T /F`
+through `platform/process-lifetime.ts`, then releases the node-pty adapter.
+The synchronous platform seam ensures disposal cannot abandon an in-flight
+taskkill command. Taskkill has a 3,000 ms deadline per tree. Other platforms
+retain node-pty termination. A native exit suppresses a later tree kill against
+a possibly reused PID, while retaining adapter cleanup.
+
+At app startup, before runtime initialization and project repair, the Windows
+reaper selects only the same executable path, the exact host marker, matching
+recorded parent PID, a known creation time and a parent absent from both the
+process snapshot and the existence probe. It re-enumerates and checks creation
+time before killing each host tree. It logs reaped PIDs, count and ages.
+It never selects an unmarked process or a foreign Electron installation.
+
+### Runtime evidence and reference decisions
+
+Read the prescribed VS Code utilityProcess.ts `createEnv`, bootstrap-fork.ts
+parent watcher, ipc.cp.ts fork environment, processes.ts `killTree`,
+ptyHostMain.ts service composition, ptyService.ts terminal ownership and
+shutdown, and terminal/test/node/ptyHostService.test.ts listener-lifetime test.
+Adopted parent identity, periodic existence checks, explicit process-tree
+termination and one terminal registry owner. Rejected exiting before killing
+owned terminals, interpreting every probe error as death, and using node-pty's
+Windows root kill as sufficient evidence that descendants died. EPERM is not
+proof of a dead parent; only ESRCH is.
+
+[Node's process documentation](https://nodejs.org/api/process.html#signal-events)
+explicitly describes signal 0 as a platform-independent existence check,
+including Windows. It sends no terminating signal. Windows process-group
+signalling is unsupported, which is why taskkill owns tree termination.
+
+Read the installed electron@42.0.0 ParentPort typings and the
+[ParentPort documentation](https://www.electronjs.org/docs/latest/api/parent-port).
+Only `message` is documented. Also inspected Electron v42.0.0
+[shell/browser/api/electron_api_utility_process.cc](https://github.com/electron/electron/blob/v42.0.0/shell/browser/api/electron_api_utility_process.cc),
+[shell/services/node/node_service.cc](https://github.com/electron/electron/blob/v42.0.0/shell/services/node/node_service.cc),
+[shell/services/node/parent_port.cc](https://github.com/electron/electron/blob/v42.0.0/shell/services/node/parent_port.cc),
+[shell/common/node_bindings.cc](https://github.com/electron/electron/blob/v42.0.0/shell/common/node_bindings.cc)
+and [lib/utility/init.ts](https://github.com/electron/electron/blob/v42.0.0/lib/utility/init.ts).
+The native disconnect closes the port without emitting a JavaScript close or
+disconnect event. The JS initializer starts the native port when the first
+message listener is added. Removed the redundant manual optional start call.
+The installed Electron runtime was probed on Linux: both argv arrays and the
+OS command line contained the marker and parent PID when `execArgv` was supplied.
+The installed node-pty Windows conout reader creates a worker thread, not a
+child process. A second installed-Electron probe confirmed that a worker can
+start with these inherited exec arguments and remains in the host process.
+
+### Trash diagnosis, authority and compensation
+
+An aborted local Windows trash operation now tries a sibling rename and
+restores the original name. A sharing violation reports `busy`; a successful
+round trip reports `aborted`. A restore failure records `restore_failed` with
+both complete paths. Subsequent retries detect the recovery directory before
+interpreting a missing original as success. Recovery requires restoring that
+folder manually; the application never silently chooses a new project path.
+
+A busy failure asks the live host about its terminal cwds, and inspects only
+descendants of positively identified orphan hosts. Windows orphan cwd lookup
+reads a 64-bit PEB through a read-only process handle and closes that handle on
+every path. Unsupported WOW64 processes and unreadable cwds remain unknown.
+[Microsoft documents PEB as an internal, changeable structure](https://learn.microsoft.com/en-us/windows/win32/api/winternl/ns-winternl-peb);
+this diagnostic requires Windows verification and fails closed if the memory
+read cannot be completed. The resolver has a 15-second total deadline.
+
+The holder DTO identifies a live Vex terminal, a previous-session Vex terminal,
+or an external holder. Unknown external PIDs are not invented. A project's
+name and ID accompany a live terminal when known. Complete folder and recovery
+paths are display diagnostics only. Native errors and command lines are not
+returned to the renderer. Legacy reason-only tombstones remain readable;
+structured failures are stored in the existing text column. No migration is
+needed. An older build cannot display the richer cause, but retains and retries
+the obligation.
+
+| Authority | Source | Revalidation and effect |
+| --- | --- | --- |
+| Deleted project and original trash intent | Tombstone transaction | A retry cannot change the recorded folder choice |
+| Cleanup directory | Configured root and stored slug | Resolve and confine to a direct root child |
+| Live terminal ownership | Host registry and current known cwd | Host performs the folder query and termination |
+| Orphan ownership | Own binary, marker, dead parent, creation time | Re-enumerate host and shell, check ancestry and cwd before taskkill |
+| User close intent | Strict existing delete input, `closeHolders` | Renderer supplies no PID, path or process-kind authority |
+| Cancellation | Existing request ID and cancellation gate | Stop before holder termination; already-issued termination cannot be undone |
+| Completion and attempts | Existing cleanup owner | One retry, fifth failure remains pending, success marks the same tombstone done |
+
+Both host requests and replies use strict shared schemas. The existing delete
+channel, main sender/subframe gate and safe Result contract remain the sole
+renderer operation. `projects.deleteAbortable` exposes its cancellation through
+preload, and the renderer adapter cancels on request or unmount. Pending reads
+refresh holder observations so saved PIDs cannot authorize a kill or silently
+masquerade as a fresh process observation.
+
+### Rail presentation
+
+Read deepseek-harness ConnectionBanner, Pill, DisclosureRow and HoverCard,
+including each module stylesheet. Adopted the compact disclosure header,
+semantic state dot, quiet secondary copy and keyboard disclosure. Used Vex's
+DisclosureRow, StateDot, Button and surface tokens. Rejected a center-column
+banner and a hover-only remediation action: neither fits a durable,
+keyboard-accessible cleanup obligation. Long summary names remain reachable
+through horizontal scrolling, and detail paths wrap without cutting text.
+
+The notice is mounted below the Projects list in StudioSidebar, including the
+empty-project state. The center no longer mounts it. In the collapsed rail the
+named status button expands the rail. Details include cause, folder, known
+holder, attempt count and Retry or Close it and retry. The section retains its
+accessible name and each pending project is a status region.
+
+### Compatibility limits and verification contract
+
+Already-running hosts from builds before this marker cannot be identified
+under the required selection rule. They require the coordinator's measured,
+PID-specific one-time cleanup. Process name alone is never a fallback.
+The startup reaper is Windows-only. POSIX hosts receive the parent watchdog;
+a portable startup reaper needs a separate identity/ancestry adapter because
+POSIX reparents orphans instead of retaining Windows' historical parent PID.
+
+A healthy marked orphan present before startup is automatically reaped and its
+cleanup can finish before any notice appears. Therefore the rail remediation
+test must introduce an orphan after startup, or exercise an orphan the startup
+reaper could not terminate. Expecting both successful automatic reaping and a
+persistent holder row for that same process is contradictory.
+
+The five-second check is the first coordinator observation, not a strict
+worst-case deadline: death immediately after a poll can consume the entire
+5,000 ms cadence before Windows tree termination starts. Native taskkill
+latency and an unresponsive utility event loop remain platform limits. The
+startup reaper covers a host whose event loop cannot run its watchdog.

--- a/vex-app/docs/STUDIO_TRASH_CI_REPORT.md
+++ b/vex-app/docs/STUDIO_TRASH_CI_REPORT.md
@@ -1,0 +1,102 @@
+# Studio trash CI follow-up
+
+Started from clean commit `55d0f5b5a` on `fix/studio-trash-windows` for PR #183.
+This follow-up addresses CI run `34347112097`. No commits, branch changes,
+stash or reset were performed.
+
+## Changes and platform reasoning
+
+| File | Change and reason |
+| --- | --- |
+| `src/main/studio/__tests__/trash-project-folder.test.ts` | Resolve the existing fixture folder before asserting Windows' detailed aborted result, and assert the trash capability receives that exact resolved path. Windows alone performs the aborted rename probe, so the existing `process.platform === "win32"` result-shape branch remains explicit. |
+| Same file, recovery case | The original folder is absent, so derive its name from `await realpath(root)`. Resolve the existing recovery directory with `await realpath(recovery)` and compare the complete result exactly. This models the resolved directory supplied by the cleanup owner without trying to resolve a nonexistent original. |
+| `src/main/studio/__tests__/close-cleanup.test.ts` | Capture the folder's realpath before successful cleanup removes it, then require exactly `[resolvedDirectory, true, undefined]` for the holder-closing call. The true flag and cancellation argument remain pinned. |
+| `src/renderer/features/appShell/studio/projects/ProjectCleanupNotices.tsx` | Add an error-visibility prop. The query stays mounted, but its error is suppressed while the projects read is pending or has failed. Successful pending-cleanup data is unaffected. |
+| `src/renderer/features/appShell/studio/sidebar/StudioSidebar.tsx` | Derive error visibility from the projects state. The existing projects Retry refetches projects and invalidates every pending-cleanup page key, which refetches the active cleanup query. |
+| `src/renderer/features/appShell/studio/projects/__tests__/ProjectCleanupNotices.test.tsx` | Pin suppression for Result failures and transport rejections. When projects recover, the same still-failed cleanup query shows its own error without remounting or fetching again. |
+| `src/renderer/features/appShell/studio/sidebar/__tests__/StudioSidebar.test.tsx` | Pin exactly one status and one Retry for shared failure, prove that retry reaches both reads, and prove that a cleanup-only failure retains its own retry without refetching projects. |
+| `docs/STUDIO_TRASH_CI_REPORT.md` | This report. |
+
+Windows CI uses a short `%TEMP%` path containing `RUNNER~1`; filesystem
+resolution returns `runneradmin`. macOS resolves `/var/folders` through
+`/private/var/folders`. Linux's ordinary `/tmp` does not expose either mismatch.
+The expectations now follow the filesystem's canonical identity on every
+platform. Lexical normalization, including `path.win32.normalize`, cannot
+replace this filesystem resolution. No production trash or holder-path code
+was changed, and no assertion was weakened or platform case skipped.
+
+The focused rail test also caught an initial ordering case: cleanup can fail
+before the projects query settles. Error visibility waits for successful
+projects loading, preventing a brief cleanup error from appearing before the
+shared projects failure surface.
+
+`e2e/studio.spec.ts` is unchanged. Its non-exact Retry locator remains intact.
+No query, IPC or cleanup schemas changed. Repository-wide searches confirmed
+that the notice is mounted only by the sidebar and its tests. No existing code
+became dead.
+
+File-growth decision: StudioSidebar was 817 lines and its test was 1461 lines.
+The production change is three net composition lines; the additional test cases
+use the existing query/rail integration harness. Retained both owners rather
+than splitting a shared fixture or extracting this small composition callback.
+
+## Pre-existing watchFile warnings
+
+The supplied macOS log at lines 2238-2253 attributes the warning to
+`StudioCenter.test.tsx`, through `StudioCenter` -> `ExplorerRegistry.switchTo`
+-> `ExplorerSession.activate` -> `watchProjectFiles`. Windows logs contain the
+same route. It is not a cleanup-notice activation path.
+
+At main's baseline `eeb1f602e` and the accepted commit `55d0f5b5a`, these files
+have identical Git blob IDs:
+
+| File | Blob |
+| --- | --- |
+| `StudioCenter.test.tsx` | `27be2c85474e6ea52512bf45b37fe0c5fc669e27` |
+| `explorer/explorer-session.ts` | `fa3b898a832f9d2cc794c6a6bce4176b94ca13ad` |
+| `src/renderer/lib/api/files.ts` | `003f13e47611d02dae48cfc06c7a9ea42fc900f2` |
+
+The fixture supplies `files.list` and `files.watch`, but the API adapter calls
+`files.watchFile`. The only StudioCenter change in the accepted commit removed
+the cleanup notice's import and mount; its explorer activation effect did not
+change.
+
+A temporary source snapshot was made with `git archive eeb1f602e`, outside this
+worktree. Its unchanged StudioCenter suite passed 28 tests locally. A separate
+temporary probe using that baseline's real ExplorerRegistry and the same
+fixture shape asserted the exact warning and TypeError:
+`window.vex.files.watchFile is not a function`. That probe passed. This proves
+the mismatch predates the rail change; the ordinary local suite need not print
+the same timing-dependent console output as CI. Explorer code and those
+pre-existing fixtures were left unchanged.
+
+## Verification
+
+From `vex-app/`:
+
+| Command | Result |
+| --- | --- |
+| `pnpm exec vitest run src/main/studio src/renderer/features/appShell/studio` | Passed: 139 files, 2791 tests; 2 files and 34 tests skipped by existing gates |
+| `pnpm exec vitest run src/main/studio/__tests__/trash-project-folder.test.ts src/main/studio/__tests__/close-cleanup.test.ts` with `TMPDIR` set to a symlink to a separate temporary directory | Passed: 2 files, 13 tests; exercises real temp-path indirection on Linux |
+| `pnpm exec vitest run src/renderer/features/appShell/studio/projects/__tests__/ProjectCleanupNotices.test.tsx src/renderer/features/appShell/studio/sidebar/__tests__/StudioSidebar.test.tsx` | Passed: 2 files, 67 tests |
+| `xvfb-run -a pnpm exec playwright test e2e/studio.spec.ts e2e/studio-cleanup.spec.ts` | Passed: both specs, 2 tests; neither spec was modified |
+| `VITE_VEX_SETUP_TOUR=1 pnpm run build:renderer` | Passed; rebuilt the renderer for the browser tests |
+
+The first focused rail run exposed the initial-query ordering case described
+above. After the error-visibility correction, the focused and full suites
+passed. No test assertions, timeouts or locators were loosened.
+
+The Windows-path classification table remains active on Linux by explicitly
+passing `win32`; it covers drive, extended drive, UNC and extended UNC paths.
+Actual Windows 8.3 expansion and macOS `/private/var` resolution were not run
+on this machine. Native CI reruns remain their confirmation; the Linux
+symlink-temp run exercises the same need to derive canonical fixture identity.
+
+`pnpm run lint` passed, including the typechecks, type ratchet and process
+boundaries. The ratchet reported 312 known errors at or below the unchanged
+baseline.
+
+From the repository root, `pnpm run check:em-dash`,
+`pnpm run test:unsafe-escapes`, and `git diff --check` all passed.
+HEAD remains `55d0f5b5a`; the worktree contains only the six implementation/test
+files listed above and this report. Ready for Windows and macOS CI reruns.

--- a/vex-app/docs/STUDIO_TRASH_REPORT.md
+++ b/vex-app/docs/STUDIO_TRASH_REPORT.md
@@ -1,0 +1,364 @@
+# Studio trash implementation report
+
+Implemented in `fix/studio-trash-windows`, based on `eeb1f602e`, without commits,
+branch changes, stash or reset. Windows verification remains required.
+
+## Behavior
+
+- Main and the pty host carry the same explicit parent identity. Parent loss
+  closes admission, kills owned terminals and exits the utility host.
+- Windows terminal closure kills the shell tree. Startup reaps positively
+  identified orphan host trees before project cleanup runs.
+- A Windows aborted trash now probes directory rename capability. Locks,
+  non-recyclable items and failed restoration have distinct outcomes.
+- Pending cleanup identifies current Vex holders and previous-session Vex
+  holders. Close it and retry revalidates ownership, terminates only owned
+  holders and retries through the existing tombstone cleanup owner. Attempt
+  accounting and the fifth-failure escalation are preserved.
+- The notice is a compact, keyboard-accessible disclosure below Projects in
+  the rail. It no longer occupies space in StudioCenter. Retry supports
+  cancellation; a collapsed rail exposes a named expand control.
+
+The lifecycle contract, authority matrix, compatibility and pattern decisions
+are recorded in [PTY_SHUTDOWN_AUDIT.md](PTY_SHUTDOWN_AUDIT.md).
+
+## Reading record
+
+Read first from `/home/kubas/Vex`:
+
+- `.claude/CLAUDE.md`.
+- Every Markdown rule: `00-priority-evidence-and-scope`,
+  `01-senior-operating-method`, `02-git-worktree-safety`,
+  `03-architecture-files-reuse-and-docs`, `04-types-api-errors-and-versioning`,
+  `05-async-lifecycle-performance-and-observability`,
+  `06-testing-verification-and-readiness`,
+  `07-security-privacy-and-dependencies`,
+  `08-frontend-state-and-accessibility`,
+  `09-ai-tools-prompts-and-approvals`, `10-live-provider-verification`,
+  `90-vex-product-delta`, all under `.claude/rules/` with `.md` extensions.
+- Root and vex-app package.json, followed by the actual worktree check and
+  build scripts. Loaded Electron architecture, IPC and testing SKILL.md files.
+
+Reference checkout reading under `/home/kubas/Vex/agents-colab`:
+
+- `vscode/src/vs/platform/utilityProcess/electron-main/utilityProcess.ts`:
+  parent-bound environment and fork; `vscode/src/bootstrap-fork.ts`: parent
+  liveness watcher; `vscode/src/vs/base/parts/ipc/node/ipc.cp.ts`: parent PID
+  propagation; `vscode/src/vs/base/node/processes.ts`: Windows tree kill.
+- `vscode/src/vs/platform/terminal/node/ptyHostMain.ts`, the ownership and
+  shutdown sections of sibling `ptyService.ts`, and
+  `vscode/src/vs/platform/terminal/test/node/ptyHostService.test.ts`.
+- `deepseek-harness/packages/client/ui-primitives/src/ConnectionBanner.tsx`,
+  `Pill.tsx`, `DisclosureRow.tsx`, `HoverCard.tsx`, and all four module CSS files.
+
+Adopted the parent poll and dedicated process owner, but rejected immediate
+exit without terminal cleanup and treating EPERM as death. Adopted explicit
+Windows tree termination instead of relying on a root PTY kill. Adopted the
+compact disclosure and semantic status vocabulary, but rejected a banner in
+the center and hover-only access to remediation. Vex's existing primitives and
+tokens remain the visual owners. Detailed reasons and primary-source links
+are in the audit.
+
+Read all requested local lifecycle, deletion, cleanup schema, StudioCenter,
+ProjectCleanupNotices and projects-rail modules and their relevant tests.
+Followed their callers through the host protocol, terminal domain, tombstone
+reader, IPC registration, preload and renderer adapter. Searched every
+`vex-app/e2e/*.spec.ts` for `pending cleanup`, cleanup and trash. No existing
+spec pinned the old notice placement; added `studio-cleanup.spec.ts` to prove
+rail placement and unchanged center, terminal and dialog geometry.
+
+Read the owner log at
+`/tmp/claude-1000/-home-kubas-Vex/0a8d6421-1c2d-45bc-a92c-66fbd16d9c64/scratchpad/owner-log-2026-09-09-trash.txt`
+and inspected the screenshot at
+`/home/kubas/.claude/image-cache/0a8d6421-1c2d-45bc-a92c-66fbd16d9c64/44.png`.
+Verified Electron 42 ParentPort typings against its docs and tagged source,
+and Node's documented Windows signal-0 semantics. The additional runtime
+probe established that `execArgv`, as well as ordinary fork arguments, is
+necessary for an OS-visible identity marker.
+
+## File growth and dead code
+
+Conscious decisions for existing files above 750 lines:
+
+| File | Before | Decision |
+| --- | ---: | --- |
+| `src/main/studio/terminals.ts` | 1277 | Retain the domain facade; the small folder query delegates to its existing starter and validates the reply |
+| `src/pty-host/host-service.ts` | 1505 | Retain the cohesive registry/control kernel; new operations require that registry, and shared port disposal has one private owner |
+| `src/pty-host/terminal-process.ts` | 1008 | Keep PID/cwd matching with the terminal; extract OS termination into the platform seam |
+| `src/renderer/features/appShell/studio/sidebar/StudioSidebar.tsx` | 814 | Composition-only mount and expand callback; the notice remains a separate component |
+| `src/shared/schemas/terminal.ts` | 1540 | Keep the protocol facade; put the new request/reply definitions in terminal-holders.ts |
+| `src/main/studio/__tests__/project-delete-e2e.int.test.ts` | 2746 | Keep the platform-specific expected failure beside its existing database/filesystem scenario; splitting would duplicate the fixture |
+
+Repository-wide reference searches preceded removal of the old center mount
+and its import, the unused public remediation-constant export, and the manual
+optional ParentPort start call. Electron starts the port when its first
+message listener is registered. The remediation table remains private because
+its copy helper still consumes it. The new privileged platform directory is
+also rejected by the renderer/shared process-boundary check.
+
+## Windows verification for the coordinator
+
+Use a disposable project and the same Electron executable as the app under
+test. Record the main, host and shell PIDs and their creation times before
+termination. Do not select processes by name alone.
+
+### A. Hard main-process death
+
+1. Start the patched app, open a disposable project's terminal, and start a
+   long-running child command in that terminal to exercise a descendant.
+2. In a separate PowerShell window, run:
+
+```powershell
+$mainProcessId = [int](Read-Host 'PID of the Vex main process under test')
+$mainProcess = Get-CimInstance Win32_Process -Filter "ProcessId = $mainProcessId"
+if ($null -eq $mainProcess) { throw 'Main process not found' }
+$electronPath = $mainProcess.ExecutablePath
+$before = @(Get-CimInstance Win32_Process | Where-Object {
+  $_.ExecutablePath -eq $electronPath -and
+  $_.CommandLine -match '(?:^|\s)--vex-pty-host(?:\s|$)' -and
+  $_.CommandLine -match "(?:^|\s)--vex-parent-pid=$mainProcessId(?:\s|$)"
+})
+if ($before.Count -ne 1) { throw 'Expected exactly one identified host for this main process' }
+$before | Select-Object ProcessId, ParentProcessId, CreationDate, CommandLine
+& "$env:SystemRoot\System32\taskkill.exe" /PID $mainProcessId /F
+Start-Sleep -Seconds 5
+$survivors = @(Get-CimInstance Win32_Process | Where-Object {
+  $_.ExecutablePath -eq $electronPath -and
+  $_.CommandLine -match '(?:^|\s)--vex-pty-host(?:\s|$)' -and
+  $_.CommandLine -match "(?:^|\s)--vex-parent-pid=$mainProcessId(?:\s|$)"
+})
+if ($survivors.Count) {
+  $survivors | Select-Object ProcessId, ParentProcessId, CreationDate, CommandLine
+  throw 'A host survived the five-second observation'
+}
+```
+
+3. Independently confirm that the recorded shell and descendant processes
+   disappeared and that the project directory can be renamed and restored.
+   Do not use `/T` when killing main: that would mask the watchdog defect.
+4. If the five-second observation fails, retain that result and measure when
+   termination completes. The poll cadence is itself five seconds, with native
+   tree-kill time additional. Do not silently convert this into a looser pass.
+
+### B. Holder-specific rail recovery and startup reaping
+
+Successful startup reaping removes a marked orphan before its cleanup row can
+persist. Test the two outcomes separately. A pre-marker leftover cannot safely
+be attributed or reaped under the required marker rule; use the already
+measured PID-specific cleanup for those old binaries.
+
+For the rail action, first start the patched app. Create a disposable project
+and keep the app running. The following isolated fixture simulates an older
+marked host without the new watchdog, using the exact app binary. It introduces
+its orphan after startup so automatic startup reaping does not consume the
+remediation scenario.
+
+```powershell
+$electronPath = Read-Host 'Exact ExecutablePath of the running Vex Electron binary'
+$env:VEX_TRASH_PROBE_DIRECTORY = Read-Host 'Full folder path of the disposable project'
+if (-not (Test-Path -LiteralPath $env:VEX_TRASH_PROBE_DIRECTORY -PathType Container)) {
+  throw 'Project folder does not exist'
+}
+$fixtureDir = Join-Path $env:TEMP ('vex-trash-verification-' + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $fixtureDir | Out-Null
+@'
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+const directory = process.argv[4];
+const shell = spawn(path.join(process.env.SystemRoot, 'System32', 'cmd.exe'), ['/d', '/k'], {
+  cwd: directory, windowsHide: true, stdio: ['pipe', 'ignore', 'ignore']
+});
+shell.once('spawn', () => process.parentPort.postMessage({ pid: shell.pid }));
+shell.once('exit', () => process.exit(0));
+shell.once('error', () => process.exit(1));
+'@ | Set-Content -LiteralPath (Join-Path $fixtureDir 'orphan-child.cjs') -Encoding UTF8
+@'
+const { app, utilityProcess } = require('electron');
+const fs = require('node:fs');
+const path = require('node:path');
+const profile = path.join(__dirname, 'profile');
+fs.mkdirSync(profile, { recursive: true });
+app.setPath('userData', profile);
+app.whenReady().then(() => {
+  const identity = ['--vex-pty-host', `--vex-parent-pid=${process.pid}`];
+  const child = utilityProcess.fork(path.join(__dirname, 'orphan-child.cjs'),
+    [...identity, process.env.VEX_TRASH_PROBE_DIRECTORY], { execArgv: identity, stdio: 'inherit' });
+  child.once('message', message => {
+    fs.writeFileSync(path.join(__dirname, 'pids.json'), JSON.stringify({
+      main: process.pid, host: child.pid, shell: message.pid
+    }));
+    app.exit(0);
+  });
+});
+'@ | Set-Content -LiteralPath (Join-Path $fixtureDir 'orphan-main.cjs') -Encoding UTF8
+$fixture = Start-Process -FilePath $electronPath -ArgumentList ('"{0}"' -f (Join-Path $fixtureDir 'orphan-main.cjs')) -PassThru
+if (-not $fixture.WaitForExit(15000)) { throw 'Fixture main did not exit' }
+Get-Content -LiteralPath (Join-Path $fixtureDir 'pids.json')
+```
+
+1. Delete the disposable project with moving its folder to trash selected.
+   Confirm it is tombstoned and the folder remains. The compact row must be
+   under Projects, with no shift in the terminal or editor.
+2. Expand the row using Enter or Space. Assert the sentence
+   `A Vex terminal from a previous session still uses this folder. Close it and retry.`,
+   the fixture shell PID and the complete folder path.
+3. Click `Close it and retry`. Assert the recorded shell tree is gone, the
+   folder is in the Recycle Bin, and the pending row disappears. Verify the
+   tombstone cleanup state is done and the original trash choice was honored.
+4. Repeat with a fresh disposable project and fixture, but restart the app
+   while cleanup is pending instead of clicking the action. Assert the startup
+   reaper logs the fixture host PID, count and age, no marked orphan tree
+   remains, and startup cleanup resolves the tombstone without needing a row.
+5. Remove the temporary fixture files after its recorded processes have exited.
+   Never use a broad electron.exe or cmd.exe kill command.
+
+## Deviations and remaining risks
+
+- Startup reaping is Windows-only; the parent watcher is cross-platform.
+  POSIX reparenting needs a separate startup identity/ancestry implementation.
+- Unmarked earlier releases cannot be safely selected. Their cleanup remains
+  the coordinator's measured one-time operation.
+- Normal startup success and a persistent row for the same orphan are mutually
+  exclusive; the procedure above exercises both outcomes separately.
+- Windows PEB cwd inspection is a read-only diagnostic over an internal native
+  structure. WOW64/unreadable processes stay unknown. A failed inspection does
+  not offer termination from stale stored PIDs.
+- Cancellation cannot undo a tree kill already issued. Before that boundary it
+  prevents termination; the tombstone remains pending if cleanup was cancelled.
+- Native Windows behavior is not proven by Linux tests. The exact Windows
+  verification above is the remaining release gate.
+- An extra full prebuild attempt copied migrations successfully, then stopped
+  because the signer build requires Go 1.27.0 and Go was absent from PATH.
+  No signer, dependency, package or baseline files were changed for this task.
+
+## Files changed
+
+- `vex-app/docs/PTY_SHUTDOWN_AUDIT.md`
+- `vex-app/docs/STUDIO_TRASH_REPORT.md`
+- `vex-app/e2e/studio-cleanup.spec.ts`
+- `vex-app/scripts/check-process-boundaries.mjs`
+- `vex-app/src/main/database/projects/pending-cleanups.ts`
+- `vex-app/src/main/index.ts`
+- `vex-app/src/main/ipc/__tests__/projects-ipc.test.ts`
+- `vex-app/src/main/ipc/projects/pending-cleanups.ts`
+- `vex-app/src/main/studio/__tests__/close-cleanup.test.ts`
+- `vex-app/src/main/studio/__tests__/pending-cleanup-holders.test.ts`
+- `vex-app/src/main/studio/__tests__/project-delete-e2e.int.test.ts`
+- `vex-app/src/main/studio/__tests__/project-trash-holders.test.ts`
+- `vex-app/src/main/studio/__tests__/pty-host-reaper.test.ts`
+- `vex-app/src/main/studio/__tests__/pty-host-starter.test.ts`
+- `vex-app/src/main/studio/__tests__/trash-failure.test.ts`
+- `vex-app/src/main/studio/__tests__/trash-project-folder.test.ts`
+- `vex-app/src/main/studio/pending-cleanup-holders.ts`
+- `vex-app/src/main/studio/project-delete-runtime.ts`
+- `vex-app/src/main/studio/project-delete.ts`
+- `vex-app/src/main/studio/project-trash-holders.ts`
+- `vex-app/src/main/studio/pty-host-reaper.ts`
+- `vex-app/src/main/studio/pty-host-starter.ts`
+- `vex-app/src/main/studio/terminals.ts`
+- `vex-app/src/main/studio/trash-failure.ts`
+- `vex-app/src/main/studio/trash-project-folder.ts`
+- `vex-app/src/main/studio/windows-processes.ts`
+- `vex-app/src/platform/process-lifetime.ts`
+- `vex-app/src/preload/__tests__/project-cleanup-bridge.test.ts`
+- `vex-app/src/preload/agent/projects.ts`
+- `vex-app/src/pty-host/__tests__/parent-lifetime.test.ts`
+- `vex-app/src/pty-host/__tests__/shutdown-settlement.test.ts`
+- `vex-app/src/pty-host/host-service.ts`
+- `vex-app/src/pty-host/index.ts`
+- `vex-app/src/pty-host/parent-lifetime.ts`
+- `vex-app/src/pty-host/terminal-process.ts`
+- `vex-app/src/renderer/features/appShell/studio/StudioCenter.tsx`
+- `vex-app/src/renderer/features/appShell/studio/projects/ProjectCleanupNotices.tsx`
+- `vex-app/src/renderer/features/appShell/studio/projects/ProjectDeleteDialog.tsx`
+- `vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectCleanupNotices.test.tsx`
+- `vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectDeleteDialog.test.tsx`
+- `vex-app/src/renderer/features/appShell/studio/sidebar/StudioSidebar.tsx`
+- `vex-app/src/renderer/features/appShell/studio/sidebar/__tests__/StudioSidebar.test.tsx`
+- `vex-app/src/renderer/lib/api/projects.ts`
+- `vex-app/src/shared/schemas/project-cleanup.test.ts`
+- `vex-app/src/shared/schemas/project-cleanup.ts`
+- `vex-app/src/shared/schemas/projects.ts`
+- `vex-app/src/shared/schemas/pty-lifetime.ts`
+- `vex-app/src/shared/schemas/terminal-holders.ts`
+- `vex-app/src/shared/schemas/terminal.ts`
+- `vex-app/src/shared/types/bridge/agent/projects.ts`
+
+## Verification results
+
+From `vex-app/`:
+
+```text
+pnpm exec vitest run src/pty-host src/main/studio src/renderer/features/appShell/studio src/shared/schemas/project-cleanup.test.ts src/main/database/projects/__tests__/pending-cleanups.test.ts src/main/ipc/__tests__/projects-ipc.test.ts src/preload/__tests__
+```
+
+Passed: 164 test files, 3,133 tests. Two files and 35 tests were skipped by
+existing suite gates. This includes the requested three directory scopes plus
+schema, persistence-reader, IPC and preload coverage. After making the
+existing trash assertion portable to Windows' richer failure shape, its focused
+suite also passed all 11 tests. The dedicated Postgres `.int.test.ts` lane was
+not run; its existing aborted-refusal expectation was updated for Windows.
+
+Two earlier expanded runs encountered unchanged filesystem-watcher timing
+assertions in `files-domain-races.test.ts`. An isolated rerun encountered a
+sibling timing assertion. Those files and assertions were not changed or
+weakened. The final complete expanded run passed them.
+
+`pnpm run lint` passed, including shared, pty-host, worker and e2e typechecks,
+the existing main/preload/renderer type ratchet and process-boundary checks.
+The ratchet reported 312 known errors at or below its baseline. No baseline
+or compiler configuration was modified.
+
+```text
+xvfb-run -a pnpm exec playwright test e2e/studio-cleanup.spec.ts
+```
+
+Passed the one Studio cleanup browser scenario against the built Electron app
+and isolated database. It verifies the rail location, keyboard disclosure,
+readable cause, Tab focus on Retry, and exact unchanged bounding boxes for the
+center, terminal and open dialog. The baseline measurement waits for the
+existing dialog entrance animation instead of weakening the geometry check.
+The final screenshot waits for the disclosure's existing reveal animation.
+A screenshot is written to the test's `cleanup-rail.png` artifact.
+
+The first browser attempt ran before the renderer bundle existed and failed
+at the shell-window prerequisite. A later attempt exposed the 8-pixel dialog
+entrance transform in the baseline measurement. After building the renderer
+and awaiting that animation, the scenario passed. The independent Docker CLI
+probe failed in its systemd wrapper, but the repository's isolated-stack fixture
+was able to start the database and run this browser test.
+
+Direct production bundles passed:
+
+```text
+pnpm run build:main
+pnpm run build:preload
+pnpm run build:pty-host
+VITE_VEX_SETUP_TOUR=1 pnpm run build:renderer
+```
+
+The renderer build used the repository's diagnostic tour required by the Studio
+E2E fixture. Existing dynamic-import/chunk-size warnings remain. The optional
+full prebuild limitation is recorded above.
+
+Two additional installed-Electron probes ran under xvfb:
+
+- Fork identity: child argv, execArgv and the Linux OS process command line
+  all contained the exact host marker and parent PID.
+- Hard-death smoke: the built production pty host created a real `/bin/sh`,
+  then its Electron main was killed with SIGKILL. An independent observer found
+  neither host nor shell running at 5,000 ms. The final observation recorded
+  host PID 103, shell PID 156 and an empty survivor list. These are Linux
+  observations, not claims about Windows ConPTY or taskkill.
+
+From the repository root:
+
+```text
+pnpm run check:em-dash
+pnpm run test:unsafe-escapes
+git diff --check
+```
+
+All passed. No commits were created and HEAD remains `eeb1f602e` on
+`fix/studio-trash-windows`. Readiness is conditional on the coordinator's
+Windows verification, particularly native tree termination and PEB cwd lookup.

--- a/vex-app/e2e/studio-cleanup.spec.ts
+++ b/vex-app/e2e/studio-cleanup.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "./fixtures/vex-app-with-database.js";
+import { enterStudio, openFirstProjectWithATerminal, TOUR_SKIP_REASON } from "./fixtures/studio-shell.js";
+import type { ProjectsBridge } from "../src/shared/types/bridge/agent/projects.js";
+
+test("pending cleanup stays in the rail and leaves terminal and dialog geometry unchanged", async ({ vexDb }, testInfo) => {
+  test.setTimeout(300000);
+  const page = vexDb.shell;
+  test.skip(!await enterStudio(page), TOUR_SKIP_REASON);
+  await openFirstProjectWithATerminal(page, "cleanup-layout-");
+  const center = page.locator('[data-vex-area="studio-center"]');
+  const terminal = page.locator(".vex-terminal-surface--active");
+  const centerBefore = await center.boundingBox();
+  const terminalBefore = await terminal.boundingBox();
+  const rail = page.locator('[data-vex-rail-pane="projects"]');
+  await page.getByRole("button", { name: "New project", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "New project" });
+  await dialog.evaluate(async (element) => { await Promise.all(element.getAnimations().map((animation) => animation.finished)); });
+  const dialogBefore = await dialog.boundingBox();
+  // Only the OS boundary refuses. Tombstone, persistence, preload and rail query stay real.
+  await vexDb.app.evaluate(({ shell }) => {
+    shell.trashItem = async () => { throw Object.assign(new Error("busy"), { code: "EBUSY" }); };
+  });
+  await page.evaluate(async () => {
+    function isProjectsBridge(value: unknown): value is Pick<ProjectsBridge, "create" | "list" | "delete"> {
+      return typeof value === "object" && value !== null
+        && "create" in value && typeof value.create === "function"
+        && "list" in value && typeof value.list === "function"
+        && "delete" in value && typeof value.delete === "function";
+    }
+    if (!("vex" in window) || typeof window.vex !== "object" || window.vex === null
+      || !("projects" in window.vex) || !isProjectsBridge(window.vex.projects)) throw new Error("Projects bridge missing");
+    const bridge = window.vex.projects;
+    const created = await bridge.create({ name: "Pending cleanup example", permission: "restricted", agents: [], wallets: { evm: null, solana: null } });
+    if (!created.ok) throw new Error(created.error.message);
+    const listed = await bridge.list();
+    if (!listed.ok) throw new Error(listed.error.message);
+    const project = listed.data.find((item) => item.name === "Pending cleanup example");
+    if (!project) throw new Error("Created project missing");
+    const deleted = await bridge.delete({ projectId: project.id, expectedName: project.name, alsoTrashFolder: true });
+    if (!deleted.ok || deleted.data.outcome !== "cleanup_pending") throw new Error("Expected durable cleanup obligation");
+  });
+  const notice = rail.getByRole("status", { name: "Pending cleanup for Pending cleanup example" });
+  await expect(notice).toBeVisible({ timeout: 45000 });
+  expect(await center.boundingBox()).toEqual(centerBefore);
+  expect(await terminal.boundingBox()).toEqual(terminalBefore);
+  expect(await dialog.boundingBox()).toEqual(dialogBefore);
+  await expect(center.getByLabel("Unfinished project cleanups")).toHaveCount(0);
+  await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+  const disclosure = notice.getByRole("button", { name: /Pending cleanup example.*Pending cleanup/ });
+  await disclosure.focus();
+  await page.keyboard.press("Enter");
+  await notice.locator(".vex-disclosure-body").evaluate(async (element) => { await Promise.all(element.getAnimations().map((animation) => animation.finished)); });
+  await expect(notice.locator(".vex-disclosure-body")).toHaveCSS("opacity", "1");
+  await expect(notice.getByText(/Another program is using this folder/)).toBeVisible();
+  const retry = notice.getByRole("button", { name: "Retry cleanup for Pending cleanup example" });
+  await page.keyboard.press("Tab");
+  await expect(retry).toBeFocused();
+  await expect(retry).toBeVisible();
+  expect(await terminal.boundingBox()).toEqual(terminalBefore);
+  await page.screenshot({ path: testInfo.outputPath("cleanup-rail.png") });
+});

--- a/vex-app/scripts/check-process-boundaries.mjs
+++ b/vex-app/scripts/check-process-boundaries.mjs
@@ -164,6 +164,7 @@ function checkRendererFile(file) {
       (resolved !== null &&
         (isInside(resolved, path.join(srcRoot, "main")) ||
           isInside(resolved, path.join(srcRoot, "preload")) ||
+          isInside(resolved, path.join(srcRoot, "platform")) ||
           isInside(resolved, rootLibDir) ||
           isInside(resolved, rootAgentDir)));
     if (forbidden) {
@@ -189,6 +190,7 @@ function checkSharedFile(file) {
       (resolved !== null &&
         (isInside(resolved, path.join(srcRoot, "main")) ||
           isInside(resolved, path.join(srcRoot, "preload")) ||
+          isInside(resolved, path.join(srcRoot, "platform")) ||
           isInside(resolved, path.join(srcRoot, "renderer")) ||
           isInside(resolved, rootLibDir) ||
           isInside(resolved, rootAgentDir)));

--- a/vex-app/src/main/database/projects/pending-cleanups.ts
+++ b/vex-app/src/main/database/projects/pending-cleanups.ts
@@ -1,5 +1,5 @@
 import { ok, type Result } from "@shared/ipc/result.js";
-import { projectTrashFailureSchema, type ProjectPendingCleanups } from "@shared/schemas/project-cleanup.js";
+import { parseStoredTrashFailure, type ProjectPendingCleanups } from "@shared/schemas/project-cleanup.js";
 import { dbError, withClient } from "../sessions/connection.js";
 
 /** Read durable obligations, including old rows whose cause was not classified. */
@@ -17,14 +17,11 @@ export async function readPendingProjectCleanups(offset: number): Promise<Result
       return ok({
         items: page.map((row) => {
           // No legacy native error text crosses IPC, even if a prior writer stored it.
-          const parsed = projectTrashFailureSchema.safeParse(
-            row.cleanup_last_error?.startsWith("trash:") ? row.cleanup_last_error.slice(6) : null,
-          );
           return {
             projectId: row.id, name: row.name, folder: row.slug,
             trashRequested: row.cleanup_state === "trash_pending",
             attempts: row.cleanup_attempts,
-            trashFailure: parsed.success ? parsed.data : null,
+            trashFailure: parseStoredTrashFailure(row.cleanup_last_error),
           };
         }),
         nextOffset: result.rows.length > 50 ? offset + 50 : null,

--- a/vex-app/src/main/index.ts
+++ b/vex-app/src/main/index.ts
@@ -15,6 +15,7 @@
  *   8. Open main window.
  */
 
+import { reapOrphanedPtyHosts } from "./studio/pty-host-reaper.js";
 import { app } from "electron";
 import { mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
@@ -557,6 +558,8 @@ let bootRuntimeInitialized = false;
 
 app.whenReady().then(async () => {
   log.info("[main] app.whenReady — initializing");
+
+  await reapOrphanedPtyHosts();
 
   const disposition = await runProductionEarlyBoot(
     () => {

--- a/vex-app/src/main/ipc/__tests__/projects-ipc.test.ts
+++ b/vex-app/src/main/ipc/__tests__/projects-ipc.test.ts
@@ -211,6 +211,7 @@ const CHANNELS = [
       projectId: PROJECT_ID,
       alsoTrashFolder: false,
       expectedName: "My App",
+      closeHolders: true,
     },
   },
 ] as const;
@@ -252,6 +253,7 @@ describe("vex:projects:* - registration and the shared boundary paths", () => {
     // The origin never appears in the public error payload.
     expect(JSON.stringify(r.error)).not.toContain("evil.example");
     // And nothing reached the DB owner.
+    expect(mocks.deleteProject).not.toHaveBeenCalled();
     expect(mocks.createProject).not.toHaveBeenCalled();
     expect(mocks.updateProjectScope).not.toHaveBeenCalled();
     expect(mocks.getProject).not.toHaveBeenCalled();
@@ -605,4 +607,17 @@ describe("pending cleanup IPC", () => {
     expect(result.ok).toBe(false);
     expect(JSON.stringify(result)).not.toContain("native uncontrolled");
   });
+});
+
+
+it("accepts close-and-retry intent without accepting renderer-selected process identities", async () => {
+  mocks.deleteProject.mockResolvedValue({ ok: true, data: { outcome: "already_removed" } });
+  const input = { projectId: PROJECT_ID, expectedName: "My App", alsoTrashFolder: true, closeHolders: true };
+  expect(await call(CH.projects.delete, input)).toMatchObject({ ok: true });
+  expect(mocks.deleteProject).toHaveBeenCalledWith(input, REQUEST_ID, expect.anything(), expect.any(AbortSignal));
+  mocks.deleteProject.mockClear();
+  for (const invalid of [{ ...input, pid: 6484 }, { ...input, directory: "C:\\outside" }, { ...input, closeHolders: "yes" }]) {
+    expect(await call(CH.projects.delete, invalid)).toMatchObject({ ok: false, error: { code: "validation.invalid_input" } });
+  }
+  expect(mocks.deleteProject).not.toHaveBeenCalled();
 });

--- a/vex-app/src/main/ipc/projects/pending-cleanups.ts
+++ b/vex-app/src/main/ipc/projects/pending-cleanups.ts
@@ -1,3 +1,4 @@
+import { refreshCleanupHolders } from "../../studio/pending-cleanup-holders.js";
 import { CH } from "@shared/ipc/channels.js";
 import { projectPendingCleanupsInputSchema, projectPendingCleanupsSchema } from "@shared/schemas/project-cleanup.js";
 import { readPendingProjectCleanups } from "../../database/projects/pending-cleanups.js";
@@ -10,6 +11,10 @@ export function registerProjectsPendingCleanupsHandler(): () => void {
     domain: "projects",
     inputSchema: projectPendingCleanupsInputSchema,
     outputSchema: projectPendingCleanupsSchema,
-    handle: async (input) => readPendingProjectCleanups(input.offset),
+    handle: async (input, ctx) => {
+      const result = await readPendingProjectCleanups(input.offset);
+      if (!result.ok) return result;
+      return { ok: true, data: await refreshCleanupHolders(result.data, ctx.signal) };
+    },
   });
 }

--- a/vex-app/src/main/studio/__tests__/close-cleanup.test.ts
+++ b/vex-app/src/main/studio/__tests__/close-cleanup.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { deleteProject } from "../project-delete.js";
+import { resetProjectLifecycleGateForTests } from "../project-lifecycle-gate.js";
+const state = vi.hoisted(() => ({ root: "", attempts: 0, done: vi.fn(), failed: vi.fn() }));
+vi.mock("../../logger/index.js", () => ({ log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } }));
+vi.mock("../projects-root.js", () => ({
+  resolveProjectsRoot: async () => ({ ok: true, data: state.root }),
+  resolveProjectDirectory: (root: string, slug: string) => path.join(root, slug),
+}));
+vi.mock("../../database/projects/delete.js", () => ({
+  tombstoneProject: async () => ({ ok: true, data: { kind: "already_tombstoned", slug: "example", cleanupState: "trash_pending" } }),
+  tombstoneRequestedTrash: () => true,
+  recordProjectCleanupFailure: async (...args: unknown[]) => { state.failed(...args); state.attempts += 1; return { ok: true, data: state.attempts }; },
+  markProjectCleanupDone: async (...args: unknown[]) => { state.done(...args); return { ok: true, data: true }; },
+  readTombstonedProject: vi.fn(), listUnfinishedProjectCleanups: vi.fn(), slugHeldByUnfinishedCleanup: vi.fn(),
+}));
+vi.mock("../../database/projects/installer-provenance.js", () => ({
+  readArtifactProvenance: async () => ({ ok: true, data: new Map() }), clearArtifactProvenance: vi.fn(),
+}));
+beforeEach(async () => {
+  state.root = await mkdtemp(path.join(os.tmpdir(), "vex-close-cleanup-"));
+  await mkdir(path.join(state.root, "example"));
+  state.attempts = 4; vi.clearAllMocks(); resetProjectLifecycleGateForTests();
+});
+afterEach(async () => { resetProjectLifecycleGateForTests(); await rm(state.root, { recursive: true, force: true }); });
+it("preserves the fifth failure and resolves the tombstone after close and one retry", async () => {
+  let closed = false;
+  const holders = vi.fn(async (_directory: string, close: boolean) => {
+    if (close) closed = true;
+    return [{ kind: "vex_terminal" as const, pid: 6484, project: "Example" }];
+  });
+  const trash = vi.fn(async (directory: string) => {
+    if (!closed) throw Object.assign(new Error("locked"), { code: "EBUSY" });
+    await rm(directory, { recursive: true });
+  });
+  const deps = { trashItem: trash, removeTerminalSnapshot: async () => true, resolveTrashHolders: holders };
+  const input = { projectId: "11111111-1111-4111-8111-111111111111", expectedName: "Example", alsoTrashFolder: false };
+  expect(await deleteProject(input, "first", deps)).toMatchObject({ ok: true, data: {
+    outcome: "cleanup_pending", attempts: 5, trashRequested: true, trashFailure: { reason: "busy" },
+  } });
+  expect(state.done).not.toHaveBeenCalled();
+  expect(await deleteProject({ ...input, closeHolders: true }, "retry", deps)).toMatchObject({ ok: true, data: {
+    outcome: "cleanup_resumed", trash: "trashed", trashRequested: true,
+  } });
+  expect(holders).toHaveBeenCalledWith(path.join(state.root, "example"), true, undefined);
+  expect(trash).toHaveBeenCalledTimes(2);
+  expect(state.done).toHaveBeenCalledOnce();
+  expect(state.failed).toHaveBeenCalledOnce();
+});
+it("cancellation before a retry never closes a holder or reaches trash", async () => {
+  const controller = new AbortController(); controller.abort();
+  const holders = vi.fn(); const trash = vi.fn();
+  await deleteProject({ projectId: "11111111-1111-4111-8111-111111111111", expectedName: "Example", alsoTrashFolder: true, closeHolders: true },
+    "cancel", { trashItem: trash, removeTerminalSnapshot: async () => true, resolveTrashHolders: holders }, controller.signal);
+  expect(holders).not.toHaveBeenCalled(); expect(trash).not.toHaveBeenCalled();
+});

--- a/vex-app/src/main/studio/__tests__/close-cleanup.test.ts
+++ b/vex-app/src/main/studio/__tests__/close-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, realpath } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
@@ -27,6 +27,8 @@ beforeEach(async () => {
 });
 afterEach(async () => { resetProjectLifecycleGateForTests(); await rm(state.root, { recursive: true, force: true }); });
 it("preserves the fifth failure and resolves the tombstone after close and one retry", async () => {
+  // Capture the canonical identity before the successful retry removes it.
+  const resolvedDirectory = await realpath(path.join(state.root, "example"));
   let closed = false;
   const holders = vi.fn(async (_directory: string, close: boolean) => {
     if (close) closed = true;
@@ -45,7 +47,7 @@ it("preserves the fifth failure and resolves the tombstone after close and one r
   expect(await deleteProject({ ...input, closeHolders: true }, "retry", deps)).toMatchObject({ ok: true, data: {
     outcome: "cleanup_resumed", trash: "trashed", trashRequested: true,
   } });
-  expect(holders).toHaveBeenCalledWith(path.join(state.root, "example"), true, undefined);
+  expect(holders).toHaveBeenCalledWith(resolvedDirectory, true, undefined);
   expect(trash).toHaveBeenCalledTimes(2);
   expect(state.done).toHaveBeenCalledOnce();
   expect(state.failed).toHaveBeenCalledOnce();

--- a/vex-app/src/main/studio/__tests__/pending-cleanup-holders.test.ts
+++ b/vex-app/src/main/studio/__tests__/pending-cleanup-holders.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { refreshCleanupHolders } from "../pending-cleanup-holders.js";
+import type { ProjectPendingCleanups } from "@shared/schemas/project-cleanup.js";
+const holders = vi.hoisted(() => vi.fn());
+vi.mock("../project-trash-holders.js", () => ({ resolveTrashHolders: holders }));
+vi.mock("../projects-root.js", () => ({ resolveProjectsRoot: async () => ({ ok: true, data: "/projects" }), resolveProjectDirectory: () => "/projects/example" }));
+const page: ProjectPendingCleanups = { items: [{ projectId: "11111111-1111-4111-8111-111111111111", name: "Example", folder: "example", trashRequested: true, attempts: 5,
+  trashFailure: { reason: "busy", folder: "/projects/example", holders: [{ kind: "vex_orphaned_terminal", pid: 50 }] },
+}], nextOffset: null };
+beforeEach(() => vi.resetAllMocks());
+it("replaces saved holder PIDs with a current read", async () => {
+  holders.mockResolvedValue([{ kind: "external" }]);
+  const refreshed = await refreshCleanupHolders(page, new AbortController().signal);
+  expect(refreshed.items[0]?.trashFailure).toEqual({ reason: "busy", folder: "/projects/example", holders: [{ kind: "external" }] });
+  expect(holders).toHaveBeenCalledWith("/projects/example", false, expect.any(AbortSignal));
+});
+it("keeps the obligation visible without stale holder authority when inspection fails", async () => {
+  holders.mockRejectedValue(new Error("unavailable"));
+  const refreshed = await refreshCleanupHolders(page, new AbortController().signal);
+  expect(refreshed.items[0]).toMatchObject({ attempts: 5, trashFailure: { reason: "busy", folder: "/projects/example" } });
+  expect(refreshed.items[0]?.trashFailure).not.toHaveProperty("holders");
+});
+it("honors cancellation without inspecting any process", async () => {
+  const controller = new AbortController(); controller.abort();
+  await expect(refreshCleanupHolders(page, controller.signal)).rejects.toThrow();
+  expect(holders).not.toHaveBeenCalled();
+});

--- a/vex-app/src/main/studio/__tests__/project-delete-e2e.int.test.ts
+++ b/vex-app/src/main/studio/__tests__/project-delete-e2e.int.test.ts
@@ -912,7 +912,8 @@ describe("deleteProject: the trash step", () => {
     expect(result.outcome).toBe("cleanup_pending");
     if (result.outcome !== "cleanup_pending") return;
     expect(result.trash).toBe("failed");
-    expect(result.trashFailure).toBe(failure);
+    const expectedFailure = process.platform === "win32" && failure === "aborted" ? { reason: failure, folder: project.directory } : failure;
+    expect(result.trashFailure).toEqual(expectedFailure);
     // The failure must come from the TRASH CALL, not from a guard that ran
     // before it: an unasserted call count is how this test previously passed
     // while `shell` was undefined and nothing was ever attempted.
@@ -931,7 +932,7 @@ describe("deleteProject: the trash step", () => {
       [project.projectId],
     );
     expect(reason[0]?.cleanup_last_error).toBe(
-      `trash:${failure}`,
+      `trash:${typeof expectedFailure === "object" ? JSON.stringify(expectedFailure) : expectedFailure}`,
     );
     expect(reason[0]?.cleanup_last_error).not.toMatch(/EPERM/);
     expect(await exists(project.directory)).toBe(true);
@@ -939,7 +940,7 @@ describe("deleteProject: the trash step", () => {
     expect(pending.ok).toBe(true);
     if (!pending.ok) return;
     expect(pending.data.items).toEqual(expect.arrayContaining([expect.objectContaining({
-      projectId: project.projectId, trashFailure: failure, trashRequested: true, attempts: 1,
+      projectId: project.projectId, trashFailure: expectedFailure, trashRequested: true, attempts: 1,
     })]));
   });
 

--- a/vex-app/src/main/studio/__tests__/project-trash-holders.test.ts
+++ b/vex-app/src/main/studio/__tests__/project-trash-holders.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { resolveTrashHolders } from "../project-trash-holders.js";
+import type { ProcessEntry } from "../windows-processes.js";
+const fakes = vi.hoisted(() => ({ folders: vi.fn(), orphans: vi.fn(), cwd: vi.fn(), kill: vi.fn() }));
+vi.mock("../terminal-domain.js", () => ({ terminalDomain: () => ({ folderHolders: fakes.folders }) }));
+vi.mock("../pty-host-reaper.js", () => ({ orphanedHosts: fakes.orphans }));
+vi.mock("../windows-processes.js", () => ({ readWindowsCwd: fakes.cwd }));
+vi.mock("../../../platform/process-lifetime.js", () => ({ killWindowsTree: fakes.kill }));
+const folder = "C:\\projects\\trading";
+const host: ProcessEntry = { pid: 100, parentPid: 99, binary: "C:\\Vex\\electron.exe", commandLine: "marked host", startedAt: 1000 };
+const shell: ProcessEntry = { pid: 101, parentPid: 100, binary: "C:\\Windows\\cmd.exe", commandLine: "cmd", startedAt: 2000 };
+beforeEach(() => {
+  vi.resetAllMocks();
+  fakes.folders.mockResolvedValue([]);
+  fakes.orphans.mockResolvedValue({ hosts: [host], processes: [host, shell] });
+  fakes.cwd.mockResolvedValue(`${folder}\\nested`);
+});
+it("names an own orphan shell and closes its tree only after revalidation", async () => {
+  expect(await resolveTrashHolders(folder, false)).toEqual([{ kind: "vex_orphaned_terminal", pid: 101 }]);
+  expect(fakes.kill).not.toHaveBeenCalled();
+  await resolveTrashHolders(folder, true);
+  expect(fakes.kill).toHaveBeenCalledWith(101);
+});
+it("does not attribute a sibling directory or a foreign process", async () => {
+  fakes.cwd.mockResolvedValue(`${folder}-other`);
+  expect(await resolveTrashHolders(folder, true)).toEqual([{ kind: "external" }]);
+  fakes.orphans.mockResolvedValue({ hosts: [], processes: [shell] });
+  expect(await resolveTrashHolders(folder, true)).toEqual([{ kind: "external" }]);
+  expect(fakes.kill).not.toHaveBeenCalled();
+});
+it("rejects a reused shell PID before termination", async () => {
+  fakes.orphans.mockResolvedValueOnce({ hosts: [host], processes: [host, shell] })
+    .mockResolvedValue({ hosts: [host], processes: [host, { ...shell, startedAt: 3000 }] });
+  await resolveTrashHolders(folder, true);
+  expect(fakes.kill).not.toHaveBeenCalled();
+});
+it("cancellation before the action reaches neither host nor taskkill", async () => {
+  const controller = new AbortController(); controller.abort();
+  await expect(resolveTrashHolders(folder, true, controller.signal)).rejects.toThrow();
+  expect(fakes.folders).not.toHaveBeenCalled();
+  expect(fakes.kill).not.toHaveBeenCalled();
+});
+it("cancellation during cwd inspection prevents tree termination", async () => {
+  const controller = new AbortController();
+  fakes.cwd.mockImplementation(async () => { controller.abort(); return folder; });
+  await expect(resolveTrashHolders(folder, true, controller.signal)).rejects.toThrow();
+  expect(fakes.kill).not.toHaveBeenCalled();
+});

--- a/vex-app/src/main/studio/__tests__/pty-host-reaper.test.ts
+++ b/vex-app/src/main/studio/__tests__/pty-host-reaper.test.ts
@@ -1,0 +1,20 @@
+import { expect, it, vi } from "vitest";
+import { selectOrphanedHosts } from "../pty-host-reaper.js";
+import type { ProcessEntry } from "../windows-processes.js";
+vi.mock("../../logger/index.js", () => ({ log: { info: vi.fn(), warn: vi.fn() } }));
+const binary = "C:\\Vex\\electron.exe";
+const marked: ProcessEntry = { pid: 50, parentPid: 40, startedAt: 1000, binary,
+  commandLine: '"C:\\Vex\\electron.exe" --type=utility --vex-pty-host --vex-parent-pid=40' };
+it.each([
+  { name: "marked orphan", entry: marked, parent: false, selected: true },
+  { name: "live parent", entry: marked, parent: true, selected: false },
+  { name: "unmarked old release", entry: { ...marked, commandLine: "electron.exe --type=utility" }, parent: false, selected: false },
+  { name: "foreign binary", entry: { ...marked, binary: "C:\\Other\\electron.exe" }, parent: false, selected: false },
+  { name: "marker substring", entry: { ...marked, commandLine: "electron.exe --vex-pty-host-extra --vex-parent-pid=40" }, parent: false, selected: false },
+  { name: "parent mismatch", entry: { ...marked, parentPid: 39 }, parent: false, selected: false },
+  { name: "unreadable executable", entry: { ...marked, binary: null }, parent: false, selected: false },
+  { name: "case insensitive binary", entry: { ...marked, binary: binary.toUpperCase() }, parent: false, selected: true },
+])("selects only our identified orphan: $name", ({ entry, parent, selected }) => {
+  const processes = [entry, ...(parent ? [{ ...marked, pid: 40, parentPid: 1, commandLine: "main" }] : [])];
+  expect(selectOrphanedHosts(processes, binary)).toEqual(selected ? [entry] : []);
+});

--- a/vex-app/src/main/studio/__tests__/pty-host-starter.test.ts
+++ b/vex-app/src/main/studio/__tests__/pty-host-starter.test.ts
@@ -17,12 +17,14 @@ import { EventEmitter } from "node:events";
 import type { UtilityProcess } from "electron";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const defaultForkMock = vi.hoisted(() => vi.fn());
+
 vi.mock("electron", () => ({
   app: {
     getPath: () => "/tmp/vex-userdata",
     getAppPath: () => "/tmp/vex-app",
   },
-  utilityProcess: { fork: () => { throw new Error("not used: fork is injected"); } },
+  utilityProcess: { fork: defaultForkMock },
   MessageChannelMain: class {
     port1 = { close: () => {} };
     port2 = { close: () => {} };
@@ -314,4 +316,21 @@ describe("message routing", () => {
 
     expect(seen).toEqual({ terminalId: "t1", exitCode: 0 });
   });
+});
+
+
+it("places host identity in both child argv and the OS command line", async () => {
+  vi.useFakeTimers();
+  try {
+    const child = new FakeChild();
+    defaultForkMock.mockReturnValue(child);
+    const starter = new PtyHostStarter({ onTerminalExit: vi.fn(), onNotice: vi.fn(),
+      onAvailabilityChanged: vi.fn(), onHostTerminated: vi.fn() });
+    expect(starter.ensureStarted()).toBe(true);
+    const identity = ["--vex-pty-host", `--vex-parent-pid=${process.pid}`];
+    expect(defaultForkMock).toHaveBeenCalledWith(expect.any(String), identity, expect.objectContaining({ execArgv: identity }));
+    const disposal = starter.dispose();
+    child.emit("exit", 0);
+    await disposal;
+  } finally { vi.useRealTimers(); }
 });

--- a/vex-app/src/main/studio/__tests__/trash-failure.test.ts
+++ b/vex-app/src/main/studio/__tests__/trash-failure.test.ts
@@ -1,0 +1,18 @@
+import { expect, it, vi } from "vitest";
+import { probeAbortedTrash } from "../trash-failure.js";
+const folder = "C:\\projects\\example";
+const temporary = "C:\\projects\\.vex-trash-probe-test";
+it("classifies a directory sharing violation as busy", async () => {
+  const rename = vi.fn().mockRejectedValue({ code: "EBUSY" });
+  expect(await probeAbortedTrash(folder, rename, temporary)).toEqual({ reason: "busy", folder });
+  expect(rename).toHaveBeenCalledTimes(1);
+});
+it("restores a clean rename and retains the non-recyclable aborted classification", async () => {
+  const rename = vi.fn().mockResolvedValue(undefined);
+  expect(await probeAbortedTrash(folder, rename, temporary)).toEqual({ reason: "aborted", folder });
+  expect(rename.mock.calls).toEqual([[folder, temporary], [temporary, folder]]);
+});
+it("names the recovery location when restore fails", async () => {
+  const rename = vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce({ code: "EPERM" });
+  expect(await probeAbortedTrash(folder, rename, temporary)).toEqual({ reason: "restore_failed", folder, recoveryPath: temporary });
+});

--- a/vex-app/src/main/studio/__tests__/trash-project-folder.test.ts
+++ b/vex-app/src/main/studio/__tests__/trash-project-folder.test.ts
@@ -35,12 +35,12 @@ describe("OS trash refusal", () => {
     const trash = vi.fn().mockRejectedValueOnce(new Error("Operation was aborted"))
       .mockImplementationOnce(async (target: string) => { await rm(target, { recursive: true }); });
     const first = await trashProjectFolder(root, folder, "test-correlation", trash);
-    expect(first).toEqual({ trash: "failed", trashFailure: "aborted" });
+    expect(first).toEqual({ trash: "failed", trashFailure: process.platform === "win32" ? { reason: "aborted", folder } : "aborted" });
     await expect(access(folder)).resolves.toBeUndefined();
     expect(trash).toHaveBeenCalledTimes(1);
     expect(JSON.stringify(logger.warn.mock.calls)).not.toContain(root);
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("test-correlation"),
-      expect.objectContaining({ reason: "aborted", remediation: expect.stringContaining("retry") }));
+      expect.objectContaining({ reason: "aborted" }));
     expect(await trashProjectFolder(root, folder, "retry-correlation", trash)).toEqual({ trash: "trashed" });
     await expect(access(folder)).rejects.toMatchObject({ code: "ENOENT" });
   });
@@ -60,4 +60,18 @@ describe("OS trash refusal", () => {
     expect(trash).not.toHaveBeenCalled();
     await expect(access(outside)).resolves.toBeUndefined();
   });
+});
+
+it("keeps the obligation pending when a failed restore left only the recovery folder", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "vex-trash-restore-"));
+  roots.push(root);
+  const original = path.join(root, "example");
+  const recovery = path.join(root, "example.vex-trash-probe-test");
+  await mkdir(recovery);
+  const trash = vi.fn();
+  expect(await trashProjectFolder(root, original, "restore", trash)).toEqual({
+    trash: "failed", trashFailure: { reason: "restore_failed", folder: original, recoveryPath: recovery },
+  });
+  expect(trash).not.toHaveBeenCalled();
+  await expect(access(recovery)).resolves.toBeUndefined();
 });

--- a/vex-app/src/main/studio/__tests__/trash-project-folder.test.ts
+++ b/vex-app/src/main/studio/__tests__/trash-project-folder.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, access, symlink } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, access, symlink, realpath } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -32,12 +32,15 @@ describe("OS trash refusal", () => {
     roots.push(root);
     const folder = path.join(root, "example");
     await mkdir(folder);
+    const resolvedFolder = await realpath(folder);
     const trash = vi.fn().mockRejectedValueOnce(new Error("Operation was aborted"))
       .mockImplementationOnce(async (target: string) => { await rm(target, { recursive: true }); });
     const first = await trashProjectFolder(root, folder, "test-correlation", trash);
-    expect(first).toEqual({ trash: "failed", trashFailure: process.platform === "win32" ? { reason: "aborted", folder } : "aborted" });
+    // Only Windows performs the rename probe and returns its resolved folder.
+    expect(first).toEqual({ trash: "failed", trashFailure: process.platform === "win32" ? { reason: "aborted", folder: resolvedFolder } : "aborted" });
     await expect(access(folder)).resolves.toBeUndefined();
     expect(trash).toHaveBeenCalledTimes(1);
+    expect(trash).toHaveBeenCalledWith(resolvedFolder);
     expect(JSON.stringify(logger.warn.mock.calls)).not.toContain(root);
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("test-correlation"),
       expect.objectContaining({ reason: "aborted" }));
@@ -65,12 +68,14 @@ describe("OS trash refusal", () => {
 it("keeps the obligation pending when a failed restore left only the recovery folder", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "vex-trash-restore-"));
   roots.push(root);
-  const original = path.join(root, "example");
+  // The original no longer exists, so resolve its parent before deriving it.
+  const original = path.join(await realpath(root), "example");
   const recovery = path.join(root, "example.vex-trash-probe-test");
   await mkdir(recovery);
+  const recoveryPath = await realpath(recovery);
   const trash = vi.fn();
   expect(await trashProjectFolder(root, original, "restore", trash)).toEqual({
-    trash: "failed", trashFailure: { reason: "restore_failed", folder: original, recoveryPath: recovery },
+    trash: "failed", trashFailure: { reason: "restore_failed", folder: original, recoveryPath },
   });
   expect(trash).not.toHaveBeenCalled();
   await expect(access(recovery)).resolves.toBeUndefined();

--- a/vex-app/src/main/studio/pending-cleanup-holders.ts
+++ b/vex-app/src/main/studio/pending-cleanup-holders.ts
@@ -1,0 +1,31 @@
+import { trashReason, type ProjectPendingCleanups } from "@shared/schemas/project-cleanup.js";
+import { resolveTrashHolders } from "./project-trash-holders.js";
+import { resolveProjectDirectory, resolveProjectsRoot } from "./projects-root.js";
+
+/** Holder observations expire between attempts. Refresh from process owners, never from saved PIDs. */
+export async function refreshCleanupHolders(page: ProjectPendingCleanups, signal: AbortSignal): Promise<ProjectPendingCleanups> {
+  if (!page.items.some((item) => item.trashFailure !== null && ["busy", "aborted"].includes(trashReason(item.trashFailure)))) return page;
+  const root = await resolveProjectsRoot("pending-cleanup-holders");
+  if (!root.ok) return { ...page, items: page.items.map((item) => ({ ...item,
+    trashFailure: typeof item.trashFailure === "object" && item.trashFailure !== null
+      ? { ...item.trashFailure, holders: [] } : item.trashFailure,
+  })) };
+  const items = [];
+  for (const item of page.items) {
+    signal.throwIfAborted();
+    const failure = item.trashFailure;
+    const directory = resolveProjectDirectory(root.data, item.folder);
+    if (!item.trashRequested || failure === null || directory === null || !["busy", "aborted"].includes(trashReason(failure))) {
+      items.push(item); continue;
+    }
+    try {
+      const holders = await resolveTrashHolders(directory, false, signal);
+      const reason = holders.some((holder) => holder.kind !== "external") ? "busy" : trashReason(failure);
+      items.push({ ...item, trashFailure: { reason, folder: directory, holders } });
+    } catch {
+      signal.throwIfAborted();
+      items.push({ ...item, trashFailure: { reason: trashReason(failure), folder: directory } });
+    }
+  }
+  return { ...page, items };
+}

--- a/vex-app/src/main/studio/project-delete-runtime.ts
+++ b/vex-app/src/main/studio/project-delete-runtime.ts
@@ -15,11 +15,13 @@
  * disk.
  */
 
+import { resolveTrashHolders } from "./project-trash-holders.js";
 import { removeTerminalSnapshot } from "./pty-host-starter.js";
 import { trashItemToOsTrash } from "./os-trash.js";
 import type { ProjectDeleteDeps } from "./project-delete.js";
 
 export const projectDeleteRuntimeDeps: ProjectDeleteDeps = {
   trashItem: trashItemToOsTrash,
+  resolveTrashHolders,
   removeTerminalSnapshot,
 };

--- a/vex-app/src/main/studio/project-delete.ts
+++ b/vex-app/src/main/studio/project-delete.ts
@@ -66,6 +66,8 @@
  * the two stays pending, because the transient half still needs doing.
  */
 
+import path from "node:path";
+import type { ResolveTrashHolders } from "./project-trash-holders.js";
 import type { ProjectTrashFailure } from "@shared/schemas/project-cleanup.js";
 import { trashProjectFolder } from "./trash-project-folder.js";
 import { realpath } from "node:fs/promises";
@@ -125,6 +127,7 @@ import { resolveProjectDirectory, resolveProjectsRoot } from "./projects-root.js
 export interface ProjectDeleteDeps {
   /** Move an absolute path to the OS trash. Rejects when the platform refuses. */
   readonly trashItem: TrashItem;
+  readonly resolveTrashHolders?: ResolveTrashHolders;
   /**
    * Delete this project's terminal revive snapshot. Resolves `true` when the
    * file is gone, INCLUDING when it was never there.
@@ -209,6 +212,18 @@ export async function deleteProject(
     // The RESUME honours the TOMBSTONE's recorded trash intent and ignores this
     // request's checkbox: the durable decision was made at deletion time, and a
     // retry is not a second chance to change it.
+    if (input.closeHolders === true && tombstoneRequestedTrash(outcome.cleanupState)) {
+      const root = await resolveProjectsRoot(correlationId);
+      const directory = root.ok ? resolveProjectDirectory(root.data, outcome.slug) : null;
+      if (directory !== null && deps.resolveTrashHolders) {
+        const resolved = await realpathOrSelf(directory);
+        const resolvedRoot = root.ok ? await realpathOrSelf(root.data) : null;
+        if (resolvedRoot !== null && path.dirname(resolved) === resolvedRoot) {
+          signal?.throwIfAborted();
+          await deps.resolveTrashHolders(resolved, true, signal);
+        }
+      }
+    }
     await closeProjectResources(projectId);
     const resumed = await runCleanup(
       projectId,
@@ -497,6 +512,7 @@ async function runCleanupJob(
         directory,
         correlationId,
         deps.trashItem,
+        deps.resolveTrashHolders,
       );
       trash = report.trash;
       trashFailure = report.trashFailure;
@@ -509,7 +525,7 @@ async function runCleanupJob(
       return await failCleanup(
         projectId,
         trash === "failed"
-          ? `trash:${trashFailure ?? "io_error"}`
+          ? `trash:${typeof trashFailure === "object" ? JSON.stringify(trashFailure) : trashFailure ?? "io_error"}`
           : "Some of the entries Vex wrote could not be removed.",
         artifacts,
         trash,

--- a/vex-app/src/main/studio/project-trash-holders.ts
+++ b/vex-app/src/main/studio/project-trash-holders.ts
@@ -1,0 +1,59 @@
+import path from "node:path";
+import type { ProjectTrashHolder } from "@shared/schemas/project-cleanup.js";
+import { killWindowsTree } from "../../platform/process-lifetime.js";
+import { terminalDomain } from "./terminal-domain.js";
+import { orphanedHosts } from "./pty-host-reaper.js";
+import { readWindowsCwd, type ProcessEntry } from "./windows-processes.js";
+
+export type ResolveTrashHolders = (directory: string, close: boolean, signal?: AbortSignal) => Promise<ProjectTrashHolder[]>;
+
+function descendsFrom(entry: ProcessEntry, host: ProcessEntry, processes: readonly ProcessEntry[]): boolean {
+  const seen = new Set<number>();
+  let current = entry;
+  while (!seen.has(current.pid)) {
+    seen.add(current.pid);
+    if (current.parentPid === host.pid) return current.startedAt >= host.startedAt;
+    const parent = processes.find((item) => item.pid === current.parentPid);
+    if (!parent || parent.startedAt > current.startedAt) return false;
+    current = parent;
+  }
+  return false;
+}
+
+function within(directory: string, cwd: string): boolean {
+  const relative = path.win32.relative(directory, cwd);
+  return relative === "" || (!path.win32.isAbsolute(relative) && relative !== ".." && !relative.startsWith("..\\"));
+}
+
+/** Main derives the directory from the tombstone. Renderer never supplies a PID or path. */
+export const resolveTrashHolders: ResolveTrashHolders = async (directory, close, signal) => {
+  const deadline = new AbortController();
+  const timer = setTimeout(() => deadline.abort(), 15000);
+  const combined = signal === undefined ? deadline.signal : AbortSignal.any([signal, deadline.signal]);
+  try { return await inspectHolders(directory, close, combined); }
+  finally { clearTimeout(timer); }
+};
+
+const inspectHolders: ResolveTrashHolders = async (directory, close, signal) => {
+  signal?.throwIfAborted();
+  const holders: ProjectTrashHolder[] = await terminalDomain().folderHolders(directory, close);
+  const snapshot = await orphanedHosts(signal);
+  for (const host of snapshot.hosts) {
+    for (const entry of snapshot.processes) {
+      if (!descendsFrom(entry, host, snapshot.processes)) continue;
+      const cwd = await readWindowsCwd(entry.pid, signal);
+      if (cwd === null || !within(directory, cwd)) continue;
+      holders.push({ kind: "vex_orphaned_terminal", pid: entry.pid });
+      if (!close) continue;
+      // PID, ancestry, creation time and cwd must all still match at the action boundary.
+      const current = await orphanedHosts(signal);
+      const sameHost = current.hosts.find((item) => item.pid === host.pid && item.startedAt === host.startedAt);
+      const same = current.processes.find((item) => item.pid === entry.pid && item.startedAt === entry.startedAt);
+      if (!sameHost || !same || !descendsFrom(same, sameHost, current.processes)) continue;
+      const currentCwd = await readWindowsCwd(same.pid, signal);
+      signal?.throwIfAborted();
+      if (currentCwd !== null && within(directory, currentCwd)) killWindowsTree(same.pid);
+    }
+  }
+  return holders.length === 0 ? [{ kind: "external" }] : holders;
+};

--- a/vex-app/src/main/studio/pty-host-reaper.ts
+++ b/vex-app/src/main/studio/pty-host-reaper.ts
@@ -1,0 +1,53 @@
+import path from "node:path";
+import { PTY_HOST_MARKER, ptyParentPid } from "@shared/schemas/pty-lifetime.js";
+import { killWindowsTree, processExists } from "../../platform/process-lifetime.js";
+import { enumerateWindowsProcesses, type ProcessEntry } from "./windows-processes.js";
+import { log } from "../logger/index.js";
+
+/** Exact unquoted marker token, never a substring in another argument or a binary name. */
+function argumentsOf(command: string): string[] {
+  return (command.match(/"[^"]*"|[^\s]+/g) ?? []).map((arg) => arg.replace(/^"|"$/g, ""));
+}
+
+export function selectOrphanedHosts(processes: readonly ProcessEntry[], binary: string): ProcessEntry[] {
+  const live = new Set(processes.map((entry) => entry.pid));
+  const normalized = path.win32.normalize(binary).toLowerCase();
+  return processes.filter((entry) => {
+    if (entry.startedAt <= 0 || entry.binary === null || path.win32.normalize(entry.binary).toLowerCase() !== normalized) return false;
+    const args = argumentsOf(entry.commandLine ?? "");
+    const parentPid = ptyParentPid(args);
+    return args.includes("--type=utility") && args.includes(PTY_HOST_MARKER) && parentPid !== null && parentPid === entry.parentPid
+      && !live.has(parentPid);
+  });
+}
+
+export async function orphanedHosts(signal?: AbortSignal): Promise<{ processes: ProcessEntry[]; hosts: ProcessEntry[] }> {
+  if (process.platform !== "win32") return { processes: [], hosts: [] };
+  const processes = await enumerateWindowsProcesses(signal);
+  return { processes, hosts: selectOrphanedHosts(processes, process.execPath).filter((host) => !processExists(host.parentPid)) };
+}
+
+/** Re-enumerate just before termination, including creation time to reject reused PIDs. */
+export async function reapHost(host: ProcessEntry, signal?: AbortSignal): Promise<boolean> {
+  const current = await orphanedHosts(signal);
+  signal?.throwIfAborted();
+  if (!current.hosts.some((entry) => entry.pid === host.pid && entry.startedAt === host.startedAt)) return false;
+  killWindowsTree(host.pid);
+  return true;
+}
+
+export async function reapOrphanedPtyHosts(): Promise<void> {
+  if (process.platform !== "win32") return;
+  const reaped: ProcessEntry[] = [];
+  try {
+    const { hosts } = await orphanedHosts();
+    for (const host of hosts) {
+      try { if (await reapHost(host)) reaped.push(host); }
+      catch { log.warn("[studio:pty-reaper] an identified orphan could not be terminated", { pid: host.pid }); }
+    }
+  } catch { log.warn("[studio:pty-reaper] process enumeration failed"); }
+  log.info("[studio:pty-reaper] completed", {
+    count: reaped.length, pids: reaped.map((host) => host.pid),
+    agesMs: reaped.map((host) => Math.max(0, Date.now() - host.startedAt)),
+  });
+}

--- a/vex-app/src/main/studio/pty-host-starter.ts
+++ b/vex-app/src/main/studio/pty-host-starter.ts
@@ -48,6 +48,7 @@
  * open the lid.
  */
 
+import { PTY_HOST_MARKER, PTY_PARENT_ARG } from "@shared/schemas/pty-lifetime.js";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -65,6 +66,7 @@ import {
   ptyHostEnvironment,
   terminalSnapshotFileName,
   terminalHostMessageSchema,
+  terminalHostRequestSchema,
   type TerminalHostAvailability,
   type TerminalHostMessage,
   type TerminalHostRequest,
@@ -336,6 +338,7 @@ export class PtyHostStarter implements PtyHost {
     request: TerminalHostRequest,
     transfer: MessagePortMain[] = [],
   ): Promise<TerminalOutcome<unknown>> {
+    if (!terminalHostRequestSchema.safeParse(request).success) return { ok: false, code: "invalid_packet" };
     if (!this.ensureStarted()) return { ok: false, code: "host_unavailable" };
     const child = this.child;
     if (child === null) return { ok: false, code: "host_unavailable" };
@@ -548,7 +551,10 @@ function deadlineFor(request: TerminalHostRequest): number {
 }
 
 function defaultFork(entry: string, env: Record<string, string>): UtilityProcess {
-  return utilityProcess.fork(entry, [], {
+  const identityArgs = [PTY_HOST_MARKER, `${PTY_PARENT_ARG}${process.pid}`];
+  return utilityProcess.fork(entry, identityArgs, {
+    // Electron sends args over Mojo; only execArgv reaches the OS process list.
+    execArgv: identityArgs,
     serviceName: "vex-studio-pty-host",
     // The host's own configuration rides the environment and is DELETED by the
     // child before it captures the base every shell inherits (`config.ts`).

--- a/vex-app/src/main/studio/terminals.ts
+++ b/vex-app/src/main/studio/terminals.ts
@@ -36,6 +36,7 @@
  * conduit into the pty host.
  */
 
+import { terminalFolderHoldersSchema, type TerminalFolderHolder } from "@shared/schemas/terminal-holders.js";
 import { randomUUID } from "node:crypto";
 import type { MessagePortMain } from "electron";
 import {
@@ -375,6 +376,13 @@ export class TerminalDomain {
     this.unregisterCloseHook = registerProjectCloseHook((projectId) =>
       this.closeProject(projectId),
     );
+  }
+
+  async folderHolders(directory: string, close: boolean): Promise<TerminalFolderHolder[]> {
+    if (this.starter.availability.state !== "running") return [];
+    const outcome = await this.starter.send({ kind: "folderHolders", directory, close });
+    if (!outcome.ok) throw new Error("Terminal holder query failed");
+    return terminalFolderHoldersSchema.parse(outcome.value);
   }
 
   get availability(): TerminalHostAvailability {

--- a/vex-app/src/main/studio/trash-failure.ts
+++ b/vex-app/src/main/studio/trash-failure.ts
@@ -1,11 +1,11 @@
-import type { ProjectTrashFailure } from "@shared/schemas/project-cleanup.js";
+import type { ProjectTrashReason } from "@shared/schemas/project-cleanup.js";
 
 /** Electron's aborted flag does not distinguish a lock from a non-recyclable item. */
 export function classifyTrashFailure(
   cause: unknown,
   absolutePath: string,
   platform: NodeJS.Platform = process.platform,
-): ProjectTrashFailure {
+): ProjectTrashReason {
   const error = typeof cause === "object" && cause !== null ? cause : {};
   const code = "code" in error ? error.code : undefined;
   const message = "message" in error && typeof error.message === "string" ? error.message : "";
@@ -20,4 +20,21 @@ export function classifyTrashFailure(
     return "aborted";
   }
   return "io_error";
+}
+
+
+export async function probeAbortedTrash(
+  absolutePath: string,
+  rename: (from: string, to: string) => Promise<void>,
+  temporaryPath: string,
+): Promise<import("@shared/schemas/project-cleanup.js").ProjectTrashFailure> {
+  try { await rename(absolutePath, temporaryPath); }
+  catch (cause) {
+    return { reason: classifyTrashFailure(cause, absolutePath, "win32"), folder: absolutePath };
+  }
+  try { await rename(temporaryPath, absolutePath); }
+  catch {
+    return { reason: "restore_failed", folder: absolutePath, recoveryPath: temporaryPath };
+  }
+  return { reason: "aborted", folder: absolutePath };
 }

--- a/vex-app/src/main/studio/trash-project-folder.ts
+++ b/vex-app/src/main/studio/trash-project-folder.ts
@@ -1,9 +1,11 @@
-import { realpath } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import type { ResolveTrashHolders } from "./project-trash-holders.js";
+import { realpath, rename, readdir } from "node:fs/promises";
 import path from "node:path";
-import { PROJECT_TRASH_REMEDIATION, type ProjectTrashFailure } from "@shared/schemas/project-cleanup.js";
+import { trashReason, type ProjectTrashFailure } from "@shared/schemas/project-cleanup.js";
 import type { ProjectTrashOutcome } from "@shared/schemas/projects.js";
 import type { TrashItem } from "./os-trash.js";
-import { classifyTrashFailure } from "./trash-failure.js";
+import { classifyTrashFailure, probeAbortedTrash } from "./trash-failure.js";
 import { log } from "../logger/index.js";
 
 /**
@@ -26,11 +28,17 @@ export async function trashProjectFolder(
   directory: string,
   correlationId: string,
   trashItem: TrashItem,
+  holders?: ResolveTrashHolders,
 ): Promise<{ trash: ProjectTrashOutcome; trashFailure?: ProjectTrashFailure }> {
   let resolvedDirectory: string;
   let resolvedRoot: string;
   try {
     resolvedRoot = await realpath(configuredRoot);
+    const recoveryPrefix = `${path.basename(directory)}.vex-trash-probe-`;
+    const recovery = (await readdir(resolvedRoot)).find((name) => name.startsWith(recoveryPrefix));
+    if (recovery !== undefined) return { trash: "failed", trashFailure: {
+      reason: "restore_failed", folder: directory, recoveryPath: path.join(resolvedRoot, recovery),
+    } };
     resolvedDirectory = await realpath(directory);
   } catch (cause) {
     // A folder that is already gone is not a failure: the obligation was to
@@ -61,10 +69,20 @@ export async function trashProjectFolder(
     await trashItem(resolvedDirectory);
     return { trash: "trashed" };
   } catch (cause) {
-    const trashFailure = classifyTrashFailure(cause, resolvedDirectory);
+    let trashFailure: ProjectTrashFailure = classifyTrashFailure(cause, resolvedDirectory);
+    if (process.platform === "win32" && trashReason(trashFailure) === "aborted") {
+      trashFailure = await probeAbortedTrash(resolvedDirectory, rename,
+        path.join(path.dirname(resolvedDirectory), `${path.basename(resolvedDirectory)}.vex-trash-probe-${randomUUID()}`));
+    }
+    if (trashReason(trashFailure) === "busy") {
+      let found: import("@shared/schemas/project-cleanup.js").ProjectTrashHolder[] | undefined = [{ kind: "external" }];
+      try { if (holders) found = await holders(resolvedDirectory, false); }
+      catch { found = undefined; log.warn("[studio:delete] holder identification failed"); }
+      trashFailure = { reason: "busy", folder: resolvedDirectory, holders: found };
+    }
     log.warn(
       `[studio:delete] trash refused correlationId=${correlationId}`,
-      { reason: trashFailure, remediation: PROJECT_TRASH_REMEDIATION[trashFailure] },
+      { reason: trashReason(trashFailure) },
     );
     return { trash: "failed", trashFailure };
   }

--- a/vex-app/src/main/studio/windows-processes.ts
+++ b/vex-app/src/main/studio/windows-processes.ts
@@ -1,0 +1,68 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+import { z } from "zod";
+
+const run = promisify(execFile);
+const processSchema = z.object({
+  pid: z.number().int().positive(), parentPid: z.number().int().nonnegative(),
+  binary: z.string().nullable(), commandLine: z.string().nullable(),
+  startedAt: z.number().nonnegative(),
+}).strict();
+export type ProcessEntry = z.infer<typeof processSchema>;
+
+export async function enumerateWindowsProcesses(signal?: AbortSignal): Promise<ProcessEntry[]> {
+  const { stdout } = await run(powershell(), ["-NoProfile", "-NonInteractive", "-Command",
+    "$ErrorActionPreference='Stop'; [Console]::OutputEncoding=[System.Text.Encoding]::UTF8; "
+    + "$entries = @(Get-CimInstance Win32_Process | Where-Object { $_.ProcessId -gt 0 } | ForEach-Object { "
+    + "@{pid=[int]$_.ProcessId; parentPid=[int]$_.ParentProcessId; binary=$_.ExecutablePath; "
+    + "commandLine=$_.CommandLine; startedAt=$(if ($null -ne $_.CreationDate) { ([DateTimeOffset]$_.CreationDate).ToUnixTimeMilliseconds() } else { 0 })} "
+    + "}); ConvertTo-Json -InputObject $entries -Compress"], { windowsHide: true, timeout: 10000, maxBuffer: 16 * 1024 * 1024, signal });
+  return z.array(processSchema).parse(JSON.parse(stdout));
+}
+
+function powershell(): string {
+  return path.win32.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
+
+/** Read only the cwd of an already identified own descendant. Unknown stays unknown.
+ * Windows' 64-bit PEB layout is used only after rejecting WOW64 processes.
+ */
+export async function readWindowsCwd(pid: number, signal?: AbortSignal): Promise<string | null> {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+  const source = String.raw`
+using System;
+using System.Runtime.InteropServices;
+public static class VexCwd {
+  [DllImport("kernel32.dll")] static extern IntPtr OpenProcess(uint access, bool inherit, int pid);
+  [DllImport("kernel32.dll")] static extern bool CloseHandle(IntPtr h);
+  [DllImport("kernel32.dll")] static extern bool IsWow64Process(IntPtr h, out bool wow);
+  [DllImport("kernel32.dll")] static extern bool ReadProcessMemory(IntPtr h, IntPtr address, byte[] bytes, int size, out IntPtr read);
+  [DllImport("ntdll.dll")] static extern int NtQueryInformationProcess(IntPtr h, int kind, byte[] info, int size, out int needed);
+  static byte[] Read(IntPtr h, long address, int size) {
+    var bytes = new byte[size]; IntPtr read;
+    if (!ReadProcessMemory(h, new IntPtr(address), bytes, size, out read) || read.ToInt64() != size) throw new Exception();
+    return bytes;
+  }
+  public static string Get(int pid) {
+    if (IntPtr.Size != 8) return null;
+    IntPtr h = OpenProcess(0x410, false, pid);
+    if (h == IntPtr.Zero) return null;
+    try {
+      bool wow; if (!IsWow64Process(h, out wow) || wow) return null;
+      var info = new byte[48]; int needed;
+      if (NtQueryInformationProcess(h, 0, info, info.Length, out needed) != 0) return null;
+      long peb = BitConverter.ToInt64(info, 8);
+      long parameters = BitConverter.ToInt64(Read(h, peb + 0x20, 8), 0);
+      var cwd = Read(h, parameters + 0x38, 16);
+      int length = BitConverter.ToUInt16(cwd, 0);
+      if (length == 0 || length % 2 != 0) return null;
+      return System.Text.Encoding.Unicode.GetString(Read(h, BitConverter.ToInt64(cwd, 8), length));
+    } catch { return null; } finally { CloseHandle(h); }
+  }
+}`;
+  const script = `$ErrorActionPreference='Stop'; [Console]::OutputEncoding=[System.Text.Encoding]::UTF8; Add-Type -TypeDefinition @'\n${source}\n'@\n[VexCwd]::Get(${pid}) | ConvertTo-Json -Compress`;
+  const { stdout } = await run(powershell(), ["-NoProfile", "-NonInteractive", "-Command", script],
+    { windowsHide: true, timeout: 10000, signal });
+  return stdout.trim() === "" ? null : z.string().nullable().parse(JSON.parse(stdout));
+}

--- a/vex-app/src/platform/process-lifetime.ts
+++ b/vex-app/src/platform/process-lifetime.ts
@@ -1,0 +1,24 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+/** Permission failures are not evidence that a process died. */
+export function processExists(pid: number): boolean {
+  try { process.kill(pid, 0); return true; }
+  catch (cause) { return !(cause instanceof Error && "code" in cause && cause.code === "ESRCH"); }
+}
+
+/** Synchronous so a disposing utility process cannot exit before taskkill finishes. */
+export function killWindowsTree(pid: number): void {
+  if (!Number.isSafeInteger(pid) || pid <= 0) throw new Error("Invalid process id");
+  execFileSync(path.win32.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe"),
+    ["/PID", String(pid), "/T", "/F"], { windowsHide: true, stdio: "ignore", timeout: 3000 });
+}
+
+export function terminateTerminal(
+  pty: { readonly pid: number; kill(): void },
+  platform: NodeJS.Platform,
+  killTree: (pid: number) => void = killWindowsTree,
+): void {
+  try { if (platform === "win32" && pty.pid > 0) killTree(pty.pid); }
+  finally { pty.kill(); }
+}

--- a/vex-app/src/preload/__tests__/project-cleanup-bridge.test.ts
+++ b/vex-app/src/preload/__tests__/project-cleanup-bridge.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { CH } from "../../shared/ipc/channels.js";
+const invoke = vi.hoisted(() => vi.fn());
+vi.mock("electron", () => ({ ipcRenderer: { invoke } }));
+const { projects } = await import("../agent/projects.js");
+const input = { projectId: "11111111-1111-4111-8111-111111111111", expectedName: "Example", alsoTrashFolder: true, closeHolders: true };
+beforeEach(() => { invoke.mockReset(); invoke.mockResolvedValue({ ok: true, data: { outcome: "already_removed" } }); });
+it("carries close intent on the delete channel and cancels exactly that invocation", async () => {
+  const request = projects.deleteAbortable(input);
+  expect(invoke).toHaveBeenCalledWith(CH.projects.delete, { requestId: expect.any(String), payload: input });
+  const envelope = invoke.mock.calls[0]?.[1];
+  request.cancel(); request.cancel();
+  expect(invoke).toHaveBeenCalledWith(CH.cancel, expect.objectContaining({ payload: { correlationId: envelope.requestId } }));
+  expect(invoke.mock.calls.filter(([channel]) => channel === CH.cancel)).toHaveLength(1);
+  expect(await request.promise).toMatchObject({ ok: true, data: { outcome: "already_removed" } });
+});
+it("rejects caller-selected PIDs at preload without invoking main", async () => {
+  const invalid = { ...input, pid: 6484 };
+  expect(await projects.deleteAbortable(invalid).promise).toMatchObject({ ok: false, error: { code: "validation.invalid_input" } });
+  expect(invoke).not.toHaveBeenCalled();
+});

--- a/vex-app/src/preload/agent/projects.ts
+++ b/vex-app/src/preload/agent/projects.ts
@@ -15,7 +15,7 @@ import type {
   ProjectUpdateScopeInput,
 } from "../../shared/schemas/projects.js";
 import type { ProjectsBridge } from "../../shared/types/bridge/agent/projects.js";
-import { invokeWithSchema } from "../_dispatch.js";
+import { abortableInvoke, invokeWithSchema } from "../_dispatch.js";
 
 export const projects = {
   create(input: ProjectCreateInput) {
@@ -47,6 +47,9 @@ export const projects = {
   // Validated at the GATE like every sibling: `projectDeleteInputSchema` is
   // strict, so a caller-supplied extra field is rejected by name here rather
   // than travelling to a handler that destroys authority.
+  deleteAbortable(input: ProjectDeleteInput) {
+    return abortableInvoke(CH.projects.delete, input, projectDeleteInputSchema);
+  },
   delete(input: ProjectDeleteInput) {
     return invokeWithSchema(CH.projects.delete, input, projectDeleteInputSchema);
   },

--- a/vex-app/src/pty-host/__tests__/parent-lifetime.test.ts
+++ b/vex-app/src/pty-host/__tests__/parent-lifetime.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { TERMINAL_HOST_BEAT_INTERVAL_MS, type TerminalHostMessage } from "@shared/schemas/terminal.js";
+import { watchParent } from "../parent-lifetime.js";
+import { PtyHostService } from "../host-service.js";
+import { TerminalSnapshotStore } from "../snapshot-store.js";
+import { RecordingPort, fakeProbe, scriptedSpawnerPool } from "./scripted-pty.js";
+import { terminateTerminal } from "../../platform/process-lifetime.js";
+
+afterEach(() => vi.useRealTimers());
+it("kills every owned terminal before exiting when its parent disappears", async () => {
+  vi.useFakeTimers();
+  const pool = scriptedSpawnerPool();
+  const replies: TerminalHostMessage[] = [];
+  const service = new PtyHostService({
+    spawn: pool.spawn, probe: fakeProbe({ directories: ["/project"], files: ["/bin/bash"], executables: { bash: "/bin/bash" } }),
+    baseEnv: {}, snapshotStore: new TerminalSnapshotStore("/unused"), scrollbackRows: 100,
+    graceMs: 60000, shortGraceMs: 6000, platform: "linux", sendToMain: (message) => replies.push(message),
+  });
+  for (const id of ["one", "two"]) await service.handleMainMessage({ requestId: id, request: {
+    kind: "create", terminalId: id, projectId: "11111111-1111-4111-8111-111111111111", windowId: "window",
+    launch: { executable: "bash", args: [], cwd: "/project", projectLabel: "Project", cols: 80, rows: 24, env: {} },
+  } }, []);
+  expect(service.liveTerminalCount).toBe(2);
+  await service.handleMainMessage({ requestId: "holders", request: { kind: "folderHolders", directory: "/project", close: false } }, []);
+  expect(replies.find((message) => message.kind === "reply" && message.requestId === "holders")).toMatchObject({
+    kind: "reply", outcome: { ok: true, value: [
+      { kind: "vex_terminal", pid: 4242, project: "Project", projectId: "11111111-1111-4111-8111-111111111111" },
+      { kind: "vex_terminal", pid: 4242, project: "Project", projectId: "11111111-1111-4111-8111-111111111111" },
+    ] },
+  });
+  await service.handleMainMessage({ requestId: "invalid", request: { kind: "folderHolders", directory: "/project", close: true, pid: 4242 } }, []);
+  expect(replies.some((message) => message.kind === "reply" && message.requestId === "invalid")).toBe(false);
+  expect(pool.ptys.every((pty) => !pty.killed)).toBe(true);
+  const port = new RecordingPort();
+  await service.handleMainMessage({ requestId: "port", request: { kind: "attachWindow", windowId: "window", nonce: "n".repeat(16) } }, [port]);
+  port.receive({ kind: "folderHolders", directory: "/project", close: true });
+  expect(pool.ptys.every((pty) => !pty.killed)).toBe(true);
+  let alive = true;
+  const exit = vi.fn(() => {
+    expect(pool.ptys.every((pty) => pty.killed)).toBe(true);
+    expect(service.liveTerminalCount).toBe(0);
+    expect(port.closed).toBe(true);
+  });
+  const stop = watchParent({ parentPid: 41, exists: () => alive,
+    shutdown: () => service.shutdownAfterParentLoss(), exit, heartbeat: vi.fn(), log: vi.fn() });
+  await vi.advanceTimersByTimeAsync(TERMINAL_HOST_BEAT_INTERVAL_MS);
+  expect(exit).not.toHaveBeenCalled();
+  alive = false;
+  await vi.advanceTimersByTimeAsync(TERMINAL_HOST_BEAT_INTERVAL_MS);
+  expect(exit).toHaveBeenCalledOnce();
+  await vi.advanceTimersByTimeAsync(TERMINAL_HOST_BEAT_INTERVAL_MS);
+  expect(exit).toHaveBeenCalledOnce();
+  stop();
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it.each(["win32", "linux", "darwin"] as const)("terminates the shell through the %s platform seam", (platform) => {
+  const pty = { pid: 6484, kill: vi.fn() };
+  const tree = vi.fn();
+  terminateTerminal(pty, platform, tree);
+  if (platform === "win32") expect(tree).toHaveBeenCalledWith(6484);
+  else expect(tree).not.toHaveBeenCalled();
+  expect(pty.kill).toHaveBeenCalledOnce();
+});

--- a/vex-app/src/pty-host/__tests__/shutdown-settlement.test.ts
+++ b/vex-app/src/pty-host/__tests__/shutdown-settlement.test.ts
@@ -35,6 +35,7 @@ beforeEach(async () => {
     shortGraceMs: 6_000,
     sendToMain: (message) => messages.push(message),
     platform: "win32",
+    killTree: vi.fn(),
   });
 });
 

--- a/vex-app/src/pty-host/host-service.ts
+++ b/vex-app/src/pty-host/host-service.ts
@@ -1,3 +1,4 @@
+import { terminalFolderHoldersSchema, type TerminalFolderHolder } from "@shared/schemas/terminal-holders.js";
 /**
  * THE PTY HOST SERVICE: the one owner of every terminal in this process.
  *
@@ -78,6 +79,7 @@ export interface HostServiceDeps {
   /** Everything the host tells main. Replies and unsolicited events both. */
   readonly sendToMain: (message: TerminalHostMessage) => void;
   readonly platform?: NodeJS.Platform;
+  readonly killTree?: (pid: number) => void;
   readonly log?: (line: string) => void;
 }
 
@@ -322,6 +324,16 @@ export class PtyHostService {
     ports: readonly HostPort[],
   ): Promise<TerminalOutcome<unknown>> {
     switch (request.kind) {
+      case "folderHolders": {
+        const holders: TerminalFolderHolder[] = [];
+        for (const terminal of this.terminals.values()) {
+          const holder = terminal.process.holderUnder(request.directory);
+          if (holder === null) continue;
+          holders.push({ ...holder, kind: "vex_terminal", projectId: terminal.options.projectId });
+          if (request.close) await terminal.process.shutdown(true);
+        }
+        return accept(terminalFolderHoldersSchema.parse(holders));
+      }
       case "attachWindow":
         return this.attachWindow(request.windowId, request.nonce, ports[0] ?? null);
       case "create":
@@ -463,6 +475,7 @@ export class PtyHostService {
       options.launch,
       {
         spawn: this.deps.spawn,
+        killTree: this.deps.killTree,
         probe: this.deps.probe,
         baseEnv: this.deps.baseEnv,
         scrollbackRows: this.deps.scrollbackRows,
@@ -483,6 +496,10 @@ export class PtyHostService {
       return refuse(started.code);
     }
 
+    if (!this.admitting) {
+      process.dispose();
+      return refuse("host_unavailable");
+    }
     const persistent = new PersistentTerminal(
       {
         terminalId: options.terminalId,
@@ -1311,6 +1328,16 @@ export class PtyHostService {
     return this.shutdownPromise;
   }
 
+  async shutdownAfterParentLoss(): Promise<void> {
+    this.admitting = false;
+    // No snapshot commit on hard parent loss: kill immediately, including detached shells.
+    for (const terminal of this.terminals.values()) {
+      try { terminal.dispose(); } catch { this.log("[pty-host] parent-loss terminal disposal failed"); }
+    }
+    this.terminals.clear();
+    this.closeWindows();
+  }
+
   private async runShutdown(): Promise<void> {
     // 1. Close admission.
     this.admitting = false;
@@ -1362,6 +1389,10 @@ export class PtyHostService {
       }
     }
     this.terminals.clear();
+    this.closeWindows();
+  }
+
+  private closeWindows(): void {
     for (const entry of this.windows.values()) {
       try {
         entry.port.close();

--- a/vex-app/src/pty-host/index.ts
+++ b/vex-app/src/pty-host/index.ts
@@ -28,9 +28,11 @@
  */
 
 import {
-  TERMINAL_HOST_BEAT_INTERVAL_MS,
   type TerminalHostMessage,
 } from "@shared/schemas/terminal.js";
+import { ptyParentPid } from "@shared/schemas/pty-lifetime.js";
+import { processExists } from "../platform/process-lifetime.js";
+import { watchParent } from "./parent-lifetime.js";
 import { readAndClearPtyHostConfig } from "./config.js";
 import { PtyHostService, type HostPort } from "./host-service.js";
 import { filesystemLaunchProbe } from "./launch-probe.js";
@@ -58,7 +60,6 @@ interface UtilityProcessMessageEvent {
 interface UtilityProcessParentPort {
   on(event: "message", listener: (event: UtilityProcessMessageEvent) => void): void;
   postMessage(value: unknown): void;
-  start?(): void;
 }
 
 function parentPortOf(target: NodeJS.Process): UtilityProcessParentPort | undefined {
@@ -98,6 +99,12 @@ function main(): void {
     return;
   }
 
+  const parentPid = ptyParentPid(process.argv);
+  if (parentPid === null) {
+    console.error("[pty-host] missing or invalid parent identity");
+    process.exit(1);
+    return;
+  }
   const baseEnv = scrubEnvironment(process.env);
 
   const sendToMain = (message: TerminalHostMessage): void => {
@@ -134,9 +141,10 @@ function main(): void {
    * for. `unref` is deliberately NOT called - the beat is this process's reason
    * to stay alive when it holds no other handle.
    */
-  setInterval(() => sendToMain({ kind: "heartbeat" }), TERMINAL_HOST_BEAT_INTERVAL_MS);
-
-  parentPort.start?.();
+  watchParent({
+    parentPid, exists: processExists, shutdown: () => service.shutdownAfterParentLoss(),
+    exit: () => process.exit(0), heartbeat: () => sendToMain({ kind: "heartbeat" }), log,
+  });
 
   console.log(
     `vex-studio pty host: ready (pid=${String(process.pid)}, `

--- a/vex-app/src/pty-host/parent-lifetime.ts
+++ b/vex-app/src/pty-host/parent-lifetime.ts
@@ -1,0 +1,22 @@
+import { TERMINAL_HOST_BEAT_INTERVAL_MS } from "@shared/schemas/terminal.js";
+
+/** Owns the fail-safe timer. Stops admission and kills before announcing exit. */
+export function watchParent(deps: {
+  readonly parentPid: number;
+  readonly exists: (pid: number) => boolean;
+  readonly shutdown: () => Promise<void>;
+  readonly exit: () => void;
+  readonly heartbeat: () => void;
+  readonly log: (message: string) => void;
+}): () => void {
+  let closing = false;
+  const timer = setInterval(() => {
+    if (closing) return;
+    if (deps.exists(deps.parentPid)) { deps.heartbeat(); return; }
+    closing = true;
+    clearInterval(timer);
+    void deps.shutdown().catch(() => deps.log("[pty-host] parent-loss cleanup failed"))
+      .finally(deps.exit);
+  }, TERMINAL_HOST_BEAT_INTERVAL_MS);
+  return () => { closing = true; clearInterval(timer); };
+}

--- a/vex-app/src/pty-host/terminal-process.ts
+++ b/vex-app/src/pty-host/terminal-process.ts
@@ -52,6 +52,8 @@ import {
   type TerminalLaunch,
   type TerminalProperty,
 } from "@shared/schemas/terminal.js";
+import { terminateTerminal } from "../platform/process-lifetime.js";
+import path from "node:path";
 import { TerminalDataBufferer } from "./data-bufferer.js";
 import { deriveDisplayCwd } from "./display-cwd.js";
 import { TerminalMirror } from "./mirror.js";
@@ -91,6 +93,7 @@ export interface TerminalProcessDeps {
   readonly baseEnv: IProcessEnvironment;
   readonly scrollbackRows: number;
   readonly platform?: NodeJS.Platform;
+  readonly killTree?: (pid: number) => void;
 }
 
 export type TerminalStartResult =
@@ -185,6 +188,7 @@ export class TerminalProcess {
    */
   private pidDeferral: PtyDisposable | null = null;
 
+  private nativeExited = false;
   private exitCode: number | null = null;
   private exitSignal: number | null = null;
   private closeTimer: NodeJS.Timeout | null = null;
@@ -333,6 +337,7 @@ export class TerminalProcess {
     this.subscriptions.push(pty.onData((data) => this.handlePtyData(data)));
     this.subscriptions.push(
       pty.onExit((event) => {
+        this.nativeExited = true;
         this.exitCode = event.exitCode;
         this.exitSignal = event.signal ?? null;
         // THE PROCESS IS GONE, as the OS sees it. `kill` waits for this before
@@ -749,13 +754,17 @@ export class TerminalProcess {
     return { cols: this.cols, rows: this.rows };
   }
 
-  /**
-   * The shell's directory AS A LABEL.
-   *
-   * There is deliberately no accessor for `currentCwd`. The raw path is an
-   * implementation detail of change detection, and an accessor for it is how it
-   * would eventually find its way into a message.
-   */
+  /** Match a folder inside the host without exporting the raw cwd. */
+  holderUnder(directory: string): { pid: number; project: string } | null {
+    if (!this.alive || this.pty === null || this.pty.pid <= 0) return null;
+    const paths = (this.deps.platform ?? process.platform) === "win32" ? path.win32 : path.posix;
+    const relative = paths.relative(directory, this.currentCwd);
+    if (relative === "" || (!paths.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${paths.sep}`))) {
+      return { pid: this.pty.pid, project: this.launch.projectLabel };
+    }
+    return null;
+  }
+
   get displayCwd(): string {
     return deriveDisplayCwd(
       { projectRoot: this.launch.cwd, projectLabel: this.launch.projectLabel },
@@ -915,7 +924,10 @@ export class TerminalProcess {
     if (this.killIssued) return;
     this.killIssued = true;
     try {
-      this.pty?.kill();
+      if (this.pty !== null) {
+        if (this.nativeExited) this.pty.kill();
+        else terminateTerminal(this.pty, this.deps.platform ?? process.platform, this.deps.killTree);
+      }
     } catch {
       // Already dead. The exit is still owed to the consumer.
     }

--- a/vex-app/src/renderer/features/appShell/studio/StudioCenter.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/StudioCenter.tsx
@@ -39,7 +39,6 @@
  * therefore never reaches zero, and one that leaves does.
  */
 
-import { ProjectCleanupNotices } from "./projects/ProjectCleanupNotices.js";
 
 import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
 import type { ProjectDto } from "@shared/schemas/projects.js";
@@ -480,7 +479,6 @@ export function StudioCenter({
       data-vex-area="studio-center"
       className="relative flex h-full min-h-0 w-full min-w-0 flex-col"
     >
-      <ProjectCleanupNotices />
       {welcomeShown ? (
         <StudioWelcome
           onCreateProject={onCreateProject}

--- a/vex-app/src/renderer/features/appShell/studio/projects/ProjectCleanupNotices.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/projects/ProjectCleanupNotices.tsx
@@ -1,16 +1,23 @@
+import { DisclosureRow } from "../../../../components/ui/disclosure-row.js";
+import { StateDot } from "../../../../components/ui/state-dot.js";
 import { useState, type JSX } from "react";
-import { PROJECT_TRASH_REMEDIATION, type ProjectPendingCleanup } from "@shared/schemas/project-cleanup.js";
+import { trashRemediation, type ProjectPendingCleanup } from "@shared/schemas/project-cleanup.js";
 import { PROJECT_DELETE_OUTCOME_SENTENCES } from "./projects-copy.js";
 import { Button } from "../../../../components/ui/button.js";
 import { useDeleteProject, usePendingProjectCleanups } from "../../../../lib/api/projects.js";
 
 /** Reads tombstones so closing a dialog or restarting cannot hide an unfinished delete. */
-export function ProjectCleanupNotices(): JSX.Element | null {
+export function ProjectCleanupNotices({ collapsed = false, onExpand }: { readonly collapsed?: boolean; readonly onExpand?: () => void }): JSX.Element | null {
   const [offset, setOffset] = useState(0);
   const query = usePendingProjectCleanups(offset);
   if (query.isPending) return null;
   if (query.isError || (query.data !== undefined && !query.data.ok)) {
-    return <section role="status" className="m-3 rounded-lg border border-line-2 p-3 text-sm text-warning">
+    if (collapsed) return <section role="status" aria-label="Unfinished project cleanups could not be loaded.">
+      <button type="button" aria-label="Show unfinished project cleanup error" onClick={onExpand} className="flex h-6 w-full items-center justify-center">
+        <StateDot state="warning" size={8} />
+      </button>
+    </section>;
+    return <section role="status" className="p-2 text-xs text-warning">
       Unfinished project cleanups could not be loaded.
       <Button variant="ghost" onClick={() => void query.refetch()}>Retry loading cleanups</Button>
     </section>;
@@ -19,9 +26,8 @@ export function ProjectCleanupNotices(): JSX.Element | null {
   const page = query.data.data;
   const nextOffset = page.nextOffset;
   if (page.items.length === 0 && offset === 0) return null;
-  return <section aria-label="Unfinished project cleanups" className="m-3 max-h-64 shrink-0 overflow-y-auto flex flex-col gap-2 rounded-lg border border-line-2 p-3">
-    <h3 className="text-sm text-ink-primary">Deleted projects with files still pending cleanup</h3>
-    {page.items.map((item) => <CleanupNotice key={item.projectId} item={item} />)}
+  return <section aria-label="Unfinished project cleanups" className="min-w-0 py-2">
+    {page.items.map((item) => <CleanupNotice key={item.projectId} item={item} collapsed={collapsed} onExpand={onExpand} />)}
     <div className="flex gap-2">
       {offset > 0 ? <Button variant="ghost" onClick={() => setOffset(Math.max(0, offset - 50))}>Previous cleanups</Button> : null}
       {nextOffset !== null ? <Button variant="ghost" onClick={() => setOffset(nextOffset)}>More cleanups</Button> : null}
@@ -29,23 +35,45 @@ export function ProjectCleanupNotices(): JSX.Element | null {
   </section>;
 }
 
-function CleanupNotice({ item }: { readonly item: ProjectPendingCleanup }): JSX.Element {
-  const mutation = useDeleteProject();
+function CleanupNotice({ item, collapsed, onExpand }: { readonly item: ProjectPendingCleanup; readonly collapsed: boolean; readonly onExpand: (() => void) | undefined }): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const mutation = useDeleteProject(true);
   const result = mutation.data;
   const failure = result?.ok && result.data.outcome === "cleanup_pending"
     ? result.data.trashFailure ?? item.trashFailure : item.trashFailure;
-  return <article className="flex flex-col gap-1 text-xs text-ink-secondary">
+  const ownHolder = typeof failure === "object" && failure !== null
+    && failure.holders?.some((holder) => holder.kind !== "external");
+  if (collapsed) return <article role="status" aria-label={`Pending cleanup for ${item.name}`}>
+    <button type="button" aria-label={`Show pending cleanup for ${item.name}`} onClick={onExpand}
+      className="flex h-6 w-full items-center justify-center rounded focus-visible:ring-2 focus-visible:ring-accent-primary">
+      <StateDot state="warning" size={8} />
+    </button>
+  </article>;
+  return <article role="status" aria-label={`Pending cleanup for ${item.name}`} className="min-w-0 text-xs text-ink-secondary">
+    <DisclosureRow icon={<StateDot state="warning" size={8} />} title={item.name}
+      collapsedContent={<span className="ml-2 whitespace-nowrap text-ink-tertiary">Pending cleanup</span>}
+      className="[&>.vex-disclosure-row]:overflow-x-auto" titleClassName="shrink-0 whitespace-nowrap" open={open} expandable expandOnRowClick
+      onToggle={() => setOpen((value) => !value)} bodyClassName="flex min-w-0 flex-col gap-2 p-2 break-words">
+
     <p className="font-medium text-ink-primary">{item.name} - folder: {item.folder}</p>
     <p>{item.trashRequested
       ? "This project is deleted, but moving its folder to the trash is still pending."
       : "This project is deleted. Its folder will be kept, but removal of Vex's entries is still pending."}</p>
-    <p>{failure ? PROJECT_TRASH_REMEDIATION[failure] : "The previous cleanup did not finish. Retry to check the folder and resume cleanup."}</p>
+    <p>{failure ? trashRemediation(failure) : "The previous cleanup did not finish. Retry to check the folder and resume cleanup."}</p>
+    {typeof failure === "object" && failure !== null ? <>
+      <p className="break-all">Folder: {failure.folder}</p>
+      {failure.holders?.map((holder, index) => holder.kind === "external" ? null :
+        <p key={index}>PID {holder.pid}{holder.project ? ` - project: ${holder.project}` : ""}</p>)}
+    </> : null}
     <p>{item.attempts} cleanup attempts. Retrying honors the original folder choice.</p>
     {result?.ok ? <p role="status">{PROJECT_DELETE_OUTCOME_SENTENCES[result.data.outcome]}</p> : null}
     {mutation.isError ? <p role="alert">Cleanup could not be reached. Try again.</p> : null}
     {result !== undefined && !result.ok ? <p role="alert">{result.error.message}</p> : null}
     <Button variant="ghost" disabled={mutation.isPending} onClick={() => mutation.mutate({
       projectId: item.projectId, expectedName: item.name, alsoTrashFolder: item.trashRequested,
-    })}>{mutation.isPending ? "Retrying cleanup..." : `Retry cleanup for ${item.name}`}</Button>
+      ...(ownHolder ? { closeHolders: true } : {}),
+    })}>{mutation.isPending ? "Retrying cleanup" : ownHolder ? "Close it and retry" : `Retry cleanup for ${item.name}`}</Button>
+    {mutation.isPending ? <Button variant="ghost" onClick={mutation.cancel}>Cancel cleanup</Button> : null}
+    </DisclosureRow>
   </article>;
 }

--- a/vex-app/src/renderer/features/appShell/studio/projects/ProjectCleanupNotices.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/projects/ProjectCleanupNotices.tsx
@@ -7,11 +7,17 @@ import { Button } from "../../../../components/ui/button.js";
 import { useDeleteProject, usePendingProjectCleanups } from "../../../../lib/api/projects.js";
 
 /** Reads tombstones so closing a dialog or restarting cannot hide an unfinished delete. */
-export function ProjectCleanupNotices({ collapsed = false, onExpand }: { readonly collapsed?: boolean; readonly onExpand?: () => void }): JSX.Element | null {
+export function ProjectCleanupNotices({ collapsed = false, onExpand, showReadError = true }: {
+  readonly collapsed?: boolean;
+  readonly onExpand?: () => void;
+  /** The rail shows this error only after projects loaded successfully. */
+  readonly showReadError?: boolean;
+}): JSX.Element | null {
   const [offset, setOffset] = useState(0);
   const query = usePendingProjectCleanups(offset);
   if (query.isPending) return null;
   if (query.isError || (query.data !== undefined && !query.data.ok)) {
+    if (!showReadError) return null;
     if (collapsed) return <section role="status" aria-label="Unfinished project cleanups could not be loaded.">
       <button type="button" aria-label="Show unfinished project cleanup error" onClick={onExpand} className="flex h-6 w-full items-center justify-center">
         <StateDot state="warning" size={8} />

--- a/vex-app/src/renderer/features/appShell/studio/projects/ProjectDeleteDialog.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/projects/ProjectDeleteDialog.tsx
@@ -113,7 +113,7 @@
  * choice), which the disabled confirm reinforces on first open.
  */
 
-import { PROJECT_TRASH_REMEDIATION } from "@shared/schemas/project-cleanup.js";
+import { trashRemediation } from "@shared/schemas/project-cleanup.js";
 
 import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
 import type {
@@ -669,7 +669,7 @@ function DeleteOutcome({
             data-vex-delete-trash={outcome.trash}
           >
             {PROJECT_TRASH_SENTENCES[outcome.trash]}
-            {outcome.trashFailure ? ` ${PROJECT_TRASH_REMEDIATION[outcome.trashFailure]}` : ""}
+            {outcome.trashFailure ? ` ${trashRemediation(outcome.trashFailure)}` : ""}
           </p>
           {outcome.cleanup.length > 0 ? (
             <div className="flex flex-col gap-1.5">

--- a/vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectCleanupNotices.test.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectCleanupNotices.test.tsx
@@ -74,3 +74,28 @@ it("names the own orphan, sends only project intent, and exposes cancellation", 
   view.unmount();
   finish({ ok: true, data: { outcome: "already_removed" } });
 });
+
+
+it.each(["result", "transport"] as const)("leaves a shared %s failure to the projects error surface", async (failureKind) => {
+  const failure = { ok: false, error: { message: "No database" } };
+  const list = vi.fn(async () => {
+    if (failureKind === "transport") throw new Error("Bridge unavailable");
+    return failure;
+  });
+  Object.defineProperty(window, "vex", { configurable: true, value: { projects: { pendingCleanups: list } } });
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  const tree = (projectsReadFailed: boolean) => <QueryClientProvider client={client}>
+    <ProjectCleanupNotices showReadError={!projectsReadFailed} />
+  </QueryClientProvider>;
+  const view = render(tree(true));
+  await waitFor(() => expect(list).toHaveBeenCalledOnce());
+  await waitFor(() => expect(client.isFetching()).toBe(0));
+  expect(screen.queryByRole("status")).toBeNull();
+  expect(screen.queryByRole("button", { name: "Retry loading cleanups" })).toBeNull();
+
+  // The cleanup read still failed after projects recovered, so it now owns its error.
+  view.rerender(tree(false));
+  await screen.findByText("Unfinished project cleanups could not be loaded.");
+  expect(screen.getByRole("button", { name: "Retry loading cleanups" })).toBeDefined();
+  expect(list).toHaveBeenCalledOnce();
+});

--- a/vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectCleanupNotices.test.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectCleanupNotices.test.tsx
@@ -12,22 +12,27 @@ describe("unfinished delete notices", () => {
     };
     let pending = true;
     const list = vi.fn(async () => ({ ok: true, data: { items: pending ? [item] : [], nextOffset: null } }));
-    const retry = vi.fn(async () => { pending = false; return { ok: true, data: { outcome: "already_removed" } }; });
-    Object.defineProperty(window, "vex", { configurable: true, value: { projects: { pendingCleanups: list, delete: retry } } });
+    const retry = vi.fn(async (_input: unknown) => { pending = false; return { ok: true, data: { outcome: "already_removed" } }; });
+    Object.defineProperty(window, "vex", { configurable: true, value: { projects: { pendingCleanups: list, deleteAbortable: (input: unknown) => ({ promise: retry(input), cancel: vi.fn() }) } } });
     const mount = () => render(<QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })}>
       <ProjectCleanupNotices />
     </QueryClientProvider>);
     const first = mount();
-    await screen.findByText(/The folder is in use/);
+    const disclosure = await screen.findByRole("button", { name: /Example.*Pending cleanup/ });
+    expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText(/Another program is using/)).toBeNull();
+    fireEvent.keyDown(disclosure, { key: "Enter" });
+    await screen.findByText(/Another program is using/);
     expect(retry).not.toHaveBeenCalled();
     first.unmount();
     mount();
+    fireEvent.keyDown(await screen.findByRole("button", { name: /Example.*Pending cleanup/ }), { key: " " });
     const button = await screen.findByRole("button", { name: "Retry cleanup for Example" });
     fireEvent.click(button);
     await waitFor(() => expect(retry).toHaveBeenCalledWith({
       projectId: item.projectId, expectedName: item.name, alsoTrashFolder: true,
     }));
-    await waitFor(() => expect(screen.queryByText(/The folder is in use/)).toBeNull());
+    await waitFor(() => expect(screen.queryByText(/Another program is using/)).toBeNull());
   });
 
   it("does not present a failed obligation read as an empty success", async () => {
@@ -40,4 +45,32 @@ describe("unfinished delete notices", () => {
     await screen.findByText("Unfinished project cleanups could not be loaded.");
     expect(screen.getByRole("button", { name: "Retry loading cleanups" })).toBeDefined();
   });
+});
+
+it("names the own orphan, sends only project intent, and exposes cancellation", async () => {
+  const cancel = vi.fn();
+  let finish: (value: unknown) => void = () => {};
+  const retry = vi.fn(() => ({ promise: new Promise((resolve) => { finish = resolve; }), cancel }));
+  const item = { projectId: "11111111-1111-4111-8111-111111111111", name: "Trading", folder: "trading",
+    trashRequested: true, attempts: 5, trashFailure: { reason: "busy", folder: "C:\\projects\\trading",
+      holders: [{ kind: "vex_orphaned_terminal", pid: 6484 }] } };
+  Object.defineProperty(window, "vex", { configurable: true, value: { projects: {
+    pendingCleanups: async () => ({ ok: true, data: { items: [item], nextOffset: null } }), deleteAbortable: retry,
+  } } });
+  const view = render(<QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })}>
+    <ProjectCleanupNotices />
+  </QueryClientProvider>);
+  const row = await screen.findByRole("button", { name: /Trading.*Pending cleanup/ });
+  row.focus();
+  fireEvent.keyDown(row, { key: "Enter" });
+  expect(screen.getByText(/A Vex terminal from a previous session/)).toBeDefined();
+  expect(screen.getByText("PID 6484")).toBeDefined();
+  fireEvent.click(screen.getByRole("button", { name: "Close it and retry" }));
+  await waitFor(() => expect(retry).toHaveBeenCalledWith({
+    projectId: item.projectId, expectedName: "Trading", alsoTrashFolder: true, closeHolders: true,
+  }));
+  fireEvent.click(await screen.findByRole("button", { name: "Cancel cleanup" }));
+  expect(cancel).toHaveBeenCalledOnce();
+  view.unmount();
+  finish({ ok: true, data: { outcome: "already_removed" } });
 });

--- a/vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectDeleteDialog.test.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/projects/__tests__/ProjectDeleteDialog.test.tsx
@@ -889,8 +889,8 @@ describe("diagnosed OS trash refusal", () => {
     } });
     const harness = renderDialog();
     await confirmDelete();
-    await screen.findByText(/The OS aborted the trash operation/);
-    expect(screen.getByText(/Close programs and retry/)).toBeDefined();
+    await screen.findByText(/The OS could not recycle this folder/);
+    expect(screen.getByText(/Move the folder yourself, or retry cleanup/)).toBeDefined();
     expect(confirmButton().disabled).toBe(false);
     expect(harness.onClose).not.toHaveBeenCalled();
   });

--- a/vex-app/src/renderer/features/appShell/studio/sidebar/StudioSidebar.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/sidebar/StudioSidebar.tsx
@@ -53,6 +53,7 @@
  * when the answer was collected and that reopening the search picks it up.
  */
 
+import { ProjectCleanupNotices } from "../projects/ProjectCleanupNotices.js";
 import {
   useCallback,
   useEffect,
@@ -518,6 +519,8 @@ export function StudioSidebar({
           onShowAllChange={setShowAllProjects}
         />
       )}
+
+      <ProjectCleanupNotices collapsed={!wide} onExpand={onToggleSidebar} />
 
       <div className="mt-2">
         <RailRow

--- a/vex-app/src/renderer/features/appShell/studio/sidebar/StudioSidebar.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/sidebar/StudioSidebar.tsx
@@ -54,6 +54,7 @@
  */
 
 import { ProjectCleanupNotices } from "../projects/ProjectCleanupNotices.js";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   useCallback,
   useEffect,
@@ -83,7 +84,7 @@ import { useCollapseChoreography } from "../../../../lib/useCollapseChoreography
 import { useQuietScrollbars } from "../../../../lib/useQuietScrollbars.js";
 import { useScrollbarVisibility } from "../../../../lib/useScrollbarVisibility.js";
 import { cn } from "../../../../lib/utils.js";
-import { useProjects } from "../../../../lib/api/projects.js";
+import { projectKeys, useProjects } from "../../../../lib/api/projects.js";
 import { useUiStore } from "../../../../stores/uiStore.js";
 import { SidebarHomeSigil } from "../../SidebarHomeSigil.js";
 import { SidebarProfile } from "../../SidebarProfile.js";
@@ -223,6 +224,7 @@ export function StudioSidebar({
   explorerRegistry,
 }: StudioSidebarProps): JSX.Element {
   const query = useProjects();
+  const queryClient = useQueryClient();
 
   const { wide, fading, railIn, frozenWidth } = useCollapseChoreography(
     collapsed,
@@ -417,7 +419,8 @@ export function StudioSidebar({
 
   const retry = useCallback((): void => {
     void query.refetch();
-  }, [query]);
+    void queryClient.invalidateQueries({ queryKey: projectKeys.pendingCleanups() });
+  }, [query, queryClient]);
 
   // The header's actions act on the session the TREE holds. `peek` reads it
   // without taking a reference, which is what keeps the header a sibling of the
@@ -520,7 +523,7 @@ export function StudioSidebar({
         />
       )}
 
-      <ProjectCleanupNotices collapsed={!wide} onExpand={onToggleSidebar} />
+      <ProjectCleanupNotices collapsed={!wide} onExpand={onToggleSidebar} showReadError={!query.isPending && !readFailed} />
 
       <div className="mt-2">
         <RailRow

--- a/vex-app/src/renderer/features/appShell/studio/sidebar/__tests__/StudioSidebar.test.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/sidebar/__tests__/StudioSidebar.test.tsx
@@ -13,6 +13,7 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { StrictMode } from "react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Result } from "@shared/ipc/result.js";
+import type { ProjectPendingCleanups } from "@shared/schemas/project-cleanup.js";
 import type { ProjectList } from "@shared/schemas/projects.js";
 import { ExplorerRegistry } from "../../explorer/index.js";
 import {
@@ -23,6 +24,7 @@ import {
 } from "../../__tests__/studio-fixtures.js";
 
 const projectsListMock = vi.fn<() => Promise<Result<ProjectList>>>();
+const pendingCleanupsMock = vi.fn<() => Promise<Result<ProjectPendingCleanups>>>();
 /** The two request shapes the rail sends, so the mocks type their calls. */
 interface SearchQueryInput {
   readonly projectId: string;
@@ -123,6 +125,8 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  pendingCleanupsMock.mockReset();
+  pendingCleanupsMock.mockResolvedValue({ ok: true, data: { items: [], nextOffset: null } });
   projectsListMock.mockReset();
   projectsListMock.mockResolvedValue({ ok: true, data: [] });
   searchFileNamesMock.mockReset();
@@ -135,7 +139,7 @@ beforeEach(() => {
   Object.defineProperty(window, "vex", {
     configurable: true,
     value: {
-      projects: { list: projectsListMock, pendingCleanups: async () => ({ ok: true, data: { items: [], nextOffset: null } }) },
+      projects: { list: projectsListMock, pendingCleanups: pendingCleanupsMock },
       files: {
         list: () => Promise.resolve({ ok: true, data: null }),
         watch: () => Promise.resolve({ ok: true, data: null }),
@@ -719,7 +723,8 @@ describe("list states", () => {
     expect(await screen.findByText("No projects yet.")).not.toBeNull();
   });
 
-  it("shows a status line with Retry on a failed read, never a blank rail", async () => {
+  it("shows one error and retries both reads when projects and cleanup reads fail", async () => {
+    pendingCleanupsMock.mockResolvedValue({ ok: false, error: makeError("db down") });
     projectsListMock.mockResolvedValue({
       ok: false,
       error: makeError("db down"),
@@ -728,13 +733,36 @@ describe("list states", () => {
     const status = await screen.findByRole("status");
     expect(status.textContent).toContain("Vex could not read your projects.");
 
+    await waitFor(() => expect(pendingCleanupsMock).toHaveBeenCalledOnce());
+    expect(screen.getAllByRole("status")).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: /Retry/ })).toHaveLength(1);
+    expect(screen.queryByText("Unfinished project cleanups could not be loaded.")).toBeNull();
     const retry = screen.getByRole("button", { name: "Retry" });
+    pendingCleanupsMock.mockResolvedValue({ ok: true, data: { items: [], nextOffset: null } });
     projectsListMock.mockResolvedValue({
       ok: true,
       data: [makeProject({ name: "vex-core" })],
     });
     fireEvent.click(retry);
     await screen.findByText("vex-core");
+    await waitFor(() => expect(pendingCleanupsMock).toHaveBeenCalledTimes(2));
+    expect(projectsListMock).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText("Unfinished project cleanups could not be loaded.")).toBeNull();
+  });
+
+  it("keeps an independent cleanup error and retries only that read", async () => {
+    projectsListMock.mockResolvedValue({ ok: true, data: [makeProject({ name: "vex-core" })] });
+    pendingCleanupsMock.mockResolvedValue({ ok: false, error: makeError("cleanup read failed") });
+    renderSidebar();
+    await screen.findByText("vex-core");
+    await screen.findByText("Unfinished project cleanups could not be loaded.");
+    expect(screen.queryByText("Vex could not read your projects.")).toBeNull();
+    expect(screen.getAllByRole("button", { name: /Retry/ })).toHaveLength(1);
+    pendingCleanupsMock.mockResolvedValue({ ok: true, data: { items: [], nextOffset: null } });
+    fireEvent.click(screen.getByRole("button", { name: "Retry loading cleanups" }));
+    await waitFor(() => expect(screen.queryByText("Unfinished project cleanups could not be loaded.")).toBeNull());
+    expect(pendingCleanupsMock).toHaveBeenCalledTimes(2);
+    expect(projectsListMock).toHaveBeenCalledOnce();
   });
 
   it("a REJECTED read is a failure, not an empty list", async () => {

--- a/vex-app/src/renderer/features/appShell/studio/sidebar/__tests__/StudioSidebar.test.tsx
+++ b/vex-app/src/renderer/features/appShell/studio/sidebar/__tests__/StudioSidebar.test.tsx
@@ -135,7 +135,7 @@ beforeEach(() => {
   Object.defineProperty(window, "vex", {
     configurable: true,
     value: {
-      projects: { list: projectsListMock },
+      projects: { list: projectsListMock, pendingCleanups: async () => ({ ok: true, data: { items: [], nextOffset: null } }) },
       files: {
         list: () => Promise.resolve({ ok: true, data: null }),
         watch: () => Promise.resolve({ ok: true, data: null }),

--- a/vex-app/src/renderer/lib/api/projects.ts
+++ b/vex-app/src/renderer/lib/api/projects.ts
@@ -14,6 +14,7 @@
  * re-apply a stale intent.
  */
 
+import { useEffect, useRef } from "react";
 import type { ProjectPendingCleanups } from "@shared/schemas/project-cleanup.js";
 
 import {
@@ -200,14 +201,22 @@ export function useRepairProjectFiles(): UseMutationResult<
  * flight, the other says the row is not what the cache thinks it is - so the
  * next read comes from main either way.
  */
-export function useDeleteProject(): UseMutationResult<
+export function useDeleteProject(cancellable = false): UseMutationResult<
   Result<ProjectDeleteResult>,
   Error,
   ProjectDeleteInput
-> {
+> & { readonly cancel: () => void } {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (input: ProjectDeleteInput) => window.vex.projects.delete(input),
+  const cancelRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => cancelRef.current?.(), []);
+  const mutation = useMutation({
+    mutationFn: async (input: ProjectDeleteInput) => {
+      if (!cancellable) return window.vex.projects.delete(input);
+      const invocation = window.vex.projects.deleteAbortable(input);
+      cancelRef.current = invocation.cancel;
+      try { return await invocation.promise; }
+      finally { if (cancelRef.current === invocation.cancel) cancelRef.current = null; }
+    },
     retry: false,
     onSuccess: (result, input) => {
       if (!result.ok) return;
@@ -216,6 +225,7 @@ export function useDeleteProject(): UseMutationResult<
       void queryClient.invalidateQueries({ queryKey: projectKeys.list() });
     },
   });
+  return { ...mutation, cancel: () => cancelRef.current?.() };
 }
 
 export function usePendingProjectCleanups(offset: number): UseQueryResult<Result<ProjectPendingCleanups>> {

--- a/vex-app/src/shared/schemas/project-cleanup.test.ts
+++ b/vex-app/src/shared/schemas/project-cleanup.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from "vitest";
+import { parseStoredTrashFailure, projectTrashFailureSchema, trashRemediation } from "./project-cleanup.js";
+import { projectDeleteInputSchema } from "./projects.js";
+import { ptyParentPid } from "./pty-lifetime.js";
+import { terminalFolderRequestSchema, terminalFolderHoldersSchema } from "./terminal-holders.js";
+it("reads legacy obligations and complete structured holder observations", () => {
+  expect(parseStoredTrashFailure("trash:busy")).toBe("busy");
+  const failure = { reason: "busy", folder: "C:\\projects\\trading", holders: [{ kind: "vex_orphaned_terminal", pid: 6484 }] };
+  expect(parseStoredTrashFailure(`trash:${JSON.stringify(failure)}`)).toEqual(failure);
+  expect(trashRemediation(projectTrashFailureSchema.parse(failure))).toContain("previous session");
+  expect(parseStoredTrashFailure("trash:private native error")).toBeNull();
+  expect(projectTrashFailureSchema.safeParse({ ...failure, holders: [{ kind: "vex_terminal", pid: -1 }] }).success).toBe(false);
+});
+it("accepts only cleanup intent, never caller-selected paths or PIDs", () => {
+  const input = { projectId: "11111111-1111-4111-8111-111111111111", expectedName: "Example", alsoTrashFolder: true, closeHolders: true };
+  expect(projectDeleteInputSchema.safeParse(input).success).toBe(true);
+  for (const extra of [{ pid: 1 }, { directory: "/outside" }, { closeHolders: "true" }]) {
+    expect(projectDeleteInputSchema.safeParse({ ...input, ...extra }).success).toBe(false);
+  }
+});
+it("requires a marker and exactly one positive parent PID", () => {
+  expect(ptyParentPid(["--vex-pty-host", "--vex-parent-pid=41"])).toBe(41);
+  for (const args of [["--vex-parent-pid=41"], ["--vex-pty-host", "--vex-parent-pid=0"], ["--vex-pty-host", "--vex-parent-pid=41", "--vex-parent-pid=42"]]) expect(ptyParentPid(args)).toBeNull();
+});
+it("rejects off-contract host queries and responses", () => {
+  expect(terminalFolderRequestSchema.safeParse({ kind: "folderHolders", directory: "/project", close: false }).success).toBe(true);
+  expect(terminalFolderRequestSchema.safeParse({ kind: "folderHolders", directory: "/project", close: true, pid: 1 }).success).toBe(false);
+  expect(terminalFolderHoldersSchema.safeParse([{ kind: "external", pid: 1 }]).success).toBe(false);
+});
+it("does not attribute an unidentified lock to another program", () => {
+  expect(trashRemediation({ reason: "busy", folder: "C:\\projects\\example" })).toContain("could not be identified");
+});

--- a/vex-app/src/shared/schemas/project-cleanup.ts
+++ b/vex-app/src/shared/schemas/project-cleanup.ts
@@ -1,20 +1,48 @@
 import { z } from "zod";
 
-/** Allowlisted causes only: native messages and absolute paths never cross IPC. */
-export const projectTrashFailureSchema = z.enum([
+/** Allowlisted causes. Paths are diagnostic display values and never accepted as action input. */
+export const projectTrashReasonSchema = z.enum([
   "busy", "nonlocal_volume", "aborted", "permission_denied", "invalid_path",
-  "path_unresolved", "outside_root", "io_error",
+  "path_unresolved", "outside_root", "io_error", "restore_failed",
 ]);
+export type ProjectTrashReason = z.infer<typeof projectTrashReasonSchema>;
+export const projectTrashHolderSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("external") }).strict(),
+  z.object({ kind: z.enum(["vex_terminal", "vex_orphaned_terminal"]),
+    pid: z.number().int().positive(), project: z.string().optional(),
+    projectId: z.string().uuid().optional(),
+  }).strict(),
+]);
+export type ProjectTrashHolder = z.infer<typeof projectTrashHolderSchema>;
+export const projectTrashFailureSchema = z.union([projectTrashReasonSchema, z.object({
+  reason: projectTrashReasonSchema,
+  folder: z.string().min(1),
+  holders: z.array(projectTrashHolderSchema).optional(),
+  recoveryPath: z.string().min(1).optional(),
+}).strict()]);
+export function trashReason(failure: ProjectTrashFailure): ProjectTrashReason {
+  return typeof failure === "string" ? failure : failure.reason;
+}
+export function trashRemediation(failure: ProjectTrashFailure): string {
+  if (typeof failure !== "string") {
+    if (failure.reason === "busy" && !failure.holders?.length) return "The folder is in use. Its holder could not be identified. Close programs using it and retry cleanup.";
+    if (failure.reason === "restore_failed") return `The folder was renamed but could not be restored. Recover it from ${failure.recoveryPath} to ${failure.folder} before retrying.`;
+    if (failure.holders?.some((holder) => holder.kind === "vex_orphaned_terminal")) return "A Vex terminal from a previous session still uses this folder. Close it and retry.";
+    if (failure.holders?.some((holder) => holder.kind === "vex_terminal")) return "A Vex terminal still uses this folder. Close it and retry.";
+  }
+  return PROJECT_TRASH_REMEDIATION[trashReason(failure)];
+}
 export type ProjectTrashFailure = z.infer<typeof projectTrashFailureSchema>;
 
-export const PROJECT_TRASH_REMEDIATION: Readonly<Record<ProjectTrashFailure, string>> = {
-  busy: "The folder is in use. Close terminals, agents and other programs using it, then retry cleanup.",
+const PROJECT_TRASH_REMEDIATION: Readonly<Record<ProjectTrashReason, string>> = {
+  busy: "Another program is using this folder. Close it, then retry cleanup.",
   nonlocal_volume: "The OS refused to trash a network or WSL folder. This location may not support the Recycle Bin. Move the folder yourself, or retry after closing programs using it.",
-  aborted: "The OS aborted the trash operation. It may be unable to recycle this folder, or a program may still be using it. Close programs and retry; if it still fails, move the folder yourself.",
+  aborted: "The OS could not recycle this folder. Move the folder yourself, or retry cleanup.",
   permission_denied: "The OS denied permission to trash the folder. Check its permissions, then retry cleanup or move the folder yourself.",
   invalid_path: "The OS could not parse the folder path. Check the projects root in settings, then retry cleanup.",
   path_unresolved: "The folder could not be resolved. Check that the projects drive is connected and accessible, then retry cleanup.",
   outside_root: "The folder resolves outside the projects root. Check the folder and root in settings; Vex will not trash a different location.",
+  restore_failed: "The folder was renamed but could not be restored. Recover the folder from the reported temporary path before retrying.",
   io_error: "The OS could not move the folder to the trash and supplied no recognized cause. Close programs using it and retry, or move the folder yourself.",
 };
 
@@ -37,3 +65,15 @@ export const projectPendingCleanupsSchema = z.object({
   nextOffset: z.number().int().nonnegative().nullable(),
 }).strict();
 export type ProjectPendingCleanups = z.infer<typeof projectPendingCleanupsSchema>;
+
+/** Legacy reason-only rows remain readable; stored native messages remain private. */
+export function parseStoredTrashFailure(stored: string | null): ProjectTrashFailure | null {
+  if (stored === null || !stored.startsWith("trash:")) return null;
+  const payload = stored.replace(/^trash:/, "");
+  let value: unknown = payload;
+  if (payload.startsWith("{")) {
+    try { value = JSON.parse(payload); } catch { return null; }
+  }
+  const parsed = projectTrashFailureSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}

--- a/vex-app/src/shared/schemas/projects.ts
+++ b/vex-app/src/shared/schemas/projects.ts
@@ -348,6 +348,7 @@ export const projectDeleteInputSchema = z
   .object({
     projectId: z.string().uuid(),
     alsoTrashFolder: z.boolean(),
+    closeHolders: z.boolean().optional(),
     expectedName: z.string().min(1).max(80),
   })
   .strict();

--- a/vex-app/src/shared/schemas/pty-lifetime.ts
+++ b/vex-app/src/shared/schemas/pty-lifetime.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const PTY_HOST_MARKER = "--vex-pty-host";
+export const PTY_PARENT_ARG = "--vex-parent-pid=";
+export const ptyParentPidSchema = z.coerce.number().int().positive().safe();
+export function ptyParentPid(argv: readonly string[]): number | null {
+  if (!argv.includes(PTY_HOST_MARKER)) return null;
+  const args = argv.filter((arg) => arg.startsWith(PTY_PARENT_ARG));
+  if (args.length !== 1) return null;
+  const parsed = ptyParentPidSchema.safeParse(args[0]?.replace(PTY_PARENT_ARG, ""));
+  return parsed.success ? parsed.data : null;
+}

--- a/vex-app/src/shared/schemas/terminal-holders.ts
+++ b/vex-app/src/shared/schemas/terminal-holders.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const terminalFolderRequestSchema = z.object({
+  kind: z.literal("folderHolders"),
+  directory: z.string().min(1),
+  close: z.boolean(),
+}).strict();
+export const terminalFolderHoldersSchema = z.array(z.object({
+  kind: z.literal("vex_terminal"), pid: z.number().int().positive(),
+  project: z.string(), projectId: z.string().uuid(),
+}).strict()).max(24);
+export type TerminalFolderHolder = z.infer<typeof terminalFolderHoldersSchema>[number];

--- a/vex-app/src/shared/schemas/terminal.ts
+++ b/vex-app/src/shared/schemas/terminal.ts
@@ -55,6 +55,7 @@
  * and a refused write is refused by name rather than truncated.
  */
 
+import { terminalFolderRequestSchema } from "./terminal-holders.js";
 import { z } from "zod";
 
 /* ------------------------------------------------------------------ *
@@ -717,6 +718,7 @@ export const terminalLaunchSchema = z
 export type TerminalLaunch = z.infer<typeof terminalLaunchSchema>;
 
 export const terminalHostRequestSchema = z.discriminatedUnion("kind", [
+  terminalFolderRequestSchema,
   /** Associate a freshly transferred port with a window. Sent with the transfer. */
   z
     .object({

--- a/vex-app/src/shared/types/bridge/agent/projects.ts
+++ b/vex-app/src/shared/types/bridge/agent/projects.ts
@@ -1,3 +1,4 @@
+import type { AbortableInvocation } from "../common.js";
 import type { ProjectPendingCleanups, ProjectPendingCleanupsInput } from "../../../schemas/project-cleanup.js";
 import type { Result } from "../../../ipc/result.js";
 import type {
@@ -79,6 +80,8 @@ export interface ProjectsBridge {
    * `cleanup_pending` means the authority commit stands and the file work is
    * still owed, and `already_removed` means there was nothing left to do.
    */
+  /** Same validated delete operation, with cancellation before holder termination. */
+  readonly deleteAbortable: (input: ProjectDeleteInput) => AbortableInvocation<ProjectDeleteResult>;
   readonly delete: (
     input: ProjectDeleteInput
   ) => Promise<Result<ProjectDeleteResult>>;


### PR DESCRIPTION
Root cause, measured on the owner's Windows machine on 2026-09-09: a pty host (Electron utility process) from a Vex main process killed on 2026-09-04 was still alive with a `cmd.exe` whose current directory was a deleted project's folder. Windows refuses to move a directory that is a live process's cwd, Electron's `shell.trashItem` reports only "Operation was aborted", and the notice told the user to close programs without knowing the program was Vex's own orphan. A second orphaned host from 2026-09-08 sat next to it.

Three parts, following VS Code's parent-bound utility process (`utilityProcess.ts`, `bootstrap-fork.ts`, `processes.ts`) and the deepseek-harness disclosure grammar:

1. The pty host never outlives main: explicit `--vex-pty-host` and `--vex-parent-pid` identity (in execArgv so the OS process list carries it), a parent liveness poll at the heartbeat cadence, terminal tree kills on Windows, exit after cleanup. A startup reaper kills orphaned hosts selected by our binary path, the marker and a dead parent, re-verified by creation time before the kill.
2. Delete diagnostics: an aborted trash on Windows is probed with a rename and restore (`restore_failed` carries the recovery path if the restore fails). A lock reports `busy` with holders named from the pty host's own terminals and from orphaned hosts (PEB cwd read of identified descendants only). "Close it and retry" kills only re-validated own holders, then runs the existing tombstone cleanup; the attempt counter and the fifth-failure escalation stay.
3. The cleanup notice moves from the top of the Studio center to a compact disclosure row under Projects in the rail, keyboard reachable, with a named expand control when the rail is collapsed; the center, terminal and dialogs keep their geometry (new e2e `studio-cleanup.spec.ts`).

Verified on Linux: 308 test files / 4909 tests, app lint (type ratchet, process boundaries), root em-dash and unsafe-escape gates, Playwright studio specs under xvfb, and a hard-death probe (no surviving host or shell after five seconds). Windows verification steps for the coordinator are in `vex-app/docs/STUDIO_TRASH_REPORT.md`; pre-marker orphans from older builds were cleaned once by hand.
