### PR TITLE
fix: keep the Lighter fill ledger idempotent under concurrent observers and point the privacy link at the live docs

### DIFF
--- a/src/__tests__/lighter/lighter-fill-observation-hooks.test.ts
+++ b/src/__tests__/lighter/lighter-fill-observation-hooks.test.ts
@@ -39,6 +39,7 @@ import {
 } from "@vex-agent/tools/protocols/lighter/order-repair.js";
 import {
   LIGHTER_FILL_FOLLOW_UP_TRADES_LIMIT,
+  observeLighterFills,
   observeLighterFillsFromAccountTrades,
   resetLighterMarketAssetsCache,
   resolveLighterMarketAssets,
@@ -937,5 +938,54 @@ describe("market assets: a perpetual names its instrument and its collateral, a 
     await expect(resolveLighterMarketAssets("core", 0, marketDeps(perp, [wrongId, eth]))).rejects.toThrow(/verified core USDC collateral/);
     const wrongAddress = { ...collateral, l1_address: "0x0000000000000000000000000000000000000001" };
     await expect(resolveLighterMarketAssets("core", 0, marketDeps(perp, [wrongAddress, eth]))).rejects.toThrow(/verified core USDC collateral/);
+  });
+});
+
+describe("observation counters: the report says what the ledger answered", () => {
+  const intent = {
+    intentId: "lighter-order-counters",
+    environment: "core" as const,
+    accountIndex: ACCOUNT_INDEX,
+    marketIndex: 0,
+    side: "buy" as const,
+    clientOrderIndex: CLIENT_ORDER_INDEX,
+  };
+
+  it("counts a fill the ledger enriched as already held, never as a failure", async () => {
+    // The ledger held the row without the account's own fields and this
+    // observation supplied them: nothing was inserted and nothing failed. The
+    // revision the ledger bumped is its own business and not a count here.
+    const recordFill = vi.fn<LighterFillObservationDeps["recordFill"]>(async () => ({
+      kind: "enriched" as const,
+      fillId: 1,
+      revision: 1,
+    }));
+
+    const report = await observeLighterFills({
+      intent,
+      trades: [trade()],
+      authorizedFees: null,
+      deps: fillDeps(recordFill),
+    });
+
+    expect(recordFill).toHaveBeenCalledTimes(1);
+    expect(report).toEqual({ observed: 1, recorded: 0, duplicates: 1, failed: 0 });
+  });
+
+  it("counts an identity conflict as a failure, because the second report contradicts the ledger", async () => {
+    const recordFill = vi.fn<LighterFillObservationDeps["recordFill"]>(async () => ({
+      kind: "conflict" as const,
+      fillId: 1,
+      fields: ["price"],
+    }));
+
+    const report = await observeLighterFills({
+      intent,
+      trades: [trade()],
+      authorizedFees: null,
+      deps: fillDeps(recordFill),
+    });
+
+    expect(report).toEqual({ observed: 1, recorded: 0, duplicates: 0, failed: 1 });
   });
 });

--- a/src/vex-agent/tools/protocols/lighter/agentscan-activity.ts
+++ b/src/vex-agent/tools/protocols/lighter/agentscan-activity.ts
@@ -738,6 +738,22 @@ const ATTACH_FILL_SQL = `
      AND execution_intent_id IS NULL
   RETURNING id`;
 
+/**
+ * NO ARBITER ON THE CONFLICT CLAUSE, on purpose.
+ *
+ * The row carries two unique identities that name the same fill: the
+ * canonical string and the (environment, account, market, trade id) tuple it
+ * is derived from. Naming `(canonical_identity)` as the arbiter made only that
+ * index arbitrated: the arbiter pre-check runs unlocked, so a second observer
+ * racing the first can miss the winner's insertion there and go on to collide
+ * on the tuple index, which is not arbitrated and raises `unique_violation`
+ * instead of resolving to "already held". Measured 2026-09-11 on a live
+ * install: the order-evidence follow-up and a concurrent observation of the
+ * same trade, 8 ms apart, and the loser logged `ledger_write_failed` for a
+ * fill the ledger held. With no arbiter named, every unique index arbitrates,
+ * so a concurrent duplicate waits for the winner and resolves to DO NOTHING,
+ * which is what idempotence by identity promised all along.
+ */
 const INSERT_FILL_SQL = `
   INSERT INTO lighter_fills (
     canonical_identity, environment, account_index, market_index, provider_trade_id,
@@ -761,7 +777,7 @@ const INSERT_FILL_SQL = `
     $21,$22::timestamptz,$23,$24,$25,$26,$27,$28,$29,$30,
     $31,$32,$33,$34,$35,$36,$37,$38,$39,$40,$41,$42,$43,$44,$45
   )
