### PR TITLE
fix(agentscan): Superboard share token in the deployed body shape, Copy for a pending token

### DIFF
--- a/src/__tests__/vex-agent/agentscan/share-token-client.test.ts
+++ b/src/__tests__/vex-agent/agentscan/share-token-client.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { formatWithOptions } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildShareTokenClient } from "../../../vex-agent/agentscan/share-token-client.js";
 import { generateShareToken } from "../../../vex-agent/agentscan/share-token.js";
@@ -23,8 +24,31 @@ function stubFetch(response: Response | Error): ReturnType<typeof vi.fn> {
   return mock;
 }
 
+const logSpies = () => [
+  vi.spyOn(console, "log").mockImplementation(() => undefined),
+  vi.spyOn(console, "info").mockImplementation(() => undefined),
+  vi.spyOn(console, "warn").mockImplementation(() => undefined),
+  vi.spyOn(console, "error").mockImplementation(() => undefined),
+  vi.spyOn(console, "debug").mockImplementation(() => undefined),
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true),
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true),
+];
+let logs: ReturnType<typeof logSpies>;
+
+beforeEach(() => {
+  logs = logSpies();
+});
+
 afterEach(() => {
+  const lines = logs.flatMap((spy) => spy.mock.calls.map((args) => formatWithOptions(
+    { depth: null, maxArrayLength: null, maxStringLength: null }, ...args,
+  )));
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  for (const line of lines) {
+    expect(line).not.toContain(SHARE);
+    expect(line).not.toContain(INGEST);
+  }
 });
 
 describe("generateShareToken", () => {
@@ -36,22 +60,25 @@ describe("generateShareToken", () => {
 });
 
 describe("buildShareTokenClient.register", () => {
-  it("POSTs only the lowercase SHA-256 shareTokenHash with Bearer ingest token", async () => {
+  it("POSTs the plaintext shareToken only in the body to the configured URL with Bearer ingest token", async () => {
     const mock = stubFetch(jsonResponse(200, { status: "registered" }));
-    const client = buildShareTokenClient("http://localhost");
+    const client = buildShareTokenClient("https://agentscan.example");
     const outcome = await client.register({ ingestToken: INGEST, shareToken: SHARE });
 
     expect(outcome).toEqual({ kind: "registered" });
     expect(mock).toHaveBeenCalledTimes(1);
     const [url, init] = mock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("http://localhost/v1/agents/share-token");
+    expect(url).toBe("https://agentscan.example/v1/agents/share-token");
     expect((init.headers as Record<string, string>)["Authorization"]).toBe(`Bearer ${INGEST}`);
     expect(init.method).toBe("POST");
     expect(JSON.parse(init.body as string)).toEqual({
-      shareTokenHash: "b0679324228c35931acdfa8a487f94873c05094138a477994a5bdba6d6c24a56",
+      shareToken: SHARE,
     });
-    expect(init.body).not.toContain(SHARE);
-    expect(JSON.stringify(init.headers)).not.toContain(SHARE);
+    const { body, ...requestMetadata } = init;
+    expect(body).not.toContain(INGEST);
+    expect(JSON.stringify({ url, ...requestMetadata })).not.toContain(SHARE);
+    expect(init.redirect).toBe("error");
+    expect(JSON.stringify(outcome)).not.toContain(SHARE);
   });
 
   it("preserves a base-URL subpath", async () => {
@@ -96,7 +123,7 @@ describe("buildShareTokenClient.register", () => {
     stubFetch(jsonResponse(400, { error: { code: "validation_failed" } }));
     const client = buildShareTokenClient("http://localhost");
     const outcome = await client.register({ ingestToken: INGEST, shareToken: SHARE });
-    expect(outcome.kind).toBe("invalid");
+    expect(outcome).toEqual({ kind: "invalid", detail: "HTTP 400 validation_failed" });
   });
 
   it("maps 429/500 and network failure to retryable", async () => {
@@ -108,10 +135,11 @@ describe("buildShareTokenClient.register", () => {
       retryAfterSeconds: 30,
     });
 
-    stubFetch(jsonResponse(500, { error: { code: "internal" } }));
+    stubFetch(jsonResponse(500, { error: { code: "internal" } }, { "retry-after": "15" }));
     expect(await client.register({ ingestToken: INGEST, shareToken: SHARE })).toMatchObject({
       kind: "retryable",
       status: 500,
+      retryAfterSeconds: 15,
     });
 
     stubFetch(new Error("fetch failed"));
@@ -121,16 +149,32 @@ describe("buildShareTokenClient.register", () => {
     });
   });
 
-  it("never leaks the share token into a retryable or invalid detail", async () => {
-    stubFetch(jsonResponse(500, { error: { code: `internal ${SHARE}` } }));
+  it.each([400, 429, 500])("never leaks credentials from a %i response into details or logs", async (status) => {
+    stubFetch(jsonResponse(status, { error: { code: `internal ${SHARE} ${INGEST}`, message: SHARE } }));
     const client = buildShareTokenClient("http://localhost");
     const server = await client.register({ ingestToken: INGEST, shareToken: SHARE });
+    expect(server.kind).toBe(status === 400 ? "invalid" : "retryable");
     expect(JSON.stringify(server)).not.toContain(SHARE);
+    expect(JSON.stringify(server)).not.toContain(INGEST);
+  });
 
-    stubFetch(new Error(`connect ECONNREFUSED near ${SHARE}`));
+  it("never leaks credentials from a network error into details or logs", async () => {
+    stubFetch(new Error(`connect ECONNREFUSED near ${SHARE} ${INGEST}`));
+    const client = buildShareTokenClient("http://localhost");
     const network = await client.register({ ingestToken: INGEST, shareToken: SHARE });
     expect(JSON.stringify(network)).not.toContain(SHARE);
+    expect(JSON.stringify(network)).not.toContain(INGEST);
     expect(network.kind).toBe("retryable");
+  });
+
+  it("reports an oversized provider detail explicitly without returning a cut-off message", async () => {
+    stubFetch(jsonResponse(400, { error: { code: "invalid field ".repeat(30) } }));
+    const outcome = await buildShareTokenClient("https://agentscan.example")
+      .register({ ingestToken: INGEST, shareToken: SHARE });
+    expect(outcome).toEqual({
+      kind: "invalid",
+      detail: "HTTP 400; detail omitted (exceeds 120 characters)",
+    });
   });
 
   it("maps a malformed 200 body to invalid rather than throwing", async () => {

--- a/src/vex-agent/agentscan/share-token-client.ts
+++ b/src/vex-agent/agentscan/share-token-client.ts
@@ -1,4 +1,10 @@
-import { createHash } from "node:crypto";
+/**
+ * Bind the locally persisted Superboard token to this AgentScan identity.
+ * The plaintext crosses TLS once per registration attempt to AgentScan, the
+ * party that verifies it and stores only its SHA-256 hash. The local copy stays
+ * in this install's database. Retries reuse the same token; never log it or
+ * include it in returned details. See share-token.md for the deployed contract.
+ */
 
 import { fetchWithTimeout, readJson } from "@utils/http.js";
 import { readRetryAfterSeconds } from "@utils/http/retry-after.js";
@@ -36,14 +42,13 @@ async function registerShareToken(
   try {
     response = await fetchWithTimeout(joinUrl(baseUrl, "v1/agents/share-token"), {
       method: "POST",
+      redirect: "error",
       timeoutMs: REQUEST_TIMEOUT_MS,
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${input.ingestToken}`,
       },
-      body: JSON.stringify({
-        shareTokenHash: createHash("sha256").update(input.shareToken, "utf8").digest("hex"),
-      }),
+      body: JSON.stringify({ shareToken: input.shareToken }),
     });
   } catch (err) {
     return { kind: "retryable", status: null, retryAfterSeconds: null, detail: safeDetail(err) };
@@ -95,14 +100,14 @@ function errorCode(body: unknown): string | null {
 
 function describeError(status: number, body: unknown): string {
   const code = errorCode(body);
-  return sanitize(code === null ? `HTTP ${status}` : `HTTP ${status} ${code}`);
+  return sanitize(code === null ? `HTTP ${status}` : `HTTP ${status} ${code}`, `HTTP ${status}`);
 }
 
 function safeDetail(err: unknown): string {
-  return sanitize(err instanceof Error ? `${err.name}: ${err.message}` : String(err));
+  return sanitize(err instanceof Error ? `${err.name}: ${err.message}` : String(err), "request failed");
 }
 
-function sanitize(text: string): string {
+function sanitize(text: string, fallback: string): string {
   const scrubbed = text
     .replace(/\bhttps?:\/\/\S+/gi, "<url>")
     .replace(/\b0x[0-9a-fA-F]{16,}\b/g, "<hex>")
@@ -110,5 +115,7 @@ function sanitize(text: string): string {
     .replace(/\s+/g, " ")
     .trim();
   if (scrubbed.length === 0) return "no detail";
-  return scrubbed.length > MAX_DETAIL_LEN ? `${scrubbed.slice(0, MAX_DETAIL_LEN)}…` : scrubbed;
+  return scrubbed.length > MAX_DETAIL_LEN
+    ? `${fallback}; detail omitted (exceeds ${MAX_DETAIL_LEN} characters)`
+    : scrubbed;
 }

--- a/src/vex-agent/agentscan/share-token.md
+++ b/src/vex-agent/agentscan/share-token.md
@@ -2,7 +2,10 @@
 
 Settings generates one 32-byte random token encoded as 43 base64url characters.
 The reporting singleton stores it write-once. There is no rotation or regenerate
-IPC. Copy is enabled only for a token whose registration has succeeded.
+IPC. Copy is enabled whenever a token exists, pending or registered, including
+while a status refresh is in flight. A pending token is valid locally and can be
+pasted into Superboard, but its AgentScan binding still needs to succeed. Settings
+keeps the pending message and human-readable last error after copying.
 
 ## AgentScan request
 
@@ -10,21 +13,39 @@ IPC. Copy is enabled only for a token whose registration has succeeded.
 and sends `Content-Type: application/json` with this body:
 
 ```json
-{ "shareTokenHash": "<64 lowercase hexadecimal characters>" }
+{ "shareToken": "<43 base64url characters>" }
 ```
 
-The hash is SHA-256 of the UTF-8 bytes of the complete 43-character base64url
-token, without decoding the token. The plaintext share token never appears in
-request headers or body. A successful response must contain
-`{ "status": "registered" }`.
+The plaintext crosses TLS once per registration attempt to AgentScan, the party
+that verifies it. AgentScan computes SHA-256 over the UTF-8 bytes of the complete
+token without decoding it and stores only that hash. The local plaintext copy
+stays in this install's database. The share token appears only in the request
+body, never the URL, request headers, logs, or returned error details. Requests
+use the configured base URL and reject redirects. Production uses HTTPS; explicit
+local HTTP base URLs remain supported. A successful response must contain
+`{ "status": "registered" }`. Retries send the same plaintext token again.
 
-On 2026-09-08, searches for `share-token`, `share_token`, and `shareToken` found
-no route in the AgentScan checkout's `origin/dev` (`9eb29f4069e4925e98f556782c1bd7e14ab0e5e2`)
-or its `feat/lighter-activity` working tree. `shareTokenHash` is therefore the
-client contract chosen to implement the PR's stated SHA-256-only requirement;
-the AgentScan side must implement this field and a write-once, idempotent bind.
-Live endpoint compatibility has not been verified. Until the endpoint accepts
-the hash, the locally stored token remains pending and Copy remains disabled.
+The deployed first-party contract was read on 2026-09-09 from the AgentScan
+checkout's `origin/dev` at `67fa173ad9ad22c0f1cee97abafdfc49eedc95ac`:
+
+- `apps/server/src/routes/agents.ts`: bearer ingest authentication, revoked and
+  quarantined guards, rate limiting, body validation, server hashing, and status mapping.
+- `packages/contract/src/share-token.ts`: strict `{ shareToken }` object with
+  `/^[A-Za-z0-9_-]{43}$/` validation.
+- `apps/server/src/repos/share-token-repo.ts`: same hash is idempotent; a
+  different hash or another agent's existing hash is a conflict.
+- `apps/server/src/__tests__/integration/share-token-mint.int.test.ts`: plaintext
+  request payload, hash-only storage, repeat success, and conflicting-token rejection.
+
+The coordinator measured the production body mismatch on 2026-09-09. This client
+adapts to that deployed contract; the coordinator runs the authenticated live
+proof with the owner's install after the local checks.
+
+Outcomes remain: 200 registered, 401 auth lost, 403 quarantined, 410 consent
+revoked, 409 conflict, and 429 or 5xx retryable with Retry-After when present.
+Other errors return invalid with sanitized detail. Sanitized details longer than
+120 characters are replaced by an explicit omission notice retaining the HTTP
+status when available, rather than silently returning a cut-off message.
 
 ## State authority and recovery
 
@@ -41,7 +62,8 @@ write-once insert, it reads the winning snapshot again. A late successful
 response cannot mark a different token or a newer generation registered.
 
 Server-reset recovery clears the registration timestamp and preserves the token.
-The next Settings read retries the same hash and shows Linking until accepted.
+The next Settings read retries the same token and shows the pending linking
+message until accepted; Copy remains available.
 Existing identity-recovery behavior clears the abandoned identity's token and
 registration timestamp; its in-flight requests cannot publish into the new
 identity. This is recovery, not a user-visible rotation operation.
@@ -51,8 +73,13 @@ identity. This is recovery, not a user-visible rotation operation.
 `153_agentscan_share_token.sql` adds the nullable token and registration timestamp
 to `agentscan_reporting_state`. It follows main's migration 152; main's 107 is
 reserved for launchpad family roles. Older code ignores the additive columns.
+The applied migration remains unchanged. Its historical comment that plaintext
+stays only on the install is superseded by the request and storage contract above.
 
-Client tests pin the exact hash and absence of plaintext. Registration tests use
+Client tests pin the exact plaintext body, configured destination, rejected
+redirects, status mapping, and absence of credentials from logs and details.
+Settings section tests copy pending tokens while retaining pending/error copy.
+Registration tests use
 controlled promises to cover recovery while a request is pending. The reporting
 repository suite exercises write-once storage, conditional registration, and
 reset invalidation against real Postgres through `vitest/studio-postgres.config.ts`.

--- a/vex-app/src/renderer/features/appShell/screens/SettingsScreen/SuperboardKeySection.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/SettingsScreen/SuperboardKeySection.tsx
@@ -49,7 +49,7 @@ export function SuperboardKeySection(): JSX.Element {
   const kind = readFailed ? "read_error" : (status?.kind ?? "loading");
   const pendingError = status?.kind === "pending" ? status.lastError : null;
   const busy = generate.isPending || query.isFetching;
-  const copyEnabled = kind === "registered" && shareToken.length > 0 && !busy;
+  const copyEnabled = shareToken.length > 0;
 
   return (
     <div

--- a/vex-app/src/renderer/features/appShell/screens/SettingsScreen/__tests__/SuperboardKeySection.test.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/SettingsScreen/__tests__/SuperboardKeySection.test.tsx
@@ -128,7 +128,7 @@ describe("SuperboardKeySection", () => {
     expect(getSuperboardKey).toHaveBeenCalledTimes(2);
   });
 
-  it("disables generation until its result arrives and keeps a pending key uncopyable", async () => {
+  it("disables generation until its result arrives and then copies the pending key", async () => {
     getSuperboardKey.mockResolvedValue(ok({ kind: "missing" }));
     const { promise, resolve: resolveGenerate } = Promise.withResolvers<Result<SuperboardKeyStatus>>();
     generateSuperboardKey.mockReturnValue(promise);
@@ -140,9 +140,10 @@ describe("SuperboardKeySection", () => {
     expect(generateSuperboardKey).toHaveBeenCalledTimes(1);
     resolveGenerate(ok({ kind: "pending", shareToken: SHARE, lastError: null }));
     const copy = await screen.findByRole("button", { name: "Copy" });
-    expect(copy).toHaveProperty("disabled", true);
+    expect(copy).toHaveProperty("disabled", false);
     fireEvent.click(copy);
-    expect(writeText).not.toHaveBeenCalled();
+    await waitFor(() => expect(writeText).toHaveBeenCalledExactlyOnceWith(SHARE));
+    expect(screen.getByText("Not linked yet.")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Generate" })).toBeNull();
     expect(getSuperboardKey).toHaveBeenCalledTimes(1);
   });
@@ -171,12 +172,21 @@ describe("SuperboardKeySection", () => {
     expect(screen.getByText("Your data stays yours")).toBeTruthy();
   });
 
-  it("disables Copy when pending", async () => {
-    getSuperboardKey.mockResolvedValue(ok({ kind: "pending", shareToken: SHARE, lastError: null }));
+  it.each([
+    { lastError: null, message: "Not linked yet." },
+    { lastError: "HTTP 400 validation_failed", message: "Couldn't link this key yet. Try again later." },
+    { lastError: "HTTP 429 rate_limited", message: "Too many attempts. Wait a moment and try again." },
+  ])("copies a pending key while keeping the honest status: $message", async ({ lastError, message }) => {
+    getSuperboardKey.mockResolvedValue(ok({ kind: "pending", shareToken: SHARE, lastError }));
     renderSection();
-    const copy = (await screen.findByRole("button", { name: "Copy" })) as HTMLButtonElement;
-    expect(copy.disabled).toBe(true);
+    const copy = await screen.findByRole("button", { name: "Copy" });
+    expect(copy).toHaveProperty("disabled", false);
+    fireEvent.click(copy);
+    await waitFor(() => expect(writeText).toHaveBeenCalledExactlyOnceWith(SHARE));
+    expect(screen.getByText(message)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Copied" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Generate" })).toBeNull();
+    expect(generateSuperboardKey).not.toHaveBeenCalled();
   });
 
   it("shows a human pending line instead of HTTP 404 not_found", async () => {


### PR DESCRIPTION
The owner's Superboard key stayed in the pending (Linking) state. Measured against the deployed AgentScan (route `POST /v1/agents/share-token`, PR #81 on the AgentScan side): the server validates `{ shareToken }` and hashes it itself, storing only the SHA-256 and treating the same token as idempotent. Vex sent `{ shareTokenHash }`, which fails the server's body validation.

- Client sends `{ shareToken }`, refuses redirects (the bearer token never follows a redirect), and reports an oversized detail as omitted instead of cutting it.
- Settings > Superboard key: Copy is enabled whenever a token exists (pending or registered).
- `share-token.md` records the deployed contract and the privacy consequence: the plaintext crosses TLS once to the verifying party, which stores only the hash; the local copy stays in the install database.

Verified: root AgentScan suites (264 tests), app screens and settings IPC suites (973 tests), app lint, em-dash and unsafe-escape gates. Live: the real client registered the owner's token against the deployed server (`{ kind: "registered" }`).
