### PR TITLE
feat(agent-scan): show Lighter fills with their position detail and leverage in the local feed

### DIFF
--- a/src/__tests__/integration/repos/lighter-fill-merge.int.test.ts
+++ b/src/__tests__/integration/repos/lighter-fill-merge.int.test.ts
@@ -118,12 +118,15 @@ interface StoredFill {
   readonly position_effect: string | null;
   readonly revision: number;
   readonly execution_intent_id: string | null;
+  readonly initial_margin_fraction_before: number | null;
+  readonly updated_at: Date;
 }
 
 async function stored(): Promise<StoredFill> {
   const row = await queryOne<StoredFill>(
     `SELECT price, usd_amount, trade_type, position_size_before, position_sign_changed,
-            entry_quote_before, account_pnl, position_effect, revision, execution_intent_id
+            entry_quote_before, account_pnl, position_effect, revision, execution_intent_id,
+            initial_margin_fraction_before, updated_at
        FROM lighter_fills WHERE canonical_identity = $1`,
     [IDENTITY],
   );
@@ -248,6 +251,201 @@ describe("re-observing the same fill", () => {
     // whose economics disagree, because that record is not trustworthy.
     expect(row.position_size_before).toBeNull();
     expect(Number(row.revision)).toBe(0);
+  });
+});
+
+describe("the leverage in force before the fill", () => {
+  /**
+   * MIGRATION 162'S COLUMN, against the CHECK itself.
+   *
+   * The fraction is the only honest source for "what leverage was this trade
+   * taken at": the account's leverage NOW is a different number about a
+   * different moment. It is also OPTIONAL in every sense that matters - a
+   * public trade row has no account half at all, an authenticated one may omit
+   * the field, and `marginFraction()` in `fill-position-effect.ts` hands on any
+   * nonnegative safe integer, including values the column refuses. So the two
+   * properties proved here are: a readable value is stored exactly, and an
+   * unreadable one costs the ledger NOTHING - not the fill, not the fees, not
+   * the attribution.
+   */
+  it("stores the fraction at insert when the first observation carries one", async () => {
+    expect(await recordLighterFillActivity(authenticatedRow({
+      accountFacts: {
+        positionSizeBefore: "-2.5",
+        positionSignChanged: false,
+        entryQuoteBefore: "-6000.000000",
+        accountPnl: "1.989696",
+        initialMarginFractionBefore: 1000,
+      },
+    }))).toMatchObject({ kind: "recorded" });
+    // 1000 on the provider's 10000 scale is 10x, and it is stored as the
+    // provider's own integer: no leverage is computed at the write.
+    expect((await stored()).initial_margin_fraction_before).toBe(1000);
+  });
+
+  it.each([
+    ["a zero the CHECK would refuse", 0],
+    ["a value above the 10000 tick", 20_000],
+    ["a negative value", -1],
+    ["a non-integer", 1000.5],
+    ["no value at all", null],
+  ])("records the fill and stores the leverage as unknown on %s", async (_label, value) => {
+    const outcome = await recordLighterFillActivity(authenticatedRow({
+      accountFacts: {
+        positionSizeBefore: "-2.5",
+        positionSignChanged: false,
+        entryQuoteBefore: "-6000.000000",
+        accountPnl: "1.989696",
+        initialMarginFractionBefore: value,
+      },
+    }));
+    // The fill is the fact. Failing its whole insert over an optional context
+    // field - or clamping the field into a plausible-looking leverage - are
+    // both worse than saying "unknown".
+    expect(outcome).toMatchObject({ kind: "recorded" });
+    const row = await stored();
+    expect(row.initial_margin_fraction_before).toBeNull();
+    expect(row.price).toBe("2500.5");
+    expect(row.position_size_before).toBe("-2.5");
+  });
+
+  it("fills the fraction through the account merge, in the same statement", async () => {
+    await recordLighterFillActivity(publicRow());
+    expect((await stored()).initial_margin_fraction_before).toBeNull();
+
+    expect(await recordLighterFillActivity(authenticatedRow({
+      accountFacts: {
+        positionSizeBefore: "-2.5",
+        positionSignChanged: false,
+        entryQuoteBefore: "-6000.000000",
+        accountPnl: "1.989696",
+        initialMarginFractionBefore: 1000,
+      },
+    }))).toMatchObject({ kind: "enriched", revision: 1 });
+
+    const row = await stored();
+    expect(row.initial_margin_fraction_before).toBe(1000);
+    expect(row.position_size_before).toBe("-2.5");
+  });
+
+  it("fills the fraction when the account half is ALREADY held and the merge cannot run", async () => {
+    // The defect this pins: the merge refuses once `position_size_before` is
+    // set, so a first authenticated observation without the fraction would
+    // freeze the column at NULL for the life of the row.
+    await recordLighterFillActivity(authenticatedRow({
+      accountFacts: {
+        positionSizeBefore: "-2.5",
+        positionSignChanged: false,
+        entryQuoteBefore: "-6000.000000",
+        accountPnl: "1.989696",
+        initialMarginFractionBefore: null,
+      },
+    }));
+    expect((await stored()).initial_margin_fraction_before).toBeNull();
+
+    const second = await recordLighterFillActivity(authenticatedRow({
+      accountFacts: {
+        positionSizeBefore: "-2.5",
+        positionSignChanged: false,
+        entryQuoteBefore: "-6000.000000",
+        accountPnl: "1.989696",
+        initialMarginFractionBefore: 1000,
+      },
+    }));
+
+    // The outcome is what it was about the FILL: an ordinary duplicate. The
+    // fraction is not on the AgentScan wire, so nothing was enriched for a
+    // server and the revision does not move.
+    expect(second).toMatchObject({ kind: "duplicate" });
+    const row = await stored();
+    expect(row.initial_margin_fraction_before).toBe(1000);
+    expect(Number(row.revision)).toBe(0);
+  });
+
+  it("never revises a fraction it already holds", async () => {
+    await recordLighterFillActivity(authenticatedRow({
+      accountFacts: {
+        positionSizeBefore: "-2.5",
+        positionSignChanged: false,
+        entryQuoteBefore: "-6000.000000",
+        accountPnl: "1.989696",
+        initialMarginFractionBefore: 1000,
+      },
+    }));
+
+    expect(await recordLighterFillActivity(authenticatedRow({
+      accountFacts: {
+        positionSizeBefore: "-2.5",
+        positionSignChanged: false,
+        entryQuoteBefore: "-6000.000000",
+        accountPnl: "1.989696",
+        initialMarginFractionBefore: 5000,
+      },
+    }))).toMatchObject({ kind: "duplicate" });
+
+    expect((await stored()).initial_margin_fraction_before).toBe(1000);
+  });
+
+  it("takes NOTHING from a report whose economics contradict the ledger", async () => {
+    await recordLighterFillActivity(publicRow());
+    const before = await stored();
+
+    const outcome = await recordLighterFillActivity(authenticatedRow({
+      price: "2600.0",
+      accountFacts: {
+        positionSizeBefore: "-2.5",
+        positionSignChanged: false,
+        entryQuoteBefore: "-6000.000000",
+        accountPnl: "1.989696",
+        initialMarginFractionBefore: 1000,
+      },
+    }));
+
+    // A contradicting report is a defect in whoever produced it. A field that
+    // would have been free to take is still a field from a source the ledger
+    // has just refused, so the refusal is total and the row is untouched.
+    expect(outcome.kind).toBe("conflict");
+    const row = await stored();
+    expect(row.initial_margin_fraction_before).toBeNull();
+    expect(row.updated_at.toISOString()).toBe(before.updated_at.toISOString());
+    expect(Number(row.revision)).toBe(0);
+  });
+
+  it("does not move the revision or the outcome when only the fraction is news", async () => {
+    await recordLighterFillActivity(publicRow());
+    await recordLighterFillActivity(authenticatedRow({
+      accountFacts: {
+        positionSizeBefore: "-2.5",
+        positionSignChanged: false,
+        entryQuoteBefore: "-6000.000000",
+        accountPnl: "1.989696",
+        initialMarginFractionBefore: null,
+      },
+    }));
+    // One enrichment so far: the account half. The outbox owes exactly that.
+    expect(Number((await stored()).revision)).toBe(1);
+
+    expect(await recordLighterFillActivity(authenticatedRow({
+      accountFacts: {
+        positionSizeBefore: "-2.5",
+        positionSignChanged: false,
+        entryQuoteBefore: "-6000.000000",
+        accountPnl: "1.989696",
+        initialMarginFractionBefore: 1000,
+      },
+    }))).toMatchObject({ kind: "duplicate" });
+
+    const row = await stored();
+    expect(row.initial_margin_fraction_before).toBe(1000);
+    // Bumping it here would enqueue an enrichment delivery carrying nothing
+    // the server does not already have.
+    expect(Number(row.revision)).toBe(1);
+  });
+
+  it("leaves a public re-observation unable to establish a fraction at all", async () => {
+    await recordLighterFillActivity(publicRow());
+    expect(await recordLighterFillActivity(publicRow())).toMatchObject({ kind: "duplicate" });
+    expect((await stored()).initial_margin_fraction_before).toBeNull();
   });
 });
 

--- a/src/__tests__/integration/repos/lighter-position-observations.int.test.ts
+++ b/src/__tests__/integration/repos/lighter-position-observations.int.test.ts
@@ -70,6 +70,8 @@ function position(marketIndex: number, size = "0.4"): LighterObservedPosition {
     unrealizedPnl: null,
     realizedPnl: null,
     liquidationPrice: null,
+    initialMarginFraction: null,
+    marginMode: null,
   };
 }
 
@@ -142,6 +144,59 @@ describe("migration 152's position tables", () => {
         WHERE environment = 'core' AND account_index = $1 AND market_index = 1`,
       [ACCOUNT],
     )).rejects.toThrow(/lighter_position_market_state_open_has_position/);
+  });
+});
+
+describe("the margin terms a position carries", () => {
+  /**
+   * THROUGH REAL JSONB AND BACK.
+   *
+   * `readStoredPositions` reads named fields only, so a field added to the
+   * stored shape reaches a reader exactly when the reader is taught to ask for
+   * it - and an observation written before it existed has to keep reading. A
+   * fake client cannot prove either half: the round trip is the point.
+   */
+  it("round-trips the leverage and the margin mode", async () => {
+    await storeLighterPositionObservation(observation("obs-margin", 10, {
+      positions: [{
+        ...position(1),
+        initialMarginFraction: 1000,
+        marginMode: "isolated",
+      }],
+    }));
+
+    const [stored] = await listUnsentLighterPositionObservations(10);
+    expect(stored?.positions[0]).toMatchObject({
+      marketIndex: 1,
+      size: "0.4",
+      initialMarginFraction: 1000,
+      marginMode: "isolated",
+    });
+  });
+
+  it("reads an observation stored before these fields existed as unknown, not as cross at 1x", async () => {
+    // Exactly the JSON a pre-162 build wrote: the named fields it knew, and
+    // nothing else.
+    await query(
+      `INSERT INTO lighter_position_observations
+         (environment, account_index, observation_id, observed_at, coverage_markets, complete, positions)
+       VALUES ('core', $1, 'obs-old', '2026-09-07T10:00:00.000Z', '"all"'::jsonb, TRUE, $2::jsonb)`,
+      [ACCOUNT, JSON.stringify([{
+        marketIndex: 1,
+        marketSymbol: "M1",
+        size: "0.4",
+        entryPrice: "2500.5",
+        unrealizedPnl: null,
+        realizedPnl: null,
+        liquidationPrice: null,
+      }])],
+    );
+
+    const [stored] = await listUnsentLighterPositionObservations(10);
+    expect(stored?.positions).toHaveLength(1);
+    expect(stored?.positions[0]?.size).toBe("0.4");
+    expect(stored?.positions[0]?.initialMarginFraction).toBeNull();
+    expect(stored?.positions[0]?.marginMode).toBeNull();
   });
 });
 

--- a/src/__tests__/lighter/lighter-agentscan-fill-event.test.ts
+++ b/src/__tests__/lighter/lighter-agentscan-fill-event.test.ts
@@ -329,6 +329,17 @@ describe("privacy", () => {
     ]);
   });
 
+  it("keeps the leverage before the fill OFF the wire, ledger column or not", () => {
+    // Migration 162 records `initial_margin_fraction_before` for the LOCAL
+    // activity feed. The external server was never told about it, so a ledger
+    // row that carries it must project exactly the payload above: a durable
+    // column is not a wire field, and the two grow by separate decisions.
+    const event = mapOrThrow(ledgerRow({ initial_margin_fraction_before: 1000 }));
+    expect(event.lighterFill).not.toHaveProperty("initialMarginFractionBefore");
+    expect(JSON.stringify(event)).not.toContain("initial_margin_fraction_before");
+    expect(JSON.stringify(event)).not.toContain("MarginFraction");
+  });
+
   it("never carries a counterparty, a credential, a nonce or an L1 address, even when the row does", () => {
     // A raw provider record smuggled onto the ledger row: none of it is read.
     const event = mapOrThrow(ledgerRow({

--- a/src/__tests__/lighter/lighter-fill-observation-hooks.test.ts
+++ b/src/__tests__/lighter/lighter-fill-observation-hooks.test.ts
@@ -39,6 +39,7 @@ import {
 } from "@vex-agent/tools/protocols/lighter/order-repair.js";
 import {
   LIGHTER_FILL_FOLLOW_UP_TRADES_LIMIT,
+  observeLighterFills,
   observeLighterFillsFromAccountTrades,
   resetLighterMarketAssetsCache,
   resolveLighterMarketAssets,
@@ -937,5 +938,54 @@ describe("market assets: a perpetual names its instrument and its collateral, a 
     await expect(resolveLighterMarketAssets("core", 0, marketDeps(perp, [wrongId, eth]))).rejects.toThrow(/verified core USDC collateral/);
     const wrongAddress = { ...collateral, l1_address: "0x0000000000000000000000000000000000000001" };
     await expect(resolveLighterMarketAssets("core", 0, marketDeps(perp, [wrongAddress, eth]))).rejects.toThrow(/verified core USDC collateral/);
+  });
+});
+
+describe("observation counters: the report says what the ledger answered", () => {
+  const intent = {
+    intentId: "lighter-order-counters",
+    environment: "core" as const,
+    accountIndex: ACCOUNT_INDEX,
+    marketIndex: 0,
+    side: "buy" as const,
+    clientOrderIndex: CLIENT_ORDER_INDEX,
+  };
+
+  it("counts a fill the ledger enriched as already held, never as a failure", async () => {
+    // The ledger held the row without the account's own fields and this
+    // observation supplied them: nothing was inserted and nothing failed. The
+    // revision the ledger bumped is its own business and not a count here.
+    const recordFill = vi.fn<LighterFillObservationDeps["recordFill"]>(async () => ({
+      kind: "enriched" as const,
+      fillId: 1,
+      revision: 1,
+    }));
+
+    const report = await observeLighterFills({
+      intent,
+      trades: [trade()],
+      authorizedFees: null,
+      deps: fillDeps(recordFill),
+    });
+
+    expect(recordFill).toHaveBeenCalledTimes(1);
+    expect(report).toEqual({ observed: 1, recorded: 0, duplicates: 1, failed: 0 });
+  });
+
+  it("counts an identity conflict as a failure, because the second report contradicts the ledger", async () => {
+    const recordFill = vi.fn<LighterFillObservationDeps["recordFill"]>(async () => ({
+      kind: "conflict" as const,
+      fillId: 1,
+      fields: ["price"],
+    }));
+
+    const report = await observeLighterFills({
+      intent,
+      trades: [trade()],
+      authorizedFees: null,
+      deps: fillDeps(recordFill),
+    });
+
+    expect(report).toEqual({ observed: 1, recorded: 0, duplicates: 0, failed: 1 });
   });
 });

--- a/src/__tests__/vex-agent/sync/agentscan-drain-lighter-observations.test.ts
+++ b/src/__tests__/vex-agent/sync/agentscan-drain-lighter-observations.test.ts
@@ -78,6 +78,8 @@ function observation(
       unrealizedPnl: "-12.5",
       realizedPnl: null,
       liquidationPrice: null,
+      initialMarginFraction: 1000,
+      marginMode: "isolated",
     }],
     ...overrides,
   };
@@ -255,6 +257,7 @@ describe("disjoint observations of one scope", () => {
       positions: [{
         marketIndex: 2, marketSymbol: "BTC", size: "1.0", entryPrice: "60000.0",
         unrealizedPnl: null, realizedPnl: null, liquidationPrice: null,
+        initialMarginFraction: null, marginMode: null,
       }],
     });
     const newer = observation({ id: 2, observationId: "obs-12", coverage: [1] });

--- a/src/__tests__/vex-agent/sync/lighter-position-snapshot.test.ts
+++ b/src/__tests__/vex-agent/sync/lighter-position-snapshot.test.ts
@@ -165,13 +165,18 @@ describe("projecting one provider position", () => {
     },
   );
 
+  // A non-textual fraction is a provider row this build has not seen. It is
+  // built through the DTO's own open index signature (`[key: string]: unknown`)
+  // rather than through a cast that would hide the wrong type from the reader.
+  const nonTextual: Record<string, unknown> = { ...position(), initial_margin_fraction: 10 };
+
   it.each([
-    ["a fraction Vex cannot read exactly", { initial_margin_fraction: "33.333" }],
-    ["a fraction above 100 percent", { initial_margin_fraction: "150.00" }],
-    ["a zero fraction", { initial_margin_fraction: "0" }],
-    ["a non-textual fraction", { initial_margin_fraction: 10 as unknown as string }],
-  ])("leaves the leverage unknown on %s, and still keeps the position", (_label, override) => {
-    const projected = projectLighterPosition(position(override));
+    ["a fraction Vex cannot read exactly", position({ initial_margin_fraction: "33.333" })],
+    ["a fraction above 100 percent", position({ initial_margin_fraction: "150.00" })],
+    ["a zero fraction", position({ initial_margin_fraction: "0" })],
+    ["a non-textual fraction", nonTextual as LighterAccountPosition],
+  ])("leaves the leverage unknown on %s, and still keeps the position", (_label, row) => {
+    const projected = projectLighterPosition(row);
     // The margin terms are context. The size, entry and PnL are the fact, and
     // they do not become less true because one optional field is unreadable.
     expect(projected?.size).toBe("0.4");

--- a/src/__tests__/vex-agent/sync/lighter-position-snapshot.test.ts
+++ b/src/__tests__/vex-agent/sync/lighter-position-snapshot.test.ts
@@ -50,6 +50,8 @@ const {
   recordLighterSnapshotAttempt,
   snapshotLighterPositions,
   projectLighterPosition,
+  projectLighterObservationForWire,
+  listUnsentLighterPositionObservations,
   storeLighterPositionObservation,
   LIGHTER_SNAPSHOT_SCOPES_PER_SWEEP,
 } = await import("@vex-agent/sync/lighter-position-snapshot.js");
@@ -137,13 +139,142 @@ describe("projecting one provider position", () => {
     );
     expect(Object.keys(projected ?? {}).sort()).toEqual([
       "entryPrice",
+      "initialMarginFraction",
       "liquidationPrice",
+      "marginMode",
       "marketIndex",
       "marketSymbol",
       "realizedPnl",
       "size",
       "unrealizedPnl",
     ]);
+  });
+
+  it.each([
+    ["10.00", 1, 1000, "isolated" as const],
+    ["50.00", 0, 5000, "cross" as const],
+    ["100", 0, 10_000, "cross" as const],
+  ])(
+    "reads the account endpoint's percent string %s and margin code %i as the canonical unit",
+    (percent, mode, fraction, marginMode) => {
+      const projected = projectLighterPosition(
+        position({ initial_margin_fraction: percent, margin_mode: mode }),
+      );
+      expect(projected?.initialMarginFraction).toBe(fraction);
+      expect(projected?.marginMode).toBe(marginMode);
+    },
+  );
+
+  it.each([
+    ["a fraction Vex cannot read exactly", { initial_margin_fraction: "33.333" }],
+    ["a fraction above 100 percent", { initial_margin_fraction: "150.00" }],
+    ["a zero fraction", { initial_margin_fraction: "0" }],
+    ["a non-textual fraction", { initial_margin_fraction: 10 as unknown as string }],
+  ])("leaves the leverage unknown on %s, and still keeps the position", (_label, override) => {
+    const projected = projectLighterPosition(position(override));
+    // The margin terms are context. The size, entry and PnL are the fact, and
+    // they do not become less true because one optional field is unreadable.
+    expect(projected?.size).toBe("0.4");
+    expect(projected?.entryPrice).toBe("2500.5");
+    expect(projected?.initialMarginFraction).toBeNull();
+  });
+
+  it("leaves an unknown margin-mode code unknown rather than calling it cross", () => {
+    const projected = projectLighterPosition(position({ margin_mode: 7 }));
+    expect(projected?.marginMode).toBeNull();
+    expect(projected?.size).toBe("0.4");
+  });
+});
+
+describe("reading an observation back out of storage", () => {
+  /** One stored row as the owed-observations query returns it. */
+  function storedRow(positions: unknown): Record<string, unknown> {
+    return {
+      id: 1,
+      environment: "core",
+      account_index: "743799",
+      observation_id: "obs-1",
+      observed_at: "2026-09-07T10:00:00.000Z",
+      coverage_markets: "all",
+      complete: true,
+      positions,
+    };
+  }
+
+  it("reads the margin terms back through their own named fields", async () => {
+    mockQuery.mockResolvedValue([storedRow([{
+      marketIndex: 1, marketSymbol: "ETH-USD", size: "0.4",
+      entryPrice: "2500.5", unrealizedPnl: null, realizedPnl: null, liquidationPrice: null,
+      initialMarginFraction: 1000, marginMode: "isolated",
+    }])]);
+
+    const [observation] = await listUnsentLighterPositionObservations(10);
+    expect(observation?.positions[0]).toMatchObject({
+      initialMarginFraction: 1000,
+      marginMode: "isolated",
+    });
+  });
+
+  it.each([
+    ["an observation stored before these fields existed", {}],
+    ["an explicit null", { initialMarginFraction: null, marginMode: null }],
+    ["a fraction outside the canonical range", { initialMarginFraction: 20_000, marginMode: "sideways" }],
+    ["values of the wrong type", { initialMarginFraction: "1000", marginMode: 1 }],
+  ])("reads %s as unknown, without losing the position", async (_label, margin) => {
+    mockQuery.mockResolvedValue([storedRow([{
+      marketIndex: 1, marketSymbol: "ETH-USD", size: "0.4",
+      entryPrice: "2500.5", unrealizedPnl: null, realizedPnl: null, liquidationPrice: null,
+      ...margin,
+    }])]);
+
+    const [observation] = await listUnsentLighterPositionObservations(10);
+    expect(observation?.positions).toHaveLength(1);
+    expect(observation?.positions[0]?.size).toBe("0.4");
+    expect(observation?.positions[0]?.initialMarginFraction).toBeNull();
+    expect(observation?.positions[0]?.marginMode).toBeNull();
+  });
+});
+
+describe("the AgentScan wire payload", () => {
+  it("does not grow a key because the ledger learned one", () => {
+    const payload = projectLighterObservationForWire(
+      {
+        id: 1,
+        environment: "core",
+        accountIndex: 743799,
+        observationId: "obs-1",
+        observedAt: "2026-09-07T10:00:00.000Z",
+        coverage: "all",
+        complete: true,
+        positions: [{
+          marketIndex: 1,
+          marketSymbol: "ETH-USD",
+          size: "0.4",
+          entryPrice: "2500.5",
+          unrealizedPnl: "12.5",
+          realizedPnl: null,
+          liquidationPrice: "1800",
+          initialMarginFraction: 1000,
+          marginMode: "isolated",
+        }],
+      },
+      new Map([[1, 4]]),
+    );
+
+    // The mapper names every field it sends, which is exactly what keeps a new
+    // durable fact off the external wire until someone decides to send it.
+    expect(Object.keys(payload?.positions[0] ?? {}).sort()).toEqual([
+      "entryPrice",
+      "liquidationPrice",
+      "marketIndex",
+      "marketSymbol",
+      "realizedPnl",
+      "size",
+      "sizeDecimals",
+      "unrealizedPnl",
+    ]);
+    expect(JSON.stringify(payload)).not.toContain("initialMarginFraction");
+    expect(JSON.stringify(payload)).not.toContain("marginMode");
   });
 });
 
@@ -338,6 +469,8 @@ describe("storing an observation", () => {
         unrealizedPnl: "12.5",
         realizedPnl: null,
         liquidationPrice: "1800",
+        initialMarginFraction: 1000,
+        marginMode: "isolated",
       }],
     });
 
@@ -359,6 +492,7 @@ describe("storing an observation", () => {
       positions: [{
         marketIndex: 1, marketSymbol: "ETH-USD", size: "0.4",
         entryPrice: null, unrealizedPnl: null, realizedPnl: null, liquidationPrice: null,
+        initialMarginFraction: null, marginMode: null,
       }],
     });
 
@@ -401,6 +535,7 @@ describe("storing an observation", () => {
       positions: [{
         marketIndex: 1, marketSymbol: "ETH-USD", size: "0.4",
         entryPrice: null, unrealizedPnl: null, realizedPnl: null, liquidationPrice: null,
+        initialMarginFraction: null, marginMode: null,
       }],
     });
 

--- a/src/tools/lighter/margin-fraction.ts
+++ b/src/tools/lighter/margin-fraction.ts
@@ -31,8 +31,16 @@ import { ErrorCodes, VexError } from "../../errors.js";
  */
 export const LIGHTER_MARGIN_FRACTION_TICK = 10_000;
 
-/** The smallest fraction the provider accepts: 10000x, one tick of margin. */
-const MINIMUM_INITIAL_MARGIN_FRACTION = 1;
+/**
+ * The smallest fraction the provider accepts: 10000x, one tick of margin.
+ *
+ * Exported because it is also the LOWER BOUND OF THE DURABLE RANGE: the
+ * `lighter_fills.initial_margin_fraction_before` CHECK (migration 162) admits
+ * exactly `MINIMUM_INITIAL_MARGIN_FRACTION..LIGHTER_MARGIN_FRACTION_TICK`, and
+ * the writer that normalizes a provider value against it must read the bound
+ * from this owner rather than spelling a 1 of its own.
+ */
+export const MINIMUM_INITIAL_MARGIN_FRACTION = 1;
 
 /** Two decimals is exactly what the account endpoint emits ("50.00"). */
 const PERCENT_DECIMALS = 2;

--- a/src/vex-agent/db/migrations/162_lighter_fills_margin_fraction_and_traded_index.sql
+++ b/src/vex-agent/db/migrations/162_lighter_fills_margin_fraction_and_traded_index.sql
@@ -1,0 +1,59 @@
+-- The leverage in force BEFORE a Lighter fill, and the access path the local
+-- activity feed reads fills by.
+--
+-- WHY THE COLUMN EXISTS. A fill is the only place the account's leverage at
+-- that moment can honestly come from. The account's CURRENT leverage is a
+-- different number and belongs to a different question: showing it beside a
+-- fill from last week would state something nobody observed. Lighter's own
+-- trade record already carries the answer as
+-- `taker_initial_margin_fraction_before` / `maker_initial_margin_fraction_before`
+-- (measured live 2026-09-10: a 10000-scale INTEGER, 1000 = 10x, the same scale
+-- the market endpoint and the wire use, and NOT the percent string the account
+-- endpoint reports for a position), and `readLighterAccountFillFacts` has been
+-- reading it into `LighterAccountFillFacts.initialMarginFractionBefore` since
+-- migration 152 without anywhere to put it. This column is that place.
+--
+-- WHAT NULL MEANS, and it is one thing: UNKNOWN. The writer stores the value
+-- only when the provider reported a whole number inside 1..10000, which is the
+-- range the CHECK admits and the range
+-- `initialMarginFractionToLeverageDisplay` can read. Anything else - a public
+-- trade row that carries no account half at all, a record where the provider
+-- omitted the field, a 0, a value above the tick - is stored as NULL rather
+-- than clamped into a plausible-looking number, because a clamped leverage is
+-- a sentence about the user's money that nobody measured. A NULL is rendered
+-- as "leverage unknown", never as a current value passed off as a historical
+-- one.
+--
+-- ROWS WRITTEN BEFORE THIS MIGRATION start NULL and are not bulk-backfilled:
+-- reading the venue's trade history per account is a privileged read and a
+-- separate decision. They are null UNTIL A LATER MATCHING OBSERVATION CARRIES
+-- THE FRACTION - `recordLighterFillActivity` fills the column once, null to
+-- known, on a re-observation whose economics agree.
+--
+-- DELIBERATELY OUTSIDE `lighter_fills_account_facts_whole`. That constraint
+-- exists because a position classification resting on half a reading is a
+-- guess; this fraction classifies nothing and stands alone. An authenticated
+-- observation whose trade record omits the fraction must still be able to
+-- establish the account half, and a fill whose account half is already known
+-- must still be able to learn the fraction later.
+
+ALTER TABLE lighter_fills
+  ADD COLUMN IF NOT EXISTS initial_margin_fraction_before INTEGER;
+
+ALTER TABLE lighter_fills
+  DROP CONSTRAINT IF EXISTS lighter_fills_initial_margin_fraction_before_range;
+ALTER TABLE lighter_fills
+  ADD CONSTRAINT lighter_fills_initial_margin_fraction_before_range
+  CHECK (initial_margin_fraction_before IS NULL
+         OR initial_margin_fraction_before BETWEEN 1 AND 10000);
+
+COMMENT ON COLUMN lighter_fills.initial_margin_fraction_before IS
+  'The account''s initial margin fraction BEFORE this fill, on the provider''s 10000 scale (1000 = 10x): the leverage before the fill, never the account''s effective leverage now. Read from this trade record''s own taker_/maker_initial_margin_fraction_before by the role the account played. NULL means unknown - a public trade row, a record the provider omitted it from, or a reported value outside 1..10000, which the writer stores as unknown rather than as a clamped number. Rows written before migration 162 are null until a later matching observation carries the fraction (no bulk backfill).';
+
+-- THE FEED READS FILLS BY VENUE TIME, not by observation time. The existing
+-- `idx_lighter_fills_scope` orders by `observed_at`, which is when Vex saw the
+-- fill; a timeline a human reads is ordered by when the VENUE matched it, and
+-- the keyset page breaks ties on `id`. Without this index every page of the
+-- local activity feed sorts the account's whole fill history.
+CREATE INDEX IF NOT EXISTS idx_lighter_fills_traded
+  ON lighter_fills (environment, account_index, traded_at DESC, id DESC);

--- a/src/vex-agent/sync/lighter-position-snapshot.ts
+++ b/src/vex-agent/sync/lighter-position-snapshot.ts
@@ -90,6 +90,12 @@ import { randomUUID } from "node:crypto";
 import { query, withTransaction } from "@vex-agent/db/client.js";
 import { getLighterClient } from "@tools/lighter/client.js";
 import type { LighterEnvironment } from "@tools/lighter/constants.js";
+import {
+  LIGHTER_MARGIN_FRACTION_TICK,
+  marginModeFromWire,
+  positionInitialMarginFractionToProviderScale,
+  type LighterMarginMode,
+} from "@tools/lighter/margin-fraction.js";
 import type { LighterAccountPosition } from "@tools/lighter/types.js";
 import { resolveLighterReadOnlyAccountAuth } from "@vex-agent/tools/protocols/lighter/read-account-auth.js";
 import {
@@ -200,6 +206,22 @@ export interface LighterObservedPosition {
   readonly unrealizedPnl: string | null;
   readonly realizedPnl: string | null;
   readonly liquidationPrice: string | null;
+  /**
+   * The position's initial margin fraction on the canonical 10000-scale
+   * (1000 = 10x), converted from the percent string the account endpoint
+   * reports ("50.00" -> 5000). NULL when the provider omitted it or reported
+   * something this build cannot read exactly: a leverage nobody measured is
+   * not shown, and there is no safe default for "how much margin does this
+   * position hold".
+   */
+  readonly initialMarginFraction: number | null;
+  /**
+   * Cross or isolated, from the provider's own code (0 / 1). NULL for a code
+   * Vex does not know - never cross by default, because the two have
+   * different liquidation behavior and a wrong label is a wrong sentence in
+   * front of the user.
+   */
+  readonly marginMode: LighterMarginMode | null;
 }
 
 /**
@@ -229,7 +251,37 @@ export function projectLighterPosition(dto: LighterAccountPosition): LighterObse
     unrealizedPnl: signedDecimalOrNull(dto.unrealized_pnl),
     realizedPnl: signedDecimalOrNull(dto.realized_pnl),
     liquidationPrice: decimalOrNull(dto.liquidation_price),
+    initialMarginFraction: readInitialMarginFraction(dto.initial_margin_fraction),
+    marginMode: readMarginMode(dto.margin_mode),
   };
+}
+
+/**
+ * The margin terms are CONTEXT, never a reason to lose a position.
+ *
+ * Both owners in `margin-fraction.ts` refuse rather than default, which is the
+ * right posture for a consent path: nothing there may guess what leverage a
+ * user is about to sign for. Here the position itself is the fact being
+ * recorded, and its size, entry and PnL do not become less true because the
+ * provider sent a margin field this build cannot read. So the refusal is
+ * caught and becomes NULL - unknown - and the position is still stored.
+ */
+function readInitialMarginFraction(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  try {
+    return positionInitialMarginFractionToProviderScale(value);
+  } catch {
+    return null;
+  }
+}
+
+function readMarginMode(value: unknown): LighterMarginMode | null {
+  if (typeof value !== "number") return null;
+  try {
+    return marginModeFromWire(value);
+  } catch {
+    return null;
+  }
 }
 
 /** One observation, ready to be stored. */
@@ -810,8 +862,23 @@ function readStoredPositions(value: unknown): readonly LighterObservedPosition[]
       unrealizedPnl: signedDecimalOrNull(row.unrealizedPnl),
       realizedPnl: signedDecimalOrNull(row.realizedPnl),
       liquidationPrice: decimalOrNull(row.liquidationPrice),
+      // Absent on every observation stored before these fields existed, and
+      // that reads as what it is: unknown. A stored row is durable state that
+      // has crossed JSONB, so it is validated here rather than trusted.
+      initialMarginFraction: storedInitialMarginFraction(row.initialMarginFraction),
+      marginMode: row.marginMode === "cross" || row.marginMode === "isolated" ? row.marginMode : null,
     }];
   });
+}
+
+/**
+ * A stored fraction is trusted only inside the range the canonical unit
+ * defines (1..10000); anything else is unknown rather than a number a reader
+ * would divide by.
+ */
+function storedInitialMarginFraction(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isInteger(value)) return null;
+  return value >= 1 && value <= LIGHTER_MARGIN_FRACTION_TICK ? value : null;
 }
 
 /**

--- a/src/vex-agent/tools/protocols/lighter/agentscan-activity.ts
+++ b/src/vex-agent/tools/protocols/lighter/agentscan-activity.ts
@@ -81,6 +81,10 @@ import type { PoolClient } from "pg";
 
 import { execute, executeWith, queryOne, queryOneWith } from "@vex-agent/db/client.js";
 import type { LighterEnvironment } from "@tools/lighter/constants.js";
+import {
+  LIGHTER_MARGIN_FRACTION_TICK,
+  MINIMUM_INITIAL_MARGIN_FRACTION,
+} from "@tools/lighter/margin-fraction.js";
 import type { LighterTrade, LighterTradeType } from "@tools/lighter/types.js";
 import logger from "@utils/logger.js";
 
@@ -477,6 +481,27 @@ const IMMUTABLE_FILL_FIELDS = [
 ] as const;
 
 /**
+ * PURE: a provider initial-margin fraction -> the value the ledger may hold.
+ *
+ * `readLighterAccountFillFacts` accepts ANY nonnegative safe integer the trade
+ * record carries, because reading is not judging; migration 162's column
+ * accepts only `MINIMUM_INITIAL_MARGIN_FRACTION..LIGHTER_MARGIN_FRACTION_TICK`,
+ * because those are the fractions that mean a leverage a human can be shown.
+ * A value outside that range - a 0, a number above the tick - becomes NULL,
+ * which the column documents as UNKNOWN.
+ *
+ * NEVER CLAMPED, and never allowed to fail the write. Clamping would invent a
+ * leverage nobody measured, and letting the CHECK reject the statement would
+ * lose the whole fill - the economics, the fees, the attribution - over one
+ * optional field. The fill is the fact; the fraction is context.
+ */
+function storableInitialMarginFraction(value: number | null | undefined): number | null {
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) return null;
+  if (value < MINIMUM_INITIAL_MARGIN_FRACTION || value > LIGHTER_MARGIN_FRACTION_TICK) return null;
+  return value;
+}
+
+/**
  * THE FILL COMMIT POINT.
  *
  * Call it at the same durable transition where an order execution intent
@@ -539,6 +564,9 @@ export async function recordLighterFillActivity(
     record.exchangeFeeEstimatedUsd,
     record.collectorAccountIndex,
     record.feeAuthorizationIntentId,
+    // Normalized, never raw: the CHECK must not be able to refuse a fill over
+    // a provider value this ledger simply does not know how to read.
+    storableInitialMarginFraction(record.accountFacts?.initialMarginFractionBefore),
   ];
 
   // DO NOTHING, never DO UPDATE: an insert conflict is a fill we already hold,
@@ -580,12 +608,46 @@ export async function recordLighterFillActivity(
     return { kind: "conflict", fillId, fields: [...fields] };
   }
 
+  // THE INITIAL MARGIN FRACTION FILLS ONCE, AND INDEPENDENTLY OF THE MERGE.
+  //
+  // It cannot ride only on the account merge below: that merge refuses to run
+  // at all once `position_size_before` is set, so a first authenticated
+  // observation whose trade record omitted the fraction would freeze this
+  // column at NULL for the life of the row - and the fraction is exactly the
+  // field a later observation is most likely to be the first to carry. Where
+  // the merge DOES run, it carries the fraction in its own statement, so the
+  // account's half and the leverage that produced it commit together.
+  //
+  // Only past the conflict check above, and never on a `conflict`: a report
+  // whose economics contradict the ledger is a defect in whoever produced it,
+  // and nothing from it is trusted, not even a field that would have been free
+  // to take.
+  //
+  // NO REVISION BUMP. The enrichment outbox selects rows by (fill, revision)
+  // and the fraction is not on the AgentScan wire, so moving the revision
+  // would enqueue a delivery carrying nothing new. The outcome kinds below are
+  // unchanged by this write for the same reason: what the caller observed
+  // about the FILL is still a duplicate or an enrichment.
+  const fraction = storableInitialMarginFraction(record.accountFacts?.initialMarginFractionBefore);
+  const fractionIsNews = fraction !== null && existing.initial_margin_fraction_before === null;
+  // Through the caller's transaction client when there is one, so the fraction
+  // commits with the transition that observed it.
+  const fillFraction = async (): Promise<void> => {
+    const fractionParams = [record.canonicalIdentity, fraction];
+    if (client === undefined) {
+      await execute(FILL_INITIAL_MARGIN_FRACTION_SQL, fractionParams);
+    } else {
+      await executeWith(client, FILL_INITIAL_MARGIN_FRACTION_SQL, fractionParams);
+    }
+  };
+
   // THE ECONOMICS AGREE. If this observation knows the account's own half and
   // the held row does not, that is knowledge arriving, not a revision: fill it
   // once and move the revision so it reaches a server that already has the
   // fill. If the row already knows, or this observation does not, nothing
   // happens and the report is an ordinary duplicate.
   if (record.accountFacts === null || existing.position_size_before !== null) {
+    if (fractionIsNews) await fillFraction();
     return { kind: "duplicate", fillId };
   }
   const mergeParams = [
@@ -595,13 +657,18 @@ export async function recordLighterFillActivity(
     record.accountFacts.entryQuoteBefore,
     record.accountFacts.accountPnl,
     record.positionEffect,
+    fraction,
   ];
   const merged = client === undefined
     ? await queryOne<{ id: string | number; revision: number }>(MERGE_FILL_ACCOUNT_FACTS_SQL, mergeParams)
     : await queryOneWith<{ id: string | number; revision: number }>(client, MERGE_FILL_ACCOUNT_FACTS_SQL, mergeParams);
   // A concurrent observation won the race and established the same knowledge
-  // first. Nothing was lost and nothing is claimed twice.
-  if (merged === null) return { kind: "duplicate", fillId };
+  // first. Nothing was lost and nothing is claimed twice - but the winner may
+  // have had no fraction to give, so this observation still offers its own.
+  if (merged === null) {
+    if (fractionIsNews) await fillFraction();
+    return { kind: "duplicate", fillId };
+  }
   return { kind: "enriched", fillId: Number(merged.id), revision: Number(merged.revision) };
 }
 
@@ -771,11 +838,12 @@ const INSERT_FILL_SQL = `
     integrator_fee_charged_raw,
     exchange_fee_tick_observed, exchange_fee_charged_raw,
     integrator_fee_estimated_usd, exchange_fee_estimated_usd,
-    collector_account_index, fee_authorization_intent_id
+    collector_account_index, fee_authorization_intent_id,
+    initial_margin_fraction_before
   ) VALUES (
     $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,
     $21,$22::timestamptz,$23,$24,$25,$26,$27,$28,$29,$30,
-    $31,$32,$33,$34,$35,$36,$37,$38,$39,$40,$41,$42,$43,$44,$45
+    $31,$32,$33,$34,$35,$36,$37,$38,$39,$40,$41,$42,$43,$44,$45,$46
   )
   ON CONFLICT DO NOTHING
   RETURNING id`;
@@ -783,7 +851,7 @@ const INSERT_FILL_SQL = `
 const SELECT_FILL_BY_IDENTITY_SQL = `
   SELECT id, side, price, base_size, quote_notional, block_height,
          trade_type, usd_amount, to_char(traded_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS traded_at,
-         position_size_before, execution_intent_id
+         position_size_before, initial_margin_fraction_before, execution_intent_id
     FROM lighter_fills WHERE canonical_identity = $1`;
 
 /**
@@ -799,6 +867,12 @@ const SELECT_FILL_BY_IDENTITY_SQL = `
  * which a second observation could revise a price, a size or a notional - and
  * the revision bump is what carries the new knowledge to a server that already
  * holds the fill.
+ *
+ * The initial margin fraction rides along under a COALESCE rather than under
+ * the five-column rule: it is outside the whole-or-nothing CHECK (migration
+ * 162) and an observation can know the account's half without knowing the
+ * fraction, or the other way round. COALESCE keeps the transition one-way:
+ * a fraction this row already holds is never revised by the merge.
  */
 const MERGE_FILL_ACCOUNT_FACTS_SQL = `
   UPDATE lighter_fills
@@ -807,12 +881,28 @@ const MERGE_FILL_ACCOUNT_FACTS_SQL = `
          entry_quote_before = $4,
          account_pnl = $5,
          position_effect = $6,
+         initial_margin_fraction_before = COALESCE(initial_margin_fraction_before, $7),
          revision = revision + 1,
          updated_at = NOW()
    WHERE canonical_identity = $1
      AND position_size_before IS NULL
      AND $2::text IS NOT NULL
   RETURNING id, revision`;
+
+/**
+ * THE FRACTION FILL, null to known, once.
+ *
+ * `IS NULL` in the WHERE is the whole guard: a fraction the row already holds
+ * is a fact established by an earlier observation and this statement cannot
+ * reach it. `updated_at` moves because the row changed; `revision` does not,
+ * because nothing the AgentScan wire carries did (see the call site).
+ */
+const FILL_INITIAL_MARGIN_FRACTION_SQL = `
+  UPDATE lighter_fills
+     SET initial_margin_fraction_before = $2,
+         updated_at = NOW()
+   WHERE canonical_identity = $1
+     AND initial_margin_fraction_before IS NULL`;
 
 /**
  * THE ENRICHMENT PATH - the only write that may touch a recorded fill.

--- a/src/vex-agent/tools/protocols/lighter/agentscan-activity.ts
+++ b/src/vex-agent/tools/protocols/lighter/agentscan-activity.ts
@@ -738,6 +738,22 @@ const ATTACH_FILL_SQL = `
      AND execution_intent_id IS NULL
   RETURNING id`;
 
+/**
+ * NO ARBITER ON THE CONFLICT CLAUSE, on purpose.
+ *
+ * The row carries two unique identities that name the same fill: the
+ * canonical string and the (environment, account, market, trade id) tuple it
+ * is derived from. Naming `(canonical_identity)` as the arbiter made only that
+ * index arbitrated: the arbiter pre-check runs unlocked, so a second observer
+ * racing the first can miss the winner's insertion there and go on to collide
+ * on the tuple index, which is not arbitrated and raises `unique_violation`
+ * instead of resolving to "already held". Measured 2026-09-11 on a live
+ * install: the order-evidence follow-up and a concurrent observation of the
+ * same trade, 8 ms apart, and the loser logged `ledger_write_failed` for a
+ * fill the ledger held. With no arbiter named, every unique index arbitrates,
+ * so a concurrent duplicate waits for the winner and resolves to DO NOTHING,
+ * which is what idempotence by identity promised all along.
+ */
 const INSERT_FILL_SQL = `
   INSERT INTO lighter_fills (
     canonical_identity, environment, account_index, market_index, provider_trade_id,
@@ -761,7 +777,7 @@ const INSERT_FILL_SQL = `
     $21,$22::timestamptz,$23,$24,$25,$26,$27,$28,$29,$30,
     $31,$32,$33,$34,$35,$36,$37,$38,$39,$40,$41,$42,$43,$44,$45
   )
-  ON CONFLICT (canonical_identity) DO NOTHING
+  ON CONFLICT DO NOTHING
   RETURNING id`;
 
 const SELECT_FILL_BY_IDENTITY_SQL = `

--- a/src/vex-agent/tools/protocols/lighter/fill-observation.ts
+++ b/src/vex-agent/tools/protocols/lighter/fill-observation.ts
@@ -467,7 +467,12 @@ async function writeFill(
   try {
     const outcome = await deps.recordFill(record);
     if (outcome.kind === "recorded") return "recorded";
-    if (outcome.kind === "duplicate") return "duplicate";
+    // Already held with the same economics: a plain duplicate, or one that
+    // learned the account's own fields on the way (`enriched`). Neither is a
+    // failure - the row exists and says what this observation says - and the
+    // revision bump an enrichment carries is the ledger's business, not a
+    // count here.
+    if (outcome.kind === "duplicate" || outcome.kind === "enriched") return "duplicate";
     // A conflict is already logged with its fields by the writer; it is a
     // defect in whoever produced the second report and never an overwrite.
     return "failed";

--- a/vex-app/src/main/database/__tests__/agent-scan-db-mapping.test.ts
+++ b/vex-app/src/main/database/__tests__/agent-scan-db-mapping.test.ts
@@ -14,7 +14,10 @@ import {
   mapAgentScanRow,
   STALLED_VERIFICATION_ATTEMPTS,
 } from "../agent-scan-db-mappers.js";
-import { agentScanEntrySchema } from "@shared/schemas/agent-scan-feed.js";
+import {
+  agentScanActivityEntrySchema,
+  agentScanEntrySchema,
+} from "@shared/schemas/agent-scan-feed.js";
 import type { AgentScanRow } from "../agent-scan-db-types.js";
 
 const BASE_CHAIN_ID = 8453;
@@ -24,6 +27,8 @@ const SOLANA_PROVIDER_CHAIN_ID = 20011000000;
 
 function row(overrides: Partial<AgentScanRow> = {}): AgentScanRow {
   return {
+    // The arm discriminator SQL selects as a literal: 0 = `agent_activity`.
+    source_rank: 0,
     source_id: "42",
     created_at: new Date("2026-05-21T10:00:00.000Z"),
     cursor_ts: "2026-05-21T10:00:00.000000Z",
@@ -81,7 +86,10 @@ function row(overrides: Partial<AgentScanRow> = {}): AgentScanRow {
 }
 
 it("carries a native input lower-bound basis through the IPC schema without changing the output basis", () => {
-  const entry = agentScanEntrySchema.parse(mapAgentScanRow(row({ protocol: "uniswap", token_in_address: null,
+  // Parsed through the ACTIVITY member of the union: the feed's entry schema is
+  // a discriminated union now, and this assertion is about an activity row's
+  // legs, which the Lighter member does not have.
+  const entry = agentScanActivityEntrySchema.parse(mapAgentScanRow(row({ protocol: "uniswap", token_in_address: null,
     token_in_symbol: "ETH", token_in_decimals: 18, executed_amount_in_raw: "1999999999999999999",
     evidence_source: "native_balance_delta_bound" })));
   expect(entry.input.amountBasis).toBe("lower_bound");

--- a/vex-app/src/main/database/__tests__/agent-scan-db.test.ts
+++ b/vex-app/src/main/database/__tests__/agent-scan-db.test.ts
@@ -46,6 +46,7 @@ vi.mock("../db-config.js", () => ({ buildPoolConfig: mocks.buildPoolConfig }));
 vi.mock("@vex-lib/wallet.js", () => ({ listWallets: mocks.listWallets }));
 vi.mock("../../logger/index.js", () => ({ log: mocks.log }));
 
+const { agentScanCursorSchema } = await import("@shared/schemas/agent-scan-feed.js");
 const { getAgentScan } = await import("../agent-scan-db.js");
 const { AGENT_ACTIVITY_LOGICAL_ROW_PREDICATE } = await import(
   "../agent-activity-logical-row.js"
@@ -66,6 +67,7 @@ class FakeDbError extends Error {
 
 function row(overrides: Partial<Record<string, unknown>> = {}) {
   return {
+    source_rank: 0,
     source_id: "1",
     created_at: new Date("2026-05-21T10:00:00.000Z"),
     cursor_ts: "2026-05-21T10:00:00.000000Z",
@@ -118,6 +120,81 @@ function pageCall(): { sql: string; params: readonly unknown[] } {
   );
   if (call === undefined) throw new Error("no page query issued");
   return { sql: call[0] as string, params: (call[1] ?? []) as readonly unknown[] };
+}
+
+/** The Lighter arm's page SELECT, or `null` when the arm was excluded. */
+function lighterCall(): { sql: string; params: readonly unknown[] } | null {
+  const call = mocks.query.mock.calls.find(
+    (c) => typeof c[0] === "string" && c[0].includes("FROM lighter_fills"),
+  );
+  if (call === undefined) return null;
+  return { sql: call[0] as string, params: (call[1] ?? []) as readonly unknown[] };
+}
+
+/**
+ * One `lighter_fills` row as the Lighter arm selects it. Only the fields this
+ * suite's assertions read are spelled out here; the full row and its mapping
+ * are the subject of `agent-scan-lighter-mappers.test.ts`.
+ */
+function lighterRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    source_rank: 1,
+    source_id: "7",
+    cursor_ts: "2026-05-21T10:00:00.000000Z",
+    traded_at: new Date("2026-05-21T10:00:00.000Z"),
+    observed_at: new Date("2026-05-21T10:00:02.000Z"),
+    environment: "core",
+    market_index: 1,
+    market_symbol: "ETH",
+    side: "buy",
+    trade_type: "trade",
+    position_effect: null,
+    base_size: "0.005",
+    price: "2598.09",
+    quote_notional: "12.99045",
+    usd_amount: "12.99",
+    block_height: "10453221",
+    base_asset_symbol: "ETH",
+    base_asset_decimals: 18,
+    quote_asset_symbol: "USDC",
+    quote_asset_decimals: 6,
+    position_size_before: null,
+    entry_quote_before: null,
+    account_pnl: null,
+    initial_margin_fraction_before: null,
+    fee_side: "taker",
+    integrator_fee_charged_raw: null,
+    integrator_fee_estimated_raw: null,
+    integrator_fee_estimate_basis: null,
+    integrator_fee_estimate_tick_source: null,
+    integrator_fee_estimated_usd: null,
+    integrator_fee_asset_symbol: null,
+    integrator_fee_asset_decimals: null,
+    integrator_fee_tick_observed: null,
+    integrator_fee_tick_authorized: null,
+    exchange_fee_charged_raw: null,
+    exchange_fee_estimated_usd: null,
+    exchange_fee_tick_observed: null,
+    provider_trade_id: "918273645",
+    provider_order_id: null,
+    execution_intent_id: "lighter-exec-1",
+    position_observed_at: null,
+    position_open: null,
+    position_now: null,
+    ...overrides,
+  };
+}
+
+/** Answer both arms independently, so a page can mix them. */
+function respondWithArms(
+  activityRows: ReadonlyArray<Record<string, unknown>>,
+  fillRows: ReadonlyArray<Record<string, unknown>>,
+): void {
+  mocks.query.mockImplementation(async (text: string) => {
+    if (text.includes("FROM agent_activity")) return { rows: activityRows };
+    if (text.includes("FROM lighter_fills")) return { rows: fillRows };
+    return { rows: [] };
+  });
 }
 
 function respondWith(rows: ReadonlyArray<Record<string, unknown>>): void {
@@ -362,10 +439,10 @@ describe("getAgentScan row selection", () => {
     expect(pageCall().sql).toContain("ORDER BY aa.created_at DESC, aa.id DESC");
   });
 
-  it("runs inside a bounded READ ONLY transaction", async () => {
+  it("runs BOTH arms inside ONE bounded REPEATABLE READ READ ONLY snapshot", async () => {
     await getAgentScan(EMPTY_INPUT, CORRELATION_ID);
     const texts = mocks.query.mock.calls.map((c) => c[0] as string);
-    expect(texts).toContain("BEGIN READ ONLY");
+    expect(texts).toContain("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY");
     expect(texts.some((t) => t.includes("SET LOCAL statement_timeout = '2s'"))).toBe(true);
     expect(texts).toContain("COMMIT");
   });
@@ -458,12 +535,15 @@ describe("getAgentScan keyset pagination", () => {
 
   it("compares the id NUMERICALLY at equal timestamps", async () => {
     await getAgentScan({
-      cursor: { createdAt: "2026-05-21T10:00:00.123456Z", sourceId: "500" },
+      cursor: { createdAt: "2026-05-21T10:00:00.123456Z", sourceId: "500", sourceRank: 0 },
       filters: {},
     }, CORRELATION_ID);
     const { sql, params } = pageCall();
     expect(sql).toMatch(/aa\.created_at < \$\d+::timestamptz/);
-    expect(sql).toMatch(/aa\.created_at = \$\d+::timestamptz AND aa\.id < \$\d+::bigint/);
+    // The 3-field boundary: the arm's rank is a LITERAL, compared against the
+    // cursor's, and only a tie on both reaches the id compare.
+    expect(sql).toMatch(/aa\.created_at = \$\d+::timestamptz AND 0 < \$\d+::int/);
+    expect(sql).toMatch(/AND 0 = \$\d+::int AND aa\.id < \$\d+::bigint/);
     expect(params).toContain("2026-05-21T10:00:00.123456Z");
     expect(params).toContain("500");
   });
@@ -498,6 +578,9 @@ describe("getAgentScan keyset pagination", () => {
     expect(outcome.data.nextCursor).toEqual({
       createdAt: "2026-05-21T10:00:00.000051Z",
       sourceId: "51",
+      // The arm the page ended on. Without it the next page could not resume
+      // on the right side of a cross-arm tie at the same microsecond.
+      sourceRank: 0,
     });
   });
 
@@ -556,5 +639,184 @@ describe("getAgentScan bounded-read failure", () => {
     mocks.buildPoolConfig.mockResolvedValue(null);
     const outcome = await getAgentScan(EMPTY_INPUT, CORRELATION_ID);
     expect(outcome.ok).toBe(false);
+  });
+});
+
+// ── The two arms ──────────────────────────────────────────────────────────
+
+describe("getAgentScan two-arm composition", () => {
+  it("issues BOTH arm queries inside the SAME transaction", async () => {
+    await getAgentScan(EMPTY_INPUT, CORRELATION_ID);
+    const texts = mocks.query.mock.calls.map((c) => c[0] as string);
+    const begin = texts.findIndex((t) => t.startsWith("BEGIN"));
+    const commit = texts.indexOf("COMMIT");
+    const activity = texts.findIndex((t) => t.includes("FROM agent_activity"));
+    const lighter = texts.findIndex((t) => t.includes("FROM lighter_fills"));
+    expect(begin).toBeGreaterThanOrEqual(0);
+    expect(activity).toBeGreaterThan(begin);
+    expect(lighter).toBeGreaterThan(begin);
+    expect(commit).toBeGreaterThan(Math.max(activity, lighter));
+  });
+
+  /**
+   * REPEATABLE READ, not the default READ COMMITTED: at READ COMMITTED each
+   * statement takes its OWN snapshot, so a fill inserted between the two arm
+   * queries could be counted by one arm's `limit + 1` probe while the other
+   * arm's boundary had already moved past it.
+   */
+  it("reads both arms from ONE snapshot", async () => {
+    await getAgentScan(EMPTY_INPUT, CORRELATION_ID);
+    const texts = mocks.query.mock.calls.map((c) => c[0] as string);
+    expect(texts).toContain("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY");
+    expect(texts.some((t) => t.includes("SET LOCAL statement_timeout = '2s'"))).toBe(true);
+  });
+
+  it("binds the SAME inventory allow-list to both arms", async () => {
+    await getAgentScan(EMPTY_INPUT, CORRELATION_ID);
+    const lighter = lighterCall();
+    expect(lighter).not.toBeNull();
+    expect(lighter?.params[0]).toEqual(pageCall().params[0]);
+  });
+
+  it("skips the Lighter arm entirely when the filters exclude it", async () => {
+    await getAgentScan({ cursor: null, filters: { kinds: ["swap"] } }, CORRELATION_ID);
+    expect(lighterCall()).toBeNull();
+  });
+
+  it("reads the Lighter arm when kinds names just that feed kind", async () => {
+    respondWithArms([row()], [lighterRow()]);
+    await getAgentScan({ cursor: null, filters: { kinds: ["lighter_fill"] } }, CORRELATION_ID);
+    // The activity arm's own `kind` predicate compiles the same value, which
+    // matches no `agent_activity.kind` - `lighter_fill` is a FEED kind, not a
+    // ledger one, so that arm legitimately returns nothing for it.
+    expect(pageCall().params).toContainEqual(["lighter_fill"]);
+    expect(lighterCall()).not.toBeNull();
+  });
+
+  it("interleaves the two arms into one time-ordered page", async () => {
+    respondWithArms(
+      [
+        row({ source_id: "20", cursor_ts: "2026-05-21T10:00:03.000000Z" }),
+        row({ source_id: "18", cursor_ts: "2026-05-21T10:00:01.000000Z" }),
+      ],
+      [lighterRow({ source_id: "7", cursor_ts: "2026-05-21T10:00:02.000000Z" })],
+    );
+    const outcome = await getAgentScan(EMPTY_INPUT, CORRELATION_ID);
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok || outcome.data.status !== "available") return;
+    expect(outcome.data.entries.map((entry) => [entry.source, entry.id])).toEqual([
+      ["agent_activity", "20"],
+      ["lighter_fill", "7"],
+      ["agent_activity", "18"],
+    ]);
+  });
+
+  it("carries the arm the page ended on into nextCursor", async () => {
+    // 51 rows across the two arms, 49 of them newer activity rows: the page
+    // keeps 50, so the last kept row is the FIRST fill and the cursor has to
+    // say which arm it came from.
+    const activityRows = Array.from({ length: 49 }, (_, i) =>
+      row({
+        source_id: String(100 - i),
+        cursor_ts: `2026-05-21T10:00:00.${String(900 - i).padStart(6, "0")}Z`,
+      }),
+    );
+    respondWithArms(activityRows, [
+      lighterRow({ source_id: "7", cursor_ts: "2026-05-21T10:00:00.000100Z" }),
+      lighterRow({ source_id: "6", cursor_ts: "2026-05-21T10:00:00.000090Z" }),
+    ]);
+    const outcome = await getAgentScan(EMPTY_INPUT, CORRELATION_ID);
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok || outcome.data.status !== "available") return;
+    expect(outcome.data.entries).toHaveLength(50);
+    expect(outcome.data.hasMore).toBe(true);
+    expect(outcome.data.nextCursor).toEqual({
+      createdAt: "2026-05-21T10:00:00.000100Z",
+      sourceId: "7",
+      sourceRank: 1,
+    });
+  });
+
+  it("applies the SAME cursor boundary to both arms", async () => {
+    await getAgentScan({
+      cursor: { createdAt: "2026-05-21T10:00:00.123456Z", sourceId: "500", sourceRank: 1 },
+      filters: {},
+    }, CORRELATION_ID);
+    expect(pageCall().params).toContain("2026-05-21T10:00:00.123456Z");
+    expect(lighterCall()?.params).toContain("2026-05-21T10:00:00.123456Z");
+    expect(pageCall().params).toContain(1);
+    expect(lighterCall()?.params).toContain(1);
+  });
+
+  /**
+   * A timeout on EITHER arm fails the WHOLE read closed. Returning the arm that
+   * answered would present half a history as the history, on a surface whose
+   * whole promise is that nothing is hidden.
+   */
+  it("fails the whole read closed when the LIGHTER arm times out", async () => {
+    mocks.query.mockImplementation(async (text: string) => {
+      if (text.includes("FROM lighter_fills")) throw new FakeDbError("57014");
+      if (text.includes("FROM agent_activity")) return { rows: [row()] };
+      return { rows: [] };
+    });
+    const outcome = await getAgentScan(EMPTY_INPUT, CORRELATION_ID);
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.data).toEqual({ status: "unavailable", reason: "query_timeout" });
+  });
+
+  it("rolls back and errors on any other LIGHTER arm failure", async () => {
+    mocks.query.mockImplementation(async (text: string) => {
+      if (text.includes("FROM lighter_fills")) throw new FakeDbError("42P01");
+      if (text.includes("FROM agent_activity")) return { rows: [] };
+      return { rows: [] };
+    });
+    const outcome = await getAgentScan(EMPTY_INPUT, CORRELATION_ID);
+    expect(outcome.ok).toBe(false);
+    expect(mocks.query.mock.calls.map((c) => c[0] as string)).toContain("ROLLBACK");
+  });
+
+  it("returns the empty page WITHOUT issuing either arm when the inventory is empty", async () => {
+    mocks.listWallets.mockReturnValue([]);
+    await getAgentScan(EMPTY_INPUT, CORRELATION_ID);
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+});
+
+// ── Cursor compatibility ──────────────────────────────────────────────────
+
+describe("the feed cursor across the two arms", () => {
+  /**
+   * A cursor minted before the second arm existed carries no `sourceRank`. It
+   * must still parse, and must resume on the ACTIVITY side of a tie - which is
+   * where it was issued.
+   */
+  it("parses a cursor minted before the Lighter arm existed", () => {
+    const parsed = agentScanCursorSchema.parse({
+      createdAt: "2026-05-21T10:00:00.123456Z",
+      sourceId: "500",
+    });
+    expect(parsed).toEqual({
+      createdAt: "2026-05-21T10:00:00.123456Z",
+      sourceId: "500",
+      sourceRank: 0,
+    });
+  });
+
+  it("round-trips a cursor the feed itself minted", () => {
+    const minted = {
+      createdAt: "2026-05-21T10:00:00.123456Z",
+      sourceId: "500",
+      sourceRank: 1,
+    };
+    expect(agentScanCursorSchema.parse(minted)).toEqual(minted);
+  });
+
+  it("refuses a rank outside the two arms that exist", () => {
+    expect(agentScanCursorSchema.safeParse({
+      createdAt: "2026-05-21T10:00:00.123456Z",
+      sourceId: "500",
+      sourceRank: 2,
+    }).success).toBe(false);
   });
 });

--- a/vex-app/src/main/database/__tests__/agent-scan-lighter-mappers.test.ts
+++ b/vex-app/src/main/database/__tests__/agent-scan-lighter-mappers.test.ts
@@ -1,0 +1,473 @@
+/**
+ * `agent-scan-lighter-mappers` - one `lighter_fills` row plus its market's
+ * newest observation into one feed entry.
+ *
+ * Every mapped entry is parsed through `agentScanLighterFillEntrySchema`
+ * before anything else is asserted: the mapper's real contract is not "returns
+ * an object" but "returns something the IPC boundary accepts", and a shape the
+ * DTO would refuse must fail HERE rather than as a blank page in front of the
+ * user.
+ *
+ * The posture these tests pin comes from metamask-core's
+ * `PendingTransactionTracker`: a fact is reported as OBSERVED, with its own
+ * timestamp, and a fact nobody established is UNKNOWN - never a zero, never a
+ * default, never the current value passed off as the historical one.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  LIGHTER_SPOT_MARKET_INDEX_FLOOR,
+  mapAgentScanLighterRow,
+  type AgentScanLighterMappingStats,
+} from "../agent-scan-lighter-mappers.js";
+import { agentScanLighterFillEntrySchema } from "@shared/schemas/agent-scan-lighter-entry.js";
+import type { AgentScanLighterRow } from "../agent-scan-lighter-types.js";
+
+const TRADED_AT = new Date("2026-09-08T12:00:00.000Z");
+const OBSERVED_AT = new Date("2026-09-08T12:00:03.000Z");
+const POSITION_OBSERVED_AT = new Date("2026-09-08T16:49:00.000Z");
+
+/** A perpetual ETH taker buy with a full account half and a proven integrator fee. */
+function row(overrides: Partial<AgentScanLighterRow> = {}): AgentScanLighterRow {
+  return {
+    source_rank: 1,
+    source_id: "77",
+    cursor_ts: "2026-09-08T12:00:00.000000Z",
+    traded_at: TRADED_AT,
+    observed_at: OBSERVED_AT,
+    environment: "core",
+    market_index: 1,
+    market_symbol: "ETH",
+    side: "buy",
+    trade_type: "trade",
+    position_effect: "open",
+    base_size: "0.0050",
+    price: "2598.09",
+    quote_notional: "12.99045",
+    usd_amount: "12.99",
+    block_height: "10453221",
+    base_asset_symbol: "ETH",
+    base_asset_decimals: 18,
+    quote_asset_symbol: "USDC",
+    quote_asset_decimals: 6,
+    position_size_before: "0",
+    entry_quote_before: "0",
+    account_pnl: "0",
+    initial_margin_fraction_before: 1000,
+    fee_side: "taker",
+    integrator_fee_charged_raw: "3247",
+    integrator_fee_estimated_raw: "3247",
+    integrator_fee_estimate_basis: "quote_notional",
+    integrator_fee_estimate_tick_source: "observed",
+    integrator_fee_estimated_usd: "0.003247",
+    integrator_fee_asset_symbol: "USDC",
+    integrator_fee_asset_decimals: 6,
+    integrator_fee_tick_observed: 250,
+    integrator_fee_tick_authorized: 250,
+    exchange_fee_charged_raw: "1299",
+    exchange_fee_estimated_usd: "0.001299",
+    exchange_fee_tick_observed: 100,
+    provider_trade_id: "918273645",
+    provider_order_id: "112233",
+    execution_intent_id: "lighter-exec-6f4c2c60-0d3f-4a77-8f7f-0b4ce9a11111",
+    position_observed_at: null,
+    position_open: null,
+    position_now: null,
+    ...overrides,
+  };
+}
+
+/** Map, then prove the result survives the IPC output schema. */
+function mapValid(
+  source: AgentScanLighterRow,
+  stats?: AgentScanLighterMappingStats,
+) {
+  const entry = mapAgentScanLighterRow(source, stats);
+  const parsed = agentScanLighterFillEntrySchema.safeParse(entry);
+  expect(parsed.success).toBe(true);
+  return entry;
+}
+
+// ── Identity and market ───────────────────────────────────────────────────
+
+describe("identity, time and market", () => {
+  it("uses traded_at as the feed time and keeps observed_at as its own fact", () => {
+    const entry = mapValid(row());
+    expect(entry.source).toBe("lighter_fill");
+    expect(entry.id).toBe("77");
+    // The VENUE's match time, which is what the page is ordered and cut by.
+    expect(entry.createdAt).toBe("2026-09-08T12:00:00.000Z");
+    // When VEX saw it - a different fact, and never substituted for the first.
+    expect(entry.observedAt).toBe("2026-09-08T12:00:03.000Z");
+  });
+
+  /**
+   * The venue's own spot-market index boundary, measured by the engine's wire
+   * mapper (`src/vex-agent/sync/agentscan-report/lighter-fill-event.ts:85` and
+   * `src/vex-agent/tools/protocols/lighter/agentscan-activity.ts:95`). A spot
+   * fill has no position, so the flag is what lets a renderer stop claiming
+   * one.
+   */
+  it("classifies spot by the venue's own market index floor", () => {
+    expect(LIGHTER_SPOT_MARKET_INDEX_FLOOR).toBe(2048);
+    expect(mapValid(row({ market_index: 2047 })).spot).toBe(false);
+    expect(mapValid(row({ market_index: 2048 })).spot).toBe(true);
+    expect(mapValid(row({ market_index: 4096 })).spot).toBe(true);
+  });
+
+  it("falls back to the market index when the symbol is missing, never to a blank label", () => {
+    expect(mapValid(row({ market_symbol: null, market_index: 12 })).marketSymbol).toBe("12");
+  });
+});
+
+// ── Leverage ──────────────────────────────────────────────────────────────
+
+describe("leverage before the fill", () => {
+  /**
+   * The display comes from `initialMarginFractionToLeverageDisplay`, the one
+   * owner of Lighter's 10000-scale unit: TRUNCATED to two decimals, because
+   * 3334 is 2.9994x and "3.00x" would state leverage the exchange will not give.
+   */
+  it.each([
+    [10_000, "1.00"],
+    [5000, "2.00"],
+    [3334, "2.99"],
+    [1000, "10.00"],
+    [333, "30.03"],
+    [200, "50.00"],
+    [1, "10000.00"],
+  ])("renders fraction %i as %s", (fraction, display) => {
+    const entry = mapValid(row({ initial_margin_fraction_before: fraction }));
+    expect(entry.leverage).toEqual({ initialMarginFraction: fraction, display });
+  });
+
+  /**
+   * A public row and a row written before the column existed both hold NULL,
+   * and both mean "unknown". Rendering a current leverage beside a historical
+   * fill would state a fact nobody established.
+   */
+  it("reports NULL leverage as unknown, never as a number", () => {
+    expect(mapValid(row({ initial_margin_fraction_before: null })).leverage).toBeNull();
+  });
+
+  /**
+   * The unit owner THROWS outside 1..10000. A stored value outside that range
+   * is data this reader cannot interpret, and degrading it to "unknown" keeps
+   * one bad row from taking the whole page down.
+   */
+  it("degrades an out-of-range fraction to unknown instead of throwing", () => {
+    expect(mapValid(row({ initial_margin_fraction_before: 0 })).leverage).toBeNull();
+    expect(mapValid(row({ initial_margin_fraction_before: 10_001 })).leverage).toBeNull();
+    expect(mapValid(row({ initial_margin_fraction_before: -5 })).leverage).toBeNull();
+    expect(mapValid(row({ initial_margin_fraction_before: "garbage" })).leverage).toBeNull();
+  });
+});
+
+// ── The account half ──────────────────────────────────────────────────────
+
+describe("the account's own half of the trade record", () => {
+  it("carries the account facts as stored, including a signed short and a loss", () => {
+    const entry = mapValid(row({
+      position_size_before: "-0.25",
+      entry_quote_before: "-640.5",
+      account_pnl: "-12.44",
+      position_effect: "reduce",
+    }));
+    expect(entry.positionSizeBefore).toBe("-0.25");
+    expect(entry.entryQuoteBefore).toBe("-640.5");
+    expect(entry.accountPnl).toBe("-12.44");
+    expect(entry.positionEffect).toBe("reduce");
+  });
+
+  /**
+   * A public trade row carries no account half at all. Every field stays null:
+   * a zero here would read as "the account held nothing and realized nothing",
+   * which is a claim, not an absence.
+   */
+  it("reports a missing account half as null, never as 0", () => {
+    const entry = mapValid(row({
+      position_size_before: null,
+      entry_quote_before: null,
+      account_pnl: null,
+      position_effect: null,
+      initial_margin_fraction_before: null,
+    }));
+    expect(entry.positionSizeBefore).toBeNull();
+    expect(entry.entryQuoteBefore).toBeNull();
+    expect(entry.accountPnl).toBeNull();
+    expect(entry.positionEffect).toBeNull();
+    expect(entry.leverage).toBeNull();
+  });
+
+  /** Migration 152 admits a null `entry_quote_before` beside a present half. */
+  it("admits a null entry quote beside the other account facts", () => {
+    const entry = mapValid(row({ entry_quote_before: null }));
+    expect(entry.entryQuoteBefore).toBeNull();
+    expect(entry.accountPnl).toBe("0");
+  });
+});
+
+// ── Fee provenance ────────────────────────────────────────────────────────
+
+describe("fee provenance", () => {
+  it("carries the exact charged integrator fee with its own asset", () => {
+    const entry = mapValid(row());
+    expect(entry.integratorFee.charged).toEqual({
+      raw: "3247",
+      symbol: "USDC",
+      decimals: 6,
+    });
+    expect(entry.integratorFee.tickObserved).toBe(250);
+    expect(entry.integratorFee.tickAuthorized).toBe(250);
+  });
+
+  /**
+   * NULL is UNPROVEN, never zero (migration 152 says so in the column comment).
+   * The estimate stays beside it with its basis and the tick it used, so a
+   * renderer can show an estimate MARKED as one rather than a fabricated exact
+   * charge of nothing.
+   */
+  it("reports an unproven charged fee as null and keeps the estimate with its basis", () => {
+    const entry = mapValid(row({ integrator_fee_charged_raw: null }));
+    expect(entry.integratorFee.charged).toBeNull();
+    expect(entry.integratorFee.estimate).toEqual({
+      raw: "3247",
+      symbol: "USDC",
+      decimals: 6,
+      basis: "quote_notional",
+      tickSource: "observed",
+      usd: "0.003247",
+    });
+  });
+
+  it("reports no estimate at all when the ledger holds none", () => {
+    const entry = mapValid(row({
+      integrator_fee_estimated_raw: null,
+      integrator_fee_estimate_basis: null,
+      integrator_fee_estimate_tick_source: null,
+      integrator_fee_estimated_usd: null,
+    }));
+    expect(entry.integratorFee.estimate).toBeNull();
+  });
+
+  /** The USD estimate is NULL for the integrator fee on a spot BUY (migration 152). */
+  it("keeps a null USD estimate null rather than inventing a dollar figure", () => {
+    const entry = mapValid(row({ integrator_fee_estimated_usd: null }));
+    expect(entry.integratorFee.estimate?.usd).toBeNull();
+  });
+
+  /**
+   * The exchange fee has no asset columns of its own, so the DENOMINATION is
+   * resolved by the venue's own rule: the received BASE on a spot buy, the
+   * QUOTE asset otherwise (`lighter-fill-event.ts:513`).
+   */
+  it("denominates the exchange fee in the quote asset on a perpetual, either side", () => {
+    expect(mapValid(row({ side: "buy" })).exchangeFee.charged?.symbol).toBe("USDC");
+    expect(mapValid(row({ side: "sell" })).exchangeFee.charged?.symbol).toBe("USDC");
+  });
+
+  it("denominates the exchange fee in the received BASE on a spot buy only", () => {
+    const spotBuy = mapValid(row({ market_index: 2048, side: "buy" }));
+    expect(spotBuy.exchangeFee.charged).toEqual({ raw: "1299", symbol: "ETH", decimals: 18 });
+    const spotSell = mapValid(row({ market_index: 2048, side: "sell" }));
+    expect(spotSell.exchangeFee.charged?.symbol).toBe("USDC");
+  });
+
+  /** The exchange reports a rebate as a NEGATIVE charged amount; the sign survives. */
+  it("carries a rebate as a negative charged amount, not as a charge", () => {
+    const entry = mapValid(row({ exchange_fee_charged_raw: "-412" }));
+    expect(entry.exchangeFee.charged?.raw).toBe("-412");
+  });
+
+  it("reports an unproven exchange fee as null and keeps its USD estimate", () => {
+    const entry = mapValid(row({ exchange_fee_charged_raw: null }));
+    expect(entry.exchangeFee.charged).toBeNull();
+    expect(entry.exchangeFee.estimatedUsd).toBe("0.001299");
+    expect(entry.exchangeFee.tickObserved).toBe(100);
+  });
+});
+
+// ── positionNow ───────────────────────────────────────────────────────────
+
+describe("the market's newest observed position", () => {
+  /** Vex has never observed this market: not closed, not open - nothing to say. */
+  it("is null when no observation exists for the market", () => {
+    expect(mapValid(row()).positionNow).toBeNull();
+  });
+
+  /** Migration 152 stores `open = false, position = NULL` for a closed market. */
+  it("reports an observed CLOSURE with its observation time and no details", () => {
+    const entry = mapValid(row({
+      position_observed_at: POSITION_OBSERVED_AT,
+      position_open: false,
+      position_now: null,
+    }));
+    expect(entry.positionNow).toEqual({
+      observedAt: "2026-09-08T16:49:00.000Z",
+      open: false,
+      position: null,
+    });
+  });
+
+  it("reports an open position with every projected fact", () => {
+    const entry = mapValid(row({
+      position_observed_at: POSITION_OBSERVED_AT,
+      position_open: true,
+      position_now: {
+        marketIndex: 1,
+        marketSymbol: "ETH",
+        size: "0.0050",
+        entryPrice: "2598.09",
+        unrealizedPnl: "-0.0077",
+        realizedPnl: "0",
+        liquidationPrice: "2365.93",
+        initialMarginFraction: 1000,
+        marginMode: "isolated",
+      },
+    }));
+    expect(entry.positionNow).toEqual({
+      // VEX'S OWN observation time from the position sweep, not a venue clock.
+      observedAt: "2026-09-08T16:49:00.000Z",
+      open: true,
+      position: {
+        size: "0.0050",
+        entryPrice: "2598.09",
+        unrealizedPnl: "-0.0077",
+        realizedPnl: "0",
+        liquidationPrice: "2365.93",
+        leverage: { initialMarginFraction: 1000, display: "10.00" },
+        marginMode: "isolated",
+      },
+    });
+  });
+
+  /**
+   * An observation stored BEFORE leverage and margin mode were projected simply
+   * has no such keys. It must still read, with those two facts unknown.
+   */
+  it("reads an OLD observation that predates the leverage and margin-mode keys", () => {
+    const entry = mapValid(row({
+      position_observed_at: POSITION_OBSERVED_AT,
+      position_open: true,
+      position_now: {
+        marketIndex: 1,
+        marketSymbol: "ETH",
+        size: "-1.5",
+        entryPrice: "2600",
+        unrealizedPnl: null,
+        realizedPnl: null,
+        liquidationPrice: null,
+      },
+    }));
+    expect(entry.positionNow).toEqual({
+      observedAt: "2026-09-08T16:49:00.000Z",
+      open: true,
+      position: {
+        size: "-1.5",
+        entryPrice: "2600",
+        unrealizedPnl: null,
+        realizedPnl: null,
+        liquidationPrice: null,
+        leverage: null,
+        marginMode: null,
+      },
+    });
+  });
+
+  /**
+   * A malformed OPTIONAL fact is unknown on its own. Discarding the readable
+   * size and entry price beside it would hide facts Vex really did observe.
+   */
+  it("nulls one malformed optional fact WITHOUT discarding its neighbours", () => {
+    const entry = mapValid(row({
+      position_observed_at: POSITION_OBSERVED_AT,
+      position_open: true,
+      position_now: {
+        size: "0.5",
+        entryPrice: "2600",
+        unrealizedPnl: "not-a-number",
+        realizedPnl: "1.25",
+        liquidationPrice: "-40",
+        initialMarginFraction: 99_999,
+        marginMode: 7,
+      },
+    }));
+    expect(entry.positionNow).toEqual({
+      observedAt: "2026-09-08T16:49:00.000Z",
+      open: true,
+      position: {
+        size: "0.5",
+        entryPrice: "2600",
+        unrealizedPnl: null,
+        // A liquidation price is unsigned; a negative one is unreadable.
+        liquidationPrice: null,
+        realizedPnl: "1.25",
+        leverage: null,
+        marginMode: null,
+      },
+    });
+  });
+
+  /**
+   * `size` is what makes a position a position. Without a readable one the
+   * market is still OPEN - that is an observed fact - but its details are
+   * unavailable, and the renderer says exactly that rather than hiding the
+   * observation.
+   */
+  it("reports an open market with UNREADABLE stored details, and counts it", () => {
+    const stats: AgentScanLighterMappingStats = { unreadablePositions: 0 };
+    const entry = mapValid(row({
+      position_observed_at: POSITION_OBSERVED_AT,
+      position_open: true,
+      position_now: { size: "not-a-size", entryPrice: "2600" },
+    }), stats);
+    expect(entry.positionNow).toEqual({
+      observedAt: "2026-09-08T16:49:00.000Z",
+      open: true,
+      position: null,
+    });
+    expect(stats.unreadablePositions).toBe(1);
+  });
+
+  it("treats a non-object stored position as unreadable rather than as a closure", () => {
+    const stats: AgentScanLighterMappingStats = { unreadablePositions: 0 };
+    const entry = mapValid(row({
+      position_observed_at: POSITION_OBSERVED_AT,
+      position_open: true,
+      position_now: "corrupt",
+    }), stats);
+    expect(entry.positionNow).toEqual({
+      observedAt: "2026-09-08T16:49:00.000Z",
+      open: true,
+      position: null,
+    });
+    expect(stats.unreadablePositions).toBe(1);
+  });
+
+  it("counts nothing when every observation reads", () => {
+    const stats: AgentScanLighterMappingStats = { unreadablePositions: 0 };
+    mapValid(row({
+      position_observed_at: POSITION_OBSERVED_AT,
+      position_open: true,
+      position_now: { size: "1", entryPrice: null },
+    }), stats);
+    expect(stats.unreadablePositions).toBe(0);
+  });
+});
+
+// ── Identifiers ───────────────────────────────────────────────────────────
+
+describe("identifiers", () => {
+  it("carries the provider and intent ids exactly, never clamped", () => {
+    const entry = mapValid(row());
+    expect(entry.providerTradeId).toBe("918273645");
+    expect(entry.providerOrderId).toBe("112233");
+    expect(entry.intentId).toBe("lighter-exec-6f4c2c60-0d3f-4a77-8f7f-0b4ce9a11111");
+    expect(entry.blockHeight).toBe("10453221");
+  });
+
+  it("admits a missing provider order id", () => {
+    expect(mapValid(row({ provider_order_id: null })).providerOrderId).toBeNull();
+  });
+});

--- a/vex-app/src/main/database/__tests__/agent-scan-lighter-query.test.ts
+++ b/vex-app/src/main/database/__tests__/agent-scan-lighter-query.test.ts
@@ -1,0 +1,293 @@
+/**
+ * `agent-scan-lighter-query` - the SQL SHAPE of the feed's Lighter arm, and the
+ * four ways a filter can exclude it.
+ *
+ * SQL-text assertions are the right instrument here for the same reason the
+ * sibling `agent-scan-db.test.ts` uses them: these are statements about the
+ * predicate the reader COMPILES, and each one pins a specific way the reader
+ * could leak or lose rows. That the compiled statement then RUNS and returns
+ * the right rows is a property only a database can prove, and
+ * `agent-scan-lighter.int.test.ts` proves it against real Postgres.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { buildAgentScanLighterPageQuery } from "../agent-scan-lighter-query.js";
+import type { AgentScanFilters } from "@shared/schemas/agent-scan-feed.js";
+
+const WALLETS = ["0xAAAA", "0xaaaa"] as const;
+const PROJECT_WALLETS = ["0xAAAA"] as const;
+const SESSION = "11111111-2222-4333-8444-555555555555";
+
+function plan(filters: AgentScanFilters = {}, extra: {
+  readonly projectWallets?: readonly string[] | null;
+  readonly cursor?: { createdAt: string; sourceId: string; sourceRank: number } | null;
+} = {}) {
+  return buildAgentScanLighterPageQuery({
+    wallets: WALLETS,
+    projectWallets: extra.projectWallets ?? null,
+    filters,
+    cursor: extra.cursor ?? null,
+  });
+}
+
+/** The plan, asserted present - the arm was not excluded. */
+function sqlOf(filters: AgentScanFilters = {}, extra: Parameters<typeof plan>[1] = {}) {
+  const built = plan(filters, extra);
+  expect(built).not.toBeNull();
+  if (built === null) throw new Error("unreachable");
+  return built;
+}
+
+// ── Mandatory predicates ──────────────────────────────────────────────────
+
+describe("the Lighter arm's mandatory predicates", () => {
+  /**
+   * Migration 152: a fill with no intent is HELD - Vex observed it before it
+   * could prove which order owns it. The account may trade outside Vex, so a
+   * held row is somebody's trading that this feed has no right to attribute to
+   * the agent. This predicate is not a filter and no caller can remove it.
+   */
+  it("reads ONLY attributed fills - a held row can never be selected", () => {
+    expect(sqlOf().sql).toContain("f.execution_intent_id IS NOT NULL");
+  });
+
+  /**
+   * A CORRELATED EXISTS, never a JOIN. Migration 124 is unique on
+   * `(environment, wallet_address)` and NOT on the resolved account, so two of
+   * the user's wallets can resolve to one Lighter account - and a JOIN would
+   * then emit the same fill once per wallet, with the same cursor id behind
+   * each copy.
+   */
+  it("scopes by a correlated EXISTS over the onboarding workflows, not a JOIN", () => {
+    const { sql, params } = sqlOf();
+    expect(sql).toContain("EXISTS (");
+    expect(sql).toContain("FROM lighter_onboarding_workflows w");
+    expect(sql).toContain("w.environment = f.environment");
+    expect(sql).toContain("w.resolved_account_index = f.account_index");
+    expect(sql).toContain("w.wallet_address = ANY($1::text[])");
+    expect(sql).not.toContain("JOIN lighter_onboarding_workflows");
+    // The allow-list is the FIRST bound parameter, before any optional one -
+    // the same position it holds on the activity arm.
+    expect(params[0]).toEqual([...WALLETS]);
+  });
+
+  /**
+   * A workflow that reached `ready_to_trade` can fall back to a deposit or
+   * failure state while its resolved account stays recorded. History has to
+   * survive that: yesterday's fills do not stop being the user's because
+   * onboarding regressed today.
+   */
+  it("puts NO workflow_state condition on the scope", () => {
+    expect(sqlOf().sql).not.toContain("workflow_state");
+  });
+
+  it("never selects a fill through a LEFT JOIN that could widen the scope", () => {
+    // The only join on this statement is the LATERAL that reads the market's
+    // observed position, which cannot add a fill row.
+    const { sql } = sqlOf();
+    expect(sql).toContain("LEFT JOIN LATERAL");
+    expect(sql).toContain("FROM lighter_position_market_state s");
+    expect(sql.match(/JOIN/g)).toEqual(["JOIN"]);
+  });
+});
+
+// ── Project and session narrowing ─────────────────────────────────────────
+
+describe("the Lighter arm's narrowing predicates", () => {
+  /**
+   * Both wallet predicates sit on the SAME workflow row. Two independent
+   * existence claims would say "some wallet of the inventory resolves to this
+   * account AND some wallet of the project does", which is a weaker statement
+   * than "one wallet does both" and would reach accounts the project does not
+   * own.
+   */
+  it("intersects the project selection on the SAME workflow row", () => {
+    const { sql, params } = sqlOf({}, { projectWallets: PROJECT_WALLETS });
+    const existsBlock = sql.slice(
+      sql.indexOf("FROM lighter_onboarding_workflows w"),
+      sql.indexOf("ORDER BY"),
+    );
+    expect(existsBlock).toContain("w.wallet_address = ANY($1::text[])");
+    expect(existsBlock).toContain("w.wallet_address = ANY($2::text[])");
+    expect(params[1]).toEqual([...PROJECT_WALLETS]);
+    // Exactly one EXISTS over the workflows table.
+    expect(sql.match(/FROM lighter_onboarding_workflows/g)).toHaveLength(1);
+  });
+
+  it("omits the project predicate entirely when no project was named", () => {
+    expect(sqlOf().sql.match(/w\.wallet_address = ANY/g)).toHaveLength(1);
+  });
+
+  /**
+   * `lighter_fills.execution_intent_id` has no foreign key because ONE column
+   * points at three owning tables (migration 152's own comment): an order
+   * execution intent (115), a lifecycle intent (140) and an OCO execution
+   * intent (148). Asking only one of them would make session narrowing drop
+   * every close and every triggered protective leg.
+   */
+  it("resolves the session through ALL THREE owning intent tables", () => {
+    const { sql, params } = sqlOf({ sessionId: SESSION });
+    expect(sql).toContain("FROM lighter_order_execution_intents i");
+    expect(sql).toContain("FROM lighter_order_lifecycle_intents l");
+    expect(sql).toContain("FROM lighter_oco_execution_intents o");
+    expect(sql).toContain("i.intent_id = f.execution_intent_id");
+    expect(sql).toContain("l.intent_id = f.execution_intent_id");
+    expect(sql).toContain("o.intent_id = f.execution_intent_id");
+    expect(params).toContain(SESSION);
+  });
+
+  it("omits the session predicate entirely when no session was named", () => {
+    expect(sqlOf().sql).not.toContain("session_id");
+  });
+});
+
+// ── Keyset boundary ───────────────────────────────────────────────────────
+
+describe("the Lighter arm's keyset boundary", () => {
+  it("issues no boundary on the first page", () => {
+    expect(sqlOf().sql).not.toContain("f.traded_at <");
+  });
+
+  /**
+   * The SAME 3-field boundary the activity arm applies, with THIS arm's rank
+   * literal. Both arms must read the same boundary or the merged page would
+   * skip or repeat rows across the seam.
+   */
+  it("compares (traded_at, rank 1, id) with the id as a BIGINT", () => {
+    const { sql, params } = sqlOf({}, {
+      cursor: { createdAt: "2026-05-21T10:00:00.123456Z", sourceId: "500", sourceRank: 0 },
+    });
+    expect(sql).toMatch(/f\.traded_at < \$\d+::timestamptz/);
+    expect(sql).toMatch(/f\.traded_at = \$\d+::timestamptz AND 1 < \$\d+::int/);
+    expect(sql).toMatch(/AND 1 = \$\d+::int AND f\.id < \$\d+::bigint/);
+    expect(params).toContain("2026-05-21T10:00:00.123456Z");
+    expect(params).toContain("500");
+    expect(params).toContain(0);
+  });
+
+  it("renders the cursor timestamp at MICROSECOND precision, exactly as the other arm does", () => {
+    expect(sqlOf().sql).toContain(`'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'`);
+    expect(sqlOf().sql).toContain("AS cursor_ts");
+  });
+
+  it("orders newest-first with a deterministic id tie-break and asks for limit + 1", () => {
+    const { sql, params } = sqlOf();
+    expect(sql).toContain("ORDER BY f.traded_at DESC, f.id DESC");
+    expect(params[params.length - 1]).toBe(51);
+  });
+
+  it("selects its own arm rank as a literal, for the merge and the cursor", () => {
+    expect(sqlOf().sql).toContain("1 AS source_rank");
+    expect(sqlOf().sql).toContain("f.id::text AS source_id");
+  });
+});
+
+// ── Clamps ────────────────────────────────────────────────────────────────
+
+describe("the Lighter arm's clamps", () => {
+  /**
+   * `LEFT(...)` is applied to DISPLAY TEXT only. Clamping a number produces a
+   * different, valid-looking number; on a money surface an overlength amount
+   * must fail the read loudly instead.
+   */
+  it("clamps display text and NOTHING else", () => {
+    const { sql } = sqlOf();
+    for (const column of [
+      "f.environment",
+      "f.market_symbol",
+      "f.side",
+      "f.trade_type",
+      "f.position_effect",
+      "f.fee_side",
+      "f.integrator_fee_estimate_basis",
+      "f.integrator_fee_estimate_tick_source",
+      "f.base_asset_symbol",
+      "f.quote_asset_symbol",
+      "f.integrator_fee_asset_symbol",
+    ]) {
+      expect(sql).toContain(`LEFT(${column},`);
+    }
+    for (const column of [
+      "f.base_size",
+      "f.price",
+      "f.quote_notional",
+      "f.usd_amount",
+      "f.block_height",
+      "f.position_size_before",
+      "f.entry_quote_before",
+      "f.account_pnl",
+      "f.integrator_fee_charged_raw",
+      "f.integrator_fee_estimated_raw",
+      "f.integrator_fee_estimated_usd",
+      "f.exchange_fee_charged_raw",
+      "f.exchange_fee_estimated_usd",
+      "f.provider_trade_id",
+      "f.provider_order_id",
+      "f.execution_intent_id",
+    ]) {
+      expect(sql).not.toContain(`LEFT(${column},`);
+      expect(sql).toContain(column);
+    }
+  });
+
+  it("reads the market's newest observed position through a LATERAL on the fill's own scope", () => {
+    const { sql } = sqlOf();
+    expect(sql).toContain("s.environment  = f.environment");
+    expect(sql).toContain("s.account_index = f.account_index");
+    expect(sql).toContain("s.market_index  = f.market_index");
+    expect(sql).toContain("AS position_observed_at");
+    expect(sql).toContain("AS position_open");
+    expect(sql).toContain("AS position_now");
+  });
+});
+
+// ── Exclusion ─────────────────────────────────────────────────────────────
+
+describe("filters that exclude the Lighter arm entirely", () => {
+  it("excludes it when kinds is non-empty and does not name lighter_fill", () => {
+    expect(plan({ kinds: ["swap"] })).toBeNull();
+  });
+
+  it("excludes it when protocols is non-empty and does not name lighter", () => {
+    expect(plan({ protocols: ["kyberswap"] })).toBeNull();
+  });
+
+  /** A venue is not a chain family, and a fill has no chain of its own to claim one. */
+  it("excludes it whenever a chainFamily is named", () => {
+    expect(plan({ chainFamily: "eip155" })).toBeNull();
+    expect(plan({ chainFamily: "solana" })).toBeNull();
+  });
+
+  /** A fill is settled the moment the venue matched it: `confirmed` is its only status. */
+  it("excludes it when statuses is non-empty and does not name confirmed", () => {
+    expect(plan({ statuses: ["pending"] })).toBeNull();
+    expect(plan({ statuses: ["failed", "superseded_unproven"] })).toBeNull();
+  });
+
+  it("keeps it when a non-empty filter DOES name it", () => {
+    expect(plan({ kinds: ["swap", "lighter_fill"] })).not.toBeNull();
+    expect(plan({ protocols: ["lighter"] })).not.toBeNull();
+    expect(plan({ statuses: ["confirmed", "pending"] })).not.toBeNull();
+  });
+
+  /**
+   * An EMPTY array means "no restriction", exactly as an absent field does -
+   * the filter schema says so, and reading it as "nothing matches" would make a
+   * cleared filter chip silently empty the arm.
+   */
+  it("is NOT excluded by empty filter arrays", () => {
+    expect(plan({ kinds: [], protocols: [], statuses: [] })).not.toBeNull();
+  });
+});
+
+// ── Injection ─────────────────────────────────────────────────────────────
+
+describe("the Lighter arm's parameter binding", () => {
+  it("never interpolates a caller value into the SQL text", () => {
+    const hostile = "'; DROP TABLE lighter_fills; --";
+    const built = sqlOf({ sessionId: hostile as string });
+    expect(built.sql).not.toContain("DROP TABLE");
+    expect(built.params).toContain(hostile);
+  });
+});

--- a/vex-app/src/main/database/__tests__/agent-scan-lighter.int.test.ts
+++ b/vex-app/src/main/database/__tests__/agent-scan-lighter.int.test.ts
@@ -1,0 +1,574 @@
+/**
+ * `getAgentScan`'s LIGHTER ARM against a REAL PostgreSQL.
+ *
+ * ## Why the mocked suites beside this one are not enough
+ *
+ * They prove the builder EMITS a correlated `EXISTS` and that the mapper turns
+ * a row into an entry. They cannot prove that the compiled statement runs, that
+ * the `EXISTS` really emits one row when two wallets resolve to ONE Lighter
+ * account (a JOIN would emit two, and a text assertion cannot tell the
+ * difference), that a held fill is really unreachable, that the LATERAL finds
+ * the market state, or that walking the mixed timeline with the production page
+ * size neither skips nor repeats a row across the arm seam. Every one of those
+ * is a property of the database.
+ *
+ * So this suite seeds the real tables - two onboarding workflows resolving to
+ * the SAME account, one execution intent, attributed / foreign / held fills,
+ * an open market state and a closed one, and `agent_activity` rows on either
+ * side of the fill in time - and drives the production `getAgentScan` over them
+ * on a schema with every migration applied, migration 162 included.
+ *
+ * ## What is mocked, and why only that
+ *
+ * `@vex-lib/wallet.js` is the OS keystore boundary, which a test process cannot
+ * have. Everything else is real: the compiled SQL of both arms, the keyset
+ * ordering, the merge, the mapping and the DTO.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Inventory: two EVM wallets that BOTH onboard to the same Lighter account, and
+ * one that never does. Hoisted, because the keystore mock factory is hoisted
+ * above every module-level binding.
+ */
+const INVENTORY = vi.hoisted(() => ({
+  WALLET_A: "0xAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaa",
+  WALLET_B: "0xBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbbBBBBbbbb",
+  WALLET_A_ID: "evm_a",
+  WALLET_B_ID: "evm_b",
+}));
+const { WALLET_A, WALLET_B } = INVENTORY;
+
+vi.mock("../../logger/index.js", () => ({
+  log: {
+    debug: (): void => undefined,
+    info: (): void => undefined,
+    warn: (): void => undefined,
+    error: (): void => undefined,
+  },
+  configureLogger: (): void => undefined,
+  redact: (value: unknown): unknown => value,
+  redactArgs: (value: unknown): unknown => value,
+}));
+
+vi.mock("@vex-lib/wallet.js", () => {
+  const entries = {
+    evm: [
+      { id: INVENTORY.WALLET_A_ID, address: INVENTORY.WALLET_A, label: "a" },
+      { id: INVENTORY.WALLET_B_ID, address: INVENTORY.WALLET_B, label: "b" },
+    ],
+    solana: [],
+  } as const;
+  return {
+    listWallets: (family: "evm" | "solana") => entries[family],
+    getWalletById: (family: "evm" | "solana", id: string) =>
+      entries[family].find((entry) => entry.id === id) ?? null,
+  };
+});
+
+vi.mock("../db-config.js", () => ({
+  buildPoolConfig: (): Promise<{
+    host: string;
+    port: number;
+    database: string;
+    user: string;
+    password: string;
+  } | null> => {
+    const url = process.env.VEX_DB_URL;
+    if (url === undefined || url === "") return Promise.resolve(null);
+    const parsed = new URL(url);
+    return Promise.resolve({
+      host: parsed.hostname,
+      port: Number(parsed.port),
+      database: parsed.pathname.replace(/^\//, ""),
+      user: decodeURIComponent(parsed.username),
+      password: decodeURIComponent(parsed.password),
+    });
+  },
+}));
+
+import { ok } from "@shared/ipc/result.js";
+import {
+  AGENT_SCAN_PAGE_SIZE,
+  type AgentScanCursor,
+  type AgentScanEntry,
+  type AgentScanFilters,
+  type AgentScanLighterFillEntry,
+} from "@shared/schemas/agent-scan-feed.js";
+import { getAgentScan } from "../agent-scan-db.js";
+import { withClient } from "../sessions/connection.js";
+
+const CORRELATION_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+/** The account BOTH inventory wallets resolve to - the duplicate-mapping hazard. */
+const ACCOUNT_INDEX = 24_226;
+/** An account the inventory never onboards: its fills are somebody else's. */
+const FOREIGN_ACCOUNT_INDEX = 99_001;
+const MARKET_INDEX = 1;
+const CLOSED_MARKET_INDEX = 2;
+
+async function sql<T extends Record<string, unknown>>(
+  text: string,
+  values: readonly unknown[] = [],
+): Promise<T[]> {
+  const result = await withClient(async (client) => {
+    const rows = await client.query<T>(text, [...values]);
+    return ok(rows.rows);
+  });
+  if (!result.ok) throw new Error(`statement failed: ${text}`);
+  return result.data;
+}
+
+let sessionId = "";
+let otherSessionId = "";
+let executionId = 0;
+let intentId = "";
+let suiteTag = "";
+
+/** The fills this suite inserted, by their seeded `provider_trade_id`. */
+function isSeededFill(entry: AgentScanEntry): entry is AgentScanLighterFillEntry {
+  return entry.source === "lighter_fill" && entry.intentId.includes(suiteTag);
+}
+
+async function read(
+  filters: AgentScanFilters = {},
+  cursor: AgentScanCursor | null = null,
+) {
+  const outcome = await getAgentScan({ cursor, filters }, CORRELATION_ID);
+  expect(outcome.ok).toBe(true);
+  if (!outcome.ok) throw new Error("read failed");
+  expect(outcome.data.status).toBe("available");
+  if (outcome.data.status !== "available") throw new Error("read unavailable");
+  return outcome.data;
+}
+
+/**
+ * One `lighter_fills` row. Every NOT NULL column migration 152 declares is
+ * supplied: seeding through raw SQL still has to produce rows production could
+ * really write.
+ */
+async function seedFill(input: {
+  readonly accountIndex: number;
+  readonly marketIndex: number;
+  readonly providerTradeId: string;
+  readonly secondsAgo: number;
+  readonly intent: string | null;
+  readonly marginFraction: number | null;
+}): Promise<void> {
+  await sql(
+    `INSERT INTO lighter_fills (
+       canonical_identity, environment, account_index, market_index,
+       provider_trade_id, provider_order_id, execution_intent_id,
+       market_symbol, side, price, base_size, quote_notional,
+       base_asset_id, base_asset_symbol, base_asset_decimals,
+       quote_asset_id, quote_asset_symbol, quote_asset_decimals,
+       block_height, trade_type, traded_at, usd_amount,
+       position_size_before, position_sign_changed, entry_quote_before,
+       account_pnl, position_effect, initial_margin_fraction_before,
+       fee_side, integrator_fee_tick_authorized, integrator_fee_tick_observed,
+       integrator_fee_asset_id, integrator_fee_asset_symbol, integrator_fee_asset_decimals,
+       integrator_fee_estimated_raw, integrator_fee_estimate_basis,
+       integrator_fee_estimate_tick_source, integrator_fee_charged_raw,
+       integrator_fee_estimated_usd, exchange_fee_tick_observed,
+       exchange_fee_charged_raw, exchange_fee_estimated_usd, observed_at
+     ) VALUES (
+       $1, 'core', $2, $3,
+       $4, '112233', $5,
+       'ETH', 'buy', '2598.09', '0.0050', '12.99045',
+       'eth', 'ETH', 18,
+       'usdc', 'USDC', 6,
+       '10453221', 'trade', NOW() - ($6 || ' seconds')::interval, '12.99',
+       '0', false, '0',
+       '0', 'open', $7,
+       'taker', 250, 250,
+       'usdc', 'USDC', 6,
+       '3247', 'quote_notional',
+       'observed', '3247',
+       '0.003247', 100,
+       '1299', '0.001299', NOW()
+     )`,
+    [
+      `lighter:core:${input.accountIndex}:${input.marketIndex}:${input.providerTradeId}`,
+      input.accountIndex,
+      input.marketIndex,
+      input.providerTradeId,
+      input.intent,
+      String(input.secondsAgo),
+      input.marginFraction,
+    ],
+  );
+}
+
+/**
+ * One `agent_activity` swap row, `secondsAgo` back in the feed's ordering.
+ *
+ * Left `pending`: migration 044's `agent_activity_confirmed_has_hash` and
+ * `_confirmed_swap_has_executed_legs` require a real settlement record beside a
+ * confirmed row, and nothing this suite asserts depends on the lifecycle. The
+ * nonce is not decoration either - 045 refuses a locally-signed EVM row that
+ * staged a `tx_hash` without one.
+ */
+async function seedSwap(txHash: string, secondsAgo: number): Promise<void> {
+  await sql(
+    `INSERT INTO agent_activity
+       (protocol_execution_id, event_index, event_role, kind, protocol,
+        chain_id, chain_slug, chain_family, status, wallet_address, session_id,
+        token_in_symbol, amount_in_raw, tx_hash, nonce, created_at)
+     VALUES ($1, $2::int, 'swap', 'swap', 'kyberswap',
+             8453, 'base', 'eip155', 'pending', $3, $4,
+             'USDC', '1000000', $5, $6::bigint, NOW() - ($7 || ' seconds')::interval)`,
+    [
+      executionId,
+      secondsAgo,
+      WALLET_A.toLowerCase(),
+      sessionId,
+      txHash,
+      secondsAgo,
+      String(secondsAgo),
+    ],
+  );
+}
+
+beforeEach(async () => {
+  sessionId = randomUUID();
+  otherSessionId = randomUUID();
+  suiteTag = sessionId.slice(0, 8);
+  intentId = `lighter-exec-${sessionId}`;
+
+  await sql(
+    "INSERT INTO sessions (id, mode, scope) VALUES ($1, 'agent', 'vex_studio'), ($2, 'agent', 'vex_studio')",
+    [sessionId, otherSessionId],
+  );
+  const executions = await sql<{ id: number }>(
+    `INSERT INTO protocol_executions (tool_id, namespace, session_id, success)
+     VALUES ('kyberswap.swap', 'kyberswap', $1, true) RETURNING id`,
+    [sessionId],
+  );
+  executionId = executions[0]?.id ?? 0;
+
+  // TWO wallets, ONE resolved account. Migration 124 is unique on
+  // (environment, wallet_address) only, and its CHECK requires the address
+  // LOWERCASE - the inventory holds the checksummed form.
+  await sql(
+    `INSERT INTO lighter_onboarding_workflows
+       (environment, wallet_address, workflow_state, resolved_account_index)
+     VALUES ('core', $1, 'ready_to_trade', $3),
+            ('core', $2, 'deposit_l2_pending', $3)`,
+    [WALLET_A.toLowerCase(), WALLET_B.toLowerCase(), ACCOUNT_INDEX],
+  );
+
+  // A real order-execution intent, with the preview it is required to reference
+  // (migration 114/115). Seeding through raw SQL still has to produce rows
+  // production could really write, and the session narrowing this suite
+  // exercises is resolved THROUGH this row.
+  const previewId = `lighter-preview-${sessionId}`;
+  const matchHash = "a".repeat(64);
+  await sql(
+    `INSERT INTO lighter_order_previews
+       (preview_id, session_id, match_hash, environment, account_index, api_key_index,
+        market_index, side, base_amount_integer, price_integer, order_type,
+        time_in_force, reduce_only, order_expiry_ms, client_order_index_policy,
+        provider_version, preview_json, live_source_json, expires_at)
+     VALUES ($1, $2, $3, 'core', $4, 4,
+             $5, 'buy', '50000', '259809', 'market',
+             'immediate-or-cancel', FALSE, 0, 'sequential',
+             'test', '{}'::jsonb, '{}'::jsonb, NOW() + INTERVAL '1 hour')`,
+    [previewId, sessionId, matchHash, ACCOUNT_INDEX, MARKET_INDEX],
+  );
+  await sql(
+    `INSERT INTO lighter_order_execution_intents
+       (intent_id, session_id, preview_id, match_hash, environment, account_index,
+        api_key_index, market_index, side, base_amount_integer, price_integer,
+        order_type, time_in_force, reduce_only, order_expiry_ms,
+        client_order_index_policy, provider_version, credential_ref_json,
+        execution_state, expires_at)
+     VALUES ($1, $2, $3, $4, 'core', $5,
+             4, $6, 'buy', '50000', '259809',
+             'market', 'immediate-or-cancel', FALSE, 0,
+             'sequential', 'test', '{}'::jsonb,
+             'filled', NOW() + INTERVAL '1 hour')`,
+    [intentId, sessionId, previewId, matchHash, ACCOUNT_INDEX, MARKET_INDEX],
+  );
+
+  // The attributed fill, the foreign account's fill, and a HELD one.
+  await seedFill({
+    accountIndex: ACCOUNT_INDEX,
+    marketIndex: MARKET_INDEX,
+    providerTradeId: `1${suiteTag.replace(/\D/g, "0")}1`,
+    secondsAgo: 20,
+    intent: intentId,
+    marginFraction: 1000,
+  });
+  await seedFill({
+    accountIndex: FOREIGN_ACCOUNT_INDEX,
+    marketIndex: MARKET_INDEX,
+    providerTradeId: `2${suiteTag.replace(/\D/g, "0")}2`,
+    secondsAgo: 19,
+    intent: intentId,
+    marginFraction: 1000,
+  });
+  await seedFill({
+    accountIndex: ACCOUNT_INDEX,
+    marketIndex: MARKET_INDEX,
+    providerTradeId: `3${suiteTag.replace(/\D/g, "0")}3`,
+    secondsAgo: 18,
+    intent: null,
+    marginFraction: 1000,
+  });
+
+  await sql(
+    `INSERT INTO lighter_position_market_state
+       (environment, account_index, market_index, observed_at, observation_id, open, position)
+     VALUES ('core', $1, $2, NOW(), $3, TRUE, $4::jsonb),
+            ('core', $1, $5, NOW(), $3, FALSE, NULL)`,
+    [
+      ACCOUNT_INDEX,
+      MARKET_INDEX,
+      randomUUID(),
+      JSON.stringify({
+        marketIndex: MARKET_INDEX,
+        marketSymbol: "ETH",
+        size: "0.0050",
+        entryPrice: "2598.09",
+        unrealizedPnl: "-0.0077",
+        realizedPnl: "0",
+        liquidationPrice: "2365.93",
+        initialMarginFraction: 1000,
+        marginMode: "isolated",
+      }),
+      CLOSED_MARKET_INDEX,
+    ],
+  );
+
+  // One activity row on each side of the fill in time.
+  await seedSwap(`0xbefore-${suiteTag}`, 30);
+  await seedSwap(`0xafter-${suiteTag}`, 10);
+});
+
+afterEach(async () => {
+  await sql("DELETE FROM lighter_fills WHERE account_index IN ($1, $2)", [
+    ACCOUNT_INDEX,
+    FOREIGN_ACCOUNT_INDEX,
+  ]);
+  await sql("DELETE FROM lighter_position_market_state WHERE account_index = $1", [
+    ACCOUNT_INDEX,
+  ]);
+  await sql("DELETE FROM lighter_order_execution_intents WHERE session_id = $1", [sessionId]);
+  await sql("DELETE FROM lighter_order_previews WHERE session_id = $1", [sessionId]);
+  await sql("DELETE FROM lighter_onboarding_workflows WHERE resolved_account_index = $1", [
+    ACCOUNT_INDEX,
+  ]);
+  await sql("DELETE FROM agent_activity WHERE protocol_execution_id = $1", [executionId]);
+  await sql("DELETE FROM protocol_executions WHERE id = $1", [executionId]);
+  await sql("DELETE FROM sessions WHERE id IN ($1, $2)", [sessionId, otherSessionId]);
+});
+
+describe("the Lighter arm against a real database", () => {
+  /**
+   * THE DUPLICATE-MAPPING HAZARD. Two of the inventory's wallets resolve to one
+   * Lighter account, which migration 124 permits. A JOIN over the workflow
+   * table would emit this fill TWICE, with the same cursor id behind each copy;
+   * the correlated `EXISTS` emits it once.
+   */
+  it("returns the attributed fill EXACTLY ONCE despite two wallets resolving to one account", async () => {
+    const page = await read();
+    const fills = page.entries.filter(isSeededFill);
+    expect(fills).toHaveLength(1);
+  });
+
+  it("maps every field of the attributed fill", async () => {
+    const page = await read();
+    const fill = page.entries.filter(isSeededFill)[0];
+    expect(fill).toBeDefined();
+    if (fill === undefined) return;
+    expect(fill.environment).toBe("core");
+    expect(fill.marketIndex).toBe(MARKET_INDEX);
+    expect(fill.marketSymbol).toBe("ETH");
+    expect(fill.spot).toBe(false);
+    expect(fill.side).toBe("buy");
+    expect(fill.tradeType).toBe("trade");
+    expect(fill.positionEffect).toBe("open");
+    expect(fill.baseSize).toBe("0.0050");
+    expect(fill.price).toBe("2598.09");
+    expect(fill.quoteNotional).toBe("12.99045");
+    expect(fill.usdAmount).toBe("12.99");
+    expect(fill.blockHeight).toBe("10453221");
+    expect(fill.baseAsset).toEqual({ symbol: "ETH", decimals: 18 });
+    expect(fill.quoteAsset).toEqual({ symbol: "USDC", decimals: 6 });
+    expect(fill.positionSizeBefore).toBe("0");
+    expect(fill.entryQuoteBefore).toBe("0");
+    expect(fill.accountPnl).toBe("0");
+    // Migration 162's column, read back through the unit owner's display rule.
+    expect(fill.leverage).toEqual({ initialMarginFraction: 1000, display: "10.00" });
+    expect(fill.feeSide).toBe("taker");
+    expect(fill.integratorFee.charged).toEqual({ raw: "3247", symbol: "USDC", decimals: 6 });
+    expect(fill.integratorFee.estimate?.basis).toBe("quote_notional");
+    expect(fill.integratorFee.estimate?.tickSource).toBe("observed");
+    expect(fill.exchangeFee.charged).toEqual({ raw: "1299", symbol: "USDC", decimals: 6 });
+    expect(fill.intentId).toBe(intentId);
+    expect(fill.providerOrderId).toBe("112233");
+  });
+
+  /**
+   * Two rows that must NEVER appear: a fill on an account the inventory does
+   * not onboard, and a HELD fill Vex has not proven an owner for. Either would
+   * attribute somebody's trading to the agent.
+   */
+  it("never returns a foreign account's fill or a held one", async () => {
+    const page = await read();
+    const fills = page.entries.filter(
+      (entry): entry is AgentScanLighterFillEntry => entry.source === "lighter_fill",
+    );
+    // Only the attributed row survives; the other two share this suite's tag in
+    // their trade ids but have no intent or no onboarded account.
+    expect(fills.map((fill) => fill.intentId)).toEqual([intentId]);
+    const held = await sql<{ count: string }>(
+      "SELECT COUNT(*) AS count FROM lighter_fills WHERE account_index = $1 AND execution_intent_id IS NULL",
+      [ACCOUNT_INDEX],
+    );
+    // The held row really is in the table - the feed's silence about it is the
+    // predicate working, not the fixture missing.
+    expect(held[0]?.count).toBe("1");
+  });
+
+  it("interleaves the fill between the activity rows by TIME", async () => {
+    const page = await read();
+    const timeline = page.entries
+      .filter((entry) =>
+        (entry.source === "agent_activity" && entry.txHash?.includes(suiteTag) === true)
+        || isSeededFill(entry))
+      .map((entry) => (entry.source === "lighter_fill" ? "fill" : entry.txHash));
+    expect(timeline).toEqual([`0xafter-${suiteTag}`, "fill", `0xbefore-${suiteTag}`]);
+  });
+
+  it("keeps the fill when the read is narrowed to the session that ordered it", async () => {
+    const page = await read({ sessionId });
+    expect(page.entries.filter(isSeededFill)).toHaveLength(1);
+  });
+
+  it("drops the fill when the read is narrowed to a DIFFERENT session", async () => {
+    const page = await read({ sessionId: otherSessionId });
+    expect(page.entries.filter(isSeededFill)).toHaveLength(0);
+  });
+
+  it("reports the market's open position with its observation time", async () => {
+    const page = await read();
+    const fill = page.entries.filter(isSeededFill)[0];
+    expect(fill?.positionNow?.open).toBe(true);
+    expect(fill?.positionNow?.position).toEqual({
+      size: "0.0050",
+      entryPrice: "2598.09",
+      unrealizedPnl: "-0.0077",
+      realizedPnl: "0",
+      liquidationPrice: "2365.93",
+      leverage: { initialMarginFraction: 1000, display: "10.00" },
+      marginMode: "isolated",
+    });
+    expect(typeof fill?.positionNow?.observedAt).toBe("string");
+  });
+
+  /** Migration 152 stores `open = false, position = NULL` for an observed closure. */
+  it("reports a CLOSED market as observed-closed, not as unobserved", async () => {
+    await seedFill({
+      accountIndex: ACCOUNT_INDEX,
+      marketIndex: CLOSED_MARKET_INDEX,
+      providerTradeId: `4${suiteTag.replace(/\D/g, "0")}4`,
+      secondsAgo: 15,
+      intent: intentId,
+      marginFraction: 5000,
+    });
+    const page = await read();
+    const closed = page.entries
+      .filter(isSeededFill)
+      .find((fill) => fill.marketIndex === CLOSED_MARKET_INDEX);
+    expect(closed?.positionNow?.open).toBe(false);
+    expect(closed?.positionNow?.position).toBeNull();
+    expect(closed?.leverage).toEqual({ initialMarginFraction: 5000, display: "2.00" });
+  });
+
+  it("reports NO observation at all for a market Vex has never observed", async () => {
+    await seedFill({
+      accountIndex: ACCOUNT_INDEX,
+      marketIndex: 7,
+      providerTradeId: `5${suiteTag.replace(/\D/g, "0")}5`,
+      secondsAgo: 14,
+      intent: intentId,
+      marginFraction: null,
+    });
+    const page = await read();
+    const unobserved = page.entries
+      .filter(isSeededFill)
+      .find((fill) => fill.marketIndex === 7);
+    expect(unobserved?.positionNow).toBeNull();
+    // No fraction was recorded, so the leverage is unknown - never a 0, never
+    // the current one.
+    expect(unobserved?.leverage).toBeNull();
+  });
+
+  it("routes by kind: `swap` excludes the arm, `lighter_fill` returns only it", async () => {
+    const swaps = await read({ kinds: ["swap"] });
+    expect(swaps.entries.filter(isSeededFill)).toHaveLength(0);
+    expect(
+      swaps.entries.some(
+        (entry) => entry.source === "agent_activity" && entry.txHash?.includes(suiteTag) === true,
+      ),
+    ).toBe(true);
+
+    const fills = await read({ kinds: ["lighter_fill"] });
+    expect(fills.entries.filter(isSeededFill)).toHaveLength(1);
+    // `lighter_fill` is a FEED kind, not an `agent_activity.kind`, so the other
+    // arm matches nothing for it.
+    expect(fills.entries.every((entry) => entry.source === "lighter_fill")).toBe(true);
+  });
+
+  /**
+   * THE SEAM. Walking a mixed timeline with the PRODUCTION page size must visit
+   * every row exactly once: an arm exhausting before the other, and a page
+   * ending on either arm, are the two places a keyset merge can skip or repeat.
+   */
+  it("walks the mixed timeline with the real page size, skipping and repeating nothing", async () => {
+    // Enough rows to cross the page size several times, on both arms.
+    const extraFills = AGENT_SCAN_PAGE_SIZE + 5;
+    for (let i = 0; i < extraFills; i += 1) {
+      await seedFill({
+        accountIndex: ACCOUNT_INDEX,
+        marketIndex: MARKET_INDEX,
+        providerTradeId: `9${String(i).padStart(4, "0")}${suiteTag.replace(/\D/g, "0")}`,
+        secondsAgo: 100 + i * 2,
+        intent: intentId,
+        marginFraction: 1000,
+      });
+    }
+    for (let i = 0; i < AGENT_SCAN_PAGE_SIZE; i += 1) {
+      await seedSwap(`0xwalk-${suiteTag}-${String(i)}`, 101 + i * 2);
+    }
+
+    const seen: string[] = [];
+    let cursor: AgentScanCursor | null = null;
+    for (let page = 0; page < 20; page += 1) {
+      const data = await read({}, cursor);
+      expect(data.entries.length).toBeLessThanOrEqual(AGENT_SCAN_PAGE_SIZE);
+      for (const entry of data.entries) seen.push(`${entry.source}:${entry.id}`);
+      if (!data.hasMore) break;
+      cursor = data.nextCursor;
+      expect(cursor).not.toBeNull();
+      if (cursor === null) break;
+    }
+
+    // NOTHING REPEATED: the keyset boundary is applied to both arms, so a row
+    // on one arm can never be handed out again by the other's page.
+    expect(new Set(seen).size).toBe(seen.length);
+
+    // NOTHING SKIPPED: every eligible fill of this suite was visited.
+    const eligible = await sql<{ id: string }>(
+      `SELECT id::text AS id FROM lighter_fills
+        WHERE account_index = $1 AND execution_intent_id IS NOT NULL`,
+      [ACCOUNT_INDEX],
+    );
+    for (const fill of eligible) {
+      expect(seen).toContain(`lighter_fill:${fill.id}`);
+    }
+  });
+});

--- a/vex-app/src/main/database/__tests__/agent-scan-merge.test.ts
+++ b/vex-app/src/main/database/__tests__/agent-scan-merge.test.ts
@@ -1,0 +1,233 @@
+/**
+ * `agent-scan-merge` - the two arms into ONE ordered page.
+ *
+ * A pure function, so these are table tests over its boundaries, in the spirit
+ * of VS Code's `listView.test.ts`: one ordered sequence over heterogeneous
+ * items keyed by a discriminator, with the seams (a tie, an exhausted arm, the
+ * page edge) proven rather than assumed.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { mergeAgentScanArms } from "../agent-scan-merge.js";
+
+const TS_A = "2026-09-08T12:00:03.000000Z";
+const TS_B = "2026-09-08T12:00:02.000000Z";
+const TS_C = "2026-09-08T12:00:01.000000Z";
+/** The same MICROSECOND on both arms - the tie the `sourceRank` exists for. */
+const TIE = "2026-09-08T12:00:00.500000Z";
+
+interface Row {
+  readonly cursor_ts: string;
+  readonly source_rank: number | string;
+  readonly source_id: string;
+  readonly tag: string;
+}
+
+function activity(cursor_ts: string, source_id: string): Row {
+  return { cursor_ts, source_rank: 0, source_id, tag: `a${source_id}` };
+}
+function fill(cursor_ts: string, source_id: string): Row {
+  return { cursor_ts, source_rank: 1, source_id, tag: `f${source_id}` };
+}
+function tags(rows: readonly Row[]): readonly string[] {
+  return rows.map((row) => row.tag);
+}
+
+describe("interleaving", () => {
+  it("produces one time-ordered sequence across the two arms", () => {
+    const { kept } = mergeAgentScanArms(
+      [activity(TS_A, "10"), activity(TS_C, "8")],
+      [fill(TS_B, "4")],
+      50,
+    );
+    expect(tags(kept)).toEqual(["a10", "f4", "a8"]);
+  });
+
+  it("keeps each arm's own order untouched", () => {
+    const { kept } = mergeAgentScanArms(
+      [activity(TS_A, "3"), activity(TS_B, "2"), activity(TS_C, "1")],
+      [],
+      50,
+    );
+    expect(tags(kept)).toEqual(["a3", "a2", "a1"]);
+  });
+
+  it("drains the arm that still has rows once the other is exhausted", () => {
+    const { kept } = mergeAgentScanArms(
+      [activity(TS_A, "9")],
+      [fill(TS_B, "5"), fill(TS_C, "4")],
+      50,
+    );
+    expect(tags(kept)).toEqual(["a9", "f5", "f4"]);
+  });
+
+  /**
+   * The case this whole feature exists for: an EMPTY Lighter arm must reproduce
+   * today's single-arm behaviour exactly, byte for byte, so a user with no
+   * Lighter history sees the feed they already had.
+   */
+  it("reproduces the single-arm page exactly when the Lighter arm is empty", () => {
+    const rows = [activity(TS_A, "3"), activity(TS_B, "2"), activity(TS_C, "1")];
+    const { kept, hasMore } = mergeAgentScanArms(rows, [], 50);
+    expect(kept).toEqual(rows);
+    expect(hasMore).toBe(false);
+  });
+
+  it("returns the empty page when both arms are empty", () => {
+    const { kept, hasMore } = mergeAgentScanArms([], [], 50);
+    expect(kept).toEqual([]);
+    expect(hasMore).toBe(false);
+  });
+});
+
+describe("ties", () => {
+  /**
+   * At an identical microsecond the ARM decides, `lighter_fills` (rank 1)
+   * first under DESC. Without it the two rows would have no defined order and
+   * the cursor could not say which of them the page ended on - the next page
+   * would then either repeat one or skip one.
+   */
+  it("breaks a cross-arm tie by source_rank, fills before activity", () => {
+    const { kept } = mergeAgentScanArms(
+      [activity(TIE, "100")],
+      [fill(TIE, "1")],
+      50,
+    );
+    expect(tags(kept)).toEqual(["f1", "a100"]);
+  });
+
+  it("breaks a within-arm tie by id, descending", () => {
+    const { kept } = mergeAgentScanArms(
+      [activity(TIE, "9"), activity(TIE, "8"), activity(TIE, "7")],
+      [fill(TIE, "2"), fill(TIE, "1")],
+      50,
+    );
+    expect(tags(kept)).toEqual(["f2", "f1", "a9", "a8", "a7"]);
+  });
+
+  /**
+   * THE COMPARATOR IS TOTAL, and its tail is the id compared as a BIGSERIAL.
+   * `Number("9007199254740993")` is 9007199254740992, so a `Number` compare
+   * would call two distinct ids equal and the order between them would rest on
+   * nothing.
+   *
+   * In the production call the two inputs carry DIFFERENT ranks, so the rank
+   * settles every cross-arm tie and this tail is not reached there. It is
+   * asserted through the public entry point with two same-rank inputs because
+   * this comparator states the SAME order the SQL keyset boundary applies, and
+   * there the id compare IS decisive: the boundary's `id < $n::bigint` and this
+   * tail have to agree, or a page would end where the next one does not begin.
+   */
+  it("compares ids above 2^53 as BIGINTS, not as numbers", () => {
+    const low = "9007199254740992";
+    const high = "9007199254740993";
+    expect(Number(low)).toBe(Number(high));
+    const { kept } = mergeAgentScanArms(
+      [activity(TIE, low)],
+      [activity(TIE, high)],
+      50,
+    );
+    expect(tags(kept)).toEqual([`a${high}`, `a${low}`]);
+  });
+
+  /** A lexicographic id compare would order "9" after "10" and lose rows. */
+  it("does not compare ids lexicographically", () => {
+    const { kept } = mergeAgentScanArms(
+      [activity(TIE, "10"), activity(TIE, "9")],
+      [],
+      50,
+    );
+    expect(tags(kept)).toEqual(["a10", "a9"]);
+    const merged = mergeAgentScanArms([activity(TIE, "10")], [fill(TIE, "9")], 50);
+    // Ranks differ, so the rank decides before the id is ever consulted.
+    expect(tags(merged.kept)).toEqual(["f9", "a10"]);
+  });
+});
+
+describe("the page edge", () => {
+  it("keeps at most pageSize rows", () => {
+    const activityRows = Array.from({ length: 4 }, (_, i) =>
+      activity(`2026-09-08T12:00:0${String(9 - i)}.000000Z`, String(20 - i)),
+    );
+    const lighterRows = Array.from({ length: 4 }, (_, i) =>
+      fill(`2026-09-08T12:00:0${String(8 - i)}.500000Z`, String(10 - i)),
+    );
+    const { kept, hasMore } = mergeAgentScanArms(activityRows, lighterRows, 3);
+    expect(kept).toHaveLength(3);
+    expect(hasMore).toBe(true);
+  });
+
+  /**
+   * `hasMore` counts what the two `limit + 1` probes returned TOGETHER. An arm
+   * that returned fewer than its probe is exhausted, so a total at or below the
+   * page size is proof there is nothing further.
+   */
+  it("reports hasMore only when the arms together returned more than pageSize", () => {
+    const three = [activity(TS_A, "3"), activity(TS_B, "2"), activity(TS_C, "1")];
+    expect(mergeAgentScanArms(three, [], 3).hasMore).toBe(false);
+    expect(mergeAgentScanArms(three, [fill(TIE, "1")], 3).hasMore).toBe(true);
+    // Split across the arms, the same count is the same answer.
+    expect(mergeAgentScanArms(three.slice(0, 2), [fill(TIE, "1")], 3).hasMore).toBe(false);
+  });
+
+  /**
+   * The page boundary is GLOBAL, not per arm: a page may be filled entirely
+   * from one arm while the other's rows are all older, and those older rows are
+   * still reachable on the next page because both arms re-apply the same
+   * boundary.
+   */
+  it("may fill a whole page from one arm when the other's rows are all older", () => {
+    const { kept, hasMore } = mergeAgentScanArms(
+      [activity(TS_A, "3"), activity(TS_B, "2")],
+      [fill(TS_C, "1")],
+      2,
+    );
+    expect(tags(kept)).toEqual(["a3", "a2"]);
+    expect(hasMore).toBe(true);
+  });
+
+  it("handles a pageSize of zero without consuming a row", () => {
+    const { kept, hasMore } = mergeAgentScanArms([activity(TS_A, "1")], [], 0);
+    expect(kept).toEqual([]);
+    expect(hasMore).toBe(true);
+  });
+});
+
+describe("walking the whole sequence", () => {
+  /**
+   * The property the pagination rests on: repeatedly taking a page and
+   * continuing from the last kept row visits every row exactly once, in one
+   * order, whichever arm each row came from.
+   */
+  it("neither skips nor repeats a row while paging a mixed timeline", () => {
+    const all: Row[] = [];
+    for (let i = 0; i < 12; i += 1) {
+      const ts = `2026-09-08T12:00:${String(59 - i).padStart(2, "0")}.000000Z`;
+      all.push(activity(ts, String(200 - i)));
+      // Every other second also carries a fill at the SAME microsecond.
+      if (i % 2 === 0) all.push(fill(ts, String(100 - i)));
+    }
+    const activityRows = all.filter((row) => row.source_rank === 0);
+    const lighterRows = all.filter((row) => row.source_rank === 1);
+
+    const seen: string[] = [];
+    let activityIndex = 0;
+    let lighterIndex = 0;
+    for (let page = 0; page < 20; page += 1) {
+      const { kept, hasMore } = mergeAgentScanArms(
+        activityRows.slice(activityIndex, activityIndex + 4),
+        lighterRows.slice(lighterIndex, lighterIndex + 4),
+        3,
+      );
+      seen.push(...tags(kept));
+      activityIndex += kept.filter((row) => row.source_rank === 0).length;
+      lighterIndex += kept.filter((row) => row.source_rank === 1).length;
+      if (!hasMore) break;
+    }
+
+    const expected = tags(mergeAgentScanArms(activityRows, lighterRows, all.length).kept);
+    expect(seen).toEqual(expected);
+    expect(new Set(seen).size).toBe(all.length);
+  });
+});

--- a/vex-app/src/main/database/__tests__/agent-scan-project-scope.int.test.ts
+++ b/vex-app/src/main/database/__tests__/agent-scan-project-scope.int.test.ts
@@ -114,10 +114,24 @@ vi.mock("../db-config.js", () => ({
 }));
 
 import { ok } from "@shared/ipc/result.js";
+import type { AgentScanEntry } from "@shared/schemas/agent-scan-feed.js";
 import { getAgentScan } from "../agent-scan-db.js";
 import { withClient } from "../sessions/connection.js";
 
 const CORRELATION_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+/**
+ * The `tx_hash` of every ACTIVITY row on the page.
+ *
+ * The feed's entry is a discriminated union now, so the arm has to be named
+ * before a field only one arm has can be read. This suite seeds `agent_activity`
+ * only, so an entry from the other arm here would itself be the defect.
+ */
+function activityTxHashes(entries: readonly AgentScanEntry[]): readonly (string | null)[] {
+  return entries.flatMap((entry) =>
+    entry.source === "agent_activity" ? [entry.txHash] : [],
+  );
+}
 
 async function sql<T extends Record<string, unknown>>(
   text: string,
@@ -234,7 +248,7 @@ describe("getAgentScan project scope on a real database", () => {
     expect(outcome.data.status).toBe("available");
     if (outcome.data.status !== "available") return;
 
-    const hashes = outcome.data.entries.map((row) => row.txHash);
+    const hashes = activityTxHashes(outcome.data.entries);
     // The EVM row matched despite the casing difference: the project's stored
     // checksummed address is expanded to its lookup variants, exactly as the
     // inventory allow-list is. Without that, a funded project reads as
@@ -252,7 +266,7 @@ describe("getAgentScan project scope on a real database", () => {
     expect(outcome.ok).toBe(true);
     if (!outcome.ok) return;
     if (outcome.data.status !== "available") return;
-    const hashes = outcome.data.entries.map((row) => row.txHash);
+    const hashes = activityTxHashes(outcome.data.entries);
     // The same three rows the project read narrowed to two. This is the
     // control that proves the second predicate REMOVED rows rather than the
     // fixture simply lacking them.
@@ -321,7 +335,7 @@ describe("getAgentScan project scope on a real database", () => {
     expect(outcome.ok).toBe(true);
     if (!outcome.ok) return;
     if (outcome.data.status !== "available") return;
-    expect(outcome.data.entries.map((row) => row.txHash)).toEqual([
+    expect(activityTxHashes(outcome.data.entries)).toEqual([
       `sol-project-${projectId}`,
     ]);
   });

--- a/vex-app/src/main/database/agent-scan-db-mappers.ts
+++ b/vex-app/src/main/database/agent-scan-db-mappers.ts
@@ -1,5 +1,9 @@
 /**
- * `agent-scan-db.ts` row → `AgentScanEntry` mapping.
+ * `agent-scan-db.ts` `agent_activity` row → `AgentScanActivityEntry` mapping.
+ *
+ * The feed's LIGHTER arm has its own mapper (`agent-scan-lighter-mappers.ts`);
+ * `agent-scan-db.ts` routes each merged row to one of the two by its
+ * `source_rank`.
  *
  * Four decisions live here, and each one has a specific failure it exists to
  * prevent.
@@ -56,9 +60,9 @@ import { explorerTxUrl } from "@shared/explorer-links.js";
 import { sanitizeTokenSymbol } from "@shared/token-symbol-sanitizer.js";
 import {
   AGENT_SCAN_TEXT_BOUNDS,
+  type AgentScanActivityEntry,
   type AgentScanBridgeLeg,
   type AgentScanChainRef,
-  type AgentScanEntry,
   type AgentScanTokenLeg,
   type AgentScanVexFee,
 } from "@shared/schemas/agent-scan-feed.js";
@@ -266,7 +270,7 @@ function mapExecutionLegs(raw: unknown): AgentScanBridgeLeg[] {
 function resolveRowAmountBasis(
   inRes: AmountEstimateResolution,
   outRes: AmountEstimateResolution,
-): AgentScanEntry["amountBasis"] {
+): AgentScanActivityEntry["amountBasis"] {
   const voted = [inRes.basis, outRes.basis].filter((basis): basis is "executed" | "estimated" => basis !== null);
   if (voted.length === 0) return null;
   return voted.includes("estimated") ? "estimated" : "executed";
@@ -313,7 +317,7 @@ function mapVexFee(row: AgentScanRow): AgentScanVexFee | null {
 
 // ── Entry ─────────────────────────────────────────────────────────────────
 
-export function mapAgentScanRow(row: AgentScanRow): AgentScanEntry {
+export function mapAgentScanRow(row: AgentScanRow): AgentScanActivityEntry {
   const activityKind = boundedText(row.activity_kind, ACTIVITY_KIND_MAX_LENGTH) ?? "activity";
   const amountStatus = toAmountStatus(row.status);
   // Guard the decimals ONCE, here, before anything consumes them. They feed the
@@ -350,12 +354,16 @@ export function mapAgentScanRow(row: AgentScanRow): AgentScanEntry {
   // partial decode can leave exactly one populated; labelling that row
   // "executed" off the output leg would present a quoted INPUT leg as settled
   // truth. Mixed provenance ⇒ "estimated".
-  const amountBasis: AgentScanEntry["amountBasis"] = resolveRowAmountBasis(inRes, outRes);
+  const amountBasis: AgentScanActivityEntry["amountBasis"] = resolveRowAmountBasis(inRes, outRes);
 
   const chainSlug = boundedText(row.chain_slug, AGENT_SCAN_TEXT_BOUNDS.chainSlug);
   const txHash = boundedText(row.tx_hash, AGENT_SCAN_TEXT_BOUNDS.txRef);
 
   return {
+    // The ledger this entry came from. The feed unions two of them on this
+    // discriminator, and it is required rather than defaulted because both
+    // sides of the IPC ship in the same build.
+    source: "agent_activity",
     id: row.source_id,
     createdAt: toIso(row.created_at),
     activityKind,

--- a/vex-app/src/main/database/agent-scan-db-query.ts
+++ b/vex-app/src/main/database/agent-scan-db-query.ts
@@ -290,8 +290,55 @@ export interface AgentScanQueryArgs {
   readonly cursor: AgentScanCursor | null;
 }
 
-/** DB-side microsecond-precision UTC render — the keyset cursor's `createdAt`. */
-const CURSOR_TS_EXPR = `to_char(aa.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`;
+/**
+ * DB-side microsecond-precision UTC render - the keyset cursor's `createdAt`.
+ *
+ * SHARED BY BOTH ARMS (`agent-scan-lighter-query.ts` imports it). The two arms
+ * are merged into one sequence against one cursor, so a render that differed by
+ * a character between them would put the boundary in a different place for each
+ * and the page would skip or repeat rows. `new Date(...).toISOString()` is not
+ * an option for the same reason at finer grain: it truncates to milliseconds.
+ */
+export function agentScanCursorTsExpr(column: string): string {
+  return `to_char(${column} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`;
+}
+
+const CURSOR_TS_EXPR = agentScanCursorTsExpr("aa.created_at");
+
+/** The `agent_activity` arm's discriminator, selected as a SQL literal. */
+export const AGENT_SCAN_ACTIVITY_SOURCE_RANK = 0;
+
+/**
+ * The 3-field keyset boundary `(created_at, source_rank, id)` DESC, shared by
+ * both arms - the shape `token-history-db-query.ts` already uses for its
+ * multi-table union.
+ *
+ * `sourceRankLiteral` is a CONSTANT per arm rather than a column: each arm
+ * knows which rank it is, so the comparison specialises to two cheap branches
+ * instead of a row-value compare the planner cannot use an index for.
+ *
+ * The id is compared as a BIGINT. Both ledgers key on a BIGSERIAL, and a
+ * lexicographic compare would order "9" after "10" and silently drop rows from
+ * the next page.
+ */
+export function agentScanKeysetPredicate(args: {
+  readonly createdAtColumn: string;
+  readonly idColumn: string;
+  readonly sourceRankLiteral: number;
+  readonly tsParam: number;
+  readonly rankParam: number;
+  readonly idParam: number;
+}): string {
+  const { createdAtColumn, idColumn, sourceRankLiteral, tsParam, rankParam, idParam } = args;
+  return (
+    `AND (${createdAtColumn} < $${tsParam}::timestamptz`
+    + ` OR (${createdAtColumn} = $${tsParam}::timestamptz`
+    + ` AND ${sourceRankLiteral} < $${rankParam}::int)`
+    + ` OR (${createdAtColumn} = $${tsParam}::timestamptz`
+    + ` AND ${sourceRankLiteral} = $${rankParam}::int`
+    + ` AND ${idColumn} < $${idParam}::bigint))`
+  );
+}
 
 /**
  * THE VEX FEE FROM ITS SEPARATE LEG, projected onto the logical row (R1 Step 2b)
@@ -429,12 +476,17 @@ export function buildAgentScanPageQuery(args: AgentScanQueryArgs): AgentScanQuer
 
   if (cursor !== null) {
     const tsParam = push(cursor.createdAt);
-    // Compared as a BIGINT, not text: `id` is a BIGSERIAL, and a lexicographic
-    // compare would order "9" after "10" and drop rows from the next page.
+    const rankParam = push(cursor.sourceRank);
     const idParam = push(cursor.sourceId);
     predicates.push(
-      `AND (aa.created_at < $${tsParam}::timestamptz` +
-        ` OR (aa.created_at = $${tsParam}::timestamptz AND aa.id < $${idParam}::bigint))`,
+      agentScanKeysetPredicate({
+        createdAtColumn: "aa.created_at",
+        idColumn: "aa.id",
+        sourceRankLiteral: AGENT_SCAN_ACTIVITY_SOURCE_RANK,
+        tsParam,
+        rankParam,
+        idParam,
+      }),
     );
   }
 
@@ -442,6 +494,7 @@ export function buildAgentScanPageQuery(args: AgentScanQueryArgs): AgentScanQuer
 
   const sql = `
       SELECT
+        ${AGENT_SCAN_ACTIVITY_SOURCE_RANK} AS source_rank,
         aa.id::text AS source_id,
         aa.created_at,
         ${CURSOR_TS_EXPR} AS cursor_ts,

--- a/vex-app/src/main/database/agent-scan-db-types.ts
+++ b/vex-app/src/main/database/agent-scan-db-types.ts
@@ -17,6 +17,13 @@
  */
 
 export interface AgentScanRow {
+  /**
+   * Literal `0` from SQL: the arm this row belongs to. The feed merges this
+   * arm with `lighter_fills` into one sequence, and the rank is both the
+   * tie-break at an identical microsecond and the value the cursor carries so
+   * the next page resumes on the right side of a tie.
+   */
+  readonly source_rank: number | string;
   /** `agent_activity.id::text` — the DTO id AND the keyset cursor's `sourceId`. */
   readonly source_id: string;
   readonly created_at: string | Date;

--- a/vex-app/src/main/database/agent-scan-db.ts
+++ b/vex-app/src/main/database/agent-scan-db.ts
@@ -6,13 +6,28 @@
  * `pg.Client` per call, no `@vex-agent/db/repos/*` import, reading the same
  * local `vex` Postgres the engine writes to.
  *
- * SOURCE — `agent_activity` ONLY (single arm, deliberately). The token-history
- * feed UNIONs the legacy `proj_activity` / `wallet_intents` projections; this
- * one does not. Those arms keep serving the feed that already depends on them,
- * and Agent Scan gets to be built purely on the canonical vocabulary
- * (`@shared/agent-activity-vocabulary.js`) instead of inheriting the SPOT
- * taxonomy the legacy arms were minted with. One arm also means one cursor and
- * no `sourceRank` tie-break — see `agent-scan-feed.ts`'s header.
+ * SOURCE - TWO LOCAL LEDGERS, `agent_activity` and `lighter_fills`. The
+ * token-history feed UNIONs the legacy `proj_activity` / `wallet_intents`
+ * projections; this one does not. Those arms keep serving the feed that already
+ * depends on them, and Agent Scan is built purely on the canonical vocabulary
+ * (`@shared/agent-activity-vocabulary.js`) plus the venue's own fill ledger
+ * (migration 152), instead of inheriting the SPOT taxonomy the legacy arms were
+ * minted with.
+ *
+ * ONE PAGE, ONE SNAPSHOT, ONE CURSOR. Each arm has its own query
+ * (`agent-scan-db-query.ts`, `agent-scan-lighter-query.ts`), both are issued
+ * after the SAME 3-field keyset boundary with the same `limit + 1` probe, and
+ * `agent-scan-merge.ts` interleaves them into one sequence - see its header for
+ * why that is equivalent to a single ordered read, and for the late-attribution
+ * limit it cannot remove. The transaction is `REPEATABLE READ` rather than the
+ * default `READ COMMITTED` because the two statements must see ONE snapshot: at
+ * READ COMMITTED each statement takes its own, so a fill inserted between them
+ * could be counted by one arm's `hasMore` probe while the other arm's boundary
+ * had already moved past it (PostgreSQL, "Transaction Isolation": a READ
+ * COMMITTED statement sees a snapshot taken at the start of THAT statement,
+ * while a REPEATABLE READ transaction sees one taken at its first statement).
+ * The Lighter arm is SKIPPED ENTIRELY when the caller's filters exclude it, in
+ * which case this read behaves exactly as the single-arm one did.
  *
  * ROW SELECTION — one row per LOGICAL activity (owner decision), selected by
  * the shared positive role allow-list in `agent-activity-logical-row.ts`.
@@ -65,9 +80,12 @@
  * identities, tx hashes, or filter values.
  *
  * Internals split into siblings, mirroring the two feeds' own layout:
- * `agent-scan-db-types.ts` (row shape), `agent-scan-db-query.ts` (connection,
- * filter compilation, page SQL), `agent-scan-db-mappers.ts` (row → DTO). This
- * file is the public gate — `getAgentScan` is the only export.
+ * `agent-scan-db-types.ts` / `agent-scan-lighter-types.ts` (row shapes),
+ * `agent-scan-db-query.ts` (connection, filter compilation, activity page SQL,
+ * the shared keyset boundary) and `agent-scan-lighter-query.ts` (fill page
+ * SQL), `agent-scan-db-mappers.ts` / `agent-scan-lighter-mappers.ts` (row →
+ * DTO), `agent-scan-merge.ts` (the two arms → one page). This file is the
+ * public gate - `getAgentScan` is the only export.
  */
 
 import { ok, type Result, type VexError } from "@shared/ipc/result.js";
@@ -81,6 +99,13 @@ import { resolveInventoryWalletAddressLookupVariants } from "./inventory-wallets
 import { log } from "../logger/index.js";
 import { mapAgentScanRow } from "./agent-scan-db-mappers.js";
 import {
+  mapAgentScanLighterRow,
+  type AgentScanLighterMappingStats,
+} from "./agent-scan-lighter-mappers.js";
+import { buildAgentScanLighterPageQuery } from "./agent-scan-lighter-query.js";
+import { mergeAgentScanArms } from "./agent-scan-merge.js";
+import {
+  AGENT_SCAN_ACTIVITY_SOURCE_RANK,
   buildAgentScanPageQuery,
   dbError,
   isStatementTimeout,
@@ -93,6 +118,7 @@ import {
 } from "./agent-scan-db-query.js";
 import { readProjectPortfolioScope } from "./projects/portfolio-scope.js";
 import type { AgentScanRow } from "./agent-scan-db-types.js";
+import type { AgentScanLighterRow } from "./agent-scan-lighter-types.js";
 
 /** The empty available page - the one shape "there is nothing to show" takes. */
 const EMPTY_PAGE = {
@@ -192,12 +218,24 @@ export async function getAgentScan(
     filters: input.filters,
     cursor: input.cursor,
   });
+  // `null` = the caller's filters exclude the Lighter arm; no SQL is issued for
+  // it and the page is whatever the activity arm returns, exactly as before.
+  const lighterPlan = buildAgentScanLighterPageQuery({
+    wallets,
+    projectWallets,
+    filters: input.filters,
+    cursor: input.cursor,
+  });
 
   return withClient<AgentScanDto>(correlationId, async (client) => {
     try {
-      await client.query("BEGIN READ ONLY");
+      // REPEATABLE READ, not the default READ COMMITTED: both arm queries of one
+      // page must read ONE snapshot, or a row written between them could be
+      // seen by one arm's boundary and missed by the other's. READ ONLY keeps
+      // the guarantee the single-arm read already had.
+      await client.query("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY");
     } catch (cause) {
-      return dbError(correlationId, "BEGIN READ ONLY failed", cause);
+      return dbError(correlationId, "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY failed", cause);
     }
 
     try {
@@ -207,10 +245,10 @@ export async function getAgentScan(
       return dbError(correlationId, "SET LOCAL statement_timeout failed", cause);
     }
 
-    let pageRows: AgentScanRow[];
+    let activityRows: AgentScanRow[];
     try {
       const result = await client.query<AgentScanRow>(sql, [...params]);
-      pageRows = result.rows;
+      activityRows = result.rows;
     } catch (cause) {
       await rollbackQuietly(client);
       if (isStatementTimeout(cause)) {
@@ -220,19 +258,52 @@ export async function getAgentScan(
       return dbError(correlationId, "page query failed", cause);
     }
 
-    // The read asked for `limit + 1`: the extra row proves there is another
-    // page WITHOUT a second COUNT query, and is dropped before mapping.
-    const hasMore = pageRows.length > AGENT_SCAN_PAGE_SIZE;
-    const kept = hasMore ? pageRows.slice(0, AGENT_SCAN_PAGE_SIZE) : pageRows;
-    const entries = kept.map(mapAgentScanRow);
+    // A timeout on EITHER arm fails the WHOLE read closed. Returning the arm
+    // that answered would silently present a partial history as the history.
+    let lighterRows: AgentScanLighterRow[] = [];
+    if (lighterPlan !== null) {
+      try {
+        const result = await client.query<AgentScanLighterRow>(
+          lighterPlan.sql,
+          [...lighterPlan.params],
+        );
+        lighterRows = result.rows;
+      } catch (cause) {
+        await rollbackQuietly(client);
+        if (isStatementTimeout(cause)) {
+          log.info("portfolio.agent_scan_query_canceled phase=lighter");
+          return ok({ status: "unavailable", reason: "query_timeout" });
+        }
+        return dbError(correlationId, "lighter page query failed", cause);
+      }
+    }
+
+    // Each arm asked for `limit + 1`: the extra rows prove there is another page
+    // WITHOUT a second COUNT query, and are dropped by the merge.
+    const { kept, hasMore } = mergeAgentScanArms(
+      activityRows,
+      lighterRows,
+      AGENT_SCAN_PAGE_SIZE,
+    );
+    const stats: AgentScanLighterMappingStats = { unreadablePositions: 0 };
+    const entries = kept.map((row) =>
+      Number(row.source_rank) === AGENT_SCAN_ACTIVITY_SOURCE_RANK
+        ? mapAgentScanRow(row as AgentScanRow)
+        : mapAgentScanLighterRow(row as AgentScanLighterRow, stats),
+    );
 
     const lastKept = kept[kept.length - 1];
     // `cursor_ts` is the SQL-rendered microsecond string, NOT a `Date`
     // round-trip — a millisecond-truncated boundary would skip or repeat rows
-    // whenever two activities share a millisecond.
+    // whenever two activities share a millisecond. `sourceRank` travels with it
+    // so the next page resumes on the right side of a cross-arm tie.
     const nextCursor: AgentScanCursor | null =
       hasMore && lastKept !== undefined
-        ? { createdAt: lastKept.cursor_ts, sourceId: lastKept.source_id }
+        ? {
+            createdAt: lastKept.cursor_ts,
+            sourceId: lastKept.source_id,
+            sourceRank: Number(lastKept.source_rank) === AGENT_SCAN_ACTIVITY_SOURCE_RANK ? 0 : 1,
+          }
         : null;
 
     try {
@@ -242,8 +313,12 @@ export async function getAgentScan(
       return dbError(correlationId, "COMMIT failed", cause);
     }
 
+    // COUNTS AND DTO STATUS ONLY - never an address, an amount, a market, a
+    // position figure or a filter value.
     log.info(
-      `[agent-scan-db] getAgentScan ok entries=${entries.length} hasMore=${hasMore}`,
+      `[agent-scan-db] getAgentScan ok entries=${entries.length} hasMore=${hasMore}`
+      + ` activityRows=${activityRows.length} lighterRows=${lighterRows.length}`
+      + ` unreadablePositions=${stats.unreadablePositions}`,
     );
     return ok({ status: "available", entries, nextCursor, hasMore });
   });

--- a/vex-app/src/main/database/agent-scan-lighter-mappers.ts
+++ b/vex-app/src/main/database/agent-scan-lighter-mappers.ts
@@ -1,0 +1,387 @@
+/**
+ * `agent-scan-lighter-query.ts` row -> `AgentScanLighterFillEntry`.
+ *
+ * PURE, and deliberately so: every decision below is a table test away, and
+ * nothing here logs a value. The one counted observation the reader wants (how
+ * many stored positions could not be read) rides an optional stats accumulator
+ * so `agent-scan-db.ts` can log the COUNT without this module ever holding a
+ * logger or a position's figures.
+ *
+ * Four rules live here, each with the failure it exists to prevent.
+ *
+ * 1. FEE PROVENANCE SURVIVES (migration 152). `charged` is the provider's exact
+ *    amount and is NULL when unproven - never zero, because a zero is itself a
+ *    proven amount. The estimate is arithmetic on this fill's own basis and
+ *    carries that basis and the tick it used. The two are separate DTO fields
+ *    and are never added or coalesced: a renderer shows the exact figure when
+ *    it exists and otherwise the estimate, marked as one.
+ *
+ * 2. THE FEE'S DENOMINATION IS THE VENUE'S RULE, not ours. The received BASE on
+ *    a spot buy, the QUOTE asset otherwise. The ledger stores the integrator
+ *    fee's own asset columns, so the integrator fee reads them; the exchange
+ *    fee has no asset columns of its own and the rule is applied here. It is
+ *    the same rule `src/vex-agent/sync/agentscan-report/lighter-fill-event.ts`
+ *    applies at `feeDenominationAsset` (line 513), re-stated rather than
+ *    imported because that helper and `LIGHTER_SPOT_MARKET_INDEX_FLOOR` beside
+ *    it are both module-private there. The floor (2048) is the venue's own
+ *    spot-market index boundary, pinned in this module's test beside its
+ *    citation.
+ *
+ * 3. LEVERAGE IS DISPLAYED BY THE ONE OWNER OF THE UNIT.
+ *    `initialMarginFractionToLeverageDisplay` (`@tools/lighter/margin-fraction.js`)
+ *    is imported, never mirrored: it is the module that owns Lighter's
+ *    10000-scale fraction and it truncates to two decimals (3334 -> "2.99")
+ *    because rounding up would tell the user they hold leverage the exchange
+ *    will not give them. It THROWS on a value outside 1..10000; a stored
+ *    fraction outside that range is data this reader cannot interpret, so it
+ *    degrades to `leverage: null` ("unknown") rather than taking a page down.
+ *
+ * 4. A MALFORMED FACT IS UNKNOWN, NEVER A GUESS, and it never takes its
+ *    neighbours with it. The ledger's own columns are CHECK-constrained, so a
+ *    malformed value there cannot occur and would fail the DTO parse loudly
+ *    rather than ship a number nobody can read. The position JSONB has NO check
+ *    behind it, so it is validated by shape here: a malformed optional fact (a
+ *    PnL, a price, the leverage, the margin mode) becomes null while the
+ *    readable facts beside it survive, and only a malformed `size` - the one
+ *    fact that makes a position a position - collapses the whole position to
+ *    "open, details unavailable".
+ */
+
+import { initialMarginFractionToLeverageDisplay } from "@tools/lighter/margin-fraction.js";
+import { z } from "zod";
+import {
+  AGENT_SCAN_LIGHTER_TEXT_BOUNDS,
+  lighterSignedDecimalSchema,
+  lighterUnsignedDecimalSchema,
+  type AgentScanLighterFillEntry,
+  type AgentScanLighterPositionNow,
+} from "@shared/schemas/agent-scan-lighter-entry.js";
+import { TOKEN_SYMBOL_MAX_LENGTH } from "@shared/token-symbol-sanitizer.js";
+import type { AgentScanLighterRow } from "./agent-scan-lighter-types.js";
+
+/**
+ * The venue's own spot-market index boundary: a market index at or above it is
+ * a SPOT market, below it a perpetual. Measured and recorded by the engine's
+ * wire mapper (`lighter-fill-event.ts:85` and
+ * `tools/protocols/lighter/agentscan-activity.ts:95`), which keeps its own copy
+ * private; this is the reader's.
+ */
+export const LIGHTER_SPOT_MARKET_INDEX_FLOOR = 2048;
+
+/** Lighter's 10000-scale initial margin fraction: 1 = 10000x, 10000 = 1x. */
+const MIN_INITIAL_MARGIN_FRACTION = 1;
+const MAX_INITIAL_MARGIN_FRACTION = 10_000;
+
+/**
+ * Counted observations a reader may log. Values NEVER travel on it - a position
+ * figure is the user's money, and the whole point of the count is that the log
+ * can say "one market's stored position could not be read" without saying what
+ * it held.
+ */
+export interface AgentScanLighterMappingStats {
+  /** Markets observed OPEN whose stored position JSON could not be read. */
+  unreadablePositions: number;
+}
+
+// ── Scalar coercion ───────────────────────────────────────────────────────
+
+function toIso(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+/** An `INTEGER` column as a number, or null when it is not readable as one. */
+function toInteger(value: number | string | null): number | null {
+  if (value === null) return null;
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isSafeInteger(numeric) ? numeric : null;
+}
+
+/**
+ * Non-negative decimals for a venue asset. Out of range is data this reader
+ * cannot interpret; the DTO refuses a negative, so 0 is the honest floor.
+ */
+function toDecimals(value: number | string | null): number {
+  const numeric = toInteger(value);
+  return numeric !== null && numeric >= 0 ? numeric : 0;
+}
+
+/**
+ * A tolerant display string, already SQL-clamped to the same bound. This is a
+ * guard against drift, not a routine truncation: it keeps an over-long value
+ * from failing output validation and blanking the whole page.
+ */
+function boundedText(value: string | null, max: number): string | null {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+}
+
+/** The same, for a column the DTO requires. */
+function requiredText(value: string | null, max: number, fallback: string): string {
+  return boundedText(value, max) ?? fallback;
+}
+
+/**
+ * A leverage reading from a 10000-scale fraction, or null when there is none to
+ * read. Null and out-of-range are the SAME answer here - "unknown" - because a
+ * fraction the unit owner refuses is not a leverage this feed may state.
+ */
+function toLeverage(
+  fraction: number | string | null,
+): AgentScanLighterFillEntry["leverage"] {
+  const imf = toInteger(fraction);
+  if (imf === null) return null;
+  if (imf < MIN_INITIAL_MARGIN_FRACTION || imf > MAX_INITIAL_MARGIN_FRACTION) return null;
+  return { initialMarginFraction: imf, display: initialMarginFractionToLeverageDisplay(imf) };
+}
+
+// ── The stored position JSONB ─────────────────────────────────────────────
+
+/**
+ * The stored shape of one open position
+ * (`src/vex-agent/sync/lighter-position-snapshot.ts`'s
+ * `LighterObservedPosition`), validated at THIS boundary rather than left for
+ * the DTO parse to meet first.
+ *
+ * `size` is the only required fact: it is what makes the row a position at all,
+ * and a position without a readable size is not a position with one unknown
+ * field. Every other fact `.catch(null)`s independently, which is also what
+ * makes an observation stored BEFORE leverage and margin mode were projected
+ * read correctly: the keys are simply absent and become null.
+ *
+ * `marketIndex` and `marketSymbol` are stored on the row too and are
+ * deliberately NOT read: the fill already names its own market, and a second
+ * copy of that name on the same line could only ever disagree with it.
+ */
+const storedPositionSchema = z.object({
+  size: lighterSignedDecimalSchema,
+  entryPrice: lighterUnsignedDecimalSchema.nullable().catch(null),
+  unrealizedPnl: lighterSignedDecimalSchema.nullable().catch(null),
+  realizedPnl: lighterSignedDecimalSchema.nullable().catch(null),
+  liquidationPrice: lighterUnsignedDecimalSchema.nullable().catch(null),
+  /** 10000-scale integer, projected from the account endpoint's percent string. */
+  initialMarginFraction: z
+    .number()
+    .int()
+    .min(MIN_INITIAL_MARGIN_FRACTION)
+    .max(MAX_INITIAL_MARGIN_FRACTION)
+    .nullable()
+    .catch(null),
+  marginMode: z
+    .string()
+    .max(AGENT_SCAN_LIGHTER_TEXT_BOUNDS.marginMode)
+    .nullable()
+    .catch(null),
+});
+
+/**
+ * The market's newest observed state, as CONTEXT beside a historical fill.
+ *
+ * FOUR outcomes, and each is a different sentence the renderer owes the user:
+ *
+ *   no row at all      -> `null`: Vex has never observed this market.
+ *   `open = false`     -> observed CLOSED (migration 152 stores `position` NULL
+ *                         with it), and the observation time still travels.
+ *   `open = true`, read -> the position as last observed.
+ *   `open = true`, unread -> "open, details unavailable": the observation is a
+ *                         fact even when the details behind it are not, and
+ *                         hiding it would understate what Vex knows.
+ *
+ * `observedAt` is VEX'S OWN observation time, assigned by the position sweep
+ * (`src/vex-agent/sync/lighter-position-snapshot.ts:528`), not a venue
+ * timestamp and not the fill's. It is on every one of these states because
+ * these are facts about THEN, beside a fill that happened earlier.
+ */
+function toPositionNow(
+  row: AgentScanLighterRow,
+  stats: AgentScanLighterMappingStats | undefined,
+): AgentScanLighterPositionNow | null {
+  if (row.position_observed_at === null || row.position_open === null) return null;
+  const observedAt = toIso(row.position_observed_at);
+  if (!row.position_open) return { observedAt, open: false, position: null };
+
+  const parsed = storedPositionSchema.safeParse(row.position_now);
+  if (!parsed.success) {
+    if (stats !== undefined) stats.unreadablePositions += 1;
+    return { observedAt, open: true, position: null };
+  }
+  const stored = parsed.data;
+  return {
+    observedAt,
+    open: true,
+    position: {
+      size: stored.size,
+      entryPrice: stored.entryPrice,
+      unrealizedPnl: stored.unrealizedPnl,
+      realizedPnl: stored.realizedPnl,
+      liquidationPrice: stored.liquidationPrice,
+      leverage: toLeverage(stored.initialMarginFraction),
+      marginMode: boundedText(stored.marginMode, AGENT_SCAN_LIGHTER_TEXT_BOUNDS.marginMode),
+    },
+  };
+}
+
+// ── Fees ──────────────────────────────────────────────────────────────────
+
+interface VenueAsset {
+  readonly symbol: string;
+  readonly decimals: number;
+}
+
+/**
+ * The asset this fill's fees are denominated in: the received BASE on a spot
+ * buy, the QUOTE asset otherwise. The venue's own behaviour, established by
+ * `order-evidence.ts` and applied identically by the AgentScan wire mapper
+ * (`lighter-fill-event.ts:513`).
+ */
+function feeDenominationAsset(
+  side: string,
+  spot: boolean,
+  baseAsset: VenueAsset,
+  quoteAsset: VenueAsset,
+): VenueAsset {
+  return spot && side === "buy" ? baseAsset : quoteAsset;
+}
+
+function mapIntegratorFee(
+  row: AgentScanLighterRow,
+): AgentScanLighterFillEntry["integratorFee"] {
+  // The ledger's own asset columns: any integrator fee figure is refused by
+  // migration 152's CHECK unless all three are present beside it.
+  const symbol = boundedText(row.integrator_fee_asset_symbol, TOKEN_SYMBOL_MAX_LENGTH);
+  const decimals = toDecimals(row.integrator_fee_asset_decimals);
+  const asset = symbol === null ? null : { symbol, decimals };
+
+  // NULL means UNPROVEN and stays null. Substituting "0" here would report a
+  // charge of zero that nobody measured.
+  const charged = row.integrator_fee_charged_raw !== null && asset !== null
+    ? { raw: row.integrator_fee_charged_raw, symbol: asset.symbol, decimals: asset.decimals }
+    : null;
+
+  const estimate = row.integrator_fee_estimated_raw !== null
+    && row.integrator_fee_estimate_basis !== null
+    && row.integrator_fee_estimate_tick_source !== null
+    && asset !== null
+    ? {
+        raw: row.integrator_fee_estimated_raw,
+        symbol: asset.symbol,
+        decimals: asset.decimals,
+        basis: requiredText(
+          row.integrator_fee_estimate_basis,
+          AGENT_SCAN_LIGHTER_TEXT_BOUNDS.feeBasis,
+          "unknown",
+        ),
+        tickSource: requiredText(
+          row.integrator_fee_estimate_tick_source,
+          AGENT_SCAN_LIGHTER_TEXT_BOUNDS.feeTickSource,
+          "unknown",
+        ),
+        // NULL for the integrator fee on a spot BUY, which is charged in the
+        // received base and keeps that denomination (migration 152).
+        usd: row.integrator_fee_estimated_usd,
+      }
+    : null;
+
+  return {
+    charged,
+    estimate,
+    tickObserved: toInteger(row.integrator_fee_tick_observed),
+    tickAuthorized: toInteger(row.integrator_fee_tick_authorized),
+  };
+}
+
+function mapExchangeFee(
+  row: AgentScanLighterRow,
+  asset: VenueAsset,
+): AgentScanLighterFillEntry["exchangeFee"] {
+  return {
+    // Signed: the exchange reports a rebate as a negative charged amount, and
+    // the DTO admits the sign rather than presenting a rebate as a charge.
+    charged: row.exchange_fee_charged_raw === null
+      ? null
+      : { raw: row.exchange_fee_charged_raw, symbol: asset.symbol, decimals: asset.decimals },
+    estimatedUsd: row.exchange_fee_estimated_usd,
+    tickObserved: toInteger(row.exchange_fee_tick_observed),
+  };
+}
+
+// ── The row ───────────────────────────────────────────────────────────────
+
+/**
+ * One `lighter_fills` row plus its market's newest observation -> one feed
+ * entry.
+ *
+ * @param stats optional counter the caller may log; values never travel on it.
+ */
+export function mapAgentScanLighterRow(
+  row: AgentScanLighterRow,
+  stats?: AgentScanLighterMappingStats,
+): AgentScanLighterFillEntry {
+  const marketIndex = toInteger(row.market_index) ?? 0;
+  const spot = marketIndex >= LIGHTER_SPOT_MARKET_INDEX_FLOOR;
+  const side = requiredText(row.side, AGENT_SCAN_LIGHTER_TEXT_BOUNDS.side, "unknown");
+
+  const baseAsset: VenueAsset = {
+    symbol: requiredText(row.base_asset_symbol, TOKEN_SYMBOL_MAX_LENGTH, "unknown"),
+    decimals: toDecimals(row.base_asset_decimals),
+  };
+  const quoteAsset: VenueAsset = {
+    symbol: requiredText(row.quote_asset_symbol, TOKEN_SYMBOL_MAX_LENGTH, "unknown"),
+    decimals: toDecimals(row.quote_asset_decimals),
+  };
+
+  return {
+    source: "lighter_fill",
+    id: row.source_id,
+    // `traded_at` is the VENUE's match time and the feed time of this row;
+    // `observed_at` is when Vex saw it, and the two are different facts.
+    createdAt: toIso(row.traded_at),
+    observedAt: toIso(row.observed_at),
+    environment: requiredText(
+      row.environment,
+      AGENT_SCAN_LIGHTER_TEXT_BOUNDS.environment,
+      "unknown",
+    ),
+    marketIndex,
+    marketSymbol: requiredText(
+      row.market_symbol,
+      AGENT_SCAN_LIGHTER_TEXT_BOUNDS.marketSymbol,
+      String(marketIndex),
+    ),
+    spot,
+    side,
+    tradeType: requiredText(
+      row.trade_type,
+      AGENT_SCAN_LIGHTER_TEXT_BOUNDS.tradeType,
+      "unknown",
+    ),
+    // NULL is a real state: the account's own half was never supplied, and the
+    // renderer says "position facts unknown" rather than inventing an effect.
+    positionEffect: boundedText(
+      row.position_effect,
+      AGENT_SCAN_LIGHTER_TEXT_BOUNDS.positionEffect,
+    ),
+    baseSize: row.base_size,
+    price: row.price,
+    quoteNotional: row.quote_notional,
+    usdAmount: row.usd_amount,
+    blockHeight: row.block_height,
+    baseAsset,
+    quoteAsset,
+    positionSizeBefore: row.position_size_before,
+    entryQuoteBefore: row.entry_quote_before,
+    accountPnl: row.account_pnl,
+    leverage: toLeverage(row.initial_margin_fraction_before),
+    feeSide: requiredText(row.fee_side, AGENT_SCAN_LIGHTER_TEXT_BOUNDS.feeSide, "unknown"),
+    integratorFee: mapIntegratorFee(row),
+    exchangeFee: mapExchangeFee(
+      row,
+      feeDenominationAsset(side, spot, baseAsset, quoteAsset),
+    ),
+    providerTradeId: row.provider_trade_id,
+    providerOrderId: row.provider_order_id,
+    intentId: row.execution_intent_id,
+    positionNow: toPositionNow(row, stats),
+  };
+}

--- a/vex-app/src/main/database/agent-scan-lighter-query.ts
+++ b/vex-app/src/main/database/agent-scan-lighter-query.ts
@@ -1,0 +1,243 @@
+/**
+ * The Agent Scan feed's LIGHTER arm: the page SQL over `lighter_fills`
+ * (migration 152), scoped by the same server-resolved wallet allow-list the
+ * `agent_activity` arm is scoped by.
+ *
+ * The sibling `agent-scan-db-query.ts` owns the activity arm; this module owns
+ * this one. They share the KEYSET BOUNDARY (`agentScanKeysetPredicate`) and
+ * the microsecond cursor render (`agentScanCursorTsExpr`) - imported from
+ * there, never re-spelled, because the two arms are merged into ONE sequence
+ * and a boundary that disagreed by a character would skip or repeat rows.
+ *
+ * THREE PREDICATES CARRY THE WHOLE SCOPE, and each one has a specific failure
+ * it exists to prevent.
+ *
+ * 1. `f.execution_intent_id IS NOT NULL` is MANDATORY, not a filter. Migration
+ *    152: a fill with no intent is HELD - observed before Vex could prove which
+ *    order owns it. Showing one would attribute a stranger's trading, or the
+ *    user's own manual trading, to the agent.
+ *
+ * 2. The wallet scope is a CORRELATED `EXISTS` over
+ *    `lighter_onboarding_workflows`, NEVER a JOIN. Migration 124 is unique on
+ *    `(environment, wallet_address)` and NOT on `(environment,
+ *    resolved_account_index)`: two of the user's wallets can legitimately
+ *    resolve to one Lighter account (`lighter-position-snapshot.ts`'s scope
+ *    query has to `GROUP BY` for exactly this reason), and a JOIN would emit
+ *    the same fill once per matching wallet - a duplicated row in an audit
+ *    feed, with a duplicated cursor id behind it. The project narrowing goes
+ *    inside the SAME `EXISTS`, on the SAME workflow row, so the intersection is
+ *    real rather than two independent existence claims.
+ *
+ *    There is deliberately NO `workflow_state` condition. A workflow that
+ *    reached `ready_to_trade` can later fall back to a deposit or failure state
+ *    while its `resolved_account_index` stays recorded, and history must
+ *    survive that: an account's past fills do not stop being the user's because
+ *    its onboarding regressed today.
+ *
+ * 3. The session narrowing is an `EXISTS` over the THREE intent tables that can
+ *    own a fill (`lighter_order_execution_intents` migration 115,
+ *    `lighter_order_lifecycle_intents` 140, `lighter_oco_execution_intents`
+ *    148). `lighter_fills.execution_intent_id` has no foreign key precisely
+ *    because one column points at several owning tables (migration 152's own
+ *    comment), so the reader has to ask all three.
+ *
+ * CLAMPS ARE FOR DISPLAY TEXT ONLY. `LEFT(...)` is applied to the vocabularies
+ * and labels whose bounds `AGENT_SCAN_LIGHTER_TEXT_BOUNDS` names, and to
+ * nothing else. Amounts, USD figures, the block height, provider ids and the
+ * intent id are selected AS-IS and validated by shape in the DTO: silently
+ * clamping a number produces a different, valid-looking number, which on a
+ * money surface is worse than failing the read.
+ */
+
+import {
+  AGENT_SCAN_PAGE_SIZE,
+  type AgentScanCursor,
+  type AgentScanFilters,
+} from "@shared/schemas/agent-scan-feed.js";
+import { AGENT_SCAN_LIGHTER_TEXT_BOUNDS } from "@shared/schemas/agent-scan-lighter-entry.js";
+import { TOKEN_SYMBOL_MAX_LENGTH } from "@shared/token-symbol-sanitizer.js";
+import {
+  agentScanCursorTsExpr,
+  agentScanKeysetPredicate,
+  type AgentScanQueryPlan,
+} from "./agent-scan-db-query.js";
+import { AGENT_SCAN_LIGHTER_SOURCE_RANK } from "./agent-scan-lighter-types.js";
+
+/**
+ * The FEED kind that routes this arm. Not an `agent_activity.kind` - the kind
+ * lockstep gate reads that vocabulary and is untouched by this value.
+ */
+export const AGENT_SCAN_LIGHTER_FEED_KIND = "lighter_fill";
+/** The protocol name this arm answers to in the `protocols` filter. */
+export const AGENT_SCAN_LIGHTER_PROTOCOL = "lighter";
+/** A fill is settled the moment the venue matched it: it has exactly one status. */
+const AGENT_SCAN_LIGHTER_STATUS = "confirmed";
+
+export interface AgentScanLighterQueryArgs {
+  /** Server-resolved inventory allow-list. NEVER caller-supplied, never omitted. */
+  readonly wallets: readonly string[];
+  /**
+   * The PROJECT's own server-resolved address lookup variants when
+   * `filters.projectId` was supplied, else `null`. An INTERSECTION applied to
+   * the SAME workflow row as the allow-list, never a replacement for it.
+   */
+  readonly projectWallets: readonly string[] | null;
+  readonly filters: AgentScanFilters;
+  readonly cursor: AgentScanCursor | null;
+}
+
+/**
+ * Whether the caller's filters exclude this arm entirely.
+ *
+ * An EMPTY array means "no restriction", exactly as the filter schema says, so
+ * only a NON-EMPTY list that omits this arm's value excludes it. `chainFamily`
+ * excludes unconditionally: a venue is not a chain family, and a fill has no
+ * chain of its own to claim one.
+ */
+function isLighterArmExcluded(filters: AgentScanFilters): boolean {
+  const { kinds, protocols, statuses, chainFamily } = filters;
+  if (kinds !== undefined && kinds.length > 0
+    && !kinds.includes(AGENT_SCAN_LIGHTER_FEED_KIND)) return true;
+  if (protocols !== undefined && protocols.length > 0
+    && !protocols.includes(AGENT_SCAN_LIGHTER_PROTOCOL)) return true;
+  if (chainFamily !== undefined) return true;
+  if (statuses !== undefined && statuses.length > 0
+    && !statuses.includes(AGENT_SCAN_LIGHTER_STATUS)) return true;
+  return false;
+}
+
+/**
+ * The Lighter arm's page query, or `null` when the caller's filters exclude
+ * the arm (in which case no SQL is issued for it at all).
+ *
+ * `null` is the arm's own "no restriction matched me" answer and is NOT an
+ * empty page: the other arm still runs, and the merged page is whatever it
+ * returns.
+ */
+export function buildAgentScanLighterPageQuery(
+  args: AgentScanLighterQueryArgs,
+): AgentScanQueryPlan | null {
+  const { wallets, projectWallets, filters, cursor } = args;
+  if (isLighterArmExcluded(filters)) return null;
+
+  const params: unknown[] = [];
+  const push = (value: unknown): number => {
+    params.push(value);
+    return params.length;
+  };
+
+  // $1 is the wallet allow-list, always, before any optional predicate - the
+  // same position it holds on the activity arm.
+  const walletsParam = push([...wallets]);
+  const projectClause = projectWallets === null
+    ? ""
+    : `\n             AND w.wallet_address = ANY($${push([...projectWallets])}::text[])`;
+
+  const predicates: string[] = [];
+
+  // NARROWS to one session. The wallet EXISTS above is unconditional, so this
+  // can only ever remove rows. All three owning intent tables are asked: the
+  // column points at whichever one authorized the money.
+  if (filters.sessionId !== undefined) {
+    const sessionParam = push(filters.sessionId);
+    predicates.push(
+      `AND EXISTS (`
+      + `SELECT 1 FROM lighter_order_execution_intents i`
+      + ` WHERE i.intent_id = f.execution_intent_id AND i.session_id = $${sessionParam}`
+      + ` UNION ALL`
+      + ` SELECT 1 FROM lighter_order_lifecycle_intents l`
+      + ` WHERE l.intent_id = f.execution_intent_id AND l.session_id = $${sessionParam}`
+      + ` UNION ALL`
+      + ` SELECT 1 FROM lighter_oco_execution_intents o`
+      + ` WHERE o.intent_id = f.execution_intent_id AND o.session_id = $${sessionParam}`
+      + `)`,
+    );
+  }
+
+  if (cursor !== null) {
+    const tsParam = push(cursor.createdAt);
+    const rankParam = push(cursor.sourceRank);
+    // Compared as a BIGINT, not text: `id` is a BIGSERIAL, and a lexicographic
+    // compare would order "9" after "10" and drop rows from the next page.
+    const idParam = push(cursor.sourceId);
+    predicates.push(
+      agentScanKeysetPredicate({
+        createdAtColumn: "f.traded_at",
+        idColumn: "f.id",
+        sourceRankLiteral: AGENT_SCAN_LIGHTER_SOURCE_RANK,
+        tsParam,
+        rankParam,
+        idParam,
+      }),
+    );
+  }
+
+  const limitParam = push(AGENT_SCAN_PAGE_SIZE + 1);
+
+  const sql = `
+      SELECT
+        ${AGENT_SCAN_LIGHTER_SOURCE_RANK} AS source_rank,
+        f.id::text AS source_id,
+        ${agentScanCursorTsExpr("f.traded_at")} AS cursor_ts,
+        f.traded_at,
+        f.observed_at,
+        LEFT(f.environment, ${AGENT_SCAN_LIGHTER_TEXT_BOUNDS.environment}) AS environment,
+        f.market_index,
+        LEFT(f.market_symbol, ${AGENT_SCAN_LIGHTER_TEXT_BOUNDS.marketSymbol}) AS market_symbol,
+        LEFT(f.side, ${AGENT_SCAN_LIGHTER_TEXT_BOUNDS.side}) AS side,
+        LEFT(f.trade_type, ${AGENT_SCAN_LIGHTER_TEXT_BOUNDS.tradeType}) AS trade_type,
+        LEFT(f.position_effect, ${AGENT_SCAN_LIGHTER_TEXT_BOUNDS.positionEffect}) AS position_effect,
+        f.base_size,
+        f.price,
+        f.quote_notional,
+        f.usd_amount,
+        f.block_height,
+        LEFT(f.base_asset_symbol, ${TOKEN_SYMBOL_MAX_LENGTH}) AS base_asset_symbol,
+        f.base_asset_decimals,
+        LEFT(f.quote_asset_symbol, ${TOKEN_SYMBOL_MAX_LENGTH}) AS quote_asset_symbol,
+        f.quote_asset_decimals,
+        f.position_size_before,
+        f.entry_quote_before,
+        f.account_pnl,
+        f.initial_margin_fraction_before,
+        LEFT(f.fee_side, ${AGENT_SCAN_LIGHTER_TEXT_BOUNDS.feeSide}) AS fee_side,
+        f.integrator_fee_charged_raw,
+        f.integrator_fee_estimated_raw,
+        LEFT(f.integrator_fee_estimate_basis, ${AGENT_SCAN_LIGHTER_TEXT_BOUNDS.feeBasis}) AS integrator_fee_estimate_basis,
+        LEFT(f.integrator_fee_estimate_tick_source, ${AGENT_SCAN_LIGHTER_TEXT_BOUNDS.feeTickSource}) AS integrator_fee_estimate_tick_source,
+        f.integrator_fee_estimated_usd,
+        LEFT(f.integrator_fee_asset_symbol, ${TOKEN_SYMBOL_MAX_LENGTH}) AS integrator_fee_asset_symbol,
+        f.integrator_fee_asset_decimals,
+        f.integrator_fee_tick_observed,
+        f.integrator_fee_tick_authorized,
+        f.exchange_fee_charged_raw,
+        f.exchange_fee_estimated_usd,
+        f.exchange_fee_tick_observed,
+        f.provider_trade_id,
+        f.provider_order_id,
+        f.execution_intent_id,
+        pos.observed_at AS position_observed_at,
+        pos.open        AS position_open,
+        pos.position    AS position_now
+      FROM lighter_fills f
+      LEFT JOIN LATERAL (
+        SELECT s.observed_at, s.open, s.position
+          FROM lighter_position_market_state s
+         WHERE s.environment  = f.environment
+           AND s.account_index = f.account_index
+           AND s.market_index  = f.market_index
+      ) pos ON TRUE
+      WHERE f.execution_intent_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+            FROM lighter_onboarding_workflows w
+           WHERE w.environment = f.environment
+             AND w.resolved_account_index = f.account_index
+             AND w.wallet_address = ANY($${walletsParam}::text[])${projectClause}
+        )
+        ${predicates.join("\n        ")}
+      ORDER BY f.traded_at DESC, f.id DESC
+      LIMIT $${limitParam}`;
+
+  return { sql, params };
+}

--- a/vex-app/src/main/database/agent-scan-lighter-types.ts
+++ b/vex-app/src/main/database/agent-scan-lighter-types.ts
@@ -1,0 +1,107 @@
+/**
+ * The Agent Scan feed's LIGHTER arm row shape - one row of `lighter_fills`
+ * (migration 152) plus the market's newest observed position state, as
+ * `agent-scan-lighter-query.ts` selects it.
+ *
+ * A sibling of `agent-scan-db-types.ts` rather than a section of it, for the
+ * same reason the DTO splits: the two arms read different tables, carry
+ * different vocabularies and change for different reasons.
+ *
+ * NODE-POSTGRES TYPE NOTES, which `agent-scan-lighter-mappers.ts` depends on:
+ *  - `BIGINT` arrives as a STRING (node-postgres refuses to lose precision past
+ *    2^53). `id` is therefore selected as `::text` and stays a string all the
+ *    way into the cursor, and `account_index` is never selected at all.
+ *  - `INTEGER` and `SMALLINT` fit a number and arrive as one; they are still
+ *    typed `number | string` where a parser configuration could widen them, and
+ *    narrowed in the mapper.
+ *  - Every AMOUNT in this ledger is already a TEXT decimal string with its own
+ *    `CHECK` (migration 152), so amounts arrive as strings and are never
+ *    converted to a JS number anywhere on this path.
+ *  - `TIMESTAMPTZ` arrives as a `Date` (or a string, depending on parser
+ *    configuration); `cursor_ts` is deliberately a pre-rendered STRING built by
+ *    SQL `to_char(...)` so the keyset cursor never passes through `Date`.
+ *  - `JSONB` (`position_now`) arrives already parsed as `unknown`. It is the
+ *    ONE value on this row with no database CHECK behind it, so the mapper
+ *    validates it by shape and degrades a field it cannot read to null.
+ */
+
+/** The arm discriminator, selected as a SQL literal. 1 = `lighter_fills`. */
+export const AGENT_SCAN_LIGHTER_SOURCE_RANK = 1;
+
+export interface AgentScanLighterRow {
+  /** Literal `1` from SQL: the arm this row belongs to, for the merge and the cursor. */
+  readonly source_rank: number | string;
+  /** `lighter_fills.id::text` - the DTO id AND the keyset cursor's `sourceId`. */
+  readonly source_id: string;
+  /** SQL-rendered microsecond UTC render of `traded_at` - the cursor's `createdAt`. */
+  readonly cursor_ts: string;
+  /** When the VENUE matched the fill. The feed time of this row. */
+  readonly traded_at: string | Date;
+  /** When VEX saw the fill. A different fact from `traded_at`. */
+  readonly observed_at: string | Date;
+
+  /** `core` or `rhc`, SQL-clamped to the DTO bound. */
+  readonly environment: string | null;
+  readonly market_index: number | string;
+  readonly market_symbol: string | null;
+  readonly side: string | null;
+  readonly trade_type: string | null;
+  /** NULL on a public row whose account half was never supplied. */
+  readonly position_effect: string | null;
+
+  readonly base_size: string;
+  readonly price: string;
+  readonly quote_notional: string;
+  /** Lighter's OWN usd notional for the fill - settled, not an estimate. */
+  readonly usd_amount: string;
+  readonly block_height: string;
+
+  readonly base_asset_symbol: string | null;
+  readonly base_asset_decimals: number | string;
+  readonly quote_asset_symbol: string | null;
+  readonly quote_asset_decimals: number | string;
+
+  /** The account's own half: whole or nothing (`entry_quote_before` may be null alone). */
+  readonly position_size_before: string | null;
+  readonly entry_quote_before: string | null;
+  readonly account_pnl: string | null;
+
+  /**
+   * Migration 162. The trade record's own initial margin fraction BEFORE the
+   * fill, on the provider's 10000 scale. NULL on a public row and on a row
+   * written before the column existed and not yet re-observed.
+   */
+  readonly initial_margin_fraction_before: number | string | null;
+
+  readonly fee_side: string | null;
+  /** EXACT integrator fee. NULL is UNPROVEN, never zero (migration 152). */
+  readonly integrator_fee_charged_raw: string | null;
+  readonly integrator_fee_estimated_raw: string | null;
+  readonly integrator_fee_estimate_basis: string | null;
+  readonly integrator_fee_estimate_tick_source: string | null;
+  readonly integrator_fee_estimated_usd: string | null;
+  readonly integrator_fee_asset_symbol: string | null;
+  readonly integrator_fee_asset_decimals: number | string | null;
+  readonly integrator_fee_tick_observed: number | string | null;
+  readonly integrator_fee_tick_authorized: number | string | null;
+
+  /** Signed: the exchange reports a rebate as a negative charged amount. */
+  readonly exchange_fee_charged_raw: string | null;
+  readonly exchange_fee_estimated_usd: string | null;
+  readonly exchange_fee_tick_observed: number | string | null;
+
+  readonly provider_trade_id: string;
+  readonly provider_order_id: string | null;
+  /** Mandatory on this arm: a fill without an intent is HELD and never read. */
+  readonly execution_intent_id: string;
+
+  /**
+   * `lighter_position_market_state` for this fill's (environment, account,
+   * market), or all null when no observation has ever covered the market.
+   * `position_observed_at` is VEX'S OWN observation time from the sweep.
+   */
+  readonly position_observed_at: string | Date | null;
+  readonly position_open: boolean | null;
+  /** The stored position JSONB, already parsed by node-postgres. Validated in the mapper. */
+  readonly position_now: unknown;
+}

--- a/vex-app/src/main/database/agent-scan-merge.ts
+++ b/vex-app/src/main/database/agent-scan-merge.ts
@@ -1,0 +1,135 @@
+/**
+ * The Agent Scan feed's TWO-ARM MERGE: `agent_activity` rows and
+ * `lighter_fills` rows into ONE time-ordered page.
+ *
+ * PURE. It takes what the two arm queries returned and returns the page; it
+ * issues no SQL, reads no clock and logs nothing, so every ordering and
+ * boundary property below is provable by a table test.
+ *
+ * ## The order
+ *
+ * `(cursor_ts DESC, source_rank DESC, source_id DESC)`, the same total order
+ * both arms sort by and the same three fields the cursor carries.
+ *
+ *  - `cursor_ts` is the SQL-rendered fixed-width microsecond string, so a plain
+ *    string comparison IS the chronological one. It never passes through
+ *    `Date`, which truncates to milliseconds and would make two rows written in
+ *    the same millisecond straddle the boundary.
+ *  - `source_rank` breaks a tie BETWEEN the arms (1 = `lighter_fills` sorts
+ *    before 0 = `agent_activity` under DESC). Without it two rows sharing a
+ *    microsecond across the arms would have no defined order, and the cursor
+ *    could not say which of them a page ended on.
+ *  - `source_id` is the tail that makes the order TOTAL, compared as a BIGINT
+ *    and never as text: both ledgers key on a BIGSERIAL, ids above 2^53 are
+ *    real, a lexicographic compare would order "9" after "10", and `Number`
+ *    would call two distinct ids equal. In THIS function the tail is not
+ *    reached by the production caller, whose two inputs carry different ranks;
+ *    it is here because this comparator must state the same order the SQL
+ *    keyset boundary applies, where `id < $n::bigint` IS decisive. A page that
+ *    ended by one order and resumed by another would skip or repeat rows.
+ *
+ * ## Why merging in TypeScript is correct
+ *
+ * Each arm is queried after the SAME keyset boundary with `LIMIT pageSize + 1`.
+ * A row in the global first `pageSize` after that boundary has at most
+ * `pageSize - 1` predecessors globally, so it has at most `pageSize - 1`
+ * predecessors WITHIN ITS OWN ARM, so it is inside that arm's first `pageSize`
+ * rows and was fetched. Every row an arm did not return therefore sorts after
+ * every row this function keeps, and the next page - which applies the same
+ * boundary to both arms - reaches it. Nothing is skipped and nothing repeats.
+ *
+ * `hasMore` follows from the same counting: the arms together returned more
+ * than `pageSize` rows exactly when at least one row beyond this page exists,
+ * because each arm's `+1` probe is what proves its own remainder.
+ *
+ * ## The documented limit
+ *
+ * ATTRIBUTION IS NOT INSTANT. A fill is HELD (`execution_intent_id IS NULL`)
+ * until Vex proves which order owns it, and it becomes eligible for this feed
+ * at that moment - not at its `traded_at`. So a fill that becomes eligible
+ * AFTER a cursor was issued and whose `traded_at` sorts BEFORE that boundary
+ * (newer than it) is missed while paging deeper, and appears on the next
+ * refresh from the top. A newly eligible fill that sorts AFTER the boundary is
+ * still reached on a later page. This is a property of late attribution, not of
+ * the merge: no keyset cursor can show a row that enters the set above the
+ * boundary it already passed.
+ */
+
+/** The three cursor fields every mergeable row carries, whichever arm it is from. */
+export interface AgentScanMergeKey {
+  /** SQL-rendered microsecond UTC string. Fixed width, so string order is time order. */
+  readonly cursor_ts: string;
+  /** 0 = `agent_activity`, 1 = `lighter_fills`. */
+  readonly source_rank: number | string;
+  /** The arm's own BIGSERIAL as a decimal string. */
+  readonly source_id: string;
+}
+
+export interface AgentScanMergeResult<T> {
+  /** At most `pageSize` rows, in the feed's order. */
+  readonly kept: readonly T[];
+  /** Whether at least one further row exists across the two arms. */
+  readonly hasMore: boolean;
+}
+
+/**
+ * `a` sorts BEFORE `b` in the feed (i.e. `a` is newer, or wins the tie-break).
+ *
+ * Total on the three fields, so two distinct rows never compare equal: within
+ * an arm the BIGSERIAL is unique, and across the arms the rank separates them.
+ */
+function sortsBefore(a: AgentScanMergeKey, b: AgentScanMergeKey): boolean {
+  if (a.cursor_ts !== b.cursor_ts) return a.cursor_ts > b.cursor_ts;
+  const rankA = Number(a.source_rank);
+  const rankB = Number(b.source_rank);
+  if (rankA !== rankB) return rankA > rankB;
+  // BigInt, not Number: a BIGSERIAL past 2^53 is representable in this ledger
+  // and `Number` would make two distinct ids compare equal.
+  return BigInt(a.source_id) > BigInt(b.source_id);
+}
+
+/**
+ * Merge two already-sorted arms into one page.
+ *
+ * Both inputs MUST already be in the feed's own DESC order within their arm -
+ * which is exactly what each arm's `ORDER BY ... DESC` produced. This function
+ * does not re-sort them: re-sorting would hide an arm whose SQL ordering had
+ * drifted, and that drift is the defect a test should catch, not the merge.
+ */
+export function mergeAgentScanArms<A extends AgentScanMergeKey, B extends AgentScanMergeKey>(
+  activityRows: readonly A[],
+  lighterRows: readonly B[],
+  pageSize: number,
+): AgentScanMergeResult<A | B> {
+  const kept: (A | B)[] = [];
+  let activityIndex = 0;
+  let lighterIndex = 0;
+
+  while (kept.length < pageSize) {
+    const activityRow = activityRows[activityIndex];
+    const lighterRow = lighterRows[lighterIndex];
+    if (activityRow === undefined && lighterRow === undefined) break;
+    if (lighterRow === undefined) {
+      kept.push(activityRow as A);
+      activityIndex += 1;
+      continue;
+    }
+    if (activityRow === undefined) {
+      kept.push(lighterRow);
+      lighterIndex += 1;
+      continue;
+    }
+    if (sortsBefore(activityRow, lighterRow)) {
+      kept.push(activityRow);
+      activityIndex += 1;
+    } else {
+      kept.push(lighterRow);
+      lighterIndex += 1;
+    }
+  }
+
+  // Each arm asked for `pageSize + 1`, so a total above `pageSize` is proof of
+  // a further row and not merely of how the two arms happened to split.
+  const hasMore = activityRows.length + lighterRows.length > pageSize;
+  return { kept, hasMore };
+}

--- a/vex-app/src/main/security/__tests__/url.test.ts
+++ b/vex-app/src/main/security/__tests__/url.test.ts
@@ -59,8 +59,6 @@ describe("isAllowedExternalUrl", () => {
   // two in sync — every new production entry needs both an allow case
   // and a near-miss deny case below.
   const allowlist: ReadonlyArray<ExternalAllowEntry> = [
-    "vex.ai",
-    "docs.vex.ai",
     "portal.jup.ag",
     "app.tavily.com",
     "openrouter.ai",
@@ -77,6 +75,7 @@ describe("isAllowedExternalUrl", () => {
     "polygonscan.com",
     "optimistic.etherscan.io",
     { host: "projectvex.ai", pathPrefix: "/releases" },
+    { host: "projectvex.ai", pathPrefix: "/docs" },
     { host: "github.com", pathPrefix: "/electron/electron/releases" },
     {
       host: "chromewebstore.google.com",
@@ -90,8 +89,6 @@ describe("isAllowedExternalUrl", () => {
   ];
 
   it.each([
-    "https://vex.ai/",
-    "https://docs.vex.ai/",
     "https://portal.jup.ag/keys",
     "https://app.tavily.com/",
     "https://app.tavily.com/home",
@@ -102,6 +99,8 @@ describe("isAllowedExternalUrl", () => {
     "https://docs.docker.com/desktop/setup/install/mac-install/",
     "https://projectvex.ai/releases",
     "https://projectvex.ai/releases/v0-2-0",
+    "https://projectvex.ai/docs",
+    "https://projectvex.ai/docs/security/privacy",
     "https://github.com/electron/electron/releases",
     "https://github.com/electron/electron/releases/tag/v42.0.0",
     "https://dexscreener.com/solana/8sLbNZoA1cfnvMJLPfp98ZLAnFSYCFApfJKMbiXNLwxj",
@@ -122,7 +121,7 @@ describe("isAllowedExternalUrl", () => {
   });
 
   it.each([
-    "http://vex.ai/", // wrong scheme
+    "http://projectvex.ai/docs", // wrong scheme
     "javascript:alert(1)",
     "file:///etc/passwd",
     "data:text/html,<script>",
@@ -141,9 +140,15 @@ describe("isAllowedExternalUrl", () => {
     "https://github.com/Vex-Foundation/Vex",
     "https://github.com/Vex-Foundation/Vex/releases",
     // projectvex.ai near-misses: path boundary, host root, exact-host only
-    "https://projectvex.ai/", // root not under /releases
+    "https://projectvex.ai/", // root not under /releases or /docs
     "https://projectvex.ai/releasesX",
     "https://projectvex.ai/release",
+    "https://projectvex.ai/docsX",
+    "https://projectvex.ai/doc",
+    // Regression: the placeholder `vex.ai` / `docs.vex.ai` host-wide entries
+    // died with the docs repoint (2026-09-11) - must stay denied.
+    "https://vex.ai/",
+    "https://docs.vex.ai/security/local-vault",
     "https://www.projectvex.ai/releases", // exact-host match, no subdomains
     "https://projectvex.ai.evil.com/releases",
     // Traversal in path
@@ -188,7 +193,9 @@ describe("isAllowedExternalUrl", () => {
   });
 
   it("URL spec normalizes hostname to lowercase - mixed case still allowed", () => {
-    expect(isAllowedExternalUrl("https://VEX.AI/", allowlist)).toBe(true);
+    expect(
+      isAllowedExternalUrl("https://PROJECTVEX.AI/docs/security/privacy", allowlist)
+    ).toBe(true);
     expect(
       isAllowedExternalUrl("https://PROJECTvex.ai/releases", allowlist)
     ).toBe(true);

--- a/vex-app/src/main/windows/main-window.ts
+++ b/vex-app/src/main/windows/main-window.ts
@@ -20,6 +20,7 @@ import { EXPLORER_EXTERNAL_ALLOW } from "@shared/explorer-links.js";
 import { observeWindowForFiles } from "../studio/files/files-composition.js";
 import { observeWindowForTerminals } from "../studio/terminal-domain.js";
 import { CHART_ATTRIBUTION_EXTERNAL_ALLOW } from "@shared/chart-attribution.js";
+import { DOCS_EXTERNAL_ALLOW } from "@shared/docs-links.js";
 import {
   clampToVisibleArea,
   type DisplayInfo,
@@ -50,8 +51,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * NOT `/electron/electron/releases-malicious`. See `pathStartsWithBoundary`.
  */
 const ALLOWED_EXTERNAL: ReadonlyArray<ExternalAllowEntry> = [
-  "vex.ai",
-  "docs.vex.ai",
   "portal.jup.ag",
   "app.tavily.com",
   "openrouter.ai",
@@ -82,6 +81,13 @@ const ALLOWED_EXTERNAL: ReadonlyArray<ExternalAllowEntry> = [
   // just does nothing. Exact host `www.tradingview.com`; lookalikes denied by
   // `isAllowedExternalUrl`'s hostname equality.
   ...CHART_ATTRIBUTION_EXTERNAL_ALLOW,
+  // The "Your data stays yours" privacy link (Settings Superboard section and
+  // the wizard footer). Single source of truth in `@shared/docs-links`, for
+  // the same drift reason as the two spreads above. Path-scoped to the docs
+  // tree on the apex host. The former host-wide `vex.ai` / `docs.vex.ai`
+  // entries died with this repoint: `docs.vex.ai` does not resolve and the
+  // apex is a third party's, and no consumer remains.
+  ...DOCS_EXTERNAL_ALLOW,
   // Vex release notes (updater toast CTA) — path-scoped per owner decision
   // 2026-07-22. The former github.com/Vex-Foundation/ entry died with this
   // repoint (it existed solely for the release-notes CTA; zero remaining

--- a/vex-app/src/renderer/features/appShell/ActivityBadge.tsx
+++ b/vex-app/src/renderer/features/appShell/ActivityBadge.tsx
@@ -170,8 +170,11 @@ const KIND_LABEL: Record<FeedActivityKind, string> = {
   // it carries the decoded effect (`TX·APPROVE`, `TX·CALL`).
   transaction: "TX",
   // Migration 152 - money moved between the wallet and a venue account
-  // (Lighter deposits and withdrawals). Fills never reach this feed: they live
-  // in the venue's own fill ledger.
+  // (Lighter deposits and withdrawals). A venue FILL is not one of these rows
+  // and never will be: it reaches the feed through the SECOND arm, straight
+  // from the venue's own `lighter_fills` ledger, carrying its own vocabulary
+  // and its own labels (`agent-scan/agent-scan-lighter-display.ts`). This
+  // record stays total over the `agent_activity` database vocabulary alone.
   exchange: "EXCHANGE",
   activity: "ACTIVITY",
 };

--- a/vex-app/src/renderer/features/appShell/__tests__/SessionActivityCard.test.tsx
+++ b/vex-app/src/renderer/features/appShell/__tests__/SessionActivityCard.test.tsx
@@ -22,6 +22,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { AgentScanEntry } from "@shared/schemas/agent-scan-feed.js";
+import { lighterFill } from "../screens/__tests__/_agent-scan-fixtures.js";
 
 const mockUseAgentScanInfinite = vi.hoisted(() => vi.fn());
 vi.mock("../../../lib/api/portfolio.js", () => ({
@@ -38,6 +39,7 @@ const PROJECT_SCOPE = { kind: "project", projectId: PROJECT } as const;
 
 function entry(overrides: Partial<AgentScanEntry> & { readonly id: string }): AgentScanEntry {
   return {
+    source: "agent_activity",
     createdAt: "2026-05-21T10:00:00.000Z",
     activityKind: "swap",
     eventRole: null,
@@ -239,6 +241,36 @@ describe("SessionActivityCard", () => {
       origin: { x: 0, y: 0, width: 0, height: 0 },
       projectId: PROJECT,
     });
+  });
+
+  /**
+   * TWO LEDGERS, ONE CARD. The page main sends is already merged and ordered;
+   * the card's only job is to render each row in the grammar its ledger
+   * deserves and to key them on `(source, id)` - the two BIGSERIAL sequences
+   * share id space, and keying on the id alone reconciles one row onto the
+   * other.
+   */
+  it("renders BOTH row kinds of a mixed page, in main's order and with distinct keys", () => {
+    mockFeed([
+      entry({ id: "42" }),
+      lighterFill({ id: "42", createdAt: "2026-05-21T09:00:00.000Z" }),
+    ]);
+    const { container } = render(<SessionActivityCard scope={SESSION_SCOPE} />);
+
+    const rows = container.querySelectorAll("li");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.textContent).toContain("100 USDC");
+    expect(rows[1]?.textContent).toContain("Buy 0.0050 ETH");
+    // The venue's own SETTLED usd, plain, plus the leverage before the fill.
+    expect(rows[1]?.textContent).toContain("$12.99");
+    expect(rows[1]?.textContent).toContain("10.00x");
+    expect(rows[1]?.textContent).not.toContain("est.");
+  });
+
+  it("a fill line carries NO explorer link - there is no settlement transaction", () => {
+    mockFeed([lighterFill({ id: "7" })]);
+    render(<SessionActivityCard scope={SESSION_SCOPE} />);
+    expect(screen.queryByRole("link")).toBeNull();
   });
 
   it("'View all' opens the Agent Scan screen PRESET to this session", () => {

--- a/vex-app/src/renderer/features/appShell/book/SessionActivityCard.tsx
+++ b/vex-app/src/renderer/features/appShell/book/SessionActivityCard.tsx
@@ -20,6 +20,12 @@
  * forward; keeping a second pipeline alive just to show them was the debt the
  * retirement removes.
  *
+ * TWO LEDGERS, ONE CARD. The feed's page is discriminated on `source`, and
+ * this card renders both arms in the order main sent them - an `agent_activity`
+ * row and a Lighter fill - with a compact line each. It never filters or sorts
+ * a row out itself: the scope is a wire filter, and a renderer-side skip would
+ * make the rail disagree with the audit screen about what happened.
+ *
  * The row grammar is AgentScanRow's, compacted to one line: protocol mark ·
  * ActivityBadge · `IN → OUT` legs · time · TX↗. Amounts use `displayAmount`
  * ONLY — never `amountHuman`, which is a raw unscaled figure. An estimated
@@ -34,7 +40,12 @@
  */
 
 import { useMemo, type JSX, type MouseEvent } from "react";
-import type { AgentScanDto, AgentScanEntry } from "@shared/schemas/agent-scan-feed.js";
+import type {
+  AgentScanActivityEntry,
+  AgentScanDto,
+  AgentScanEntry,
+} from "@shared/schemas/agent-scan-feed.js";
+import type { AgentScanLighterFillEntry } from "@shared/schemas/agent-scan-lighter-entry.js";
 import type { Result } from "@shared/ipc/result.js";
 import {
   IconChevronRight,
@@ -46,13 +57,21 @@ import { useUiStore } from "../../../stores/uiStore.js";
 import type { ShellRoute } from "../../../stores/uiStore/shell-route.js";
 import { ProtocolMark } from "../../../components/common/ProtocolMark.js";
 import { resolveProtocolMark } from "../../../lib/protocol-marks.js";
-import { ActivityBadge } from "../ActivityBadge.js";
+import { ActivityBadge, ActivityChip } from "../ActivityBadge.js";
 import {
   entryClockText,
   isEstimatedBasis,
   legAmountText,
   legSymbolText,
 } from "../screens/agent-scan/agent-scan-display.js";
+import {
+  lighterAttentionTradeTypeText,
+  lighterCompactTradeText,
+  lighterEffectLabel,
+  lighterKindLabel,
+  lighterLeverageChipText,
+  lighterUsdSettledText,
+} from "../screens/agent-scan/agent-scan-lighter-display.js";
 import { CardStateNote, PortfolioCard } from "./portfolio/PortfolioCard.js";
 
 /** The card shows the newest few; the Agent Scan screen has the full feed. */
@@ -176,8 +195,10 @@ export function SessionActivityCard({
   } else {
     body = (
       <ul className="flex flex-col">
+        {/* `(source, id)` - the two ledgers share id space, so the id alone
+          * is not an identity and React would reconcile the wrong row. */}
         {entries.map((entry) => (
-          <ActivityRow key={entry.id} entry={entry} />
+          <ActivityRow key={`${entry.source}:${entry.id}`} entry={entry} />
         ))}
       </ul>
     );
@@ -198,8 +219,77 @@ export function SessionActivityCard({
   );
 }
 
-/** One compact activity line — the AgentScanRow grammar without the audit detail. */
+/**
+ * One compact line, dispatched on the entry's ledger. The card renders EVERY
+ * row main sent, in the order main sent them: narrowing is a wire filter
+ * (`sessionId` / `projectId`) and never a renderer-side skip, or the card
+ * would quietly disagree with the audit screen about what happened.
+ */
 function ActivityRow({ entry }: { readonly entry: AgentScanEntry }): JSX.Element {
+  switch (entry.source) {
+    case "agent_activity":
+      return <AgentActivityRow entry={entry} />;
+    case "lighter_fill":
+      return <LighterFillRow entry={entry} />;
+  }
+}
+
+/**
+ * One compact LIGHTER FILL line: badge, the executed trade, the venue's own
+ * settled USD, the leverage before the fill, the clock. No link and no status
+ * chip - a fill has neither a settlement transaction nor a lifecycle.
+ */
+function LighterFillRow({
+  entry,
+}: {
+  readonly entry: AgentScanLighterFillEntry;
+}): JSX.Element {
+  const clock = entryClockText(entry.createdAt);
+  const leverage = entry.spot ? null : lighterLeverageChipText(entry.leverage);
+  const attention = lighterAttentionTradeTypeText(entry.tradeType);
+
+  return (
+    <li className="flex flex-col gap-0.5 border-b border-line-1 py-1.5 last:border-b-0 last:pb-0.5">
+      <div className="flex items-center gap-1.5">
+        <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+          <ProtocolMark mark={resolveProtocolMark("lighter")} size={13} />
+        </span>
+        <ActivityChip
+          tone="solid"
+          text={`${lighterKindLabel(entry.spot)}·${lighterEffectLabel(entry.positionEffect)}`}
+        />
+        {attention !== null ? (
+          <ActivityChip
+            tone="accent"
+            text={attention}
+            title="The venue acted on this account - this fill was not a trade the user placed."
+          />
+        ) : null}
+      </div>
+      <div className="flex items-baseline gap-1.5 overflow-hidden whitespace-nowrap pl-[20px] text-[10.5px] tabular-nums text-ink-secondary">
+        <span className="truncate">{lighterCompactTradeText(entry)}</span>
+        <span title={entry.usdAmount} className="shrink-0">
+          {lighterUsdSettledText(entry.usdAmount)}
+        </span>
+        {leverage !== null ? (
+          <span className="shrink-0 text-ink-tertiary" title="Leverage before this fill">
+            {leverage}
+          </span>
+        ) : null}
+        {clock !== null ? (
+          <span className="ml-auto shrink-0 text-ink-tertiary">{clock}</span>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+/** One compact activity line - the AgentScanRow grammar without the audit detail. */
+function AgentActivityRow({
+  entry,
+}: {
+  readonly entry: AgentScanActivityEntry;
+}): JSX.Element {
   const mark = resolveProtocolMark(entry.protocol);
   const estimated = isEstimatedBasis(entry);
   const clock = entryClockText(entry.createdAt);

--- a/vex-app/src/renderer/features/appShell/screens/AgentScanScreen.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/AgentScanScreen.tsx
@@ -6,8 +6,11 @@
  * survives Clear and shows as its own non-clearable chip.
  *
  * Where `TokenHistoryScreen` answers "what happened to THIS token?", this
- * screen answers "what has the agent DONE?" — every `agent_activity` row,
- * newest first, filterable, each carrying its receipt.
+ * screen answers "what has the agent DONE?": every `agent_activity` row AND
+ * every attributed Lighter fill, newest first, filterable, each carrying its
+ * own receipt. The two ledgers arrive as ONE time-ordered page from main
+ * (`AgentScanEntry` is discriminated on `source`); the screen never merges,
+ * filters or sorts them itself.
  *
  * VIRTUALIZED (`@tanstack/react-virtual`). This is an unbounded feed: it pages
  * forever and must never retain a DOM node per fetched row, or a long-running
@@ -28,7 +31,12 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import type { AgentScanDto, AgentScanEntry } from "@shared/schemas/agent-scan-feed.js";
+import type {
+  AgentScanActivityEntry,
+  AgentScanDto,
+  AgentScanEntry,
+} from "@shared/schemas/agent-scan-feed.js";
+import type { AgentScanLighterFillEntry } from "@shared/schemas/agent-scan-lighter-entry.js";
 import type { Result } from "@shared/ipc/result.js";
 import { useAgentScanInfinite } from "../../../lib/api/portfolio.js";
 import { useProject } from "../../../lib/api/projects.js";
@@ -43,6 +51,7 @@ import {
   toAgentScanFilters,
   type AgentScanFilterState,
 } from "./agent-scan/AgentScanFilterBar.js";
+import { AgentScanLighterRow } from "./agent-scan/AgentScanLighterRow.js";
 import { AgentScanRow } from "./agent-scan/AgentScanRow.js";
 import { dayKey, dayLabel } from "./agent-scan/agent-scan-display.js";
 
@@ -56,11 +65,11 @@ const SCREEN_TITLE = "Agent Scan";
 function screenSubtitle(scope: AgentScanRouteScope): string {
   switch (scope.kind) {
     case "global":
-      return "Every action Vex executed on-chain, newest first - each row links to its transaction.";
+      return "Every action Vex executed on-chain, newest first - each row carries its own receipt.";
     case "session":
-      return "Everything Vex executed on-chain in THIS session, newest first - each row links to its transaction.";
+      return "Everything Vex executed on-chain in THIS session, newest first - each row carries its own receipt.";
     case "project":
-      return "Everything Vex executed on-chain with THIS project's wallets, newest first - each row links to its transaction.";
+      return "Everything Vex executed on-chain with THIS project's wallets, newest first - each row carries its own receipt.";
   }
 }
 
@@ -70,10 +79,29 @@ const ESTIMATED_ROW_PX = 56;
 /** Rows kept mounted beyond the visible window, to cover fast scrolling. */
 const OVERSCAN_ROWS = 8;
 
-/** A day divider or one activity — the flat list the virtualizer indexes. */
+/**
+ * A day divider or ONE entry from either ledger - the flat list the
+ * virtualizer indexes.
+ *
+ * The two entry members are the row TEMPLATES of a heterogeneous list: the
+ * kind is decided once, here, from the DTO's `source` discriminator, and the
+ * render branch then mounts the one component that knows that shape. This is
+ * the shape VS Code's list gives a mixed feed (`getTemplateId` picking one
+ * `IListRenderer` per kind) and it is why the screen never grows a row that
+ * branches on every field of two unrelated ledgers.
+ */
 type FeedRow =
   | { readonly kind: "day"; readonly key: string; readonly label: string }
-  | { readonly kind: "entry"; readonly key: string; readonly entry: AgentScanEntry };
+  | {
+      readonly kind: "activity";
+      readonly key: string;
+      readonly entry: AgentScanActivityEntry;
+    }
+  | {
+      readonly kind: "lighter";
+      readonly key: string;
+      readonly entry: AgentScanLighterFillEntry;
+    };
 
 /** Narrow one query page to its available payload, else null. */
 function availablePage(
@@ -97,7 +125,22 @@ function buildFeedRows(entries: readonly AgentScanEntry[]): readonly FeedRow[] {
       currentDay = key;
       rows.push({ kind: "day", key: `day:${key}`, label: dayLabel(entry.createdAt) });
     }
-    rows.push({ kind: "entry", key: `entry:${entry.id}`, entry });
+    // IDENTITY IS `(source, id)`, NEVER THE ID ALONE. The two ledgers have
+    // separate BIGSERIAL sequences and therefore share id space: `agent_activity`
+    // row 42 and `lighter_fills` row 42 can both be on one page, and a key
+    // collision in a virtualized list silently reuses the wrong measured row.
+    // TypeScript cannot catch this - both ids are strings.
+    const rowKey = `entry:${entry.source}:${entry.id}`;
+    // Exhaustive over the union: a third ledger is a compile error here rather
+    // than an entry that is silently dropped from the feed.
+    switch (entry.source) {
+      case "agent_activity":
+        rows.push({ kind: "activity", key: rowKey, entry });
+        break;
+      case "lighter_fill":
+        rows.push({ kind: "lighter", key: rowKey, entry });
+        break;
+    }
   }
   return rows;
 }
@@ -243,6 +286,8 @@ export function AgentScanScreen({
                   </span>
                   <span aria-hidden className="h-px flex-1 bg-line-2" />
                 </div>
+              ) : row.kind === "lighter" ? (
+                <AgentScanLighterRow entry={row.entry} />
               ) : (
                 <AgentScanRow entry={row.entry} />
               )}

--- a/vex-app/src/renderer/features/appShell/screens/SettingsScreen/SuperboardKeySection.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/SettingsScreen/SuperboardKeySection.tsx
@@ -13,6 +13,7 @@ import {
   useSuperboardKey,
 } from "../../../../lib/api/superboard-key.js";
 import { cn } from "../../../../lib/utils.js";
+import { VEX_PRIVACY_DOC_LABEL, VEX_PRIVACY_DOC_URL } from "@shared/docs-links.js";
 import type { SuperboardKeyStatus } from "@shared/schemas/superboard-key.js";
 import { SUPERBOARD_KEY_ICON } from "./settings-sections.js";
 import { superboardPendingCopy } from "./superboard-pending-copy.js";
@@ -160,7 +161,7 @@ export function SuperboardKeySection(): JSX.Element {
       <div className="mt-6 border-t border-[var(--color-border)] pt-4">
         <div className="flex items-center gap-3 vex-micro text-ink-tertiary">
           <a
-            href="https://docs.vex.ai/security/local-vault"
+            href={VEX_PRIVACY_DOC_URL}
             target="_blank"
             rel="noopener noreferrer"
             className={cn(
@@ -169,7 +170,7 @@ export function SuperboardKeySection(): JSX.Element {
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
             )}
           >
-            Your data stays yours
+            {VEX_PRIVACY_DOC_LABEL}
             <IconArrowUpRight size={10} />
           </a>
         </div>

--- a/vex-app/src/renderer/features/appShell/screens/SettingsScreen/__tests__/SuperboardKeySection.test.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/SettingsScreen/__tests__/SuperboardKeySection.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Result } from "@shared/ipc/result.js";
+import { VEX_PRIVACY_DOC_URL } from "@shared/docs-links.js";
 import type { SuperboardKeyStatus } from "@shared/schemas/superboard-key.js";
 import { SuperboardKeySection } from "../SuperboardKeySection.js";
 
@@ -169,7 +170,11 @@ describe("SuperboardKeySection", () => {
     getSuperboardKey.mockResolvedValue(ok({ kind: "missing" }));
     renderSection();
     expect(await screen.findByRole("heading", { name: "Superboard key" })).toBeTruthy();
-    expect(screen.getByText("Your data stays yours")).toBeTruthy();
+    const privacy = screen.getByText("Your data stays yours").closest("a");
+    expect(privacy).not.toBeNull();
+    // The anchor and main's allowlist share one declaration; the href here is
+    // the URL `docs-links.test.ts` proves the allowlist admits.
+    expect(privacy?.getAttribute("href")).toBe(VEX_PRIVACY_DOC_URL);
   });
 
   it.each([

--- a/vex-app/src/renderer/features/appShell/screens/__tests__/AgentScanScreen-rows.test.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/__tests__/AgentScanScreen-rows.test.tsx
@@ -13,7 +13,11 @@
  *     explorer link, marks an ESTIMATED basis with `~`/`est.`, expands to its
  *     audit detail (per-leg explorer links, Vex fee, failure code/reason), and
  *     flags a STALE pending row as tracking delayed rather than implying
- *     progress.
+ *     progress;
+ *   - the feed's SECOND ARM: a Lighter fill renders its own row grammar and
+ *     its own drawer, states every unknown as an unknown rather than a zero,
+ *     names a fill the user did not place, and shares no identity with an
+ *     `agent_activity` row that happens to carry the same numeric id.
  *
  * `useAgentScanInfinite` is mocked — this suite owns the screen, not the query
  * wiring (the hook's pagination contract is pinned in the api layer).
@@ -28,6 +32,7 @@ import {
   GLOBAL_SCOPE,
   entry,
   installJsdomGeometry,
+  lighterFill,
   restoreJsdomGeometry,
   ROW_PX,
 } from "./_agent-scan-fixtures.js";
@@ -342,5 +347,253 @@ describe("AgentScanScreen - rows and audit detail", () => {
 
     expect(screen.getByText("verification stalled")).not.toBeNull();
     expect(screen.queryByText("tracking delayed")).toBeNull();
+  });
+});
+
+/**
+ * THE SECOND ARM. These rows come from the venue's own `lighter_fills` ledger,
+ * not from `agent_activity`: settled the moment the venue matched them, with
+ * no lifecycle, no settlement transaction and no explorer link. What they add
+ * to the audit surface is the account's own half of the record - the position
+ * before, the leverage that was in force, the fee with its provenance, and the
+ * newest observation of the market - so these tests pin the ABSENCES as hard
+ * as the figures: an unknown must never print as a zero.
+ */
+describe("AgentScanScreen - Lighter fill rows", () => {
+  function expand(): void {
+    fireEvent.click(screen.getByRole("button", { name: /Show details for this fill/ }));
+  }
+
+  it("renders the fill line: badge, executed trade, SETTLED usd, leverage, clock", () => {
+    mockQuery([availablePage([lighterFill({ id: "9" })])]);
+    mountScreen();
+
+    expect(screen.getByText("PERP·OPEN")).not.toBeNull();
+    expect(screen.getByText("Buy 0.0050 ETH @ 2,598.09")).not.toBeNull();
+    // The venue's OWN settled figure: plain, never the `~ ... est.` marker the
+    // activity arm's quote-time USD wears.
+    const usd = screen.getByText("$12.99");
+    expect(usd).not.toBeNull();
+    expect(usd.textContent).not.toContain("est.");
+    // The whole value is still reachable - the two-decimal cell hides nothing.
+    expect(usd.getAttribute("title")).toBe("12.990450");
+    expect(screen.getByText("10.00x")).not.toBeNull();
+  });
+
+  it("renders NO link for a fill - there is no settlement transaction to link to", () => {
+    mockQuery([availablePage([lighterFill({ id: "9" })])]);
+    mountScreen();
+    expect(screen.queryByRole("link")).toBeNull();
+    expand();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("expands to the whole account half: position, leverage, fees, ids and the observation", () => {
+    mockQuery([
+      availablePage([
+        lighterFill({
+          id: "9",
+          positionEffect: "reduce",
+          positionSizeBefore: "0.0120",
+          entryQuoteBefore: "-31.177080",
+          accountPnl: "-0.4412",
+        }),
+      ]),
+    ]);
+    mountScreen();
+
+    expect(screen.queryByText("Position before")).toBeNull();
+    expand();
+
+    expect(screen.getByText("Position before")).not.toBeNull();
+    // SIGNED, in the base asset: an unsigned size reads as the wrong direction.
+    expect(screen.getByText("+0.0120 ETH")).not.toBeNull();
+    expect(screen.getByText("Entry quote before")).not.toBeNull();
+    expect(screen.getByText("-31.177080 USDG")).not.toBeNull();
+    expect(screen.getByText("Realized PnL")).not.toBeNull();
+    expect(screen.getByText("-0.4412 USDG")).not.toBeNull();
+    // The leverage BEFORE the fill, as a historical fact.
+    expect(screen.getByText("Leverage")).not.toBeNull();
+    // The fee is only ESTIMATED, so it carries the marker, the basis and the tick.
+    expect(
+      screen.getByText(
+        "~ 0.012990 USDG est., on quote notional, observed tick · ~$0.012990 est.",
+      ),
+    ).not.toBeNull();
+    expect(screen.getByText("~$0.004546 est.")).not.toBeNull();
+    expect(screen.getByText("Trade")).not.toBeNull();
+    expect(screen.getByText("Lighter Core")).not.toBeNull();
+    expect(screen.getByText("18412771")).not.toBeNull();
+    expect(screen.getByText("771203")).not.toBeNull();
+    expect(screen.getByText("884412")).not.toBeNull();
+    expect(
+      screen.getByText("lighter-exec-00000000-0000-4000-8000-0000000000f1"),
+    ).not.toBeNull();
+    // The observation carries its own time, because it is a fact about THEN.
+    // The exact stamp is the display helper's own test; here it must be present
+    // and attached to the size.
+    expect(screen.getByText(/^\+0\.0050 ETH \(last observed .+\)$/)).not.toBeNull();
+    expect(screen.getByText("liquidation 2,365.93")).not.toBeNull();
+  });
+
+  it("a PUBLIC row says the position facts are unknown and shows no PnL - never a 0", () => {
+    mockQuery([
+      availablePage([
+        lighterFill({
+          id: "9",
+          positionEffect: null,
+          positionSizeBefore: null,
+          entryQuoteBefore: null,
+          accountPnl: null,
+        }),
+      ]),
+    ]);
+    mountScreen();
+
+    expect(screen.getByText("PERP·UNKNOWN")).not.toBeNull();
+    expand();
+    expect(screen.getByText("position facts unknown")).not.toBeNull();
+    expect(screen.queryByText("Realized PnL")).toBeNull();
+    expect(screen.queryByText("Entry quote before")).toBeNull();
+  });
+
+  it("the drawer repeats the settled economics WHOLE, on lines that wrap", () => {
+    // The feed line clips to the row's width and truncates the cents; the
+    // drawer must carry side, size, price, quote notional and the full USD so
+    // nothing the venue recorded is lost at a narrow width (final review).
+    mockQuery([
+      availablePage([
+        lighterFill({ id: "9", baseSize: "0.0050", price: "2598.09", quoteNotional: "12.990450", usdAmount: "12.990450" }),
+      ]),
+    ]);
+    mountScreen();
+    expand();
+
+    expect(screen.getByText("Side")).not.toBeNull();
+    expect(screen.getByText("Buy")).not.toBeNull();
+    expect(screen.getByText("Size")).not.toBeNull();
+    expect(screen.getByText("0.0050 ETH")).not.toBeNull();
+    expect(screen.getByText("Price")).not.toBeNull();
+    expect(screen.getByText("2,598.09 USDG")).not.toBeNull();
+    expect(screen.getByText("Quote notional")).not.toBeNull();
+    expect(screen.getByText("12.990450 USDG")).not.toBeNull();
+    expect(screen.getByText("USD")).not.toBeNull();
+    expect(screen.getByText("$12.990450")).not.toBeNull();
+    // The clipped line carries the whole sentence as its title.
+    expect(screen.getByTitle("Buy 0.0050 ETH @ 2,598.09")).not.toBeNull();
+  });
+
+  it("a NULL leverage renders no chip at all and reads `unknown` in the drawer", () => {
+    mockQuery([availablePage([lighterFill({ id: "9", leverage: null })])]);
+    mountScreen();
+
+    // Not "1x", not "-": an absent historical leverage is not a leverage of one.
+    expect(screen.queryByText("10.00x")).toBeNull();
+    expect(screen.queryByText("1x")).toBeNull();
+    expand();
+    expect(screen.getByText("unknown")).not.toBeNull();
+  });
+
+  it("names a LIQUIDATION as one - it is the venue acting, not a trade the user placed", () => {
+    mockQuery([availablePage([lighterFill({ id: "9", tradeType: "liquidation" })])]);
+    mountScreen();
+
+    const chip = screen.getByText("liquidation");
+    expect(chip).not.toBeNull();
+    // The word carries it: the chip is text, never colour alone.
+    expect(chip.getAttribute("title")).toContain("not a trade the user placed");
+    expand();
+    expect(screen.getByText("Liquidation")).not.toBeNull();
+  });
+
+  it("renders an UNKNOWN position effect neutrally rather than blanking the row (tolerant reader)", () => {
+    mockQuery([
+      availablePage([lighterFill({ id: "9", positionEffect: "settle_down" })]),
+    ]);
+    mountScreen();
+    expect(screen.getByText("PERP·SETTLE_DOWN")).not.toBeNull();
+    expect(screen.getByText("Buy 0.0050 ETH @ 2,598.09")).not.toBeNull();
+  });
+
+  it("a SPOT fill wears no leverage chip and shows no position lines anywhere", () => {
+    mockQuery([
+      availablePage([
+        lighterFill({ id: "9", spot: true, marketSymbol: "ETH", positionEffect: null }),
+      ]),
+    ]);
+    mountScreen();
+
+    expect(screen.getByText("SPOT·UNKNOWN")).not.toBeNull();
+    expect(screen.queryByText("10.00x")).toBeNull();
+    expand();
+    expect(screen.queryByText("Position before")).toBeNull();
+    expect(screen.queryByText("Leverage")).toBeNull();
+    expect(screen.queryByText("Position now")).toBeNull();
+  });
+
+  it("states a market observed CLOSED as closed, with when it was observed", () => {
+    mockQuery([
+      availablePage([
+        lighterFill({
+          id: "9",
+          positionNow: {
+            observedAt: "2020-01-02T16:49:00+00:00",
+            open: false,
+            position: null,
+          },
+        }),
+      ]),
+    ]);
+    mountScreen();
+    expand();
+    expect(screen.getByText(/^closed \(last observed /)).not.toBeNull();
+  });
+
+  it("states an OPEN position whose details could not be read, rather than hiding the observation", () => {
+    mockQuery([
+      availablePage([
+        lighterFill({
+          id: "9",
+          positionNow: {
+            observedAt: "2020-01-02T16:49:00+00:00",
+            open: true,
+            position: null,
+          },
+        }),
+      ]),
+    ]);
+    mountScreen();
+    expand();
+    expect(screen.getByText(/^open, details unavailable \(last observed /)).not.toBeNull();
+  });
+
+  it("renders NO position-now block when the market was never observed - absence is not `closed`", () => {
+    mockQuery([availablePage([lighterFill({ id: "9", positionNow: null })])]);
+    mountScreen();
+    expand();
+    expect(screen.queryByText("Position now")).toBeNull();
+    expect(screen.queryByText(/closed/)).toBeNull();
+  });
+
+  /**
+   * THE KEY COLLISION. The two ledgers are separate BIGSERIAL sequences, so id
+   * `42` exists in both and can land on one page. Keying rows on the id alone
+   * makes React reconcile one row onto the other's measured wrapper; the
+   * compiler cannot catch it, because both ids are strings.
+   */
+  it("renders BOTH rows when an activity row and a fill share a numeric id", () => {
+    mockQuery([
+      availablePage([
+        entry({ id: "42", createdAt: "2026-07-20T10:22:00+00:00" }),
+        lighterFill({ id: "42", createdAt: "2026-07-20T10:21:00+00:00" }),
+      ]),
+    ]);
+    mountScreen();
+
+    expect(screen.getByText("SWAP")).not.toBeNull();
+    expect(screen.getByText("PERP·OPEN")).not.toBeNull();
+    const list = screen.getByRole("list", { name: "Activity" });
+    // One day divider plus the two entry rows.
+    expect(within(list).getAllByRole("listitem")).toHaveLength(3);
   });
 });

--- a/vex-app/src/renderer/features/appShell/screens/__tests__/AgentScanScreen.test.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/__tests__/AgentScanScreen.test.tsx
@@ -147,6 +147,9 @@ describe("AgentScanScreen - filters drive the query input", () => {
       "Trench Express (legacy)",
       // Joined in Phase 3, with the launch and claim executors that write it.
       "pools.fun",
+      // Both arms write it: `exchange` deposits/withdrawals in `agent_activity`
+      // and the venue's own matched fills in `lighter_fills`.
+      "Lighter",
       "Khalani",
       "Relay",
     ]) {
@@ -159,6 +162,35 @@ describe("AgentScanScreen - filters drive the query input", () => {
     for (const label of ["Polymarket", "DexScreener", "Pendle"]) {
       expect(screen.queryByRole("button", { name: label })).toBeNull();
     }
+  });
+
+  /**
+   * The FEED kind that selects the second ledger. `kinds` is an OPEN bounded
+   * list on the contract, so this chip routes exactly like the vocabulary-derived
+   * ones - it is simply not an `agent_activity.kind`, which is why it is not in
+   * `AGENT_ACTIVITY_KINDS`.
+   */
+  it("offers a Lighter fills kind chip that toggles `kinds` like every other chip", () => {
+    mockQuery([availablePage([entry({ id: "1" })])]);
+    mountScreen();
+
+    const chip = screen.getByRole("button", { name: "Lighter fills" });
+    fireEvent.click(chip);
+    expect(lastFilters()).toEqual({ kinds: ["lighter_fill"] });
+
+    fireEvent.click(screen.getByRole("button", { name: "swap" }));
+    expect(lastFilters()).toEqual({ kinds: ["lighter_fill", "swap"] });
+
+    fireEvent.click(chip);
+    expect(lastFilters()).toEqual({ kinds: ["swap"] });
+  });
+
+  it("offers the `lighter` protocol, which both arms of the feed write", () => {
+    mockQuery([availablePage([entry({ id: "1" })])]);
+    mountScreen();
+
+    fireEvent.click(screen.getByRole("button", { name: "Lighter" }));
+    expect(lastFilters()).toEqual({ protocols: ["lighter"] });
   });
 
   it("toggles a selected value back off", () => {

--- a/vex-app/src/renderer/features/appShell/screens/__tests__/_agent-scan-fixtures.ts
+++ b/vex-app/src/renderer/features/appShell/screens/__tests__/_agent-scan-fixtures.ts
@@ -15,9 +15,11 @@
  */
 
 import type {
+  AgentScanActivityEntry,
   AgentScanDto,
   AgentScanEntry,
 } from "@shared/schemas/agent-scan-feed.js";
+import type { AgentScanLighterFillEntry } from "@shared/schemas/agent-scan-lighter-entry.js";
 import type { Result } from "@shared/ipc/result.js";
 import type { AgentScanRouteScope } from "../../../../stores/uiStore/shell-route.js";
 
@@ -38,9 +40,13 @@ export const PROJECT_SCOPE: AgentScanRouteScope = {
 export const PROJECT_NAME = "Trading";
 
 export function entry(
-  overrides: Partial<AgentScanEntry> & { readonly id: string },
-): AgentScanEntry {
+  overrides: Partial<AgentScanActivityEntry> & { readonly id: string },
+): AgentScanActivityEntry {
   return {
+    // The ledger discriminator. Required, not defaulted: both sides of the IPC
+    // ship in one build, and a fixture that could omit it would let a consumer
+    // forget to switch on it.
+    source: "agent_activity",
     createdAt: "2026-07-20T10:21:00+00:00",
     activityKind: "swap",
     eventRole: "swap",
@@ -97,6 +103,80 @@ export function entry(
   };
 }
 
+/**
+ * ONE LIGHTER FILL, fully populated - the ETH example from the plan: a 0.0050
+ * ETH buy at 2,598.09 that OPENED a 10x position, with the Vex fee still only
+ * ESTIMATED (charged is unproven, not zero), the exchange fee likewise, and a
+ * position observation taken after the fill.
+ *
+ * Every optional fact is present here on purpose, so a test that wants an
+ * absence states it as an override and the absence is visible in the test
+ * itself rather than hidden in this factory.
+ */
+export function lighterFill(
+  overrides: Partial<AgentScanLighterFillEntry> & { readonly id: string },
+): AgentScanLighterFillEntry {
+  return {
+    source: "lighter_fill",
+    createdAt: "2026-07-20T10:21:00+00:00",
+    observedAt: "2026-07-20T10:21:04+00:00",
+    environment: "core",
+    marketIndex: 1,
+    marketSymbol: "ETH-USD",
+    spot: false,
+    side: "buy",
+    tradeType: "trade",
+    positionEffect: "open",
+    baseSize: "0.0050",
+    price: "2598.09",
+    quoteNotional: "12.990450",
+    usdAmount: "12.990450",
+    blockHeight: "18412771",
+    baseAsset: { symbol: "ETH", decimals: 18 },
+    quoteAsset: { symbol: "USDG", decimals: 6 },
+    positionSizeBefore: "0",
+    entryQuoteBefore: "0",
+    accountPnl: "0",
+    leverage: { initialMarginFraction: 1000, display: "10.00" },
+    feeSide: "taker",
+    integratorFee: {
+      charged: null,
+      estimate: {
+        raw: "12990",
+        symbol: "USDG",
+        decimals: 6,
+        basis: "quote_notional",
+        tickSource: "observed",
+        usd: "0.012990",
+      },
+      tickObserved: 1000,
+      tickAuthorized: 1000,
+    },
+    exchangeFee: {
+      charged: null,
+      estimatedUsd: "0.004546",
+      tickObserved: 350,
+    },
+    providerTradeId: "884412",
+    providerOrderId: "771203",
+    intentId: "lighter-exec-00000000-0000-4000-8000-0000000000f1",
+    positionNow: {
+      observedAt: "2026-07-20T16:49:00+00:00",
+      open: true,
+      position: {
+        size: "0.0050",
+        entryPrice: "2598.09",
+        unrealizedPnl: "-0.0077",
+        realizedPnl: "0",
+        liquidationPrice: "2365.93",
+        leverage: { initialMarginFraction: 1000, display: "10.00" },
+        marginMode: "isolated",
+      },
+    },
+    ...overrides,
+  };
+}
+
 export function availablePage(
   entries: readonly AgentScanEntry[],
   options?: { readonly hasMore?: boolean },
@@ -108,7 +188,13 @@ export function availablePage(
       entries: [...entries],
       nextCursor:
         options?.hasMore === true
-          ? { createdAt: "2026-07-20T10:21:00.000000Z", sourceId: "1" }
+          ? {
+              createdAt: "2026-07-20T10:21:00.000000Z",
+              sourceId: "1",
+              // The ARM the boundary row came from, now that the cursor spans
+              // two ledgers (`(cursor_ts DESC, source_rank DESC, id DESC)`).
+              sourceRank: 0,
+            }
           : null,
       hasMore: options?.hasMore === true,
     },

--- a/vex-app/src/renderer/features/appShell/screens/__tests__/agent-scan-lighter-display.test.ts
+++ b/vex-app/src/renderer/features/appShell/screens/__tests__/agent-scan-lighter-display.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Lighter fill display readers - the pure formatters behind the Agent Scan
+ * feed's second arm.
+ *
+ * Pins, each one a contract obligation from
+ * `shared/schemas/agent-scan-lighter-entry.ts`:
+ *   - MONEY IS STRING ARITHMETIC: a base-unit integer scaled by its decimals
+ *     keeps every declared place, and the venue's own precision (`0.0050`)
+ *     survives - a `Number` round-trip would silently rewrite both;
+ *   - SETTLED IS NOT ESTIMATED: the venue's USD notional prints plain, a fee
+ *     estimate prints with the `~ ... est.` marker, its basis and its tick;
+ *   - UNKNOWN IS NOT ZERO: a null leverage reads `unknown`, a null account
+ *     half reads "position facts unknown", an unproven charge prints nothing;
+ *   - TOLERANT READER: a vocabulary value this build predates renders its own
+ *     bounded text instead of blanking the row;
+ *   - POSITION NOW has FOUR cases, and "no observation" is not "closed".
+ */
+
+import { describe, expect, it } from "vitest";
+import type { AgentScanLighterFillEntry } from "@shared/schemas/agent-scan-lighter-entry.js";
+import { lighterFill } from "./_agent-scan-fixtures.js";
+import {
+  LIGHTER_MAX_EXPANDED_DECIMALS,
+  lighterAttentionTradeTypeText,
+  lighterChargedAmountText,
+  lighterUsdFullText,
+  lighterDecimalText,
+  lighterEffectLabel,
+  lighterEntryQuoteBeforeText,
+  lighterExchangeFeeText,
+  lighterIntegratorFeeText,
+  lighterKindLabel,
+  lighterLeverageChipText,
+  lighterLeverageDrawerText,
+  lighterObservedAtText,
+  lighterPositionBeforeText,
+  lighterPositionNowLines,
+  lighterRawAmountText,
+  lighterRealizedPnlText,
+  lighterSideLabel,
+  lighterSignedDecimalText,
+  lighterTradeText,
+  lighterTradeTypeLabel,
+  lighterUsdEstimateText,
+  lighterUsdSettledText,
+  lighterVenueLabel,
+} from "../agent-scan/agent-scan-lighter-display.js";
+
+const ASSETS = { base: "ETH", quote: "USDG" } as const;
+
+/** A fixed "now" so the today/not-today branch is deterministic. */
+const NOW = new Date("2026-07-20T18:00:00");
+
+describe("lighter amounts - string arithmetic, never a float", () => {
+  it.each([
+    ["0.0050", "0.0050"],
+    ["2598.09", "2,598.09"],
+    ["1234567.5", "1,234,567.5"],
+    ["-1234.5", "-1,234.5"],
+    ["18412771", "18,412,771"],
+  ])("groups %s as %s and keeps the venue's own precision", (input, expected) => {
+    expect(lighterDecimalText(input)).toBe(expected);
+  });
+
+  it.each([
+    ["12990", 6, "0.012990"],
+    ["4546", 6, "0.004546"],
+    ["1000000000000000000", 18, "1.000000000000000000"],
+    ["12", 0, "12"],
+    ["-4546", 6, "-0.004546"],
+  ])("scales raw %s at %i decimals to %s", (raw, decimals, expected) => {
+    expect(lighterRawAmountText(raw, decimals as number)).toBe(expected);
+  });
+
+  it("refuses a raw value that is not an integer rather than printing a guess", () => {
+    expect(lighterRawAmountText("12.5", 6)).toBeNull();
+    expect(lighterRawAmountText("garbage", 6)).toBeNull();
+  });
+
+  it("scales ANY decimals count - a 37-decimal asset is no reason to hide an amount", () => {
+    // The ledger and the contract put no upper bound on decimals; a cap here
+    // made a recorded charge vanish from the drawer (final review, 2026-09-11).
+    expect(lighterRawAmountText("123", 37)).toBe(`0.${"0".repeat(34)}123`);
+    expect(lighterRawAmountText("1", 60)).toBe(`0.${"0".repeat(59)}1`);
+  });
+
+  it.each([
+    ["0.0050", "+0.0050"],
+    ["-0.0050", "-0.0050"],
+    ["0", "0"],
+    ["0.00", "0.00"],
+  ])("signs %s as %s - zero takes no sign", (input, expected) => {
+    expect(lighterSignedDecimalText(input)).toBe(expected);
+  });
+});
+
+describe("lighter USD - settled versus estimated", () => {
+  it("prints the venue's SETTLED notional plain, with no estimate marker", () => {
+    expect(lighterUsdSettledText("12.990450")).toBe("$12.99");
+    expect(lighterUsdSettledText("12.990450")).not.toContain("est.");
+    expect(lighterUsdSettledText("12.990450")).not.toContain("~");
+  });
+
+  it("TRUNCATES the cents rather than rounding a settled figure up", () => {
+    expect(lighterUsdSettledText("12.999")).toBe("$12.99");
+    expect(lighterUsdSettledText("1234")).toBe("$1,234.00");
+    expect(lighterUsdSettledText("0.5")).toBe("$0.50");
+  });
+
+  it("marks an ESTIMATE and keeps every place it carries (a sub-cent fee is not $0.00)", () => {
+    expect(lighterUsdEstimateText("0.004546")).toBe("~$0.004546 est.");
+  });
+});
+
+describe("lighter labels", () => {
+  it("names the market kind from `spot`", () => {
+    expect(lighterKindLabel(false)).toBe("PERP");
+    expect(lighterKindLabel(true)).toBe("SPOT");
+  });
+
+  it.each([
+    ["open", "OPEN"],
+    ["increase", "INCREASE"],
+    ["reduce", "REDUCE"],
+    ["close", "CLOSE"],
+    ["flip", "FLIP"],
+  ])("labels the %s effect as %s", (effect, expected) => {
+    expect(lighterEffectLabel(effect)).toBe(expected);
+  });
+
+  it("reads a NULL and an `unknown` effect the same way - we do not know", () => {
+    expect(lighterEffectLabel(null)).toBe("UNKNOWN");
+    expect(lighterEffectLabel("unknown")).toBe("UNKNOWN");
+  });
+
+  it("keeps an effect this build predates readable instead of blanking it", () => {
+    expect(lighterEffectLabel("reopen_after_settlement")).toBe("REOPEN_AFTER_SETTLEMENT");
+  });
+
+  it.each([
+    ["buy", "Buy"],
+    ["sell", "Sell"],
+  ])("labels the %s side", (side, expected) => {
+    expect(lighterSideLabel(side)).toBe(expected);
+  });
+
+  it.each([
+    ["core", "Lighter Core"],
+    ["rhc", "Lighter on Robinhood Chain"],
+    ["staging", "staging"],
+  ])("names the %s venue", (environment, expected) => {
+    expect(lighterVenueLabel(environment)).toBe(expected);
+  });
+
+  it.each([
+    ["trade", "Trade"],
+    ["liquidation", "Liquidation"],
+    ["deleverage", "Deleverage"],
+    ["market-settlement", "Market settlement"],
+  ])("names the %s trade type", (tradeType, expected) => {
+    expect(lighterTradeTypeLabel(tradeType)).toBe(expected);
+  });
+
+  it("raises an attention chip ONLY for a fill the user did not place", () => {
+    expect(lighterAttentionTradeTypeText("liquidation")).toBe("liquidation");
+    expect(lighterAttentionTradeTypeText("deleverage")).toBe("deleverage");
+    expect(lighterAttentionTradeTypeText("market-settlement")).toBe("market settlement");
+    expect(lighterAttentionTradeTypeText("trade")).toBeNull();
+  });
+
+  it("writes the executed trade as one sentence", () => {
+    expect(lighterTradeText(lighterFill({ id: "1" }))).toBe("Buy 0.0050 ETH @ 2,598.09");
+  });
+});
+
+describe("lighter leverage - absent is not 1x", () => {
+  it("renders the chip only when the fraction is on the row", () => {
+    expect(lighterLeverageChipText({ initialMarginFraction: 1000, display: "10.00" }))
+      .toBe("10.00x");
+    expect(lighterLeverageChipText(null)).toBeNull();
+  });
+
+  it("says `unknown` in the drawer - never 0x, never the current setting", () => {
+    expect(lighterLeverageDrawerText(null)).toBe("unknown");
+    expect(lighterLeverageDrawerText({ initialMarginFraction: 3334, display: "2.99" }))
+      .toBe("2.99x");
+  });
+});
+
+describe("lighter position facts", () => {
+  it("states the position before the fill, signed, in the base asset", () => {
+    const fill = lighterFill({ id: "1", positionSizeBefore: "-0.0120" });
+    expect(lighterPositionBeforeText(fill)).toBe("-0.0120 ETH");
+  });
+
+  it("says the facts are UNKNOWN on a public row - never 0", () => {
+    const fill = lighterFill({
+      id: "1",
+      positionSizeBefore: null,
+      entryQuoteBefore: null,
+      accountPnl: null,
+      positionEffect: null,
+    });
+    expect(lighterPositionBeforeText(fill)).toBe("position facts unknown");
+    expect(lighterPositionBeforeText(fill)).not.toContain("0");
+    expect(lighterEntryQuoteBeforeText(fill)).toBeNull();
+    expect(lighterRealizedPnlText(fill)).toBeNull();
+  });
+
+  it("shows the entry quote before the fill when the ledger carries it", () => {
+    const fill = lighterFill({ id: "1", entryQuoteBefore: "-12.990450" });
+    expect(lighterEntryQuoteBeforeText(fill)).toBe("-12.990450 USDG");
+  });
+
+  it.each(["reduce", "close", "flip"])(
+    "shows realized PnL on a %s fill",
+    (effect) => {
+      const fill = lighterFill({ id: "1", positionEffect: effect, accountPnl: "-0.4412" });
+      expect(lighterRealizedPnlText(fill)).toBe("-0.4412 USDG");
+    },
+  );
+
+  it.each(["open", "increase"])(
+    "shows NO realized PnL on a %s fill - a 0 there would read as a result",
+    (effect) => {
+      const fill = lighterFill({ id: "1", positionEffect: effect, accountPnl: "0" });
+      expect(lighterRealizedPnlText(fill)).toBeNull();
+    },
+  );
+});
+
+describe("lighter fees - provenance intact", () => {
+  it("prints the CHARGED integrator amount in its own asset when proven", () => {
+    const fill = lighterFill({
+      id: "1",
+      integratorFee: {
+        charged: { raw: "12990", symbol: "USDG", decimals: 6 },
+        estimate: null,
+        tickObserved: 1000,
+        tickAuthorized: 1000,
+      },
+    });
+    const text = lighterIntegratorFeeText(fill.integratorFee);
+    expect(text).toBe("0.012990 USDG");
+    expect(text).not.toContain("est.");
+  });
+
+  it("prints the ESTIMATE with the marker, the basis and the tick it used", () => {
+    const fill = lighterFill({ id: "1" });
+    expect(lighterIntegratorFeeText(fill.integratorFee)).toBe(
+      "~ 0.012990 USDG est., on quote notional, observed tick · ~$0.012990 est.",
+    );
+  });
+
+  it("names an AUTHORIZED tick as its own source", () => {
+    const fill = lighterFill({
+      id: "1",
+      integratorFee: {
+        charged: null,
+        estimate: {
+          raw: "12990",
+          symbol: "USDG",
+          decimals: 6,
+          basis: "received_base",
+          tickSource: "authorized",
+          usd: null,
+        },
+        tickObserved: null,
+        tickAuthorized: 1000,
+      },
+    });
+    expect(lighterIntegratorFeeText(fill.integratorFee)).toBe(
+      "~ 0.012990 USDG est., on the received base, authorized tick",
+    );
+  });
+
+  it("says NOTHING when neither a charge nor an estimate is recorded - never 0", () => {
+    const fill = lighterFill({
+      id: "1",
+      integratorFee: {
+        charged: null,
+        estimate: null,
+        tickObserved: null,
+        tickAuthorized: null,
+      },
+    });
+    expect(lighterIntegratorFeeText(fill.integratorFee)).toBeNull();
+  });
+
+  it("calls a NEGATIVE charged exchange fee a rebate, in words", () => {
+    const fill = lighterFill({
+      id: "1",
+      exchangeFee: {
+        charged: { raw: "-4546", symbol: "USDG", decimals: 6 },
+        estimatedUsd: null,
+        tickObserved: 350,
+      },
+    });
+    expect(lighterExchangeFeeText(fill.exchangeFee)).toBe(
+      "0.004546 USDG rebate (paid to this account)",
+    );
+  });
+
+  it("falls back to the exchange fee's USD estimate, marked as one", () => {
+    const fill = lighterFill({ id: "1" });
+    expect(lighterExchangeFeeText(fill.exchangeFee)).toBe("~$0.004546 est.");
+  });
+
+  it("never trades a RECORDED charge for an estimate: a 37-decimal asset still prints the charge", () => {
+    const integrator = lighterIntegratorFeeText({
+      charged: { raw: "123", symbol: "ASSET", decimals: 37 },
+      estimate: null,
+      tickObserved: null,
+      tickAuthorized: null,
+    });
+    expect(integrator).toBe(`0.${"0".repeat(34)}123 ASSET`);
+    const exchange = lighterExchangeFeeText({
+      charged: { raw: "123", symbol: "ASSET", decimals: 37 },
+      estimatedUsd: "0.01",
+      tickObserved: 350,
+    });
+    expect(exchange).toBe(`0.${"0".repeat(34)}123 ASSET`);
+    expect(exchange).not.toContain("est.");
+  });
+
+  it("states a charge it cannot scale in raw units rather than falling through to the estimate", () => {
+    // Unreachable through the validated contract (the DTO refuses a non-integer
+    // raw), pinned so the fallback can never silently become "use the estimate".
+    const unscalable = { raw: "12.5", symbol: "USDG", decimals: 6 };
+    expect(lighterChargedAmountText(unscalable)).toBe("12.5 raw units at 6 decimals, USDG");
+    expect(
+      lighterExchangeFeeText({ charged: unscalable, estimatedUsd: "0.01", tickObserved: null }),
+    ).toBe("12.5 raw units at 6 decimals, USDG");
+  });
+
+  it("bounds the expanded text: an absurd decimals count states raw units and never throws", () => {
+    // The ledger's INTEGER admits two billion; padding to it threw a
+    // RangeError inside the row (final review round 2). Above the bound the
+    // charge is stated in raw units, with the estimate marker kept on an
+    // estimate; nothing throws and nothing falls through to another figure.
+    const absurd = 2_147_483_647;
+    expect(lighterRawAmountText("123", absurd)).toBeNull();
+    expect(lighterRawAmountText("123", LIGHTER_MAX_EXPANDED_DECIMALS)).not.toBeNull();
+    expect(
+      lighterIntegratorFeeText({
+        charged: { raw: "123", symbol: "ASSET", decimals: absurd },
+        estimate: null,
+        tickObserved: null,
+        tickAuthorized: null,
+      }),
+    ).toBe(`123 raw units at ${absurd} decimals, ASSET`);
+    expect(
+      lighterExchangeFeeText({
+        charged: { raw: "-123", symbol: "ASSET", decimals: absurd },
+        estimatedUsd: "0.01",
+        tickObserved: null,
+      }),
+    ).toBe(`123 raw units at ${absurd} decimals, ASSET rebate (paid to this account)`);
+    expect(
+      lighterIntegratorFeeText({
+        charged: null,
+        estimate: {
+          raw: "123",
+          symbol: "ASSET",
+          decimals: absurd,
+          basis: "quote_notional",
+          tickSource: "observed",
+          usd: null,
+        },
+        tickObserved: null,
+        tickAuthorized: null,
+      }),
+    ).toBe(`~ 123 raw units at ${absurd} decimals ASSET est., on quote notional, observed tick`);
+  });
+
+  it("prints the settled USD whole for the drawer, with no cents cut", () => {
+    expect(lighterUsdFullText("12.990450")).toBe("$12.990450");
+    expect(lighterUsdFullText("1234567.5")).toBe("$1,234,567.5");
+  });
+});
+
+describe("lighter observation time", () => {
+  it("prints the clock alone for an observation made TODAY", () => {
+    expect(lighterObservedAtText("2026-07-20T16:49:00", NOW)).toBe("16:49");
+  });
+
+  it("adds the DATE the moment the observation is not today's", () => {
+    expect(lighterObservedAtText("2026-06-12T16:49:00", NOW)).toBe("Jun 12 · 16:49");
+  });
+
+  it("returns null for an unparseable timestamp rather than a fabricated time", () => {
+    expect(lighterObservedAtText("not-a-date", NOW)).toBeNull();
+  });
+});
+
+describe("lighter position now - four cases", () => {
+  function positionNowOf(
+    overrides: Partial<AgentScanLighterFillEntry>,
+  ): readonly string[] | null {
+    return lighterPositionNowLines(
+      lighterFill({ id: "1", ...overrides }).positionNow,
+      ASSETS,
+      NOW,
+    );
+  }
+
+  it("renders NO block when nothing was ever observed - absence is not `closed`", () => {
+    expect(positionNowOf({ positionNow: null })).toBeNull();
+  });
+
+  it("states a market observed CLOSED, with when it was observed", () => {
+    expect(
+      positionNowOf({
+        positionNow: {
+          observedAt: "2026-07-20T16:49:00",
+          open: false,
+          position: null,
+        },
+      }),
+    ).toEqual(["closed (last observed 16:49)"]);
+  });
+
+  it("states an OPEN position whose stored details could not be read", () => {
+    expect(
+      positionNowOf({
+        positionNow: {
+          observedAt: "2026-07-20T16:49:00",
+          open: true,
+          position: null,
+        },
+      }),
+    ).toEqual(["open, details unavailable (last observed 16:49)"]);
+  });
+
+  it("states every observed figure of an OPEN position, as facts about THEN", () => {
+    expect(
+      positionNowOf({
+        positionNow: {
+          observedAt: "2026-07-20T16:49:00",
+          open: true,
+          position: {
+            size: "0.0050",
+            entryPrice: "2598.09",
+            unrealizedPnl: "-0.0077",
+            realizedPnl: "0",
+            liquidationPrice: "2365.93",
+            leverage: { initialMarginFraction: 1000, display: "10.00" },
+            marginMode: "isolated",
+          },
+        },
+      }),
+    ).toEqual([
+      "+0.0050 ETH (last observed 16:49)",
+      "entry 2,598.09",
+      "unrealized PnL -0.0077 USDG",
+      "realized PnL 0 USDG",
+      "liquidation 2,365.93",
+      "isolated",
+      "10.00x",
+    ]);
+  });
+
+  it("omits each fact the observation lacks, without discarding the ones beside it", () => {
+    expect(
+      positionNowOf({
+        positionNow: {
+          observedAt: "2026-07-20T16:49:00",
+          open: true,
+          position: {
+            size: "-0.0050",
+            entryPrice: null,
+            unrealizedPnl: null,
+            realizedPnl: null,
+            liquidationPrice: null,
+            leverage: null,
+            marginMode: null,
+          },
+        },
+      }),
+    ).toEqual(["-0.0050 ETH (last observed 16:49)"]);
+  });
+});

--- a/vex-app/src/renderer/features/appShell/screens/agent-scan/AgentScanFilterBar.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/agent-scan/AgentScanFilterBar.tsx
@@ -41,6 +41,15 @@ import {
 } from "../../../../stores/uiStore/shell-route.js";
 import { FEED_PROTOCOL_OPTIONS } from "./agent-scan-protocols.js";
 
+/**
+ * The FEED kind that selects the Lighter fill ledger, exactly as
+ * `agentScanFiltersSchema` documents it: a member of the `kinds` list that is
+ * NOT an `agent_activity.kind`, so the engine's kind lockstep gate is
+ * untouched and main routes the second arm on it.
+ */
+const LIGHTER_FILL_KIND = "lighter_fill";
+const LIGHTER_FILL_KIND_LABEL = "Lighter fills";
+
 /** The renderer-side filter selection. `null` means "no constraint". */
 export interface AgentScanFilterState {
   readonly kinds: readonly string[];
@@ -253,6 +262,22 @@ export function AgentScanFilterBar({
             }
           />
         ))}
+        {/* The FEED kind that selects the second ledger. It sits beside the
+          * vocabulary-derived chips and routes identically (`kinds` is an OPEN
+          * bounded list on the contract), but it is deliberately NOT in
+          * `AGENT_ACTIVITY_KINDS`: a venue fill is not an `agent_activity`
+          * kind and adding it there would put a value in the database
+          * vocabulary that no row can ever carry. */}
+        <FilterChip
+          label={LIGHTER_FILL_KIND_LABEL}
+          active={state.kinds.includes(LIGHTER_FILL_KIND)}
+          onToggle={() =>
+            onChange({
+              ...state,
+              kinds: toggleValue(state.kinds, LIGHTER_FILL_KIND),
+            })
+          }
+        />
       </FilterGroup>
 
       <FilterGroup label="Status">

--- a/vex-app/src/renderer/features/appShell/screens/agent-scan/AgentScanLighterRow.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/agent-scan/AgentScanLighterRow.tsx
@@ -1,0 +1,254 @@
+/**
+ * One Agent Scan feed row for a LIGHTER FILL - the venue's own matched trade,
+ * attributed to a Vex order intent, plus its expandable detail.
+ *
+ * WHY A SECOND ROW COMPONENT AND NOT A BRANCH INSIDE `AgentScanRow`. The feed
+ * is ONE time-ordered list over TWO ledgers, and the production pattern for a
+ * heterogeneous list (VS Code's `IListVirtualDelegate.getTemplateId` +
+ * one `IListRenderer` per template id) is exactly this: one list, one renderer
+ * PER KIND chosen by the row's discriminator, never two lists merged in the
+ * view and never one renderer branching on every field. The screen stays the
+ * gate, `buildFeedRows` switches on `entry.source`, and each row component
+ * owns its own grammar.
+ *
+ * THE ROW SAYS WHAT WAS SETTLED. A fill has no lifecycle: the venue matched
+ * it, the economics are final, and there is neither a settlement-chain
+ * transaction nor an explorer link to offer - so this file renders NO link and
+ * NO status chip. What it does render is the one thing a perp row can hide:
+ * that a fill was a LIQUIDATION, a deleverage or a market settlement, which is
+ * the venue acting on the account and not a decision the user made.
+ *
+ * The drawer is always available, because the account half, the fee
+ * provenance and the observed position are the audit answer this surface
+ * exists to give.
+ */
+
+import { useId, useRef, useState, type JSX } from "react";
+import type { AgentScanLighterFillEntry } from "@shared/schemas/agent-scan-lighter-entry.js";
+import { ProtocolMark } from "../../../../components/common/ProtocolMark.js";
+import { resolveProtocolMark } from "../../../../lib/protocol-marks.js";
+import { ActivityChip } from "../../ActivityBadge.js";
+import { ExpandRegion } from "../../../../components/ui/expand-region.js";
+import { entryClockText } from "./agent-scan-display.js";
+import {
+  lighterAttentionTradeTypeText,
+  lighterBlockHeightText,
+  lighterEffectLabel,
+  lighterEntryQuoteBeforeText,
+  lighterExchangeFeeText,
+  lighterIntegratorFeeText,
+  lighterKindLabel,
+  lighterLeverageChipText,
+  lighterLeverageDrawerText,
+  lighterPositionBeforeText,
+  lighterSideLabel,
+  lighterUsdFullText,
+  lighterPositionNowLines,
+  lighterRealizedPnlText,
+  lighterDecimalText,
+  lighterTradeText,
+  lighterTradeTypeLabel,
+  lighterUsdSettledText,
+  lighterVenueLabel,
+} from "./agent-scan-lighter-display.js";
+
+/**
+ * A labelled line in the expanded detail panel. The same grammar
+ * `AgentScanRow` uses for its own drawer; it is duplicated rather than
+ * exported across the two rows because it is four lines of layout with no
+ * behaviour, and a shared "detail line" owner would be a seam with nothing
+ * behind it.
+ */
+function DetailLine({
+  label,
+  children,
+}: {
+  readonly label: string;
+  readonly children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <div className="flex gap-2">
+      <span className="w-[92px] shrink-0 vex-micro-label uppercase text-ink-secondary">
+        {label}
+      </span>
+      <span className="min-w-0 flex-1 text-[11px] leading-relaxed text-ink-secondary">
+        {children}
+      </span>
+    </div>
+  );
+}
+
+export function AgentScanLighterRow({
+  entry,
+}: {
+  readonly entry: AgentScanLighterFillEntry;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const detailId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const protocolMark = resolveProtocolMark("lighter");
+  const clock = entryClockText(entry.createdAt);
+  // A SPOT fill has no position, so it wears no leverage and shows no position
+  // lines anywhere - not "1x", not an empty section.
+  const leverageChip = entry.spot
+    ? null
+    : lighterLeverageChipText(entry.leverage);
+  const attention = lighterAttentionTradeTypeText(entry.tradeType);
+  const integratorFee = lighterIntegratorFeeText(entry.integratorFee);
+  const exchangeFee = lighterExchangeFeeText(entry.exchangeFee);
+  const realizedPnl = entry.spot ? null : lighterRealizedPnlText(entry);
+  const entryQuoteBefore = entry.spot ? null : lighterEntryQuoteBeforeText(entry);
+  const positionNowLines = entry.spot
+    ? null
+    : lighterPositionNowLines(entry.positionNow, {
+        base: entry.baseAsset.symbol,
+        quote: entry.quoteAsset.symbol,
+      });
+
+  // A plain <div>: the virtualized feed owns the <ul>/<li> structure, because
+  // each row must sit in an absolutely-positioned measured wrapper.
+  return (
+    <div className="border-b border-line-2 px-1 py-2">
+      <div className="flex items-center gap-2">
+        <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+          <ProtocolMark mark={protocolMark} size={14} />
+        </span>
+        {/* The `ActivityBadge` chrome with LIGHTER's vocabulary: that
+          * component's records are typed total over the `agent_activity`
+          * database vocabulary, and a venue fill is not one of its rows. */}
+        <ActivityChip
+          tone="solid"
+          text={`${lighterKindLabel(entry.spot)}·${lighterEffectLabel(entry.positionEffect)}`}
+        />
+        {attention !== null ? (
+          // NOT a decision the user made. The word carries it, not the hue.
+          <ActivityChip
+            tone="accent"
+            text={attention}
+            title="The venue acted on this account - this fill was not a trade the user placed."
+          />
+        ) : null}
+
+        {/* The line may be clipped by the row's width; the title carries the
+          * sentence whole and the drawer below repeats every figure on its own
+          * wrapping line, so a narrow window hides nothing. */}
+        <span className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden whitespace-nowrap font-mono text-[11.5px] leading-none text-ink-primary">
+          <span className="truncate" title={lighterTradeText(entry)}>{lighterTradeText(entry)}</span>
+        </span>
+
+        {/* SETTLED, not estimated: the venue's own USD notional for the match.
+          * The title carries the figure whole, so the two-decimal cell hides
+          * nothing. */}
+        <span
+          title={entry.usdAmount}
+          className="shrink-0 font-mono text-[11.5px] tabular-nums text-ink-primary"
+        >
+          {lighterUsdSettledText(entry.usdAmount)}
+        </span>
+        {leverageChip !== null ? (
+          <ActivityChip tone="paper" text={leverageChip} title="Leverage before this fill" />
+        ) : null}
+      </div>
+
+      <div className="mt-1 flex items-center gap-2 pl-[22px] font-mono text-[10px] tabular-nums text-ink-tertiary">
+        {clock !== null ? <span className="shrink-0">{clock}</span> : null}
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-controls={detailId}
+          aria-label={`${open ? "Hide" : "Show"} details for this fill`}
+          className="ml-auto shrink-0 uppercase tracking-[0.14em] transition-colors hover:text-ink-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
+        >
+          {open ? "Hide" : "Details"}
+        </button>
+      </div>
+
+      <ExpandRegion
+        id={detailId}
+        open={open}
+        triggerRef={triggerRef}
+        className="mt-2 flex flex-col gap-1.5 rounded-xl border border-line-1 bg-surface-1 px-3 py-2.5"
+      >
+        {/* THE SETTLED ECONOMICS, WHOLE. The feed line clips to the row's
+          * width and truncates the cents; these lines wrap, so every figure
+          * the venue recorded is readable at any width. */}
+        <DetailLine label="Side">{lighterSideLabel(entry.side)}</DetailLine>
+        <DetailLine label="Size">
+          <span className="break-all">
+            {lighterDecimalText(entry.baseSize)} {entry.baseAsset.symbol}
+          </span>
+        </DetailLine>
+        <DetailLine label="Price">
+          <span className="break-all">
+            {lighterDecimalText(entry.price)} {entry.quoteAsset.symbol}
+          </span>
+        </DetailLine>
+        <DetailLine label="Quote notional">
+          <span className="break-all">
+            {lighterDecimalText(entry.quoteNotional)} {entry.quoteAsset.symbol}
+          </span>
+        </DetailLine>
+        <DetailLine label="USD">
+          <span className="break-all">{lighterUsdFullText(entry.usdAmount)}</span>
+        </DetailLine>
+        {entry.spot ? null : (
+          <DetailLine label="Effect">{lighterEffectLabel(entry.positionEffect)}</DetailLine>
+        )}
+        {entry.spot ? null : (
+          <DetailLine label="Position before">
+            {lighterPositionBeforeText(entry)}
+          </DetailLine>
+        )}
+        {entryQuoteBefore !== null ? (
+          <DetailLine label="Entry quote before">{entryQuoteBefore}</DetailLine>
+        ) : null}
+        {realizedPnl !== null ? (
+          <DetailLine label="Realized PnL">{realizedPnl}</DetailLine>
+        ) : null}
+        {entry.spot ? null : (
+          // A HISTORICAL fact. `unknown` when the ledger holds this row without
+          // the fraction - never the account's current setting.
+          <DetailLine label="Leverage">
+            {lighterLeverageDrawerText(entry.leverage)}
+          </DetailLine>
+        )}
+        {integratorFee !== null ? (
+          <DetailLine label="Vex fee">{integratorFee}</DetailLine>
+        ) : null}
+        {exchangeFee !== null ? (
+          <DetailLine label="Exchange fee">{exchangeFee}</DetailLine>
+        ) : null}
+        <DetailLine label="Trade type">{lighterTradeTypeLabel(entry.tradeType)}</DetailLine>
+        <DetailLine label="Venue">{lighterVenueLabel(entry.environment)}</DetailLine>
+        <DetailLine label="Block">
+          <span className="font-mono text-[10px]">
+            {lighterBlockHeightText(entry.blockHeight)}
+          </span>
+        </DetailLine>
+        {entry.providerOrderId !== null ? (
+          <DetailLine label="Order">
+            <span className="font-mono text-[10px]">{entry.providerOrderId}</span>
+          </DetailLine>
+        ) : null}
+        <DetailLine label="Trade id">
+          <span className="font-mono text-[10px]">{entry.providerTradeId}</span>
+        </DetailLine>
+        <DetailLine label="Intent">
+          <span className="font-mono text-[10px]">{entry.intentId}</span>
+        </DetailLine>
+        {positionNowLines !== null ? (
+          <DetailLine label="Position now">
+            <span className="flex flex-wrap items-baseline gap-x-2">
+              {positionNowLines.map((line) => (
+                <span key={line}>{line}</span>
+              ))}
+            </span>
+          </DetailLine>
+        ) : null}
+      </ExpandRegion>
+    </div>
+  );
+}

--- a/vex-app/src/renderer/features/appShell/screens/agent-scan/AgentScanRow.tsx
+++ b/vex-app/src/renderer/features/appShell/screens/agent-scan/AgentScanRow.tsx
@@ -1,6 +1,8 @@
 /**
- * One Agent Scan feed row — the LOGICAL activity (never a per-leg row) plus
- * its expandable audit detail.
+ * One Agent Scan feed row for an AGENT_ACTIVITY entry - the LOGICAL activity
+ * (never a per-leg row) plus its expandable audit detail. The feed's second
+ * arm (a Lighter fill) is rendered by `AgentScanLighterRow`: one list, one
+ * renderer per kind, chosen by the entry's `source` discriminator.
  *
  * The row: protocol mark · ActivityBadge (kind·role + attention status) ·
  * `IN → OUT` legs · USD estimate · chain/route · time · TX↗.
@@ -21,7 +23,7 @@
 
 import { useId, useRef, useState, type JSX } from "react";
 import { IconArrowUpRight } from "../../../../components/icons/index.js";
-import type { AgentScanEntry } from "@shared/schemas/agent-scan-feed.js";
+import type { AgentScanActivityEntry } from "@shared/schemas/agent-scan-feed.js";
 import { isBridgeTrackingStale } from "@shared/bridge-tracking.js";
 import { ProtocolMark } from "../../../../components/common/ProtocolMark.js";
 import { resolveProtocolMark } from "../../../../lib/protocol-marks.js";
@@ -80,7 +82,11 @@ function DetailLine({
   );
 }
 
-export function AgentScanRow({ entry }: { readonly entry: AgentScanEntry }): JSX.Element {
+export function AgentScanRow({
+  entry,
+}: {
+  readonly entry: AgentScanActivityEntry;
+}): JSX.Element {
   const [open, setOpen] = useState(false);
   const detailId = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);

--- a/vex-app/src/renderer/features/appShell/screens/agent-scan/agent-scan-display.ts
+++ b/vex-app/src/renderer/features/appShell/screens/agent-scan/agent-scan-display.ts
@@ -1,6 +1,12 @@
 /**
- * Agent Scan field display — the honest readers that turn one
- * `AgentScanEntry` field into the exact text a row prints.
+ * Agent Scan field display - the honest readers that turn one
+ * `AgentScanActivityEntry` field into the exact text a row prints.
+ *
+ * THE ACTIVITY ARM ONLY. The feed's second arm (`lighter_fill`) has its own
+ * vocabulary, its own invariants and its own readers in
+ * `agent-scan-lighter-display.ts`; the timestamp and day-bucket helpers at the
+ * bottom of this file are the only ones both arms share, because a feed time
+ * is a feed time whichever ledger wrote it.
  *
  * The rules this file enforces, all of them contract obligations documented on
  * `shared/schemas/agent-scan-feed.ts`:
@@ -22,7 +28,7 @@
  */
 
 import type {
-  AgentScanEntry,
+  AgentScanActivityEntry,
   AgentScanTokenLeg,
 } from "@shared/schemas/agent-scan-feed.js";
 import { formatClock, formatUsd, truncateAddress } from "../../../../lib/format.js";
@@ -54,7 +60,7 @@ export function legAmountText(leg: AgentScanTokenLeg): string | null {
 }
 
 /** True when this row's shown amounts are QUOTED, not independently verified. */
-export function isEstimatedBasis(entry: AgentScanEntry): boolean {
+export function isEstimatedBasis(entry: AgentScanActivityEntry): boolean {
   return entry.amountBasis === "estimated";
 }
 
@@ -63,7 +69,7 @@ export function isEstimatedBasis(entry: AgentScanEntry): boolean {
  * rendered with the `~ … est.` marker because this feed carries no
  * settlement-time USD at all. `null` when unpriced — never a fabricated $0.00.
  */
-export function primaryUsdEstText(entry: AgentScanEntry): string | null {
+export function primaryUsdEstText(entry: AgentScanActivityEntry): string | null {
   const raw = entry.output.usdEst ?? entry.input.usdEst;
   if (raw === null) return null;
   const parsed = Number.parseFloat(raw);
@@ -83,7 +89,7 @@ export function usdEstText(value: string | null): string | null {
  * the resolved endpoints; everything else names its own chain. Empty when the
  * DTO carries no chain text at all — the row simply omits the segment.
  */
-export function chainRouteText(entry: AgentScanEntry): string | null {
+export function chainRouteText(entry: AgentScanActivityEntry): string | null {
   const from = entry.fromChain?.slug ?? null;
   const to = entry.toChain?.slug ?? null;
   if (from !== null && to !== null && from.length > 0 && to.length > 0) {
@@ -135,7 +141,7 @@ export function timestampText(iso: string): string | null {
  * own state is named instead of the row falling silent about a charge the user
  * may still be paying. `null` only when the row records no fee attempt at all.
  */
-export function vexFeeText(entry: AgentScanEntry): string | null {
+export function vexFeeText(entry: AgentScanActivityEntry): string | null {
   const fee = entry.vexFee;
   if (fee === null) return null;
   const amount = fee.amountHuman === null ? null : amountDisplay(fee.amountHuman, true);

--- a/vex-app/src/renderer/features/appShell/screens/agent-scan/agent-scan-lighter-display.ts
+++ b/vex-app/src/renderer/features/appShell/screens/agent-scan/agent-scan-lighter-display.ts
@@ -1,0 +1,504 @@
+/**
+ * Lighter fill display - the honest readers that turn one
+ * `AgentScanLighterFillEntry` field into the exact text the Lighter row
+ * prints.
+ *
+ * WHY THIS IS A SIBLING OF `agent-scan-display.ts` AND NOT A SECTION OF IT.
+ * That module reads the `agent_activity` arm: token legs, a quote-time USD
+ * estimate, a chain route, an explorer link. This arm has none of those. Its
+ * vocabulary (side, position effect, trade type, venue, fee provenance,
+ * observed position) and its invariants (settled economics, no lifecycle, no
+ * transaction) are the fill ledger's, not the activity ledger's, and they
+ * change for their own reasons - a new ledger column, a new provider fact.
+ * One module per view, exactly as the feed's two entry schemas are one file
+ * each.
+ *
+ * THE RULES THIS FILE ENFORCES, all of them contract obligations documented on
+ * `shared/schemas/agent-scan-lighter-entry.ts`:
+ *
+ *  - MONEY IS STRING ARITHMETIC. Not one figure here passes through `Number`,
+ *    `parseFloat` or `toFixed`. Every amount arrives as a decimal or integer
+ *    STRING from the venue's own ledger, and grouping, sign and scale are done
+ *    on the characters. A float round-trip of a base-unit integer is exactly
+ *    the defect rule 90 forbids on a money path.
+ *  - SETTLED IS NOT ESTIMATED. `usdAmount` is the venue's own settled USD
+ *    notional for the match, so it prints as a plain `$12.99` and NEVER wears
+ *    the `~ ... est.` marker the activity arm's quote-time figures wear. A fee
+ *    ESTIMATE does wear it, together with the basis and the tick it used.
+ *  - UNKNOWN IS NOT ZERO. A null account half is "position facts unknown", a
+ *    null leverage is "unknown", an unproven charged fee is absent - never 0,
+ *    never a current value passed off as a historical one.
+ *  - TOLERANT READER. `side`, `positionEffect`, `tradeType`, `environment`,
+ *    `marginMode` and the fee `basis`/`tickSource` are bounded OPEN strings. A
+ *    value this build predates renders as its own bounded text rather than
+ *    blanking the row.
+ *
+ * The labels below are LIGHTER's presentation vocabulary and deliberately do
+ * NOT touch `ActivityBadge`'s records: those are typed TOTAL over the
+ * canonical `agent_activity` database vocabulary, and a fill is not an
+ * `agent_activity` row. The Lighter row wears the same chip primitive
+ * (`ActivityChip`) with labels resolved here, so the chrome is shared and the
+ * vocabulary is not.
+ */
+
+import type {
+  AgentScanLighterFillEntry,
+  AgentScanLighterPositionNow,
+} from "@shared/schemas/agent-scan-lighter-entry.js";
+
+/**
+ * The entry's own field types. The contract module exports schemas for these
+ * three but only two inferred TYPES (`AgentScanLighterFillEntry`,
+ * `AgentScanLighterPositionNow`), so they are projected off the entry rather
+ * than re-inferred here: a re-inference would be a SECOND definition of a
+ * shared contract, and these stay exactly whatever the schema says.
+ */
+type AgentScanLighterLeverage = NonNullable<AgentScanLighterFillEntry["leverage"]>;
+type AgentScanLighterIntegratorFee = AgentScanLighterFillEntry["integratorFee"];
+type AgentScanLighterExchangeFee = AgentScanLighterFillEntry["exchangeFee"];
+
+/**
+ * Hard bound on any tolerant vocabulary string reaching the layout. The DTO
+ * already caps these fields; this is the presentation's own guarantee,
+ * independent of what a migration decides to send. It is a LABEL bound only -
+ * amounts, identifiers and the block height are never bounded here.
+ */
+const MAX_VOCAB_CHARS = 24;
+
+/** Effects after which the account realized something on this fill. */
+const REALIZING_EFFECTS: ReadonlySet<string> = new Set(["reduce", "close", "flip"]);
+
+/** Trade types that are NOT the user's own trade and must say so on the row. */
+const ATTENTION_TRADE_TYPES: Readonly<Record<string, string>> = {
+  liquidation: "liquidation",
+  deleverage: "deleverage",
+  "market-settlement": "market settlement",
+};
+
+const UNSIGNED_INTEGER = /^[0-9]+$/;
+const SIGNED_INTEGER = /^-?[0-9]+$/;
+const ZERO_DECIMAL = /^-?0*(\.0*)?$/;
+
+/** Trimmed, lower-cased lookup key; null for an absent or blank value. */
+function vocabularyKey(value: string | null): string | null {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed.toLowerCase();
+}
+
+/** An unrecognised vocabulary value, kept readable and bounded. */
+function rawVocabularyText(key: string): string {
+  return key.slice(0, MAX_VOCAB_CHARS);
+}
+
+/**
+ * Thousands separators on the integer part, the fraction preserved EXACTLY as
+ * the ledger wrote it (trailing zeros included: `0.0050` is the venue's own
+ * precision and rewriting it to `0.005` would restate the fill). Pure string
+ * work - a `Number` round-trip here is what loses a base-unit integer.
+ */
+export function lighterDecimalText(value: string): string {
+  const negative = value.startsWith("-");
+  const body = negative ? value.slice(1) : value;
+  const pointAt = body.indexOf(".");
+  const whole = pointAt === -1 ? body : body.slice(0, pointAt);
+  const fraction = pointAt === -1 ? null : body.slice(pointAt + 1);
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  const text = fraction === null ? grouped : `${grouped}.${fraction}`;
+  return negative ? `-${text}` : text;
+}
+
+/**
+ * A SIGNED figure with its sign always visible: `+0.0050`, `-0.0050`, `0`.
+ * A position size or a PnL whose sign is implicit reads as the wrong
+ * direction, and zero takes no sign because it has none.
+ */
+export function lighterSignedDecimalText(value: string): string {
+  if (value.startsWith("-")) return lighterDecimalText(value);
+  if (ZERO_DECIMAL.test(value)) return lighterDecimalText(value);
+  return `+${lighterDecimalText(value)}`;
+}
+
+/**
+ * A raw base-unit integer scaled by its asset's decimals, as a STRING. The
+ * fraction keeps every decimal place the asset declares (`12990` at 6
+ * decimals is `0.012990`), because a fee is not more honest for being shorter.
+ * Any decimals count a venue asset could plausibly declare is scaled (37 and
+ * 60 are covered by tests; the cap of 36 that once lived here made a recorded
+ * charge vanish from the screen). The EXPANDED text is bounded at
+ * `LIGHTER_MAX_EXPANDED_DECIMALS` places: the ledger stores decimals as a
+ * PostgreSQL INTEGER, so a count of two billion validates, and padding to it
+ * would throw `RangeError: Invalid string length` inside the row. `null` when
+ * the pair is not something we can scale (a raw value that is not an integer,
+ * a negative or absurd decimals count); the callers then state the raw units
+ * rather than printing a figure nobody can trust, and never throw.
+ */
+export const LIGHTER_MAX_EXPANDED_DECIMALS = 256;
+
+export function lighterRawAmountText(raw: string, decimals: number): string | null {
+  if (!SIGNED_INTEGER.test(raw)) return null;
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > LIGHTER_MAX_EXPANDED_DECIMALS) {
+    return null;
+  }
+  const negative = raw.startsWith("-");
+  const digits = negative ? raw.slice(1) : raw;
+  if (decimals === 0) {
+    const whole = digits.replace(/^0+(?=\d)/, "");
+    return `${negative ? "-" : ""}${lighterDecimalText(whole)}`;
+  }
+  const padded = digits.padStart(decimals + 1, "0");
+  const whole = padded.slice(0, padded.length - decimals).replace(/^0+(?=\d)/, "");
+  const fraction = padded.slice(padded.length - decimals);
+  return `${negative ? "-" : ""}${lighterDecimalText(`${whole}.${fraction}`)}`;
+}
+
+/**
+ * The venue's own SETTLED USD notional for the match: plain `$12.99`, NO
+ * estimate marker (this feed's activity arm carries only quote-time USD; this
+ * arm carries the provider's settled figure and must not be dressed as a
+ * guess).
+ *
+ * The cents are TRUNCATED, never rounded: the same discipline
+ * `initialMarginFractionToLeverageDisplay` applies to leverage, and the one
+ * that cannot make a settled figure grow by a cent on screen. The full value
+ * is never hidden - the row carries it as the cell's title.
+ */
+export function lighterUsdSettledText(usd: string): string {
+  const pointAt = usd.indexOf(".");
+  const whole = pointAt === -1 ? usd : usd.slice(0, pointAt);
+  const fraction = pointAt === -1 ? "" : usd.slice(pointAt + 1);
+  return `$${lighterDecimalText(whole)}.${`${fraction}00`.slice(0, 2)}`;
+}
+
+/**
+ * A USD ESTIMATE, with the feed's existing `~ ... est.` marker and with every
+ * decimal place the estimate carries - a sub-cent fee estimate rounded to
+ * `$0.00` would state that nothing was charged.
+ */
+export function lighterUsdEstimateText(usd: string): string {
+  return `~$${lighterDecimalText(usd)} est.`;
+}
+
+/** `PERP` or `SPOT` - the kind segment of the Lighter row's badge. */
+export function lighterKindLabel(spot: boolean): string {
+  return spot ? "SPOT" : "PERP";
+}
+
+const EFFECT_LABEL: Readonly<Record<string, string>> = {
+  open: "OPEN",
+  increase: "INCREASE",
+  reduce: "REDUCE",
+  close: "CLOSE",
+  flip: "FLIP",
+};
+
+/**
+ * The role segment: what this fill did to the position. A public row
+ * (`null`) and the ledger's own `unknown` are the SAME fact - we do not know -
+ * and both read `UNKNOWN` rather than a confident effect nobody established.
+ */
+export function lighterEffectLabel(positionEffect: string | null): string {
+  const key = vocabularyKey(positionEffect);
+  if (key === null) return "UNKNOWN";
+  return EFFECT_LABEL[key] ?? rawVocabularyText(key).toUpperCase();
+}
+
+const SIDE_LABEL: Readonly<Record<string, string>> = { buy: "Buy", sell: "Sell" };
+
+/** `Buy` / `Sell`; an unrecognised side keeps its own bounded text. */
+export function lighterSideLabel(side: string): string {
+  const key = vocabularyKey(side);
+  if (key === null) return "-";
+  return SIDE_LABEL[key] ?? rawVocabularyText(key);
+}
+
+/** `Buy 0.0050 ETH @ 2,598.09` - the row's executed-trade sentence. */
+export function lighterTradeText(entry: AgentScanLighterFillEntry): string {
+  return (
+    `${lighterSideLabel(entry.side)} ${lighterDecimalText(entry.baseSize)}`
+    + ` ${entry.baseAsset.symbol} @ ${lighterDecimalText(entry.price)}`
+  );
+}
+
+/** The compact sidebar line: `Buy 0.0050 ETH`, without the price. */
+export function lighterCompactTradeText(entry: AgentScanLighterFillEntry): string {
+  return (
+    `${lighterSideLabel(entry.side)} ${lighterDecimalText(entry.baseSize)}`
+    + ` ${entry.baseAsset.symbol}`
+  );
+}
+
+/**
+ * The leverage chip: `10.00x`, or NOTHING when the ledger holds this row
+ * without the fraction. Not `1x`, not `-`: an absent historical leverage is
+ * not a leverage of one, and a chip is a claim.
+ */
+export function lighterLeverageChipText(
+  leverage: AgentScanLighterLeverage | null,
+): string | null {
+  return leverage === null ? null : `${leverage.display}x`;
+}
+
+/**
+ * Leverage BEFORE the fill, for the drawer, where the absence itself is worth
+ * a line: `unknown` - never `0x`, and never the account's CURRENT setting,
+ * which is a fact about now and not about then.
+ */
+export function lighterLeverageDrawerText(
+  leverage: AgentScanLighterLeverage | null,
+): string {
+  return leverage === null ? "unknown" : `${leverage.display}x`;
+}
+
+const TRADE_TYPE_LABEL: Readonly<Record<string, string>> = {
+  trade: "Trade",
+  liquidation: "Liquidation",
+  deleverage: "Deleverage",
+  "market-settlement": "Market settlement",
+};
+
+/** Drawer label for the trade type; an unknown type keeps its bounded text. */
+export function lighterTradeTypeLabel(tradeType: string): string {
+  const key = vocabularyKey(tradeType);
+  if (key === null) return "unknown";
+  return TRADE_TYPE_LABEL[key] ?? rawVocabularyText(key);
+}
+
+/**
+ * The attention chip for a fill the USER DID NOT CHOOSE. A liquidation, a
+ * deleverage and a market settlement are the venue acting on the account, and
+ * a row that renders them like an ordinary trade tells the user they made a
+ * decision they never made. `null` for an ordinary trade.
+ */
+export function lighterAttentionTradeTypeText(tradeType: string): string | null {
+  const key = vocabularyKey(tradeType);
+  if (key === null) return null;
+  return ATTENTION_TRADE_TYPES[key] ?? null;
+}
+
+const VENUE_LABEL: Readonly<Record<string, string>> = {
+  core: "Lighter Core",
+  rhc: "Lighter on Robinhood Chain",
+};
+
+/** Which Lighter deployment this fill happened on. */
+export function lighterVenueLabel(environment: string): string {
+  const key = vocabularyKey(environment);
+  if (key === null) return "unknown";
+  return VENUE_LABEL[key] ?? rawVocabularyText(key);
+}
+
+/**
+ * The position this fill acted on, BEFORE it. `null` for the whole account
+ * half means the observation was a public trade row: say so, because a `0`
+ * here would state the account was flat.
+ */
+export function lighterPositionBeforeText(
+  entry: AgentScanLighterFillEntry,
+): string {
+  if (entry.positionSizeBefore === null) return "position facts unknown";
+  return `${lighterSignedDecimalText(entry.positionSizeBefore)} ${entry.baseAsset.symbol}`;
+}
+
+/** The account's quote exposure before the fill, when the ledger carries it. */
+export function lighterEntryQuoteBeforeText(
+  entry: AgentScanLighterFillEntry,
+): string | null {
+  if (entry.entryQuoteBefore === null) return null;
+  return `${lighterSignedDecimalText(entry.entryQuoteBefore)} ${entry.quoteAsset.symbol}`;
+}
+
+/**
+ * Realized PnL, shown ONLY on the effects that can realize anything
+ * (`reduce`, `close`, `flip`). An `open` or `increase` fill realizes nothing,
+ * and a `0` beside it would read as a result rather than as an absence.
+ */
+export function lighterRealizedPnlText(
+  entry: AgentScanLighterFillEntry,
+): string | null {
+  const effect = vocabularyKey(entry.positionEffect);
+  if (effect === null || !REALIZING_EFFECTS.has(effect)) return null;
+  if (entry.accountPnl === null) return null;
+  return `${lighterSignedDecimalText(entry.accountPnl)} ${entry.quoteAsset.symbol}`;
+}
+
+const FEE_BASIS_LABEL: Readonly<Record<string, string>> = {
+  quote_notional: "on quote notional",
+  received_base: "on the received base",
+};
+
+const FEE_TICK_SOURCE_LABEL: Readonly<Record<string, string>> = {
+  observed: "observed tick",
+  authorized: "authorized tick",
+};
+
+function feeBasisText(basis: string): string {
+  const key = vocabularyKey(basis);
+  if (key === null) return "on an unnamed basis";
+  return FEE_BASIS_LABEL[key] ?? `on ${rawVocabularyText(key)}`;
+}
+
+function feeTickSourceText(tickSource: string): string {
+  const key = vocabularyKey(tickSource);
+  if (key === null) return "tick source unknown";
+  return FEE_TICK_SOURCE_LABEL[key] ?? `${rawVocabularyText(key)} tick`;
+}
+
+/**
+ * The Vex integrator fee with its PROVENANCE intact: the provider's exact
+ * charged amount when it is proven, otherwise this fill's own estimate WITH
+ * the `~ ... est.` marker, the basis it was computed on and the tick it used.
+ * The two are never added and an unproven charge is never printed as `0`.
+ *
+ * `null` when the ledger holds neither - the drawer then says nothing about a
+ * fee rather than inventing one.
+ */
+export function lighterIntegratorFeeText(
+  fee: AgentScanLighterIntegratorFee,
+): string | null {
+  // A RECORDED charge is never traded for an estimate: when it cannot be
+  // scaled, the line states its raw units instead of falling through.
+  if (fee.charged !== null) return lighterChargedAmountText(fee.charged);
+  const estimate = fee.estimate;
+  if (estimate === null) return null;
+  // An estimate that cannot be scaled keeps its marker and states its raw
+  // units: the marker is the provenance, and dropping the line would read as
+  // "no fee".
+  const amount =
+    lighterRawAmountText(estimate.raw, estimate.decimals)
+    ?? `${estimate.raw} raw units at ${estimate.decimals} decimals`;
+  const head =
+    `~ ${amount} ${estimate.symbol} est., ${feeBasisText(estimate.basis)}`
+    + `, ${feeTickSourceText(estimate.tickSource)}`;
+  return estimate.usd === null
+    ? head
+    : `${head} · ${lighterUsdEstimateText(estimate.usd)}`;
+}
+
+/**
+ * The exchange's own tier fee, in the asset the venue charged it in. A
+ * NEGATIVE charged amount is a REBATE - the account was paid - and the line
+ * says so in words, because a leading minus beside a fee label reads as a
+ * cheaper fee rather than as money arriving.
+ */
+export function lighterExchangeFeeText(
+  fee: AgentScanLighterExchangeFee,
+): string | null {
+  if (fee.charged !== null) {
+    const rebate = fee.charged.raw.startsWith("-");
+    const magnitude = rebate
+      ? { ...fee.charged, raw: fee.charged.raw.slice(1) }
+      : fee.charged;
+    // A RECORDED charge (or rebate) is never traded for the USD estimate.
+    const amount = lighterChargedAmountText(magnitude);
+    return rebate ? `${amount} rebate (paid to this account)` : amount;
+  }
+  return fee.estimatedUsd === null
+    ? null
+    : lighterUsdEstimateText(fee.estimatedUsd);
+}
+
+/**
+ * A charged amount as `0.012990 USDG`, or - when the pair cannot be scaled -
+ * its raw units stated as such (`123 raw units at 37 decimals, USDG`), so a
+ * recorded charge is always on screen in SOME honest form and never replaced
+ * by an estimate or by silence.
+ */
+export function lighterChargedAmountText(charged: {
+  readonly raw: string;
+  readonly symbol: string;
+  readonly decimals: number;
+}): string {
+  const amount = lighterRawAmountText(charged.raw, charged.decimals);
+  if (amount !== null) return `${amount} ${charged.symbol}`;
+  return `${charged.raw} raw units at ${charged.decimals} decimals, ${charged.symbol}`;
+}
+
+/** The fill's settled figures for the drawer, WHOLE: no cents cut, no width limit. */
+export function lighterUsdFullText(usd: string): string {
+  return `$${lighterDecimalText(usd)}`;
+}
+
+/**
+ * When Vex LAST OBSERVED the market, for the position-now block: `16:49` on
+ * the same day, `Jun 12 · 16:49` otherwise. The date appears the moment the
+ * observation is not today's, because "16:49" on a three-week-old reading
+ * would be read as minutes ago.
+ *
+ * `now` is injectable so the "is it today" branch is a deterministic test
+ * rather than a clock race at midnight.
+ */
+export function lighterObservedAtText(
+  iso: string,
+  now: Date = new Date(),
+): string | null {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  const clock = `${hh}:${mm}`;
+  const sameDay =
+    date.getFullYear() === now.getFullYear()
+    && date.getMonth() === now.getMonth()
+    && date.getDate() === now.getDate();
+  if (sameDay) return clock;
+  const day = date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return `${day} · ${clock}`;
+}
+
+/**
+ * The newest observed state of this fill's market, as lines. FOUR cases, and
+ * the first of them is the reason this returns `null` rather than an empty
+ * array: no observation at all means the drawer shows NO position-now block,
+ * which is a different statement from "closed".
+ *
+ *  - `null`                       -> `null` (no block: nothing was observed)
+ *  - `open: false`                -> closed, with the observation time
+ *  - `open: true`, `position: null` -> open, details unavailable
+ *  - `open: true`, with details   -> the figures, each one independently
+ *                                    omitted when the observation lacks it
+ *
+ * Every line is a fact about THEN, which is why the observation time rides the
+ * first line rather than being left to the reader to assume.
+ */
+export function lighterPositionNowLines(
+  positionNow: AgentScanLighterPositionNow | null,
+  assets: { readonly base: string; readonly quote: string },
+  now: Date = new Date(),
+): readonly string[] | null {
+  if (positionNow === null) return null;
+  const observed = lighterObservedAtText(positionNow.observedAt, now);
+  const stamp = observed === null ? "" : ` (last observed ${observed})`;
+  if (!positionNow.open) return [`closed${stamp}`];
+  const position = positionNow.position;
+  if (position === null) return [`open, details unavailable${stamp}`];
+
+  const lines: string[] = [
+    `${lighterSignedDecimalText(position.size)} ${assets.base}${stamp}`,
+  ];
+  if (position.entryPrice !== null) {
+    lines.push(`entry ${lighterDecimalText(position.entryPrice)}`);
+  }
+  if (position.unrealizedPnl !== null) {
+    lines.push(
+      `unrealized PnL ${lighterSignedDecimalText(position.unrealizedPnl)} ${assets.quote}`,
+    );
+  }
+  if (position.realizedPnl !== null) {
+    lines.push(
+      `realized PnL ${lighterSignedDecimalText(position.realizedPnl)} ${assets.quote}`,
+    );
+  }
+  if (position.liquidationPrice !== null) {
+    lines.push(`liquidation ${lighterDecimalText(position.liquidationPrice)}`);
+  }
+  const marginMode = vocabularyKey(position.marginMode);
+  if (marginMode !== null) lines.push(rawVocabularyText(marginMode));
+  if (position.leverage !== null) lines.push(`${position.leverage.display}x`);
+  return lines;
+}
+
+/** The venue block height that matched this fill. Never grouped: it is an id-like figure. */
+export function lighterBlockHeightText(blockHeight: string): string {
+  return UNSIGNED_INTEGER.test(blockHeight) ? blockHeight : "-";
+}

--- a/vex-app/src/renderer/features/appShell/screens/agent-scan/agent-scan-protocols.ts
+++ b/vex-app/src/renderer/features/appShell/screens/agent-scan/agent-scan-protocols.ts
@@ -23,6 +23,15 @@
  *                         writes `agent_activity` directly, same staged path as
  *                         Jupiter Lend
  *   pools               — pools.fun launches and fee claims (Robinhood Chain)
+ *   lighter             - BOTH arms write it: the `exchange` deposit and
+ *                         withdrawal rows in `agent_activity`
+ *                         (`agentscan-activity.ts` stamps `protocol:
+ *                         "lighter"`) and the venue's own matched fills, which
+ *                         reach this feed through its SECOND ledger
+ *                         (`lighter_fills`, migration 152). The rule above is
+ *                         unchanged by that: the option exists because things
+ *                         really do write rows this feed can show, which is
+ *                         the only test an option has to pass.
  *   khalani · relay     — bridge executors
  *
  * `pools` joined the list in Phase 3, WITH the launch and claim executors that
@@ -62,6 +71,7 @@ export const KNOWN_FEED_PROTOCOLS = [
   "trench",
   "morpho",
   "pools",
+  "lighter",
   "khalani",
   "relay",
 ] as const;

--- a/vex-app/src/renderer/features/wizard/WizardStepPanel.tsx
+++ b/vex-app/src/renderer/features/wizard/WizardStepPanel.tsx
@@ -42,6 +42,7 @@ import {
   WIZARD_STEP_IDS,
   type WizardStepId,
 } from "@shared/schemas/wizard.js";
+import { VEX_PRIVACY_DOC_LABEL, VEX_PRIVACY_DOC_URL } from "@shared/docs-links.js";
 
 import type { WizardFlowMode } from "../../lib/api/wizard.js";
 import { cn } from "../../lib/utils.js";
@@ -140,7 +141,7 @@ function TrailingMeta({
         </>
       ) : null}
       <a
-        href="https://docs.vex.ai/security/local-vault"
+        href={VEX_PRIVACY_DOC_URL}
         target="_blank"
         rel="noopener noreferrer"
         className={cn(
@@ -149,7 +150,7 @@ function TrailingMeta({
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
         )}
       >
-        Your data stays yours
+        {VEX_PRIVACY_DOC_LABEL}
         <IconArrowUpRight size={10} />
       </a>
     </div>

--- a/vex-app/src/renderer/lib/__tests__/protocol-marks.test.ts
+++ b/vex-app/src/renderer/lib/__tests__/protocol-marks.test.ts
@@ -6,7 +6,7 @@
  * asset is granted ONLY to a venue actually present in the curated map, every
  * other value degrades to a monogram, and nothing ever resolves to a remote
  * URL. The venue strings below are the complete vocabulary the tools emit
- * (`khalani`, `kyberswap`, `morpho`, `pendle`, `pools`, `relay`, `trench`,
+ * (`khalani`, `kyberswap`, `lighter`, `morpho`, `pendle`, `pools`, `relay`, `trench`,
  * `uniswap`, `jupiter`, `dexscreener`, `polymarket`, `trench`, plus the
  * `solana`/`virtuals` toolId namespaces); `polymarket`, `trench` and `solana`
  * deliberately have no bundled asset
@@ -28,6 +28,7 @@ describe("resolveProtocolMark - curated venues", () => {
     ["jupiter", "/protocols/jupiter.jpg", "Jupiter"],
     ["khalani", "/protocols/khalani.svg", "Khalani"],
     ["kyberswap", "/protocols/kyberswap.svg", "KyberSwap"],
+    ["lighter", "/protocols/lighter.svg", "Lighter"],
     ["morpho", "/protocols/morpho.jpg", "Morpho"],
     ["pendle", "/protocols/pendle.jpg", "Pendle"],
     ["pools", "/protocols/pools.jpg", "pools.fun"],

--- a/vex-app/src/renderer/lib/protocol-marks.ts
+++ b/vex-app/src/renderer/lib/protocol-marks.ts
@@ -16,10 +16,10 @@
  * network from the untrusted UI).
  *
  * The curated keys are the COMPLETE venue vocabulary the agent tools emit
- * today — `khalani`, `kyberswap`, `morpho`, `pendle`, `pools`, `relay`, `trench`,
- * `uniswap`, `jupiter`, `dexscreener`, `polymarket`, `solana`, `virtuals` (the
- * last two are protocol `toolId` namespaces surfaced by the transcript's tool
- * cards).
+ * today: `khalani`, `kyberswap`, `lighter`, `morpho`, `pendle`, `pools`,
+ * `relay`, `trench`, `uniswap`, `jupiter`, `dexscreener`, `polymarket`,
+ * `solana`, `virtuals` (the last two are protocol `toolId` namespaces
+ * surfaced by the transcript's tool cards).
  * `polymarket`, `solana` and `trench` are listed with no asset on purpose: they
  * keep an honest display label while taking the monogram. For `solana` that is
  * until artwork lands; for the two RETIRED venues it is permanent - their marks
@@ -57,6 +57,7 @@ const CURATED: Readonly<Record<string, CuratedProtocol>> = {
   jupiter: { label: "Jupiter", src: "/protocols/jupiter.jpg" },
   khalani: { label: "Khalani", src: "/protocols/khalani.svg" },
   kyberswap: { label: "KyberSwap", src: "/protocols/kyberswap.svg" },
+  lighter: { label: "Lighter", src: "/protocols/lighter.svg" },
   morpho: { label: "Morpho", src: "/protocols/morpho.jpg" },
   pendle: { label: "Pendle", src: "/protocols/pendle.jpg" },
   pools: { label: "pools.fun", src: "/protocols/pools.jpg" },

--- a/vex-app/src/shared/__tests__/docs-links.test.ts
+++ b/vex-app/src/shared/__tests__/docs-links.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Docs-link coupling - the privacy anchor the Settings Superboard section and
+ * the wizard footer render, and the external-link policy that gates
+ * `shell.openExternal`, must never drift.
+ *
+ * This suite runs the REAL `isAllowedExternalUrl` against the REAL
+ * `DOCS_EXTERNAL_ALLOW` (the exact list `main-window.ts` spreads into
+ * `ALLOWED_EXTERNAL`) and the REAL `VEX_PRIVACY_DOC_URL` the components put
+ * in `href`. No mirrored fixture: the previous anchor pointed at a host that
+ * never resolved, and nothing in the test suite could have noticed.
+ *
+ * `DOCS_EXTERNAL_ALLOW` is a subset of `ALLOWED_EXTERNAL`, and the `/docs`
+ * prefix on `projectvex.ai` appears ONLY in that subset, so "allowed by the
+ * subset" implies "allowed by the full list", and a docs URL denied here is
+ * denied by the full list too. Testing the subset is therefore faithful and
+ * avoids importing `main-window.ts` (electron).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  DOCS_EXTERNAL_ALLOW,
+  VEX_PRIVACY_DOC_LABEL,
+  VEX_PRIVACY_DOC_URL,
+} from "../docs-links.js";
+import { isAllowedExternalUrl } from "../../main/security/url.js";
+
+function allowed(url: string): boolean {
+  return isAllowedExternalUrl(url, DOCS_EXTERNAL_ALLOW);
+}
+
+describe("privacy docs link", () => {
+  it("admits the exact URL the components render", () => {
+    expect(allowed(VEX_PRIVACY_DOC_URL)).toBe(true);
+  });
+
+  it("points at the product's own docs tree under the apex host", () => {
+    const url = new URL(VEX_PRIVACY_DOC_URL);
+    expect(url.protocol).toBe("https:");
+    expect(url.hostname).toBe("projectvex.ai");
+    expect(url.pathname).toBe("/docs/security/privacy");
+  });
+
+  it("keeps the label the sections and their tests render", () => {
+    expect(VEX_PRIVACY_DOC_LABEL).toBe("Your data stays yours");
+  });
+
+  it("admits the rest of the docs tree and nothing outside it", () => {
+    expect(allowed("https://projectvex.ai/docs")).toBe(true);
+    expect(allowed("https://projectvex.ai/docs/security/encryption")).toBe(true);
+    for (const url of [
+      "https://projectvex.ai/",
+      "https://projectvex.ai/docsX",
+      "https://projectvex.ai/doc",
+      "https://projectvex.ai/releases", // admitted by its own entry, not this one
+      "https://projectvex.ai/docs/../releases",
+    ]) {
+      expect(allowed(url), url).toBe(false);
+    }
+  });
+
+  it("denies lookalike hosts, the www subdomain and the retired placeholder hosts", () => {
+    for (const url of [
+      "https://www.projectvex.ai/docs/security/privacy",
+      "https://projectvex.ai.evil.example/docs/security/privacy",
+      "https://notprojectvex.ai/docs",
+      "https://evil.example/?next=https://projectvex.ai/docs",
+      "https://docs.vex.ai/security/local-vault", // what the anchor used to say
+      "https://vex.ai/docs",
+    ]) {
+      expect(allowed(url), url).toBe(false);
+    }
+  });
+
+  it("denies the same URL over http and over a non-web scheme", () => {
+    expect(allowed("http://projectvex.ai/docs/security/privacy")).toBe(false);
+    expect(allowed("file:///projectvex.ai/docs/security/privacy")).toBe(false);
+  });
+});

--- a/vex-app/src/shared/docs-links.ts
+++ b/vex-app/src/shared/docs-links.ts
@@ -1,0 +1,44 @@
+/**
+ * The "Your data stays yours" link the Settings Superboard section and the
+ * wizard footer render, and the external-link allow entry that makes it
+ * clickable.
+ *
+ * WHY BOTH FACTS LIVE HERE. Same reason as `chart-attribution.ts`: the anchor
+ * is in the renderer, the decision to open an external URL belongs to main's
+ * `ALLOWED_EXTERNAL`, and held in two places they drift silently - the link
+ * renders, the user clicks, and nothing at all happens. What shipped before
+ * this module was worse than silence: both anchors pointed at
+ * `docs.vex.ai/security/local-vault`, a host that does not resolve (measured
+ * 2026-09-11: NXDOMAIN, while the apex `vex.ai` belongs to a third party),
+ * and the allowlist admitted both hosts host-wide, so the click opened the
+ * user's browser on a DNS error. So the URL the components render
+ * and the entry the allowlist spreads are ONE declaration, and
+ * `shared/__tests__/docs-links.test.ts` asserts the real allowlist admits
+ * the real URL and denies its lookalikes.
+ *
+ * SCOPE. The apex `projectvex.ai`, path-scoped to `/docs`: the documentation
+ * tree and nothing else on the site (the release-notes CTA keeps its own
+ * `/releases` entry). `isAllowedExternalUrl` matches the hostname exactly and
+ * the path with boundary respect, so `www.projectvex.ai`,
+ * `projectvex.ai.evil.example` and `/docsX` are all denied.
+ */
+
+/** Structurally identical to main's `ExternalAllowEntry`; shared must not import main. */
+export type DocsAllowEntry =
+  | string
+  | { readonly host: string; readonly pathPrefix: string };
+
+/**
+ * The privacy page of the public docs: what stays on the machine, what leaves
+ * it, and what is opt-in. It is the page the label promises, and it exists in
+ * the landing repository's docs navigation (`/docs/security/privacy`).
+ */
+export const VEX_PRIVACY_DOC_URL = "https://projectvex.ai/docs/security/privacy";
+
+/** The visible label beside the arrow glyph. */
+export const VEX_PRIVACY_DOC_LABEL = "Your data stays yours";
+
+/** Spread verbatim into main's `ALLOWED_EXTERNAL`. */
+export const DOCS_EXTERNAL_ALLOW: readonly DocsAllowEntry[] = [
+  { host: "projectvex.ai", pathPrefix: "/docs" },
+];

--- a/vex-app/src/shared/schemas/__tests__/agent-scan-feed.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/agent-scan-feed.test.ts
@@ -47,6 +47,9 @@ function leg(overrides: Record<string, unknown> = {}) {
 
 function entry(overrides: Record<string, unknown> = {}): unknown {
   return {
+    // The feed is a union of two ledgers discriminated on `source`; this
+    // fixture is the `agent_activity` arm (the Lighter arm has its own suite).
+    source: "agent_activity",
     id: "42",
     createdAt: "2026-05-21T10:00:00.000Z",
     activityKind: "swap",
@@ -278,6 +281,8 @@ describe("agentScanEntrySchema", () => {
     expect(parsed.success).toBe(true);
     if (!parsed.success) return;
     const value: AgentScanEntry = parsed.data;
+    // Narrow to the activity arm: the union's other member has no such fields.
+    if (value.source !== "agent_activity") throw new Error("expected the activity arm");
     expect(value.activityKind).toBe("perp_futures");
     expect(value.eventRole).toBe("perp_open");
     expect(value.status).toBe("settling");
@@ -312,7 +317,7 @@ describe("agentScanEntrySchema", () => {
     // `displaySymbol`, never on `symbol`.
     const parsed = agentScanEntrySchema.safeParse(entry());
     expect(parsed.success).toBe(true);
-    if (!parsed.success) return;
+    if (!parsed.success || parsed.data.source !== "agent_activity") return;
     expect(parsed.data.output.symbol).toBe("NATIVE");
     expect(parsed.data.output.displaySymbol).toBe("NATIVE (ETH)");
   });
@@ -349,7 +354,7 @@ describe("agentScanEntrySchema", () => {
       }),
     );
     expect(parsed.success).toBe(true);
-    if (!parsed.success) return;
+    if (!parsed.success || parsed.data.source !== "agent_activity") return;
     expect(parsed.data.legs).toHaveLength(2);
     expect(parsed.data.legs[1]?.role).toBe("a_role_added_after_this_build");
   });

--- a/vex-app/src/shared/schemas/__tests__/agent-scan-lighter-entry.test.ts
+++ b/vex-app/src/shared/schemas/__tests__/agent-scan-lighter-entry.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The Lighter arm's contract, probed at runtime: the invariants the type
+ * system cannot carry alone. A closed market cannot carry details, an open
+ * market may say "details unavailable", numbers are validated by shape and
+ * not only by length, a rebate is a signed amount, and a cursor minted before
+ * the second arm existed still parses.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  agentScanCursorSchema,
+  agentScanEntrySchema,
+} from "../agent-scan-feed.js";
+import {
+  agentScanLighterFillEntrySchema,
+  agentScanLighterPositionNowSchema,
+  type AgentScanLighterFillEntry,
+} from "../agent-scan-lighter-entry.js";
+
+const OBSERVED_AT = "2026-09-11T14:49:46.033Z";
+
+function fill(overrides: Partial<AgentScanLighterFillEntry> = {}): AgentScanLighterFillEntry {
+  return {
+    source: "lighter_fill",
+    id: "1",
+    createdAt: "2026-09-11T13:58:07.000Z",
+    observedAt: "2026-09-11T13:58:08.249Z",
+    environment: "rhc",
+    marketIndex: 0,
+    marketSymbol: "ETH",
+    spot: false,
+    side: "buy",
+    tradeType: "trade",
+    positionEffect: "open",
+    baseSize: "0.0050",
+    price: "2598.09",
+    quoteNotional: "12.99045",
+    usdAmount: "12.990450",
+    blockHeight: "20430001",
+    baseAsset: { symbol: "ETH", decimals: 4 },
+    quoteAsset: { symbol: "USDG", decimals: 6 },
+    positionSizeBefore: "0.0000",
+    entryQuoteBefore: null,
+    accountPnl: "0.000000",
+    leverage: { initialMarginFraction: 1000, display: "10.00" },
+    feeSide: "taker",
+    integratorFee: {
+      charged: null,
+      estimate: {
+        raw: "12990",
+        symbol: "USDG",
+        decimals: 6,
+        basis: "quote_notional",
+        tickSource: "observed",
+        usd: "0.012990",
+      },
+      tickObserved: 1000,
+      tickAuthorized: 1000,
+    },
+    exchangeFee: { charged: null, estimatedUsd: "0.004546", tickObserved: 350 },
+    providerTradeId: "601535556",
+    providerOrderId: "281475043993191",
+    intentId: "lighter-exec-a5a46767-cae0-4a71-b8e0-f85f9c23010f",
+    positionNow: {
+      observedAt: OBSERVED_AT,
+      open: true,
+      position: {
+        size: "0.0050",
+        entryPrice: "2598.09",
+        unrealizedPnl: "-0.007650",
+        realizedPnl: "0.000000",
+        liquidationPrice: "2365.9297570850204",
+        leverage: { initialMarginFraction: 1000, display: "10.00" },
+        marginMode: "isolated",
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("agentScanLighterFillEntrySchema", () => {
+  it("accepts the measured ETH fill and round-trips it unchanged", () => {
+    const entry = fill();
+    expect(agentScanLighterFillEntrySchema.parse(entry)).toEqual(entry);
+    expect(agentScanEntrySchema.parse(entry)).toEqual(entry);
+  });
+
+  it("validates numbers by shape, not only by length", () => {
+    expect(agentScanLighterFillEntrySchema.safeParse(fill({ baseSize: "garbage" })).success).toBe(false);
+    expect(agentScanLighterFillEntrySchema.safeParse(fill({ price: "-1" })).success).toBe(false);
+    expect(agentScanLighterFillEntrySchema.safeParse(fill({ blockHeight: "12.5" })).success).toBe(false);
+    expect(agentScanLighterFillEntrySchema.safeParse(fill({ providerTradeId: "0x1" })).success).toBe(false);
+    // Signed where the ledger is signed: a short position before, a loss.
+    expect(agentScanLighterFillEntrySchema.safeParse(fill({ positionSizeBefore: "-0.0100" })).success).toBe(true);
+    expect(agentScanLighterFillEntrySchema.safeParse(fill({ accountPnl: "-0.019000" })).success).toBe(true);
+  });
+
+  it("keeps a rebate as a signed exchange fee amount and refuses a signed integrator amount", () => {
+    const rebate = fill({
+      exchangeFee: { charged: { raw: "-120", symbol: "USDG", decimals: 6 }, estimatedUsd: null, tickObserved: -10 },
+    });
+    expect(agentScanLighterFillEntrySchema.safeParse(rebate).success).toBe(true);
+    const negativeIntegrator = fill({
+      integratorFee: {
+        charged: { raw: "-1", symbol: "USDG", decimals: 6 },
+        estimate: null,
+        tickObserved: null,
+        tickAuthorized: null,
+      },
+    });
+    expect(agentScanLighterFillEntrySchema.safeParse(negativeIntegrator).success).toBe(false);
+  });
+
+  it("tolerates vocabulary values this build has never heard of, bounded", () => {
+    expect(agentScanLighterFillEntrySchema.safeParse(fill({ positionEffect: "rebalanced" })).success).toBe(true);
+    expect(agentScanLighterFillEntrySchema.safeParse(fill({ tradeType: "x".repeat(33) })).success).toBe(false);
+  });
+
+  it("refuses an unknown field: the payload is strict", () => {
+    const withExtra = { ...fill(), txHash: "0xabc" } as unknown;
+    expect(agentScanLighterFillEntrySchema.safeParse(withExtra).success).toBe(false);
+  });
+});
+
+describe("agentScanLighterPositionNowSchema", () => {
+  it("makes a closed market with details unrepresentable", () => {
+    const closedWithDetails = {
+      observedAt: OBSERVED_AT,
+      open: false,
+      position: { size: "0.0050", entryPrice: null, unrealizedPnl: null, realizedPnl: null, liquidationPrice: null, leverage: null, marginMode: null },
+    };
+    expect(agentScanLighterPositionNowSchema.safeParse(closedWithDetails).success).toBe(false);
+    expect(agentScanLighterPositionNowSchema.safeParse({ observedAt: OBSERVED_AT, open: false, position: null }).success).toBe(true);
+  });
+
+  it("lets an open market say its details are unavailable, and refuses an unreadable size", () => {
+    expect(agentScanLighterPositionNowSchema.safeParse({ observedAt: OBSERVED_AT, open: true, position: null }).success).toBe(true);
+    const garbageSize = {
+      observedAt: OBSERVED_AT,
+      open: true,
+      position: { size: "garbage", entryPrice: null, unrealizedPnl: null, realizedPnl: null, liquidationPrice: null, leverage: null, marginMode: null },
+    };
+    expect(agentScanLighterPositionNowSchema.safeParse(garbageSize).success).toBe(false);
+  });
+});
+
+describe("agentScanCursorSchema with two arms", () => {
+  it("parses a cursor minted before the second arm existed as the activity arm", () => {
+    const parsed = agentScanCursorSchema.parse({
+      createdAt: "2026-09-11T13:58:07.000000Z",
+      sourceId: "42",
+    });
+    expect(parsed.sourceRank).toBe(0);
+  });
+
+  it("carries the Lighter arm's rank and refuses a third arm", () => {
+    expect(
+      agentScanCursorSchema.parse({ createdAt: "2026-09-11T13:58:07.000000Z", sourceId: "1", sourceRank: 1 }).sourceRank,
+    ).toBe(1);
+    expect(
+      agentScanCursorSchema.safeParse({ createdAt: "2026-09-11T13:58:07.000000Z", sourceId: "1", sourceRank: 2 }).success,
+    ).toBe(false);
+  });
+});
+
+describe("agentScanEntrySchema union", () => {
+  it("routes on source and refuses an entry without one", () => {
+    const withoutSource = { ...fill() } as Record<string, unknown>;
+    delete withoutSource.source;
+    expect(agentScanEntrySchema.safeParse(withoutSource).success).toBe(false);
+  });
+});

--- a/vex-app/src/shared/schemas/agent-scan-feed.ts
+++ b/vex-app/src/shared/schemas/agent-scan-feed.ts
@@ -5,24 +5,30 @@
  * WHAT THIS IS. `portfolio-moves` answers "what did the agent do in THIS
  * session"; `token-history` answers "what happened to THIS token". Agent Scan
  * answers "what has the agent ever done", across every wallet in the configured
- * inventory, filterable and keyset-paginated. It is the first surface built on
- * the canonical `agent_activity` vocabulary alone (see
- * `../agent-activity-vocabulary.ts`) — there is NO legacy `proj_activity` /
+ * inventory, filterable and keyset-paginated. It is built on the canonical
+ * `agent_activity` vocabulary (see `../agent-activity-vocabulary.ts`) and,
+ * through its second arm, on the venue's own Lighter fill ledger
+ * (`./agent-scan-lighter-entry.ts`) - there is NO legacy `proj_activity` /
  * `wallet_intents` arm here, deliberately: the legacy arms keep serving the two
  * feeds that already union them, and this feed does not inherit the SPOT
  * taxonomy they were built on.
  *
- * SINGLE ARM, SINGLE CURSOR. Because there is exactly one source table, the
- * cursor is a plain 2-field keyset — `{ createdAt, sourceId }` over
- * `(created_at DESC, id DESC)` — with no `sourceRank` tie-breaker
- * (`token-history.ts`'s 3-field cursor needs one only because it orders a
- * 3-table UNION). `createdAt` is the EXACT microsecond serialization SQL
- * produced (`to_char(… 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`), never a `Date`
- * round-trip: `new Date(…).toISOString()` truncates to milliseconds, and two
- * rows written in the same millisecond would then straddle the boundary — the
- * page would skip or repeat rows. `sourceId` is `agent_activity.id` (BIGSERIAL)
- * as a bounded decimal string, because a bigint beyond 2^53 cannot survive a
- * JSON number.
+ * TWO ARMS, ONE CURSOR. The feed reads two local ledgers: `agent_activity`
+ * (swaps, bridges, lends, launches, Lighter deposits and withdrawals) and
+ * `lighter_fills` (the venue's own matched Lighter trades, migration 152).
+ * Each entry says which through `source`, and the page is ONE time-ordered
+ * sequence: main runs both arm queries after the SAME keyset boundary and
+ * merges them, so the cursor is the 3-field keyset `{ createdAt, sourceRank,
+ * sourceId }` over `(cursor_ts DESC, source_rank DESC, id DESC)` - the shape
+ * `token-history.ts` already uses for its multi-table UNION. `createdAt` is
+ * the EXACT microsecond serialization SQL produced (`to_char(...
+ * 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`), never a `Date` round-trip:
+ * `new Date(...).toISOString()` truncates to milliseconds, and two rows written
+ * in the same millisecond would then straddle the boundary - the page would
+ * skip or repeat rows. `sourceId` is the arm's own BIGSERIAL as a bounded
+ * decimal string, because a bigint beyond 2^53 cannot survive a JSON number;
+ * the two ledgers share id space, so `(source, id)` is the identity, never
+ * the id alone. A fill's feed time is the venue's `traded_at`.
  *
  * ROW MODEL (owner decision). One row per LOGICAL activity, with its execution
  * detail nested in `legs` — the same model the existing feeds use. A bridge
@@ -39,10 +45,12 @@
  * Bounded is not negotiable either — tolerant means "unknown values pass", not
  * "unbounded strings pass".
  *
- * INPUT IS THE OPPOSITE. Filters compile straight into SQL, so their
- * vocabularies are CLOSED and their arrays hard-capped. `statuses` and
- * `chainFamily` are enums here precisely because a value outside the set can
- * only be a bug or an attack — there is nothing to degrade gracefully to.
+ * INPUT IS THE OPPOSITE. Filters compile straight into SQL, so their arrays
+ * are hard-capped and their vocabularies are either CLOSED (`statuses`,
+ * `chainFamily`) or bounded open strings that reach SQL only as bound array
+ * parameters (`kinds`, `protocols`). `statuses` and `chainFamily` are enums
+ * here precisely because a value outside the set can only be a bug or an
+ * attack - there is nothing to degrade gracefully to.
  * `sessionId` and `projectId` NARROW the read; neither can ever widen it (main
  * always applies the inventory wallet allow-list first, and a project's
  * addresses are INTERSECTED with it - see `agent-scan-db.ts`). They are
@@ -78,6 +86,22 @@ import {
 } from "../agent-activity-vocabulary.js";
 import { TOKEN_SYMBOL_MAX_LENGTH } from "../token-symbol-sanitizer.js";
 import { bridgeAmountBasisSchema } from "./bridge-legs.js";
+import { agentScanLighterFillEntrySchema } from "./agent-scan-lighter-entry.js";
+
+export {
+  AGENT_SCAN_LIGHTER_TEXT_BOUNDS,
+  agentScanLighterFillEntrySchema,
+  agentScanLighterPositionNowSchema,
+  type AgentScanLighterAsset,
+  type AgentScanLighterAssetAmount,
+  type AgentScanLighterExchangeFee,
+  type AgentScanLighterFillEntry,
+  type AgentScanLighterIntegratorFee,
+  type AgentScanLighterLeverage,
+  type AgentScanLighterObservedPosition,
+  type AgentScanLighterPositionNow,
+  type AgentScanLighterSignedAssetAmount,
+} from "./agent-scan-lighter-entry.js";
 
 // ── Bounds ────────────────────────────────────────────────────────────────
 
@@ -156,6 +180,13 @@ export const agentScanCursorSchema = z
     sourceId: z
       .string()
       .regex(SOURCE_ID_PATTERN, "sourceId must be a decimal bigint string"),
+    /**
+     * Which arm the last row came from: 0 = `agent_activity`, 1 =
+     * `lighter_fills`. The tie-break between the two arms at an identical
+     * microsecond. Defaults to 0 so a cursor minted before the second arm
+     * existed still parses and still resumes correctly.
+     */
+    sourceRank: z.number().int().min(0).max(1).default(0),
   })
   .strict();
 export type AgentScanCursor = z.infer<typeof agentScanCursorSchema>;
@@ -183,7 +214,15 @@ export type AgentScanChainFamilyFilter = z.infer<typeof agentScanChainFamilyFilt
  * Every filter is optional and bounded. `kinds` and `protocols` stay OPEN
  * strings (a user may legitimately filter on a kind this build predates) but
  * are length- and count-capped; they reach SQL only as bound array parameters,
- * never as interpolated text.
+ * never as interpolated text. An EMPTY array means "no restriction", exactly
+ * like an absent field.
+ *
+ * `kinds` also routes the Lighter arm: the FEED kind `lighter_fill` (not an
+ * `agent_activity.kind`, so the kind lockstep gate is untouched) selects the
+ * fill ledger, and a non-empty `kinds` without it excludes that arm; likewise
+ * a non-empty `protocols` without `lighter`, any `chainFamily` (a venue is not
+ * a chain family), and a non-empty `statuses` without `confirmed` (a fill has
+ * no other status).
  */
 export const agentScanFiltersSchema = z
   .object({
@@ -376,8 +415,10 @@ export type AgentScanBridgeLeg = z.infer<typeof agentScanBridgeLegSchema>;
 
 // ── Output: entry ─────────────────────────────────────────────────────────
 
-export const agentScanEntrySchema = z
+export const agentScanActivityEntrySchema = z
   .object({
+    /** The ledger this entry came from; see the union below. */
+    source: z.literal("agent_activity"),
     /** `agent_activity.id` as a decimal string — also this row's cursor `sourceId`. */
     id: z.string().min(1).max(32),
     createdAt: z.string().datetime({ offset: true }),
@@ -462,7 +503,23 @@ export const agentScanEntrySchema = z
     pendingReason: z.string().max(FAILURE_REASON_MAX_LENGTH).nullable(),
   })
   .strict();
+export type AgentScanActivityEntry = z.infer<typeof agentScanActivityEntrySchema>;
+
+// ── Output: the entry, one of two ledgers ─────────────────────────────────
+
+/**
+ * ONE feed, TWO ledgers, discriminated on `source`. The Lighter fill entry
+ * lives in its sibling `agent-scan-lighter-entry.ts` (its own vocabulary,
+ * bounds and reasons to change). Every consumer switches on `source`;
+ * TypeScript exhaustiveness is the gate. Both sides of the IPC ship in the
+ * same build, so the discriminator is required rather than defaulted.
+ */
+export const agentScanEntrySchema = z.discriminatedUnion("source", [
+  agentScanActivityEntrySchema,
+  agentScanLighterFillEntrySchema,
+]);
 export type AgentScanEntry = z.infer<typeof agentScanEntrySchema>;
+
 
 // ── Push: a pending row terminalized (Wave P) ─────────────────────────────
 

--- a/vex-app/src/shared/schemas/agent-scan-lighter-entry.ts
+++ b/vex-app/src/shared/schemas/agent-scan-lighter-entry.ts
@@ -1,0 +1,283 @@
+/**
+ * The Lighter arm of the Agent Scan feed: one entry per fill from the local
+ * `lighter_fills` ledger (migration 152), attributed to a Vex order intent.
+ *
+ * A sibling of `agent-scan-feed.ts` rather than a section of it: the feed
+ * module owns the cursor, the filters, the page envelope and the
+ * `agent_activity` entry, and this module owns the fill entry, which has its
+ * own vocabulary (venue, market, position effect, fee provenance), its own
+ * bounds and its own reasons to change (a new ledger column, a new provider
+ * fact). The feed unions the two entries on `source`.
+ *
+ * Every rule of the feed module's header applies here unchanged: tolerant
+ * bounded open strings for vocabularies, display text bounded exactly as the
+ * feed bounds its own (the reader's `LEFT(...)` clamps and these `.max(...)`
+ * share one table), numbers and identifiers validated by shape and NEVER
+ * clamped, URLs never (a fill has none), and scope decided in main.
+ */
+
+import { z } from "zod";
+import { TOKEN_SYMBOL_MAX_LENGTH } from "../token-symbol-sanitizer.js";
+
+/**
+ * Bounds for the Lighter arm's DISPLAY-ONLY text, shared with the reader's
+ * SQL `LEFT(...)` clamps exactly like `AGENT_SCAN_TEXT_BOUNDS`. Amounts,
+ * identifiers and the block height are NOT here: they are validated by SHAPE
+ * below (a decimal is a decimal, an integer is an integer) and fail loudly
+ * when malformed or overlength, never clamped into a different valid-looking
+ * value.
+ */
+export const AGENT_SCAN_LIGHTER_TEXT_BOUNDS = {
+  environment: 16,
+  marketSymbol: 48,
+  side: 8,
+  tradeType: 32,
+  positionEffect: 16,
+  feeSide: 8,
+  feeBasis: 32,
+  feeTickSource: 16,
+  marginMode: 16,
+} as const;
+
+/**
+ * NUMBERS ARE VALIDATED BY SHAPE, not only by length. The fill ledger's own
+ * CHECKs guarantee these shapes for its columns; the position JSONB does not,
+ * and an IPC contract that accepted `"garbage"` as a size would let main's
+ * mapper ship a number nobody can read. Each pattern is the ledger's own
+ * (migration 152): unsigned and signed decimals, unsigned and signed integers.
+ * Bounded to 64 characters, far above any venue figure.
+ */
+const LIGHTER_NUMBER_MAX_LENGTH = 64;
+const UNSIGNED_DECIMAL_PATTERN = /^[0-9]+(\.[0-9]+)?$/;
+const SIGNED_DECIMAL_PATTERN = /^-?[0-9]+(\.[0-9]+)?$/;
+const UNSIGNED_INTEGER_PATTERN = /^[0-9]+$/;
+const SIGNED_INTEGER_PATTERN = /^-?[0-9]+$/;
+
+export const lighterUnsignedDecimalSchema = z
+  .string()
+  .max(LIGHTER_NUMBER_MAX_LENGTH)
+  .regex(UNSIGNED_DECIMAL_PATTERN, "expected an unsigned decimal string");
+export const lighterSignedDecimalSchema = z
+  .string()
+  .max(LIGHTER_NUMBER_MAX_LENGTH)
+  .regex(SIGNED_DECIMAL_PATTERN, "expected a signed decimal string");
+export const lighterUnsignedIntegerSchema = z
+  .string()
+  .max(LIGHTER_NUMBER_MAX_LENGTH)
+  .regex(UNSIGNED_INTEGER_PATTERN, "expected an unsigned integer string");
+export const lighterSignedIntegerSchema = z
+  .string()
+  .max(LIGHTER_NUMBER_MAX_LENGTH)
+  .regex(SIGNED_INTEGER_PATTERN, "expected a signed integer string");
+
+/** Vex intent ids (`lighter-exec-<uuid>`, `lighter-lifecycle-<uuid>`). */
+const LIGHTER_INTENT_ID_MAX_LENGTH = 128;
+/** "10.00" style leverage text from `initialMarginFractionToLeverageDisplay`. */
+const LEVERAGE_DISPLAY_MAX_LENGTH = 16;
+
+/** A venue asset on a fill: symbol and decimals only, no address (Lighter assets have none). */
+export const agentScanLighterAssetSchema = z
+  .object({
+    symbol: z.string().max(TOKEN_SYMBOL_MAX_LENGTH),
+    decimals: z.number().int().nonnegative(),
+  })
+  .strict();
+export type AgentScanLighterAsset = z.infer<typeof agentScanLighterAssetSchema>;
+
+/** An exact UNSIGNED amount in a venue asset: raw base units plus the asset it is denominated in. */
+export const agentScanLighterAssetAmountSchema = z
+  .object({
+    raw: lighterUnsignedIntegerSchema,
+    symbol: z.string().max(TOKEN_SYMBOL_MAX_LENGTH),
+    decimals: z.number().int().nonnegative(),
+  })
+  .strict();
+export type AgentScanLighterAssetAmount = z.infer<typeof agentScanLighterAssetAmountSchema>;
+
+/** The same, SIGNED: the exchange reports a rebate as a negative charged amount. */
+export const agentScanLighterSignedAssetAmountSchema = z
+  .object({
+    raw: lighterSignedIntegerSchema,
+    symbol: z.string().max(TOKEN_SYMBOL_MAX_LENGTH),
+    decimals: z.number().int().nonnegative(),
+  })
+  .strict();
+export type AgentScanLighterSignedAssetAmount = z.infer<typeof agentScanLighterSignedAssetAmountSchema>;
+
+/**
+ * A leverage reading from an initial margin fraction on the provider's 10000
+ * scale (1000 = 10x). `display` is produced in main by the same
+ * `initialMarginFractionToLeverageDisplay` rule the Lighter leverage overview
+ * uses: two decimals, TRUNCATED ("2.99" for 3334), never rounded up.
+ */
+export const agentScanLighterLeverageSchema = z
+  .object({
+    initialMarginFraction: z.number().int().min(1).max(10_000),
+    display: z.string().min(1).max(LEVERAGE_DISPLAY_MAX_LENGTH),
+  })
+  .strict();
+export type AgentScanLighterLeverage = z.infer<typeof agentScanLighterLeverageSchema>;
+
+/**
+ * The integrator (Vex) fee on a fill, with its PROVENANCE intact (migration
+ * 152): `charged` is the provider's exact amount and is null until proven
+ * (never zero as a placeholder); `estimate` is arithmetic on this fill's own
+ * basis and names the tick it used. A renderer shows `charged` when present
+ * and otherwise the estimate WITH the estimate marker; it never adds them.
+ */
+export const agentScanLighterIntegratorFeeSchema = z
+  .object({
+    charged: agentScanLighterAssetAmountSchema.nullable(),
+    estimate: z
+      .object({
+        raw: lighterUnsignedIntegerSchema,
+        symbol: z.string().max(TOKEN_SYMBOL_MAX_LENGTH),
+        decimals: z.number().int().nonnegative(),
+        /** `quote_notional` or `received_base`; tolerant bounded open string. */
+        basis: z.string().max(AGENT_SCAN_LIGHTER_TEXT_BOUNDS.feeBasis),
+        /** `observed` or `authorized`; tolerant bounded open string. */
+        tickSource: z.string().max(AGENT_SCAN_LIGHTER_TEXT_BOUNDS.feeTickSource),
+        /** USD estimate on the provider's own USD notional; null on a spot buy. */
+        usd: lighterUnsignedDecimalSchema.nullable(),
+      })
+      .strict()
+      .nullable(),
+    /** Millionths of notional as the provider stamped them; null when absent. */
+    tickObserved: z.number().int().nullable(),
+    tickAuthorized: z.number().int().nullable(),
+  })
+  .strict();
+export type AgentScanLighterIntegratorFee = z.infer<typeof agentScanLighterIntegratorFeeSchema>;
+
+/**
+ * The exchange's own tier fee. `charged` is exact when proven, denominated by
+ * the SAME rule the AgentScan wire mapper applies (the received base on a spot
+ * buy, the quote asset otherwise); a rebate is a negative raw amount. Else the
+ * USD estimate, rendered as one.
+ */
+export const agentScanLighterExchangeFeeSchema = z
+  .object({
+    charged: agentScanLighterSignedAssetAmountSchema.nullable(),
+    estimatedUsd: lighterUnsignedDecimalSchema.nullable(),
+    tickObserved: z.number().int().nullable(),
+  })
+  .strict();
+export type AgentScanLighterExchangeFee = z.infer<typeof agentScanLighterExchangeFeeSchema>;
+
+/**
+ * An open position as last observed on this fill's market. Every optional
+ * fact is independently unknown: a malformed leverage or margin mode becomes
+ * null WITHOUT discarding the readable size and prices beside it.
+ */
+export const agentScanLighterObservedPositionSchema = z
+  .object({
+    /** Signed decimal string in base units; negative while short. */
+    size: lighterSignedDecimalSchema,
+    entryPrice: lighterUnsignedDecimalSchema.nullable(),
+    unrealizedPnl: lighterSignedDecimalSchema.nullable(),
+    realizedPnl: lighterSignedDecimalSchema.nullable(),
+    liquidationPrice: lighterUnsignedDecimalSchema.nullable(),
+    /** Null on observations stored before leverage was projected, or when unreadable. */
+    leverage: agentScanLighterLeverageSchema.nullable(),
+    /** `cross` or `isolated`; tolerant bounded open string; null when not projected. */
+    marginMode: z.string().max(AGENT_SCAN_LIGHTER_TEXT_BOUNDS.marginMode).nullable(),
+  })
+  .strict();
+export type AgentScanLighterObservedPosition = z.infer<typeof agentScanLighterObservedPositionSchema>;
+
+/**
+ * The newest observed state of this fill's market, as CONTEXT beside a
+ * historical fill. A discriminated union on `open` so that the invariant is
+ * in the type, not in a comment: a market observed CLOSED has no position
+ * details (migration 152 stores `open = false, position = NULL`); a market
+ * observed OPEN carries its details, or `null` when the stored details could
+ * not be read ("open, details unavailable"), which the renderer states as
+ * such rather than hiding the observation. The entry's `positionNow` is
+ * `null` only when NO observation exists for the market.
+ *
+ * `observedAt` is the time VEX LAST OBSERVED the market (assigned by the
+ * position sweep), rendered beside every figure as "last observed", with the
+ * date when it is not today: these are facts about then, not about the fill.
+ */
+export const agentScanLighterPositionNowSchema = z.discriminatedUnion("open", [
+  z
+    .object({
+      observedAt: z.string().datetime({ offset: true }),
+      open: z.literal(false),
+      position: z.null(),
+    })
+    .strict(),
+  z
+    .object({
+      observedAt: z.string().datetime({ offset: true }),
+      open: z.literal(true),
+      position: agentScanLighterObservedPositionSchema.nullable(),
+    })
+    .strict(),
+]);
+export type AgentScanLighterPositionNow = z.infer<typeof agentScanLighterPositionNowSchema>;
+
+/**
+ * One Lighter fill from the local `lighter_fills` ledger (migration 152): the
+ * venue's own matched trade, attributed to a Vex order intent. Economics are
+ * settled the moment the venue matched them, so this entry has no lifecycle
+ * (`status` is always confirmed and is therefore not a field), no transaction
+ * hash and no explorer link. The account's own half of the record
+ * (`positionEffect`, `positionSizeBefore`, `accountPnl`) arrives whole or not
+ * at all (`entryQuoteBefore` may be null on its own); all three null means the
+ * observation was a public trade row and the renderer says "position facts
+ * unknown", never 0.
+ *
+ * `createdAt` is the venue's `traded_at` (the feed time and the cursor time);
+ * `observedAt` is when Vex saw it.
+ */
+export const agentScanLighterFillEntrySchema = z
+  .object({
+    source: z.literal("lighter_fill"),
+    /** `lighter_fills.id` as a decimal string - also this row's cursor `sourceId`. */
+    id: lighterUnsignedIntegerSchema,
+    createdAt: z.string().datetime({ offset: true }),
+    observedAt: z.string().datetime({ offset: true }),
+    /** `core` or `rhc`; tolerant bounded open string. */
+    environment: z.string().max(AGENT_SCAN_LIGHTER_TEXT_BOUNDS.environment),
+    marketIndex: z.number().int().nonnegative(),
+    marketSymbol: z.string().max(AGENT_SCAN_LIGHTER_TEXT_BOUNDS.marketSymbol),
+    /** TRUE for a spot market (index at or above the venue's spot floor). A spot fill has no position. */
+    spot: z.boolean(),
+    /** `buy` or `sell`; tolerant bounded open string. */
+    side: z.string().max(AGENT_SCAN_LIGHTER_TEXT_BOUNDS.side),
+    /** `trade`, `liquidation`, `deleverage`, `market-settlement`; tolerant. */
+    tradeType: z.string().max(AGENT_SCAN_LIGHTER_TEXT_BOUNDS.tradeType),
+    /** `open`, `increase`, `reduce`, `close`, `flip`, `unknown`; tolerant; null = public row. */
+    positionEffect: z.string().max(AGENT_SCAN_LIGHTER_TEXT_BOUNDS.positionEffect).nullable(),
+    baseSize: lighterUnsignedDecimalSchema,
+    price: lighterUnsignedDecimalSchema,
+    quoteNotional: lighterUnsignedDecimalSchema,
+    /** The provider's own USD notional for the fill; settled, not an estimate. */
+    usdAmount: lighterUnsignedDecimalSchema,
+    /** The venue's block height for the match. */
+    blockHeight: lighterUnsignedIntegerSchema,
+    baseAsset: agentScanLighterAssetSchema,
+    quoteAsset: agentScanLighterAssetSchema,
+    /** Signed; negative while short. Null on a public row. */
+    positionSizeBefore: lighterSignedDecimalSchema.nullable(),
+    entryQuoteBefore: lighterSignedDecimalSchema.nullable(),
+    /** The provider's realized PnL for the account on this fill; "0" when nothing was realized. */
+    accountPnl: lighterSignedDecimalSchema.nullable(),
+    /**
+     * Leverage BEFORE the fill. Null on public rows and on rows the ledger
+     * holds without the fraction (written before the column existed and not
+     * yet re-observed): "unknown", never a current value.
+     */
+    leverage: agentScanLighterLeverageSchema.nullable(),
+    /** `maker` or `taker`; tolerant bounded open string. */
+    feeSide: z.string().max(AGENT_SCAN_LIGHTER_TEXT_BOUNDS.feeSide),
+    integratorFee: agentScanLighterIntegratorFeeSchema,
+    exchangeFee: agentScanLighterExchangeFeeSchema,
+    providerTradeId: lighterUnsignedIntegerSchema,
+    providerOrderId: lighterUnsignedIntegerSchema.nullable(),
+    intentId: z.string().min(1).max(LIGHTER_INTENT_ID_MAX_LENGTH),
+    positionNow: agentScanLighterPositionNowSchema.nullable(),
+  })
+  .strict();
+export type AgentScanLighterFillEntry = z.infer<typeof agentScanLighterFillEntrySchema>;


### PR DESCRIPTION
## What

The local AgentScan feed (Settings -> AgentScan and the Studio Activity card, both on `vex:portfolio:listAgentScan`) now shows Lighter fills with their full detail: effect (open / increase / reduce / close / flip), side, size, price, the venue's settled USD notional, both fees with their provenance, realized PnL on a reducing fill, the leverage in force before the fill, the trade type (a liquidation is named as one), the venue, the block height, the order / trade / intent ids, and the market's last observed position as timestamped context. Until now the feed read `agent_activity` only, so a Lighter deposit showed and the fill it funded did not.

Built on top of #190 (the fill ledger idempotence and privacy link fix); merge that first.

## How

**One feed, two ledgers, one cursor.** The entry contract is a union discriminated on `source` (`agent_activity` | `lighter_fill`); the fill entry lives in its own sibling module (`agent-scan-lighter-entry.ts`) with numbers validated by shape and identifiers never clamped. The cursor is the three-field keyset `(createdAt, sourceRank, sourceId)` that `token-history` already uses for its union; an older cursor parses with rank 0. Main runs both arm queries after the same boundary under `REPEATABLE READ READ ONLY` and merges them in a pure, tested function; a timeout on either arm fails the whole read closed as before. Scope stays main's: a fill is admitted only when a Lighter onboarding workflow of an inventory wallet resolved to the fill's account (correlated `EXISTS`, so two wallets resolving to one account cannot duplicate a fill), and held fills (`execution_intent_id IS NULL`) never appear.

**Leverage before the fill is recorded, not guessed.** The trade record's own `initial_margin_fraction_before` was already read and then dropped; migration 162 adds the nullable column (plus an index by the venue's `traded_at`), the writer stores it when it is inside the provider's 1..10000 scale and NULL otherwise (never clamped, never allowed to fail the fill), and fills it once, null to known, on a later observation; never on a conflicting report, never with a revision bump (it is not on the AgentScan wire, which a test pins). Historical rows show "unknown" until a later observation carries the fraction; nothing is backfilled. Position observations now also project the account's `initialMarginFraction` and `marginMode`, so the "position now" context can say "isolated · 10.00x" beside its own observation time.

**The renderer keeps the arms apart.** Rows are keyed by `(source, id)`; a fill mounts its own row and drawer component; Lighter labels live in the renderer's own display helper and the canonical `agent_activity` badge records are untouched; a spot fill shows no leverage and no position lines; money never passes through `Number`. Filters gain a "Lighter fills" kind chip and the `lighter` protocol with the existing mark.

## Not in this PR

The agent tool `vex.AgentScan` `transactions` view (engine side, wallet-scoped) still omits Lighter fills; that is the same gap the owner's coding agent tripped over and it is the next PR.

## Verification

- Desktop: whole unit and renderer suite green on the final tree (894 files, 12478 tests); `pnpm run lint` (tsc, ratchet at baseline, process boundaries) green; new suites for the Lighter query (SQL shape and arm exclusion), the mappers (fee provenance, leverage display, four position states), the merge (ties, exhaustion, `hasMore`), the row and drawer (null account half, null leverage, liquidation, spot, closed and unavailable positions, distinct keys across ledgers), and the contract (closed market with details is unrepresentable, malformed numbers refused, signed rebates accepted, old cursors parse).
- Real Postgres (`test:studio-postgres`): the Lighter arm returns the fill exactly once through two wallets resolving to one account, never a foreign or a held fill, interleaves by time with `agent_activity`, narrows by session both ways, walks a mixed timeline of about 105 rows at the production page size with no skip and no repeat; the writer stores 0 / absent / out-of-range fractions as NULL and valid ones as given, fills once through the merge and through the independent path, and leaves a conflicting report's fraction and `updated_at` untouched.
- Root: whole unit suite green (1497 files, 22417 tests; one load flake, `lexical-retrieval`, passes alone), `tsc --noEmit` green, `check:em-dash` green. The full `test:studio-postgres` lane: 624 tests passed, no test failures; two suites whose `afterAll` pool teardown timed out under four parallel runs pass in isolation (29 tests).
- Live (rule 10): migration 162 applied to a real install database through the runner's ledger, and the Lighter arm's SQL run over its seven real attributed fills for account 24226 through the onboarding `EXISTS`: all seven returned in venue-time order with their effects, PnL and fee estimates; leverage NULL on those historical rows, as documented.
- Codex review (thread `harness-agentscan-local-feed`): plan reviewed in three rounds to GREEN LIGHT (leverage display rule, writer compatibility with the CHECK, EXISTS scope, open `kinds`, no clamping of amounts, `REPEATABLE READ`, position-state union, shape validators); final review found and this PR fixed three renderer defects (the drawer now repeats side, size, price, quote notional and the whole USD on wrapping lines; a recorded charge is never replaced by an estimate when its asset has many decimals; the expanded amount text is bounded so an absurd decimals count states raw units instead of throwing).
- Known residual gap: no seeded Electron screenshot of a Lighter row exists yet; the component suites prove the content, not the layout at a narrow width. The owner sees the real screen on the next build.