-  ON CONFLICT (canonical_identity) DO NOTHING
+  ON CONFLICT DO NOTHING
   RETURNING id`;
 
 const SELECT_FILL_BY_IDENTITY_SQL = `

--- a/src/vex-agent/tools/protocols/lighter/fill-observation.ts
+++ b/src/vex-agent/tools/protocols/lighter/fill-observation.ts
@@ -467,7 +467,12 @@ async function writeFill(
   try {
     const outcome = await deps.recordFill(record);
     if (outcome.kind === "recorded") return "recorded";
-    if (outcome.kind === "duplicate") return "duplicate";
+    // Already held with the same economics: a plain duplicate, or one that
+    // learned the account's own fields on the way (`enriched`). Neither is a
+    // failure - the row exists and says what this observation says - and the
+    // revision bump an enrichment carries is the ledger's business, not a
+    // count here.
+    if (outcome.kind === "duplicate" || outcome.kind === "enriched") return "duplicate";
     // A conflict is already logged with its fields by the writer; it is a
     // defect in whoever produced the second report and never an overwrite.
     return "failed";

--- a/vex-app/src/main/security/__tests__/url.test.ts
+++ b/vex-app/src/main/security/__tests__/url.test.ts
@@ -59,8 +59,6 @@ describe("isAllowedExternalUrl", () => {
   // two in sync — every new production entry needs both an allow case
   // and a near-miss deny case below.
   const allowlist: ReadonlyArray<ExternalAllowEntry> = [
-    "vex.ai",
-    "docs.vex.ai",
     "portal.jup.ag",
     "app.tavily.com",
     "openrouter.ai",
@@ -77,6 +75,7 @@ describe("isAllowedExternalUrl", () => {
     "polygonscan.com",
     "optimistic.etherscan.io",
     { host: "projectvex.ai", pathPrefix: "/releases" },
+    { host: "projectvex.ai", pathPrefix: "/docs" },
     { host: "github.com", pathPrefix: "/electron/electron/releases" },
     {
       host: "chromewebstore.google.com",
@@ -90,8 +89,6 @@ describe("isAllowedExternalUrl", () => {
   ];
 
   it.each([
-    "https://vex.ai/",
-    "https://docs.vex.ai/",
     "https://portal.jup.ag/keys",
     "https://app.tavily.com/",
     "https://app.tavily.com/home",
@@ -102,6 +99,8 @@ describe("isAllowedExternalUrl", () => {
     "https://docs.docker.com/desktop/setup/install/mac-install/",
     "https://projectvex.ai/releases",
     "https://projectvex.ai/releases/v0-2-0",
+    "https://projectvex.ai/docs",
+    "https://projectvex.ai/docs/security/privacy",
     "https://github.com/electron/electron/releases",
     "https://github.com/electron/electron/releases/tag/v42.0.0",
     "https://dexscreener.com/solana/8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj",
@@ -122,7 +121,7 @@ describe("isAllowedExternalUrl", () => {
   });
 
   it.each([
-    "http://vex.ai/", // wrong scheme
+    "http://projectvex.ai/docs", // wrong scheme
     "javascript:alert(1)",
     "file:///etc/passwd",
     "data:text/html,<script>",
@@ -141,9 +140,15 @@ describe("isAllowedExternalUrl", () => {
     "https://github.com/Vex-Foundation/Vex",
     "https://github.com/Vex-Foundation/Vex/releases",
     // projectvex.ai near-misses: path boundary, host root, exact-host only
-    "https://projectvex.ai/", // root not under /releases
+    "https://projectvex.ai/", // root not under /releases or /docs
     "https://projectvex.ai/releasesX",
     "https://projectvex.ai/release",
+    "https://projectvex.ai/docsX",
+    "https://projectvex.ai/doc",
+    // Regression: the placeholder `vex.ai` / `docs.vex.ai` host-wide entries
+    // died with the docs repoint (2026-09-11) - must stay denied.
+    "https://vex.ai/",
+    "https://docs.vex.ai/security/local-vault",
     "https://www.projectvex.ai/releases", // exact-host match, no subdomains
     "https://projectvex.ai.evil.com/releases",
     // Traversal in path
@@ -188,7 +193,9 @@ describe("isAllowedExternalUrl", () => {
   });
 
   it("URL spec normalizes hostname to lowercase - mixed case still allowed", () => {
-    expect(isAllowedExternalUrl("https://VEX.AI/", allowlist)).toBe(true);
+    expect(
+      isAllowedExternalUrl("https://PROJECTVEX.AI/docs/security/privacy", allowlist)
+    ).toBe(true);
     expect(
       isAllowedExternalUrl("https://PROJECTvex.ai/releases", allowlist)
     ).toBe(true);

--- a/vex-app/src/main/windows/main-window.ts
+++ b/vex-app/src/main/windows/main-window.ts
@@ -20,6 +20,7 @@ import { EXPLORER_EXTERNAL_ALLOW } from "@shared/explorer-links.js";
 import { observeWindowForFiles } from "../studio/files/files-composition.js";
 import { observeWindowForTerminals } from "../studio/terminal-domain.js";
 import { CHART_ATTRIBUTION_EXTERNAL_ALLOW } from "@shared/chart-attribution.js";
+import { DOCS_EXTERNAL_ALLOW } from "@shared/docs-links.js";
 import {
   clampToVisibleArea,
   type DisplayInfo,
@@ -50,8 +51,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * NOT `/electron/electron/releases-malicious`. See `pathStartsWithBoundary`.
  */
 const ALLOWED_EXTERNAL: ReadonlyArray<ExternalAllowEntry> = [
-  "vex.ai",
-  "docs.vex.ai",
   "portal.jup.ag",
   "app.tavily.com",
   "openrouter.ai",
@@ -82,6 +81,13 @@ const ALLOWED_EXTERNAL: ReadonlyArray<ExternalAllowEntry> = [
   // just does nothing. Exact host `www.tradingview.com`; lookalikes denied by
   // `isAllowedExternalUrl`'s hostname equality.
   ...CHART_ATTRIBUTION_EXTERNAL_ALLOW,
+  // The "Your data stays yours" privacy link (Settings Superboard section and
+  // the wizard footer). Single source of truth in `@shared/docs-links`, for
+  // the same drift reason as the two spreads above. Path-scoped to the docs
+  // tree on the apex host. The former host-wide `vex.ai` / `docs.vex.ai`
+  // entries died with this repoint: `docs.vex.ai` does not resolve and the
+  // apex is a third party's, and no consumer remains.
+  ...DOCS_EXTERNAL_ALLOW,
   // Vex release notes (updater toast CTA) — path-scoped per owner decision
   // 2026-07-22. The former github.com/Vex-Foundation/ entry died with this
   // repoint (it existed solely for the release-notes CTA; zero remaining

--- a/vex-app/src/renderer/features/appShell/screens/SettingsScreen/SuperboardKeySection.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/SettingsScreen/SuperboardKeySection.tsx
@@ -13,6 +13,7 @@ import {
   useSuperboardKey,
 } from "../../../../lib/api/superboard-key.js";
 import { cn } from "../../../../lib/utils.js";
+import { VEX_PRIVACY_DOC_LABEL, VEX_PRIVACY_DOC_URL } from "@shared/docs-links.js";
 import type { SuperboardKeyStatus } from "@shared/schemas/superboard-key.js";
 import { SUPERBOARD_KEY_ICON } from "./settings-sections.js";
 import { superboardPendingCopy } from "./superboard-pending-copy.js";
@@ -160,7 +161,7 @@ export function SuperboardKeySection(): JSX.Element {
       <div className="mt-6 border-t border-[var(--color-border)] pt-4">
         <div className="flex items-center gap-3 vex-micro text-ink-tertiary">
           <a
-            href="https://docs.vex.ai/security/local-vault"
+            href={VEX_PRIVACY_DOC_URL}
             target="_blank"
             rel="noopener noreferrer"
             className={cn(
@@ -169,7 +170,7 @@ export function SuperboardKeySection(): JSX.Element {
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
             )}
           >
-            Your data stays yours
+            {VEX_PRIVACY_DOC_LABEL}
             <IconArrowUpRight size={10} />
           </a>
         </div>

--- a/vex-app/src/renderer/features/appShell/screens/SettingsScreen/__tests__/SuperboardKeySection.test.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/SettingsScreen/__tests__/SuperboardKeySection.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Result } from "@shared/ipc/result.js";
+import { VEX_PRIVACY_DOC_URL } from "@shared/docs-links.js";
 import type { SuperboardKeyStatus } from "@shared/schemas/superboard-key.js";
 import { SuperboardKeySection } from "../SuperboardKeySection.js";
 
@@ -169,7 +170,11 @@ describe("SuperboardKeySection", () => {
     getSuperboardKey.mockResolvedValue(ok({ kind: "missing" }));
     renderSection();
     expect(await screen.findByRole("heading", { name: "Superboard key" })).toBeTruthy();
-    expect(screen.getByText("Your data stays yours")).toBeTruthy();
+    const privacy = screen.getByText("Your data stays yours").closest("a");
+    expect(privacy).not.toBeNull();
+    // The anchor and main's allowlist share one declaration; the href here is
+    // the URL `docs-links.test.ts` proves the allowlist admits.
+    expect(privacy?.getAttribute("href")).toBe(VEX_PRIVACY_DOC_URL);
   });
 
   it.each([

--- a/vex-app/src/renderer/features/wizard/WizardStepPanel.tsx
+++ b/vex-app/src/renderer/features/wizard/WizardStepPanel.tsx
@@ -42,6 +42,7 @@ import {
   WIZARD_STEP_IDS,
   type WizardStepId,
 } from "@shared/schemas/wizard.js";
+import { VEX_PRIVACY_DOC_LABEL, VEX_PRIVACY_DOC_URL } from "@shared/docs-links.js";
 
 import type { WizardFlowMode } from "../../lib/api/wizard.js";
 import { cn } from "../../lib/utils.js";
@@ -140,7 +141,7 @@ function TrailingMeta({
         </>
       ) : null}
       <a
-        href="https://docs.vex.ai/security/local-vault"
+        href={VEX_PRIVACY_DOC_URL}
         target="_blank"
         rel="noopener noreferrer"
         className={cn(
@@ -149,7 +150,7 @@ function TrailingMeta({
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
         )}
       >
-        Your data stays yours
+        {VEX_PRIVACY_DOC_LABEL}
         <IconArrowUpRight size={10} />
       </a>
     </div>

--- a/vex-app/src/shared/__tests__/docs-links.test.ts
+++ b/vex-app/src/shared/__tests__/docs-links.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Docs-link coupling - the privacy anchor the Settings Superboard section and
+ * the wizard footer render, and the external-link policy that gates
+ * `shell.openExternal`, must never drift.
+ *
+ * This suite runs the REAL `isAllowedExternalUrl` against the REAL
+ * `DOCS_EXTERNAL_ALLOW` (the exact list `main-window.ts` spreads into
+ * `ALLOWED_EXTERNAL`) and the REAL `VEX_PRIVACY_DOC_URL` the components put
+ * in `href`. No mirrored fixture: the previous anchor pointed at a host that
+ * never resolved, and nothing in the test suite could have noticed.
+ *
+ * `DOCS_EXTERNAL_ALLOW` is a subset of `ALLOWED_EXTERNAL`, and the `/docs`
+ * prefix on `projectvex.ai` appears ONLY in that subset, so "allowed by the
+ * subset" implies "allowed by the full list", and a docs URL denied here is
+ * denied by the full list too. Testing the subset is therefore faithful and
+ * avoids importing `main-window.ts` (electron).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  DOCS_EXTERNAL_ALLOW,
+  VEX_PRIVACY_DOC_LABEL,
+  VEX_PRIVACY_DOC_URL,
+} from "../docs-links.js";
+import { isAllowedExternalUrl } from "../../main/security/url.js";
+
+function allowed(url: string): boolean {
+  return isAllowedExternalUrl(url, DOCS_EXTERNAL_ALLOW);
+}
+
+describe("privacy docs link", () => {
+  it("admits the exact URL the components render", () => {
+    expect(allowed(VEX_PRIVACY_DOC_URL)).toBe(true);
+  });
+
+  it("points at the product's own docs tree under the apex host", () => {
+    const url = new URL(VEX_PRIVACY_DOC_URL);
+    expect(url.protocol).toBe("https:");
+    expect(url.hostname).toBe("projectvex.ai");
+    expect(url.pathname).toBe("/docs/security/privacy");
+  });
+
+  it("keeps the label the sections and their tests render", () => {
+    expect(VEX_PRIVACY_DOC_LABEL).toBe("Your data stays yours");
+  });
+
+  it("admits the rest of the docs tree and nothing outside it", () => {
+    expect(allowed("https://projectvex.ai/docs")).toBe(true);
+    expect(allowed("https://projectvex.ai/docs/security/encryption")).toBe(true);
+    for (const url of [
+      "https://projectvex.ai/",
+      "https://projectvex.ai/docsX",
+      "https://projectvex.ai/doc",
+      "https://projectvex.ai/releases", // admitted by its own entry, not this one
+      "https://projectvex.ai/docs/../releases",
+    ]) {
+      expect(allowed(url), url).toBe(false);
+    }
+  });
+
+  it("denies lookalike hosts, the www subdomain and the retired placeholder hosts", () => {
+    for (const url of [
+      "https://www.projectvex.ai/docs/security/privacy",
+      "https://projectvex.ai.evil.example/docs/security/privacy",
+      "https://notprojectvex.ai/docs",
+      "https://evil.example/?next=https://projectvex.ai/docs",
+      "https://docs.vex.ai/security/local-vault", // what the anchor used to say
+      "https://vex.ai/docs",
+    ]) {
+      expect(allowed(url), url).toBe(false);
+    }
+  });
+
+  it("denies the same URL over http and over a non-web scheme", () => {
+    expect(allowed("http://projectvex.ai/docs/security/privacy")).toBe(false);
+    expect(allowed("file:///projectvex.ai/docs/security/privacy")).toBe(false);
+  });
+});

--- a/vex-app/src/shared/docs-links.ts
+++ b/vex-app/src/shared/docs-links.ts
@@ -1,0 +1,44 @@
+/**
+ * The "Your data stays yours" link the Settings Superboard section and the
+ * wizard footer render, and the external-link allow entry that makes it
+ * clickable.
+ *
+ * WHY BOTH FACTS LIVE HERE. Same reason as `chart-attribution.ts`: the anchor
+ * is in the renderer, the decision to open an external URL belongs to main's
+ * `ALLOWED_EXTERNAL`, and held in two places they drift silently - the link
+ * renders, the user clicks, and nothing at all happens. What shipped before
+ * this module was worse than silence: both anchors pointed at
+ * `docs.vex.ai/security/local-vault`, a host that does not resolve (measured
+ * 2026-09-11: NXDOMAIN, while the apex `vex.ai` belongs to a third party),
+ * and the allowlist admitted both hosts host-wide, so the click opened the
+ * user's browser on a DNS error. So the URL the components render
+ * and the entry the allowlist spreads are ONE declaration, and
+ * `shared/__tests__/docs-links.test.ts` asserts the real allowlist admits
+ * the real URL and denies its lookalikes.
+ *
+ * SCOPE. The apex `projectvex.ai`, path-scoped to `/docs`: the documentation
+ * tree and nothing else on the site (the release-notes CTA keeps its own
+ * `/releases` entry). `isAllowedExternalUrl` matches the hostname exactly and
+ * the path with boundary respect, so `www.projectvex.ai`,
+ * `projectvex.ai.evil.example` and `/docsX` are all denied.
+ */
+
+/** Structurally identical to main's `ExternalAllowEntry`; shared must not import main. */
+export type DocsAllowEntry =
+  | string
+  | { readonly host: string; readonly pathPrefix: string };
+
+/**
+ * The privacy page of the public docs: what stays on the machine, what leaves
+ * it, and what is opt-in. It is the page the label promises, and it exists in
+ * the landing repository's docs navigation (`/docs/security/privacy`).
+ */
+export const VEX_PRIVACY_DOC_URL = "https://projectvex.ai/docs/security/privacy";
+
+/** The visible label beside the arrow glyph. */
+export const VEX_PRIVACY_DOC_LABEL = "Your data stays yours";
+
+/** Spread verbatim into main's `ALLOWED_EXTERNAL`. */
+export const DOCS_EXTERNAL_ALLOW: readonly DocsAllowEntry[] = [
+  { host: "projectvex.ai", pathPrefix: "/docs" },
+];


### PR DESCRIPTION
## What

Defects found while verifying the Lighter fill to AgentScan pipeline end to end on a live 0.2.8 install, plus the dead "Your data stays yours" link in Settings.

## The pipeline verdict

The client side works end to end for both entry paths (in-app agent and MCP converge on `executeApprovedLighterCreateOrder`): the owner's test LONG 0.005 ETH landed in `lighter_fills` (`lighter:rhc:24226:0:601535556`, attributed to its `lighter-exec-...` intent) and twelve seconds later sat in `agentscan_outbox` as `source_kind = lighter_fill`. The row is HELD, not lost: `last_error = capability_not_advertised lighter_v1`, because the deployed AgentScan server does not answer `GET /capabilities`. That is a routing gap on the server's edge: the route is registered at the root path, the edge only forwards `/v1`, `/api` and `/healthz` to the api, so the website answers an HTML 404 that the client reads, per contract, as "old server". The fix is a routing rule plus a smoke test on BerzanTas/vex-agentscan (patch prepared for the owner); once applied, every held row goes on the wire on its next attempt with no client change.

## Changes here

1. **Fill ledger idempotence under concurrency.** `lighter_fills` carries two unique identities for the same fill (the canonical string and the tuple it is derived from). The insert named `(canonical_identity)` as its ON CONFLICT arbiter; the arbiter pre-check runs unlocked, so a second observer racing the first could miss the winner there and then collide on the tuple index, which is not arbitrated and raises `unique_violation`. Measured on the live install: the order-evidence follow-up and a concurrent observation of the same trade, 8 ms apart; the loser logged `lighter.fill_observation.ledger_write_failed { reason: 'error' }` and counted `failed: 1` for a fill the ledger held. The clause is now `ON CONFLICT DO NOTHING` with no arbiter, so every unique index arbitrates and a concurrent duplicate waits for the winner and resolves to "already held". The race lives inside one Postgres statement and has no deterministic reproducer; the sequential duplicate, conflict and enrichment contract is covered by the existing integration suite, which passes. File-growth note: `agentscan-activity.ts` is over the 750-line gate and grows by one comment block; the change is to the ledger's own insert statement, the file is one cohesive fill-ledger kernel, and a split for a comment would be a split by line count.

2. **Observation counters.** `writeFill` counted a ledger answer of `enriched` (the row existed and learned the account's own fields) as a failure. It is counted as already held now, with a test that goes red on the old classification, and a sibling test pinning that an identity conflict stays a failure.

3. **The "Your data stays yours" link.** Settings -> Superboard key and the wizard footer both linked `https://docs.vex.ai/security/local-vault`: `docs.vex.ai` does not resolve (NXDOMAIN when checked; the apex `vex.ai` is a third party's site), and the external-link allowlist admitted both hosts host-wide. Both anchors now point at the privacy page of the public docs, `https://projectvex.ai/docs/security/privacy` (live, "what stays on your machine, what leaves it, and what is opt-in"). Following `chart-attribution.ts`, the URL, the label and the allow entry (`projectvex.ai` path-scoped to `/docs`) are one declaration in `vex-app/src/shared/docs-links.ts`, so the anchor and the allowlist cannot drift; the two dead host entries are removed.

## Not in this PR

The in-app `vex.AgentScan` read tool's `transactions` view (and the desktop AgentScan screen feed) read `agent_activity`, `proj_activity` and failed `protocol_executions` only, never `lighter_fills`, so a perpetual fill is invisible there while the `executions` view shows the tool call. That is what made the coding agent report "no entry in transactions" for a fill that was recorded and queued, and it stays so after this PR. It is a read-surface contract change with its own design (scope by the session's Lighter account, not by wallet address; attribution and deduplication) and belongs in its own PR.

## Verification

- vex-app: `docs-links.test.ts` (new), `url.test.ts` (allowlist mirror: allow, near-miss deny, regression denies for the retired hosts), `SuperboardKeySection.test.tsx` (now asserts the rendered href), `chart-attribution.test.ts`: green; `pnpm run lint` in `vex-app` (tsc, ratchet, boundaries): green.
- root: `lighter-agentscan-activity`, `lighter-fill-observation-hooks` (two new tests), `lighter-agentscan-fill-event`, `client-capabilities`, `agentscan-lighter-capability`, `agentscan-lighter-vocabulary`: green; integration `lighter-fill-merge.int` and `lighter-fill-enrichment.int` against a throwaway pgvector container: 37 tests green; `tsc --noEmit`: green; `check:em-dash`: green.
- Live: `https://projectvex.ai/docs/security/privacy` answers 200 with the privacy page; the allowlist admits exactly that URL and denies `www.`, lookalikes, `/docsX`, http and the retired hosts.
- Codex review (consult thread `harness-agentscan-pipeline`): supports both fixes and the server routing plan; asked for the counter fix in (2), the wording on the race, and the file-growth note, all applied.
